### PR TITLE
build.bat will no longer skip fulp_modules

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -32,6 +32,9 @@ const taskTgui = new Task('tgui')
 
 const taskDm = new Task('dm')
   .depends('code/**')
+  // FULP - We add our modular folder as part of the dependecies, so that build doesn't fail if the only file edited is inside it.
+  .depends('fulp_modules/**')
+  // FULP EDIT END
   .depends('goon/**')
   .depends('html/**')
   .depends('interface/**')


### PR DESCRIPTION
You know what? fuck you. *skips your fulp_modules folder*

## About The Pull Request

Makes fulp_modules part of dependencies so that it doesn't get skipped in case a change is made in ONLY that folder.

## Why It's Good For The Game

I've had multiple breakdowns but it doesn't compare to the ones i've had when I see 'skipping DM' only because I edited a file in there without editing any other file.