### PR TITLE
Minor Selene fixes

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -3567,10 +3567,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aWl" = (
-/obj/machinery/camera{
-	c_tag = "Public - Holodeck Control";
-	dir = 6
-	},
 /obj/item/paper/fluff/holodeck/disclaimer,
 /turf/open/floor/iron,
 /area/commons/fitness)
@@ -26595,6 +26591,7 @@
 /obj/structure/displaycase/forsale/kitchen{
 	pixel_y = 5
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "gSR" = (
@@ -31164,7 +31161,8 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
 /area/commons/fitness)
 "ibf" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -38552,7 +38550,8 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
 /area/commons/fitness)
 "jSL" = (
 /obj/structure/window/reinforced,
@@ -44051,6 +44050,12 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/science/cytology)
+"llu" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "llB" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -48868,9 +48873,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/fifty,
 /obj/item/stack/cable_coil,
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -85855,6 +85857,9 @@
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "vUQ" = (
@@ -86330,6 +86335,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"weC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera{
+	c_tag = "Public - Holodeck Control";
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "wfb" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -127308,8 +127321,8 @@ iQW
 iQW
 eKB
 eKB
-eKB
-eKB
+jMI
+jMI
 eKB
 eKB
 iQW
@@ -127566,7 +127579,7 @@ iQW
 eKB
 aab
 aBM
-mPq
+weC
 cUd
 eKB
 iQW
@@ -127820,12 +127833,12 @@ puQ
 puQ
 yju
 yju
-eKB
-pHB
+jMI
+llu
 aWl
 cfu
 cUw
-eKB
+jMI
 yju
 yju
 rVl

--- a/_maps/shuttles/emergency_selene.dmm
+++ b/_maps/shuttles/emergency_selene.dmm
@@ -602,6 +602,13 @@
 /obj/structure/sign/directions/supply,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
+"OP" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Cockpit";
+	req_one_access_txt = "2;19"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "Pa" = (
 /obj/machinery/light{
 	dir = 4
@@ -952,7 +959,7 @@ Xh
 mp
 GP
 GP
-wR
+OP
 xA
 xA
 wR


### PR DESCRIPTION
## Why It's Good For The Game

idk

## Changelog
:cl:
fix: Fixed Selenestation's holodeck having a misplaced camera, no light, and inconsistent entrance tiles.
fix: Selenestation's kitchen table (the one with the vend-a-tray) now has a proper firelock.
fix: Selenestation - The newscaster in the Vacant commissary is now properly located on a wall.
fix: Selenestation shuttle - The outer cockpit airlock now actually lets security through.
/:cl: