### PR TITLE
science deputy medipens now contain a sane amount of mutadone

### DIFF
--- a/fulp_modules/jobs/deputy/code/deputy.dm
+++ b/fulp_modules/jobs/deputy/code/deputy.dm
@@ -179,6 +179,9 @@ GLOBAL_LIST_INIT(available_deputy_depts, sortList(list(SEC_DEPT_ENGINEERING, SEC
 /obj/item/reagent_containers/hypospray/medipen/mutadone
 	name = "mutadone medipen"
 	desc = "Contains a chemical that will remove all of an injected target's mutations, including positive ones."
+	icon_state = "atropen"
+	inhand_icon_state = "atropen"
+	base_icon_state = "atropen"
 	volume = 10
 	amount_per_transfer_from_this = 10
 	list_reagents = list(/datum/reagent/medicine/mutadone = 10)

--- a/fulp_modules/jobs/deputy/code/deputy.dm
+++ b/fulp_modules/jobs/deputy/code/deputy.dm
@@ -178,7 +178,7 @@ GLOBAL_LIST_INIT(available_deputy_depts, sortList(list(SEC_DEPT_ENGINEERING, SEC
 /// Used for Science Deputies
 /obj/item/reagent_containers/hypospray/medipen/mutadone
 	name = "mutadone medipen"
-	desc = "Hulked lings in the RD office? Space adapt traitors bombing the Armory? You know what to do! Comes with 2 uses."
-	volume = 60
-	amount_per_transfer_from_this = 30
-	list_reagents = list(/datum/reagent/medicine/mutadone = 60)
+	desc = "Contains a chemical that will remove all of an injected target's mutations, including positive ones."
+	volume = 10
+	amount_per_transfer_from_this = 10
+	list_reagents = list(/datum/reagent/medicine/mutadone = 10)

--- a/fulp_modules/jobs/deputy/code/deputy_clothing.dm
+++ b/fulp_modules/jobs/deputy/code/deputy_clothing.dm
@@ -63,7 +63,7 @@
 		/obj/item/grenade/smokebomb=1,
 		/obj/item/melee/baton/loaded=1,
 		/obj/item/restraints/handcuffs=1,
-		/obj/item/reagent_containers/hypospray/medipen/mutadone=1,
+		/obj/item/reagent_containers/hypospray/medipen/mutadone=2,
 		/obj/item/reagent_containers/spray/pepper=1,
 		/obj/item/holosign_creator/security=1,
 		)


### PR DESCRIPTION
## About The Pull Request

The mutadone medipen that each Science deputy receives as a part of their roundstart kit now contains 10u of mutadone instead of 60u of mutadone.

Science deputies now start each shift with two mutadone medipens instead of one.

Mutadone medipens now use the sprites for atropine medipens instead of the sprites for epinephrine medipens.

## Why It's Good For The Game

John Willard gave each Science deputy a mutadone medipen as a part of their starting kit. For some ungodly reason, this mutadone medipen contains **60u of mutadone** and injects **30u of mutadone** per jab (so, unlike the epineprhine medipen it shares a sprite with, it actually contains two doses, not one. that definitely won't confuse new players!). For reference, mutadone only needs one tick to purge your mutations, and it'll keep purging your mutations every tick until it leaves your system. In the case of a 30u mutadone dose, the time needed for mutadone to leave your system is TWO AND A HALF MINUTES, which is _gross_ overkill.

The new 10u dose reduces that to a much saner 50 seconds, which should be more than enough time to finish an arrest in. It's also consistent with the dosage volumes of most of the other medipens in the game, including the atropine, oxandrolone, salicylic acid, pentetic acid, and salbutamol medipens. The new dosage also opens up the possibility of mutadone medipens being added to the list of medipens that can be refilled by medipen refillers.

Mutadone medipens should not share sprites with epinephrine medipens, as players can very easily confuse one for the other, especially since the latter is in every job's roundstart kit. Since I'm not a spriter, I decided to switch them over to the atropine medipen sprites, since atropine medipens are also pretty niche and uncommon.

## Changelog
:cl:
balance: The mutadone medipen that each Science deputy receives as a part of their roundstart kit now contains 10u of mutadone instead of 60u of mutadone.
balance: Science deputies now start each shift with two mutadone medipens instead of one.
imageadd: Mutadone medipens now use the sprites for atropine medipens instead of the sprites for epinephrine medipens.
/:cl:
