### PR TITLE
Adds a Scientific Department ID to the RD's locker

### DIFF
--- a/fulp_modules/container_init/machine_init.dm
+++ b/fulp_modules/container_init/machine_init.dm
@@ -85,6 +85,7 @@
 	. = ..()
 /obj/structure/closet/secure_closet/research_director/Initialize()
 	new /obj/item/clothing/shoes/laceup/digitigrade(src)
+	new /obj/item/card/id/departmental_budget/sci(src) /// Used in science_budget.dm
 	. = ..()
 
 /obj/structure/closet/secure_closet/chief_medical/Initialize()

--- a/fulp_modules/science_budget/readme.MD
+++ b/fulp_modules/science_budget/readme.MD
@@ -1,0 +1,18 @@
+# Folder: Science Budget
+
+## Description:
+
+	Adds a Scientific budget card to the RD's locker, to be used on Bepis.
+	Do note that this is the same as the Cargo budget card, therefore its money cannot be taken out.
+
+## TG edits:
+
+- None
+
+## TG sounds/sprites used:
+
+- 'icons/obj/card.dmi' - icon_state = "sci_budget"
+
+## Notes/Credits:
+
+- None

--- a/fulp_modules/science_budget/science_budget.dm
+++ b/fulp_modules/science_budget/science_budget.dm
@@ -1,0 +1,5 @@
+/// Science departmental card, given to the RD via their locker.
+/obj/item/card/id/departmental_budget/sci
+	department_ID = ACCOUNT_SCI
+	department_name = ACCOUNT_SCI_NAME
+	icon_state = "sci_budget"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3532,6 +3532,7 @@
 #include "fulp_modules\moth\code\moth_antennae.dm"
 #include "fulp_modules\moth\code\moth_wings.dm"
 #include "fulp_modules\nightmare_edit\nightmare.dm"
+#include "fulp_modules\science_budget\science_budget.dm"
 #include "fulp_modules\toys\code\toys.dm"
 #include "fulp_modules\ZFulpcode\modules\jobs\huds.dm"
 #include "fulp_modules\ZFulpcode\modules\jobs\inventories.dm"


### PR DESCRIPTION
## About The Pull Request

The RD's tablet can already buy things from Cargo, and Science is more likely to use Bepis over Cargo, and money cannot be taken out of departmental budget cards. There's also a cool sprite that TG had made, even if they dont use it.

## Why It's Good For The Game

Rewards Science for doing their job by letting them do more of their job.

## Changelog
:cl:
add: A Scientific Department Budget card can now be found in the Research Director's locker. Enjoy your Bepis!
/:cl: