### PR TITLE
Bloodsucker changes

### DIFF
--- a/fulp_modules/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -302,7 +302,7 @@
 	owner.current.regenerate_organs()
 	var/obj/item/organ/eyes/E = owner.current.getorganslot(ORGAN_SLOT_EYES)
 	E.flash_protect = 0
-	E.see_in_dark = 0
+	E.see_in_dark = 2
 	// Update Health
 	owner.current.setMaxHealth(100)
 	// Language

--- a/fulp_modules/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -267,9 +267,9 @@
 			to_chat(H, "As a vampiric clown, you are no longer a danger to yourself. Your clownish nature has been subdued by your thirst for blood.")
 	// Physiology
 	CheckVampOrgans() // Heart, Tongue
-	// Makes eyes flash-immune
+	// Makes eyes weaker
 	var/obj/item/organ/eyes/E = owner.current.getorganslot(ORGAN_SLOT_EYES)
-	E.flash_protect = -1
+	E.flash_protect -= 1
 	E.see_in_dark = 12
 	// Language
 	owner.current.grant_language(/datum/language/vampiric)
@@ -301,7 +301,7 @@
 	// Physiology
 	owner.current.regenerate_organs()
 	var/obj/item/organ/eyes/E = owner.current.getorganslot(ORGAN_SLOT_EYES)
-	E.flash_protect = 0
+	E.flash_protect += 1
 	E.see_in_dark = 2
 	// Update Health
 	owner.current.setMaxHealth(100)

--- a/fulp_modules/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -39,7 +39,7 @@
 	var/notice_healing //Var to see if you are healing for preventing spam of the chat message inform the user of such
 	var/FinalDeath // Have we reached final death? Used to prevent spam.
 	var/static/list/defaultTraits = list(TRAIT_NOBREATH, TRAIT_SLEEPIMMUNE, TRAIT_NOCRITDAMAGE, TRAIT_RESISTCOLD, TRAIT_RADIMMUNE, TRAIT_NIGHT_VISION, TRAIT_STABLEHEART, \
-		TRAIT_NOSOFTCRIT, TRAIT_NOHARDCRIT, TRAIT_AGEUSIA, TRAIT_NOPULSE, TRAIT_COLDBLOODED, TRAIT_VIRUSIMMUNE, TRAIT_TOXIMMUNE, TRAIT_HARDLY_WOUNDED)
+		TRAIT_NOSOFTCRIT, TRAIT_NOHARDCRIT, TRAIT_AGEUSIA, TRAIT_NOPULSE, TRAIT_COLDBLOODED, TRAIT_VIRUSIMMUNE, TRAIT_TOXIMMUNE, TRAIT_HARDLY_WOUNDED, TRAIT_THERMAL_VISION)
 /* TRAIT_HARDLY_WOUNDED can be swapped with TRAIT_NEVER_WOUNDED if it's too unbalanced. -Willard
  * Remember that Fortitude gives NODISMEMBER when balancing Traits!
  */
@@ -266,7 +266,10 @@
 			H.dna.remove_mutation(CLOWNMUT)
 			to_chat(H, "As a vampiric clown, you are no longer a danger to yourself. Your clownish nature has been subdued by your thirst for blood.")
 	// Physiology
-	CheckVampOrgans() // Heart, Eyes
+	CheckVampOrgans() // Heart, Tongue
+	// Makes eyes flash-immune
+	var/obj/item/organ/eyes/E = owner.current.getorganslot(ORGAN_SLOT_EYES)
+	E.flash_protect = -1
 	// Language
 	owner.current.grant_language(/datum/language/vampiric)
 	// Disabilities
@@ -296,6 +299,8 @@
 		REMOVE_TRAIT(owner.current, T, BLOODSUCKER_TRAIT)
 	// Physiology
 	owner.current.regenerate_organs()
+	var/obj/item/organ/eyes/E = owner.current.getorganslot(ORGAN_SLOT_EYES)
+	E.flash_protect = 0
 	// Update Health
 	owner.current.setMaxHealth(100)
 	// Language

