### PR TITLE
Deletes Selenestation

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -68640,7 +68640,8 @@
 	name = "Medbay Doors Control";
 	normaldoorcontrol = 1;
 	pixel_x = 26;
-	pixel_y = -3
+	pixel_y = -3;
+	req_access_txt = "5"
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)


### PR DESCRIPTION
## About The Pull Request

Why why why why why why

This is untested I just copied over the access to the Medical airlock its connected to, so I assume it works.

## Changelog
:cl:
fix: People can no longer climb the Medical reception desk to open the Medical doors via the button.
/:cl: