### PR TITLE
Protect HoP from antag roles

### DIFF
--- a/fulp_modules/jobs/antag_protect_hop.dm
+++ b/fulp_modules/jobs/antag_protect_hop.dm
@@ -1,0 +1,31 @@
+/datum/game_mode/changeling/New()
+	protected_jobs += "Head of Personnel"
+	. = ..()
+
+/datum/game_mode/heretics/New()
+	protected_jobs += "Head of Personnel"
+	. = ..()
+
+/datum/game_mode/traitor/New()
+	protected_jobs += "Head of Personnel"
+	. = ..()
+
+/datum/dynamic_ruleset/midround/autotraitor/New()
+	protected_roles += "Head of Personnel"
+	. = ..()
+
+/datum/dynamic_ruleset/roundstart/traitor/New()
+	protected_roles += "Head of Personnel"
+	. = ..()
+
+/datum/dynamic_ruleset/roundstart/traitorbro/New()
+	protected_roles += "Head of Personnel"
+	. = ..()
+
+/datum/dynamic_ruleset/roundstart/changeling/New()
+	protected_roles += "Head of Personnel"
+	. = ..()
+
+/datum/dynamic_ruleset/roundstart/heretics/New()
+	protected_roles += "Head of Personnel"
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3328,6 +3328,7 @@
 #include "fulp_modules\mentorhelp\mentorpm.dm"
 #include "fulp_modules\mentorhelp\mentorsay.dm"
 #include "fulp_modules\mentorhelp\mentorwho.dm"
+#include "fulp_modules\jobs\antag_protect_hop.dm"
 #include "fulp_modules\jobs\job_integration.dm"
 #include "fulp_modules\jobs\brigdoc\code\brigdoc.dm"
 #include "fulp_modules\jobs\brigdoc\code\brigdoc_clothing.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Head of Personnel to `protected_jobs` wherever Security Officer is present.

I didn't test this since ~I am lazy~ the changes are so minor.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Resolves #54

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: HoP is no longer eligible for most antag roles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