--- a/fulp_modules/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -270,6 +270,7 @@
 	// Makes eyes flash-immune
 	var/obj/item/organ/eyes/E = owner.current.getorganslot(ORGAN_SLOT_EYES)
 	E.flash_protect = -1
+	E.see_in_dark = 12
 	// Language
 	owner.current.grant_language(/datum/language/vampiric)
 	// Disabilities
@@ -301,6 +302,7 @@
 	owner.current.regenerate_organs()
 	var/obj/item/organ/eyes/E = owner.current.getorganslot(ORGAN_SLOT_EYES)
 	E.flash_protect = 0
+	E.see_in_dark = 0
 	// Update Health
 	owner.current.setMaxHealth(100)
 	// Language

--- a/fulp_modules/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -171,7 +171,13 @@
 	for(var/O in C.internal_organs)
 		var/obj/item/organ/organ = O
 		organ.setOrganDamage(0)
-	// NOTE: None of these work to fix Torpor's eye damage.
+	owner.current.cure_husk()
+	if(owner.current.stat == DEAD) /// Torpor will revive you in case you're dead.
+		owner.current.revive(full_heal = FALSE, admin_revive = FALSE)
+// NOTE: None of these work to fix Torpor's permanent blindness. It's very likely TG's fault.
+//	C.clear_fullscreen(EYE_DAMAGE, 0)
+//	C.update_sight()
+//	C.reload_fullscreen()
 //	C.cure_blind(EYE_DAMAGE)
 //	C.cure_nearsighted(EYE_DAMAGE)
 //	C.adjust_blindness(-25)
@@ -181,7 +187,6 @@
 //	C.update_sight()
 //	C.adjust_blindness(-25)
 //	C.adjust_blurriness(-25)
-	owner.current.cure_husk()
 
 
 /*
@@ -247,12 +252,12 @@
 	var/total_burn = owner.current.getFireLoss_nonProsthetic()
 	var/total_damage = total_brute + total_burn
 	// Died? Convert to Torpor (fake death)
-	if(owner.current.stat >= DEAD)
-		Torpor_Begin()
-		to_chat(owner, "<span class='danger'>Your immortal body will not yet relinquish your soul to the abyss. You enter Torpor.</span>")
-		sleep(30) //To avoid spam
+	if(owner.current.stat == DEAD)
 		if(poweron_masquerade)
 			to_chat(owner, "<span class='warning'>Your wounds will not heal until you disable the <span class='boldnotice'>Masquerade</span> power.</span>")
+		else
+			to_chat(owner, "<span class='danger'>Your immortal body will not yet relinquish your soul to the abyss. You enter Torpor.</span>")
+			Torpor_Begin()
 	// End Torpor:
 	else // No damage, AND brute healed and NOT in coffin (since you cannot heal burn)
 		if(!SSticker.mode.is_daylight() && HAS_TRAIT(owner.current, TRAIT_FAKEDEATH) && total_damage < owner.current.getMaxHealth())
@@ -275,6 +280,7 @@
 	ADD_TRAIT(owner.current, TRAIT_KNOCKEDOUT, BLOODSUCKER_TRAIT) // Go to sleep.
 	ADD_TRAIT(owner.current, TRAIT_FAKEDEATH, BLOODSUCKER_TRAIT) // Come after UNCONSCIOUS or else it fails
 	owner.current.Jitter(0)
+	CureDisabilities()
 
 /datum/antagonist/bloodsucker/proc/Torpor_End()
 	REMOVE_TRAIT(owner.current, TRAIT_FAKEDEATH, BLOODSUCKER_TRAIT)
@@ -283,8 +289,6 @@
 	ADD_TRAIT(owner.current, TRAIT_SLEEPIMMUNE, BLOODSUCKER_TRAIT)
 	to_chat(owner, "<span class='warning'>You have recovered from Torpor.</span>")
 	CureDisabilities()
-	owner.current.update_sight()
-	owner.current.reload_fullscreen()
 
 /// Standard Antags can be dead OR final death
 /datum/antagonist/proc/AmFinalDeath()

--- a/fulp_modules/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -280,7 +280,6 @@
 	ADD_TRAIT(owner.current, TRAIT_KNOCKEDOUT, BLOODSUCKER_TRAIT) // Go to sleep.
 	ADD_TRAIT(owner.current, TRAIT_FAKEDEATH, BLOODSUCKER_TRAIT) // Come after UNCONSCIOUS or else it fails
 	owner.current.Jitter(0)
-	CureDisabilities()
 
 /datum/antagonist/bloodsucker/proc/Torpor_End()
 	REMOVE_TRAIT(owner.current, TRAIT_FAKEDEATH, BLOODSUCKER_TRAIT)

--- a/fulp_modules/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -253,16 +253,18 @@
 	var/total_damage = total_brute + total_burn
 	// Died? Convert to Torpor (fake death)
 	if(owner.current.stat == DEAD)
-		if(poweron_masquerade)
+		if(poweron_masquerade) /// We won't use the spam check, we want to spam them until they notice, else they'll cry about shit being broken.
 			to_chat(owner, "<span class='warning'>Your wounds will not heal until you disable the <span class='boldnotice'>Masquerade</span> power.</span>")
-		else
+		if(!HAS_TRAIT(owner.current, TRAIT_FAKEDEATH)) /// Prevents spam
 			to_chat(owner, "<span class='danger'>Your immortal body will not yet relinquish your soul to the abyss. You enter Torpor.</span>")
 			Torpor_Begin()
+		if(HAS_TRAIT(owner.current, TRAIT_FAKEDEATH))
+			if(!SSticker.mode.is_daylight() && total_damage <= owner.current.getMaxHealth()) /// Prevents them from waking up Mid-day
+				Torpor_End()
 	// End Torpor:
 	else // No damage, AND brute healed and NOT in coffin (since you cannot heal burn)
-		if(!SSticker.mode.is_daylight() && HAS_TRAIT(owner.current, TRAIT_FAKEDEATH) && total_damage < owner.current.getMaxHealth())
-			if(total_damage <= 0 && total_brute <= 0)
-				Torpor_End()
+		if(!SSticker.mode.is_daylight() && HAS_TRAIT(owner.current, TRAIT_FAKEDEATH) && total_damage <= 0)
+			Torpor_End()
 		// Fake Unconscious
 		if(poweron_masquerade && total_damage >= owner.current.getMaxHealth() - HEALTH_THRESHOLD_FULLCRIT)
 			owner.current.Unconscious(20, 1)

--- a/fulp_modules/bloodsuckers/code/bloodsucker/bloodsucker_objects.dm
+++ b/fulp_modules/bloodsuckers/code/bloodsucker/bloodsucker_objects.dm
@@ -37,12 +37,7 @@
 		var/obj/item/organ/heart/vampheart/H = new
 		H.Insert(owner.current)
 		H.Stop() // Now... stop beating!
-	// Eyes
-	O = owner.current.getorganslot(ORGAN_SLOT_EYES)
-	if(!istype(O, /obj/item/organ/eyes/bloodsucker))
-		qdel(O)
-		var/obj/item/organ/eyes/bloodsucker/E = new
-		E.Insert(owner.current)
+	// Tongue
 	O = owner.current.getorganslot(ORGAN_SLOT_TONGUE)
 	if(!istype(O, /obj/item/organ/tongue/bloodsucker))
 		qdel(O)
@@ -53,9 +48,6 @@
 	// Heart
 	var/obj/item/organ/heart/H = new
 	H.Insert(owner.current)
-	// Eyes
-	var/obj/item/organ/eyes/E = new
-	E.Insert(owner.current)
 	// Tongue
 	var/obj/item/organ/tongue/O = new
 	O.Insert(owner.current)
@@ -93,13 +85,14 @@
 //////////////////////
 //      EYES        //
 //////////////////////
-
+/* // Removed due to Mothpeople spawning with Vampiric eyes and instantly getting lynched.
 /// Taken from augmented_eyesight.dm
 /obj/item/organ/eyes/bloodsucker
 	lighting_alpha = 180 // LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE  <--- This is too low a value at 128. We need to SEE what the darkness is so we can hide in it.
 	see_in_dark = 12
 	sight_flags = SEE_MOBS // Bloodsuckers are predators, and detect life/heartbeats nearby. - 2019 Breakdown of Bloodsuckers
 	flash_protect = -1 // These eyes are weaker to flashes, but let you see in the dark
+*/
 
 //////////////////////
 //     TONGUE       //

--- a/fulp_modules/bloodsuckers/code/gamemodes/monsterhunter_gamemode.dm
+++ b/fulp_modules/bloodsuckers/code/gamemodes/monsterhunter_gamemode.dm
@@ -18,7 +18,7 @@
 	min_players = 10
 	earliest_start = 35 MINUTES
 	alert_observers = FALSE
-	gamemode_whitelist = list("bloodsucker", "traitorsucker")
+	gamemode_whitelist = list("bloodsucker")
 
 /datum/round_event/bloodsucker_hunters
 	fakeable = FALSE
@@ -54,7 +54,7 @@
 	min_players = 10
 	earliest_start = 25 MINUTES
 	alert_observers = FALSE
-	gamemode_whitelist = list("traitorchan","changeling","heresy","cult")
+	gamemode_whitelist = list("traitorchan","changeling","heresy","cult","traitorsucker")
 
 /datum/round_event/monster_hunters
 	fakeable = FALSE

--- a/fulp_modules/bloodsuckers/code/powers/fortitude.dm
+++ b/fulp_modules/bloodsuckers/code/powers/fortitude.dm
@@ -8,7 +8,6 @@
 	amToggle = TRUE
 	warn_constant_cost = TRUE
 	var/was_running
-
 	var/fortitude_resist // So we can raise and lower your brute resist based on what your level_current WAS.
 
 /datum/action/bloodsucker/fortitude/ActivatePower()

--- a/fulp_modules/bloodsuckers/code/powers/haste.dm
+++ b/fulp_modules/bloodsuckers/code/powers/haste.dm
@@ -31,6 +31,11 @@
 		if(display_error)
 			to_chat(owner, "<span class='warning'>You cant dash while floating!</span>")
 		return FALSE
+	var/mob/living/user = owner
+	if(user.body_position == LYING_DOWN)
+		if(display_error)
+			to_chat(user, "<span class='warning'>You must be standing to tackle!</span>")
+		return
 	return TRUE
 
 /// Anything will do, if it's not me or my square

--- a/fulp_modules/bloodsuckers/code/powers/lunge.dm
+++ b/fulp_modules/bloodsuckers/code/powers/lunge.dm
@@ -77,18 +77,19 @@
 
 	// Step Two: Check if I'm at/adjectent to Target's CURRENT turf (not original...that was just a destination)
 	if(target.Adjacent(owner))
-		if(target.mind.has_antag_datum(/datum/antagonist/monsterhunter))
-			target.grabbedby(owner)
-			to_chat(owner, "<span class='warning'>You get pushed away as you advance, and fail to get a strong grasp!</span>")
-			return
 		// LEVEL 2: If behind target, mute or unconscious!
 		if(do_knockdown) // && level_current >= 1)
-			target.Paralyze(15 + 10 * level_current,1)
+			if(!target.mind.has_antag_datum(/datum/antagonist/monsterhunter))
+				target.Paralyze(15 + 10 * level_current,1)
 		// Cancel Walk (we were close enough to contact them)
 		walk(owner,0)
 		//target.Paralyze(10,1)
