### PR TITLE
[Port] Reverts the command and binary comms color

### DIFF
--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -319,7 +319,9 @@ em {
 }
 
 .binarysay {
-  color: #1e90ff;
+  color: #20c20e;
+  background-color: #000000;
+  display: block;
 }
 
 .binarysay a {
@@ -339,7 +341,7 @@ em {
 }
 
 .comradio {
-  color: #fcdf03;
+  color: #5177ff;
 }
 
 .secradio {


### PR DESCRIPTION
## About The Pull Request

Ports over the revert on command/binary comms colors from the old repo. Buzzard said they were planning on doing it, but the document says it hasnt been claimed, so I went ahead and did it. 

## Why It's Good For The Game

Closes #55 

## Changelog
:cl: John Willard
tweak: Reverted Command and Binary comms colors
/:cl:
