### PR TITLE
Makes the batong fit on the belt slot & fixes some grammar.

### DIFF
--- a/fulp_modules/toys/code/toys.dm
+++ b/fulp_modules/toys/code/toys.dm
@@ -1,11 +1,13 @@
 /obj/item/toy/plush/batong
 	name = "batong"
-	desc = "A cheaply made toy. Looks like it need some recharge maybe security can help you"
+	desc = "A cheaply made toy. Looks like it need some recharging, maybe security can help you."
 	icon = 'fulp_modules/toys/icon/toys.dmi'
 	icon_state = "batong"
+	worn_icon_state = "baton"
 	inhand_icon_state = "baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
+	slot_flags = ITEM_SLOT_BELT
 	attack_verb_continuous = list("Tries to recharge the batong in")
 	attack_verb_simple = list("try to recharge the baton in")
 	// "the monkey (958) Tries to recharge the batong in you in the chest with the batong" people wanted this.
@@ -13,7 +15,7 @@
 
 /obj/item/toy/plush/supermatter
 	name = "Supermatter toy"
-	desc = "A Supermatter plushe! you shouldnt pet the real one without Chief Engineer permission!."
+	desc = "A Supermatter plushe! you shouldn't pet the real one without the Chief Engineer's permission!."
 	icon = 'fulp_modules/toys/icon/toys.dmi'
 	icon_state = "supermatter"
 	light_range = 3

--- a/fulp_modules/toys/code/toys.dm
+++ b/fulp_modules/toys/code/toys.dm
@@ -1,6 +1,6 @@
 /obj/item/toy/plush/batong
 	name = "batong"
-	desc = "A cheaply made toy. Looks like it need some recharging, maybe security can help you."
+	desc = "A cheaply made toy. Looks like it need some recharge maybe security can help you"
 	icon = 'fulp_modules/toys/icon/toys.dmi'
 	icon_state = "batong"
 	worn_icon_state = "baton"

--- a/fulp_modules/toys/code/toys.dm
+++ b/fulp_modules/toys/code/toys.dm
@@ -15,7 +15,7 @@
 
 /obj/item/toy/plush/supermatter
 	name = "Supermatter toy"
-	desc = "A Supermatter plushe! you shouldn't pet the real one without the Chief Engineer's permission!."
+	desc = "A Supermatter plushie! you shouldn't pet the real one without the Chief Engineer's permission!."
 	icon = 'fulp_modules/toys/icon/toys.dmi'
 	icon_state = "supermatter"
 	light_range = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It makes it so that the batong can fit on your belt slot, like the real baton. Also some grammar fixes in the supermatter toy description.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The batong is now more likely to fool security, this is good. Also better grammar.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The ability to wear the batong on your belt slot!
spellcheck: Fixed some grammar errors in the supermatter toy description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