-		target.grabbedby(owner) // Taken from mutations.dm under changelings
-		target.grippedby(owner, instant = TRUE) //instant aggro grab
+		if(!target.mind.has_antag_datum(/datum/antagonist/monsterhunter))
+			target.grabbedby(owner) // Taken from mutations.dm under changelings
+			target.grippedby(owner, instant = TRUE) //instant aggro grab
+		else
+			to_chat(owner, "<span class='warning'>You get pushed away as you advance, and fail to get a strong grasp!</span>")
+			target.grabbedby(owner)
 		REMOVE_TRAIT(user, TRAIT_IMMOBILIZED, BLOODSUCKER_TRAIT)
 		//	UNCONSCIOUS or MUTE!
 		//owner.start_pulling(target,GRAB_AGGRESSIVE) // GRAB_PASSIVE, GRAB_AGGRESSIVE, GRAB_NECK, GRAB_KILL

--- a/fulp_modules/bloodsuckers/code/powers/masquerade.dm
+++ b/fulp_modules/bloodsuckers/code/powers/masquerade.dm
@@ -54,7 +54,7 @@
 	REMOVE_TRAIT(user, TRAIT_GENELESS, SPECIES_TRAIT)
 	var/obj/item/organ/heart/vampheart/H = user.getorganslot(ORGAN_SLOT_HEART)
 	var/obj/item/organ/eyes/E = user.getorganslot(ORGAN_SLOT_EYES)
-	E.flash_protect = 0
+	E.flash_protect += 1
 
 	// WE ARE ALIVE! //
 	bloodsuckerdatum.poweron_masquerade = TRUE
@@ -105,6 +105,6 @@
 	var/obj/item/organ/heart/H = user.getorganslot(ORGAN_SLOT_HEART)
 	H.Stop()
 	var/obj/item/organ/eyes/E = user.getorganslot(ORGAN_SLOT_EYES)
-	E.flash_protect = -1
+	E.flash_protect -= 1
 
 	to_chat(user, "<span class='notice'>Your heart beats one final time, while your skin dries out and your icy pallor returns.</span>")

--- a/fulp_modules/bloodsuckers/code/powers/masquerade.dm
+++ b/fulp_modules/bloodsuckers/code/powers/masquerade.dm
@@ -53,7 +53,7 @@
 	// Falsifies Genetic Analyzers
 	REMOVE_TRAIT(user, TRAIT_GENELESS, SPECIES_TRAIT)
 	var/obj/item/organ/heart/vampheart/H = user.getorganslot(ORGAN_SLOT_HEART)
-	var/obj/item/organ/eyes/bloodsucker/E = user.getorganslot(ORGAN_SLOT_EYES)
+	var/obj/item/organ/eyes/E = user.getorganslot(ORGAN_SLOT_EYES)
 	E.flash_protect = 0
 
 	// WE ARE ALIVE! //
@@ -103,9 +103,8 @@
 
 	// HEART
 	var/obj/item/organ/heart/H = user.getorganslot(ORGAN_SLOT_HEART)
-	var/obj/item/organ/eyes/bloodsucker/E = user.getorganslot(ORGAN_SLOT_EYES)
 	H.Stop()
-
+	var/obj/item/organ/eyes/E = user.getorganslot(ORGAN_SLOT_EYES)
 	E.flash_protect = -1
 
 	to_chat(user, "<span class='notice'>Your heart beats one final time, while your skin dries out and your icy pallor returns.</span>")


### PR DESCRIPTION
## About The Pull Request

Moths have eye sprites now, and Bloodsuckers, since it replaced with Bloodsucker eyes, would instnatly sell a Mothperson bloodsucker out instantly from just looking at their 1 pixel large eyeballs.
Bloodsuckers also get flooded with messages saying they're entering Torpor, but never actually revive, even if they're in their coffin.

## Changelog
:cl:
fix: Bloodsuckers now properly enter Torpor on death, and revive when under 100 Brute/Burn damage.
fix: Mothpeople bloodsuckers now have regular eyes again.
fix: Predatory lunge can now be used again, and will not permanently stun Bloodsuckers anymore.
fix: Haste can no longer be done while lying down.
balance: A monster hunter will now no longer be guaranteed to spawn during a Traitorsucker round.
/:cl: