### PR TITLE
[SeleneStation] Swaps Genetics - Toxins storage, and 2 other things.

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1335,39 +1335,6 @@
 "asf" = (
 /turf/open/floor/iron/dark,
 /area/maintenance/port/aft)
-"asi" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/item/toy/figure/geneticist{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 7;
-	pixel_y = -4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "ask" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/bot,
@@ -10846,22 +10813,6 @@
 /obj/structure/sign/departments/botany,
 /turf/closed/wall,
 /area/hallway/secondary/service)
-"cQp" = (
-/obj/machinery/nanite_programmer,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "cQw" = (
 /turf/closed/wall,
 /area/commons/dorms)
@@ -12781,6 +12732,9 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"dpk" = (
+/turf/closed/indestructible/reinforced,
+/area/security/checkpoint/science)
 "dpn" = (
 /obj/structure/cable,
 /obj/machinery/skill_station,
@@ -16094,29 +16048,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"ehr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/machinery/light,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "eht" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -16441,23 +16372,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"elr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/science/research)
 "elC" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -16507,6 +16421,29 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"emR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 23
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "enf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -17066,6 +17003,23 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"euq" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "euw" = (
 /obj/machinery/light{
 	dir = 4
@@ -17655,6 +17609,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
+"eDZ" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/science/genetics)
 "eEn" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -19145,15 +19108,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"eXH" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/science/genetics)
 "eXX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -19860,21 +19814,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"fhR" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "fhW" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plating,
@@ -25792,22 +25731,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
-"gGL" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "gGR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -27418,28 +27341,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hbu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "hby" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -28988,6 +28889,11 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"hwC" = (
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "hwM" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -29144,24 +29050,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hyt" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "hyM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -33670,10 +33558,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"iFb" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "iFq" = (
 /obj/structure/window/reinforced,
 /obj/machinery/chem_dispenser,
@@ -35419,6 +35303,19 @@
 /obj/item/storage/part_replacer,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"jeA" = (
+/obj/machinery/nanite_program_hub,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "jeE" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35631,6 +35528,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"jhL" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "jhM" = (
 /obj/structure/railing{
 	dir = 1;
@@ -40470,6 +40382,39 @@
 /obj/item/stock_parts/cell/empty,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
+"krM" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/item/toy/figure/geneticist{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "krV" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -43973,7 +43918,7 @@
 	dir = 8;
 	name = "Science purple corner"
 	},
-/obj/machinery/door/airlock/research{
+/obj/machinery/door/airlock/science/glass{
 	name = "Genetics Lab";
 	req_access_txt = "9"
 	},
@@ -44910,10 +44855,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/maintenance/department/science)
-"luq" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/science/research)
 "lus" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -44924,6 +44865,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"luz" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "luK" = (
 /obj/effect/turf_decal/trimline/purple/end{
 	color = "#4D0067";
@@ -45430,9 +45379,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"lCS" = (
-/turf/closed/indestructible/reinforced,
-/area/security/checkpoint/science)
 "lDb" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -48589,11 +48535,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"mpm" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "mps" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -56184,12 +56125,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/vault,
 /area/command/bridge)
-"oiC" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/grille,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "oiG" = (
 /obj/machinery/holopad,
 /obj/item/beacon,
@@ -58498,23 +58433,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"oSc" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "oSn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -59511,6 +59429,9 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"phH" = (
+/turf/closed/indestructible/reinforced,
+/area/science/genetics)
 "pin" = (
 /turf/open/floor/iron/white/side{
 	dir = 1
@@ -60130,7 +60051,7 @@
 	areastring = "/area/science/genetics";
 	dir = 4;
 	name = "Genetics Lab APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -60797,6 +60718,24 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"pyE" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "pzc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 4
@@ -65609,6 +65548,22 @@
 /obj/item/gavelhammer,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"qJg" = (
+/obj/machinery/nanite_programmer,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "qJp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -69910,6 +69865,29 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"rKE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/light,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "rKN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -70118,9 +70096,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
-"rOA" = (
-/turf/closed/indestructible/reinforced,
-/area/science/genetics)
 "rOD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -73532,6 +73507,24 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/grimy,
 /area/hallway/primary/port)
+"sFF" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "sFM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 6
@@ -75557,7 +75550,7 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
-/obj/machinery/door/airlock/research{
+/obj/machinery/door/airlock/science/glass{
 	name = "Genetics Lab";
 	req_access_txt = "9"
 	},
@@ -75714,6 +75707,14 @@
 	},
 /turf/open/floor/iron,
 /area/service/janitor)
+"tlu" = (
+/obj/structure/chair/office/light{
+	color = "#4D0067";
+	dir = 1
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "tlE" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -78631,19 +78632,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"tZC" = (
-/obj/machinery/nanite_program_hub,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "uad" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -79385,6 +79373,10 @@
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"uiC" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "uiF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -83685,29 +83677,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"vpk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 23
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "vpq" = (
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
@@ -84144,6 +84113,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"vvI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "vvT" = (
 /obj/structure/window/reinforced,
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
@@ -84236,6 +84216,12 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
+"vxO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "vxX" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -86452,24 +86438,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"wfe" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "wfk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
@@ -90543,17 +90511,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"xch" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "xcj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/purple{
@@ -91033,6 +90990,23 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/cytology)
+"xiO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/science/research)
 "xiQ" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
@@ -91066,6 +91040,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/department/medical)
+"xjc" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "xjw" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/tile/green{
@@ -91741,6 +91731,28 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
+"xpF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "xpG" = (
 /obj/machinery/power/emitter,
 /obj/machinery/camera{
@@ -92102,6 +92114,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"xvy" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/science/research)
 "xvC" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -94570,14 +94586,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"yaO" = (
-/obj/structure/chair/office/light{
-	color = "#4D0067";
-	dir = 1
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "yaV" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
@@ -95509,14 +95517,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
-"ylf" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "yls" = (
 /obj/structure/closet/crate,
 /obj/item/book/manual/random,
@@ -136838,8 +136838,8 @@ vfW
 qKx
 xgh
 hLk
-luq
-ehr
+xvy
+rKE
 mbf
 jHv
 kFT
@@ -137092,7 +137092,7 @@ pTC
 fSq
 pTC
 wOo
-fhR
+jhL
 nbo
 bUp
 qds
@@ -138638,7 +138638,7 @@ mRy
 dNQ
 kCd
 jYO
-hbu
+xpF
 tVc
 mii
 wtM
@@ -139659,11 +139659,11 @@ uXQ
 itU
 mGu
 uXQ
-hyt
-tZC
-cQp
-tZC
-wfe
+pyE
+jeA
+qJg
+jeA
+sFF
 pwf
 rGW
 qZP
@@ -139913,17 +139913,17 @@ euj
 xaG
 xaG
 uXQ
-lCS
-lCS
-lCS
+dpk
+dpk
+dpk
 xGn
 xGn
 xGn
 xGn
 xGn
-rOA
+phH
 jYO
-hbu
+xpF
 mTu
 dlm
 wEe
@@ -140173,12 +140173,12 @@ uPK
 bDJ
 rgl
 mGx
-rOA
+phH
 xmz
 doy
 pDN
 qTe
-mpm
+hwC
 ljO
 cuK
 mTu
@@ -140430,14 +140430,14 @@ fOq
 mOX
 mOX
 lkM
-rOA
+phH
 nuY
 rzD
 eNu
 fTZ
-oiC
-elr
-vpk
+vxO
+xiO
+emR
 mTu
 jBP
 yiK
@@ -140687,7 +140687,7 @@ sCJ
 vod
 vod
 oXj
-rOA
+phH
 mxU
 cSe
 iUO
@@ -140942,15 +140942,15 @@ qlS
 vod
 pHo
 cgO
-iFb
+uiC
 iAR
-rOA
+phH
 lcI
-yaO
+tlu
 gZb
 cZH
 tiR
-xch
+vvI
 fuz
 bsw
 ipU
@@ -141201,8 +141201,8 @@ jEZ
 qAC
 nYQ
 gwK
-rOA
-asi
+phH
+krM
 gZb
 leZ
 kAU
@@ -141458,10 +141458,10 @@ eIf
 vod
 vod
 fZv
-rOA
+phH
 pew
 gZb
-eXH
+eDZ
 ord
 nWu
 jYO
@@ -141715,7 +141715,7 @@ fXg
 hjy
 baH
 oXj
-rOA
+phH
 sfR
 nJZ
 rcw
@@ -141970,8 +141970,8 @@ jba
 oYJ
 fRv
 oYJ
-oSc
-gGL
+euq
+xjc
 xGn
 xGn
 xGn
@@ -142227,7 +142227,7 @@ qZz
 xcf
 pDY
 lIU
-ylf
+luz
 qoh
 ntY
 ppX

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -7198,6 +7198,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"bTP" = (
+/turf/closed/indestructible/reinforced,
+/area/science/genetics)
 "bTU" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -8071,6 +8074,17 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"cea" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "cer" = (
 /obj/structure/chair/wood,
 /obj/structure/disposalpipe/segment{
@@ -10711,6 +10725,23 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"cON" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "cOW" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -12732,9 +12763,6 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
-"dpk" = (
-/turf/closed/indestructible/reinforced,
-/area/security/checkpoint/science)
 "dpn" = (
 /obj/structure/cable,
 /obj/machinery/skill_station,
@@ -13071,6 +13099,29 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
+"dtU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/light,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "duj" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -14844,6 +14895,21 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"dRO" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "dRV" = (
 /obj/machinery/requests_console{
 	department = "Library Printer Room";
@@ -16421,29 +16487,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"emR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 23
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "enf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -16887,6 +16930,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
+"etc" = (
+/obj/machinery/nanite_program_hub,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "etn" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -17003,23 +17059,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"euq" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "euw" = (
 /obj/machinery/light{
 	dir = 4
@@ -17609,15 +17648,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
-"eDZ" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/science/genetics)
 "eEn" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -26812,6 +26842,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"gUD" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "gUG" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom";
@@ -28889,11 +28935,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"hwC" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "hwM" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -31637,6 +31678,24 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"igt" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "igF" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -35303,19 +35362,6 @@
 /obj/item/storage/part_replacer,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"jeA" = (
-/obj/machinery/nanite_program_hub,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "jeE" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35528,21 +35574,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"jhL" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "jhM" = (
 /obj/structure/railing{
 	dir = 1;
@@ -37095,6 +37126,22 @@
 /obj/structure/closet/crate/medical,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"jBd" = (
+/obj/machinery/nanite_programmer,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "jBq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -40382,39 +40429,6 @@
 /obj/item/stock_parts/cell/empty,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
-"krM" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/item/toy/figure/geneticist{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 7;
-	pixel_y = -4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "krV" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -44865,14 +44879,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"luz" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "luK" = (
 /obj/effect/turf_decal/trimline/purple/end{
 	color = "#4D0067";
@@ -54024,6 +54030,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"nHX" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "nIa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -54704,6 +54718,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"nPQ" = (
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "nPY" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall,
@@ -59429,9 +59448,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"phH" = (
-/turf/closed/indestructible/reinforced,
-/area/science/genetics)
 "pin" = (
 /turf/open/floor/iron/white/side{
 	dir = 1
@@ -60049,7 +60065,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/science/genetics";
-	dir = 4;
+	dir = 8;
 	name = "Genetics Lab APC";
 	pixel_x = -25
 	},
@@ -60718,24 +60734,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"pyE" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "pzc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 4
@@ -60929,6 +60927,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"pAy" = (
+/obj/structure/chair/office/light{
+	color = "#4D0067";
+	dir = 1
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "pAD" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -62682,6 +62688,9 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"pXb" = (
+/turf/closed/indestructible/reinforced,
+/area/security/checkpoint/science)
 "pXi" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -63885,6 +63894,10 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"qlk" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/science/research)
 "qll" = (
 /obj/structure/table/wood,
 /obj/item/toy/figure/ian{
@@ -65548,22 +65561,6 @@
 /obj/item/gavelhammer,
 /turf/open/floor/wood,
 /area/security/courtroom)
-"qJg" = (
-/obj/machinery/nanite_programmer,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "qJp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -69865,29 +69862,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"rKE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/machinery/light,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "rKN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -73507,24 +73481,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/grimy,
 /area/hallway/primary/port)
-"sFF" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "sFM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 6
@@ -73777,6 +73733,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"sIS" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "sIU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -74163,6 +74123,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
+"sOJ" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/science/genetics)
 "sOS" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -75707,14 +75676,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/janitor)
-"tlu" = (
-/obj/structure/chair/office/light{
-	color = "#4D0067";
-	dir = 1
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "tlE" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -79373,10 +79334,6 @@
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"uiC" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "uiF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -79469,6 +79426,28 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
+"uka" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "ukg" = (
 /obj/structure/closet/secure_closet/research_director,
 /obj/effect/turf_decal/tile/purple{
@@ -81450,6 +81429,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"uLQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "uLT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -84113,17 +84098,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
-"vvI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "vvT" = (
 /obj/structure/window/reinforced,
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
@@ -84216,12 +84190,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
-"vxO" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/grille,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "vxX" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -85962,6 +85930,24 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vUS" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "vVh" = (
 /turf/closed/wall,
 /area/hallway/primary/aft)
@@ -88002,6 +87988,23 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"wyS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/science/research)
 "wyU" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -90990,23 +90993,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/cytology)
-"xiO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/science/research)
 "xiQ" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
@@ -91040,22 +91026,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/department/medical)
-"xjc" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "xjw" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/tile/green{
@@ -91731,28 +91701,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
-"xpF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "xpG" = (
 /obj/machinery/power/emitter,
 /obj/machinery/camera{
@@ -91906,6 +91854,39 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"xsp" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/item/toy/figure/geneticist{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "xsq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -92114,10 +92095,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"xvy" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/science/research)
 "xvC" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -92506,6 +92483,29 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"xAV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 23
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "xAY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 6
@@ -136838,8 +136838,8 @@ vfW
 qKx
 xgh
 hLk
-xvy
-rKE
+qlk
+dtU
 mbf
 jHv
 kFT
@@ -137092,7 +137092,7 @@ pTC
 fSq
 pTC
 wOo
-jhL
+dRO
 nbo
 bUp
 qds
@@ -138638,7 +138638,7 @@ mRy
 dNQ
 kCd
 jYO
-xpF
+uka
 tVc
 mii
 wtM
@@ -139659,11 +139659,11 @@ uXQ
 itU
 mGu
 uXQ
-pyE
-jeA
-qJg
-jeA
-sFF
+vUS
+etc
+jBd
+etc
+igt
 pwf
 rGW
 qZP
@@ -139913,17 +139913,17 @@ euj
 xaG
 xaG
 uXQ
-dpk
-dpk
-dpk
+pXb
+pXb
+pXb
 xGn
 xGn
 xGn
 xGn
 xGn
-phH
+bTP
 jYO
-xpF
+uka
 mTu
 dlm
 wEe
@@ -140173,12 +140173,12 @@ uPK
 bDJ
 rgl
 mGx
-phH
+bTP
 xmz
 doy
 pDN
 qTe
-hwC
+nPQ
 ljO
 cuK
 mTu
@@ -140430,14 +140430,14 @@ fOq
 mOX
 mOX
 lkM
-phH
+bTP
 nuY
 rzD
 eNu
 fTZ
-vxO
-xiO
-emR
+uLQ
+wyS
+xAV
 mTu
 jBP
 yiK
@@ -140687,7 +140687,7 @@ sCJ
 vod
 vod
 oXj
-phH
+bTP
 mxU
 cSe
 iUO
@@ -140942,15 +140942,15 @@ qlS
 vod
 pHo
 cgO
-uiC
+sIS
 iAR
-phH
+bTP
 lcI
-tlu
+pAy
 gZb
 cZH
 tiR
-vvI
+cea
 fuz
 bsw
 ipU
@@ -141201,8 +141201,8 @@ jEZ
 qAC
 nYQ
 gwK
-phH
-krM
+bTP
+xsp
 gZb
 leZ
 kAU
@@ -141458,10 +141458,10 @@ eIf
 vod
 vod
 fZv
-phH
+bTP
 pew
 gZb
-eDZ
+sOJ
 ord
 nWu
 jYO
@@ -141715,7 +141715,7 @@ fXg
 hjy
 baH
 oXj
-phH
+bTP
 sfR
 nJZ
 rcw
@@ -141970,8 +141970,8 @@ jba
 oYJ
 fRv
 oYJ
-euq
-xjc
+cON
+gUD
 xGn
 xGn
 xGn
@@ -142227,7 +142227,7 @@ qZz
 xcf
 pDY
 lIU
-luz
+nHX
 qoh
 ntY
 ppX

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -3711,6 +3711,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"aZe" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "aZj" = (
 /obj/machinery/light/broken,
 /turf/open/floor/iron,
@@ -7198,9 +7213,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"bTP" = (
-/turf/closed/indestructible/reinforced,
-/area/science/genetics)
 "bTU" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -7374,6 +7386,23 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat_interior)
+"bVZ" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "bWh" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -7751,6 +7780,17 @@
 	},
 /turf/open/floor/iron,
 /area/service/library/abandoned)
+"bZy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "bZH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -8074,17 +8114,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cea" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "cer" = (
 /obj/structure/chair/wood,
 /obj/structure/disposalpipe/segment{
@@ -9420,6 +9449,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"cwC" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "cwF" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -10725,23 +10762,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"cON" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "cOW" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -13099,29 +13119,6 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
-"dtU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/machinery/light,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "duj" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -14895,21 +14892,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"dRO" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "dRV" = (
 /obj/machinery/requests_console{
 	department = "Library Printer Room";
@@ -15372,6 +15354,24 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"dXZ" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "dYi" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -16930,19 +16930,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
-"etc" = (
-/obj/machinery/nanite_program_hub,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "etn" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -22135,6 +22122,29 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"fKk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/light,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "fKo" = (
 /obj/effect/turf_decal/siding{
 	color = "grey";
@@ -26842,22 +26852,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"gUD" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "gUG" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom";
@@ -27133,6 +27127,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"gXT" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/science/genetics)
 "gYs" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -28333,6 +28336,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"hnm" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/science/research)
 "hnq" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Gallery"
@@ -31040,6 +31047,39 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"hZk" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/item/toy/figure/geneticist{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "hZl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -31678,24 +31718,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"igt" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "igF" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -35742,6 +35764,8 @@
 	department = "Toxins Lab";
 	pixel_y = 30
 	},
+/obj/structure/rack,
+/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "jlb" = (
@@ -36159,6 +36183,22 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"jpO" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "jpY" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -37126,22 +37166,6 @@
 /obj/structure/closet/crate/medical,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"jBd" = (
-/obj/machinery/nanite_programmer,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "jBq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -39028,6 +39052,28 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jXr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "jXv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48314,6 +48360,9 @@
 	},
 /turf/open/floor/plating,
 /area/science/misc_lab)
+"mlc" = (
+/turf/closed/indestructible/reinforced,
+/area/security/checkpoint/science)
 "mlj" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/newscaster{
@@ -54030,14 +54079,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"nHX" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "nIa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -54718,11 +54759,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"nPQ" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "nPY" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall,
@@ -55829,6 +55865,22 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
+"oea" = (
+/obj/machinery/nanite_programmer,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "oed" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/tile/yellow{
@@ -56155,6 +56207,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"ojb" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "ojh" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
@@ -60927,14 +60983,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"pAy" = (
-/obj/structure/chair/office/light{
-	color = "#4D0067";
-	dir = 1
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "pAD" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -62688,9 +62736,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"pXb" = (
-/turf/closed/indestructible/reinforced,
-/area/security/checkpoint/science)
 "pXi" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -63894,10 +63939,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"qlk" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/science/research)
 "qll" = (
 /obj/structure/table/wood,
 /obj/item/toy/figure/ian{
@@ -67542,6 +67583,29 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"rhK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 23
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "rhM" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -67999,6 +68063,19 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"rmU" = (
+/obj/machinery/nanite_program_hub,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "rnj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -70052,6 +70129,23 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
+"rNX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/science/research)
 "rOf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -70436,7 +70530,7 @@
 /area/cargo/sorting)
 "rTm" = (
 /obj/structure/rack,
-/obj/item/storage/toolbox/mechanical/old/heirloom,
+/obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rTC" = (
@@ -73178,6 +73272,11 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"sAR" = (
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "sBb" = (
 /obj/structure/sign/departments/court,
 /turf/closed/wall,
@@ -73733,10 +73832,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"sIS" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "sIU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -74123,15 +74218,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
-"sOJ" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/science/genetics)
 "sOS" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -78335,6 +78421,14 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
+"tWs" = (
+/obj/structure/chair/office/light{
+	color = "#4D0067";
+	dir = 1
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "tWF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -79426,28 +79520,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
-"uka" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "ukg" = (
 /obj/structure/closet/secure_closet/research_director,
 /obj/effect/turf_decal/tile/purple{
@@ -81429,12 +81501,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"uLQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/grille,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "uLT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -82314,6 +82380,24 @@
 	},
 /turf/open/floor/plating,
 /area/service/lawoffice)
+"uXv" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "uXB" = (
 /obj/structure/closet/crate/silvercrate,
 /obj/effect/turf_decal/tile/blue{
@@ -85930,24 +86014,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"vUS" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "vVh" = (
 /turf/closed/wall,
 /area/hallway/primary/aft)
@@ -86804,6 +86870,9 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"wjZ" = (
+/turf/closed/indestructible/reinforced,
+/area/science/genetics)
 "wkh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -87988,23 +88057,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"wyS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/science/research)
 "wyU" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -91854,39 +91906,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"xsp" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/item/toy/figure/geneticist{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 7;
-	pixel_y = -4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "xsq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -92483,29 +92502,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"xAV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 23
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "xAY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 6
@@ -93330,6 +93326,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"xLV" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "xLZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -136838,8 +136840,8 @@ vfW
 qKx
 xgh
 hLk
-qlk
-dtU
+hnm
+fKk
 mbf
 jHv
 kFT
@@ -137092,7 +137094,7 @@ pTC
 fSq
 pTC
 wOo
-dRO
+aZe
 nbo
 bUp
 qds
@@ -138638,7 +138640,7 @@ mRy
 dNQ
 kCd
 jYO
-uka
+jXr
 tVc
 mii
 wtM
@@ -139659,11 +139661,11 @@ uXQ
 itU
 mGu
 uXQ
-vUS
-etc
-jBd
-etc
-igt
+dXZ
+rmU
+oea
+rmU
+uXv
 pwf
 rGW
 qZP
@@ -139913,17 +139915,17 @@ euj
 xaG
 xaG
 uXQ
-pXb
-pXb
-pXb
+mlc
+mlc
+mlc
 xGn
 xGn
 xGn
 xGn
 xGn
-bTP
+wjZ
 jYO
-uka
+jXr
 mTu
 dlm
 wEe
@@ -140173,12 +140175,12 @@ uPK
 bDJ
 rgl
 mGx
-bTP
+wjZ
 xmz
 doy
 pDN
 qTe
-nPQ
+sAR
 ljO
 cuK
 mTu
@@ -140430,14 +140432,14 @@ fOq
 mOX
 mOX
 lkM
-bTP
+wjZ
 nuY
 rzD
 eNu
 fTZ
-uLQ
-wyS
-xAV
+xLV
+rNX
+rhK
 mTu
 jBP
 yiK
@@ -140687,7 +140689,7 @@ sCJ
 vod
 vod
 oXj
-bTP
+wjZ
 mxU
 cSe
 iUO
@@ -140942,15 +140944,15 @@ qlS
 vod
 pHo
 cgO
-sIS
+ojb
 iAR
-bTP
+wjZ
 lcI
-pAy
+tWs
 gZb
 cZH
 tiR
-cea
+bZy
 fuz
 bsw
 ipU
@@ -141201,8 +141203,8 @@ jEZ
 qAC
 nYQ
 gwK
-bTP
-xsp
+wjZ
+hZk
 gZb
 leZ
 kAU
@@ -141458,10 +141460,10 @@ eIf
 vod
 vod
 fZv
-bTP
+wjZ
 pew
 gZb
-sOJ
+gXT
 ord
 nWu
 jYO
@@ -141715,7 +141717,7 @@ fXg
 hjy
 baH
 oXj
-bTP
+wjZ
 sfR
 nJZ
 rcw
@@ -141970,8 +141972,8 @@ jba
 oYJ
 fRv
 oYJ
-cON
-gUD
+bVZ
+jpO
 xGn
 xGn
 xGn
@@ -142227,7 +142229,7 @@ qZz
 xcf
 pDY
 lIU
-nHX
+cwC
 qoh
 ntY
 ppX

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1291,6 +1291,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"arH" = (
+/obj/structure/chair/office/light{
+	color = "#4D0067";
+	dir = 1
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "arJ" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -1801,6 +1809,21 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/brig)
+"axh" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "axm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -2127,6 +2150,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat)
+"aBm" = (
+/turf/closed/indestructible/reinforced,
+/area/science/genetics)
 "aBw" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -3523,6 +3549,14 @@
 	},
 /turf/open/floor/iron,
 /area/service/janitor)
+"aVZ" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "aWd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -3711,21 +3745,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"aZe" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "aZj" = (
 /obj/machinery/light/broken,
 /turf/open/floor/iron,
@@ -3830,6 +3849,24 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"baC" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "baG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -5346,6 +5383,29 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"bup" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/light,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "bus" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -7386,23 +7446,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat_interior)
-"bVZ" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "bWh" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -7780,17 +7823,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/library/abandoned)
-"bZy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "bZH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -9449,14 +9481,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"cwC" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "cwF" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -10524,6 +10548,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"cJz" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/science/research)
 "cJD" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -15354,24 +15382,6 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"dXZ" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "dYi" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -16487,6 +16497,23 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"emW" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "enf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -20437,6 +20464,23 @@
 	},
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
+"foT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/science/research)
 "fpf" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -22122,29 +22166,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"fKk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/machinery/light,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "fKo" = (
 /obj/effect/turf_decal/siding{
 	color = "grey";
@@ -27070,6 +27091,22 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"gXv" = (
+/obj/machinery/nanite_programmer,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "gXG" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -27127,15 +27164,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"gXT" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/science/genetics)
 "gYs" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -28336,10 +28364,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"hnm" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/science/research)
 "hnq" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Gallery"
@@ -31047,39 +31071,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"hZk" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/item/toy/figure/geneticist{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 7;
-	pixel_y = -4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "hZl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -36183,22 +36174,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"jpO" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "jpY" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -36855,6 +36830,28 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"jxb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "jxx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -37182,6 +37179,22 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/iron/grimy,
 /area/service/bar)
+"jBz" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "jBK" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -38626,6 +38639,18 @@
 /obj/structure/grille/broken,
 /turf/open/floor/iron,
 /area/maintenance/department/engine/atmos)
+"jSb" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "jSk" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -39052,28 +39077,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jXr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "jXv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48360,9 +48363,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/misc_lab)
-"mlc" = (
-/turf/closed/indestructible/reinforced,
-/area/security/checkpoint/science)
 "mlj" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/newscaster{
@@ -53220,6 +53220,7 @@
 	name = "Genetics requests console";
 	pixel_y = 30
 	},
+/obj/machinery/camera,
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "nvh" = (
@@ -55865,22 +55866,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
-"oea" = (
-/obj/machinery/nanite_programmer,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "oed" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/tile/yellow{
@@ -56207,10 +56192,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ojb" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "ojh" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
@@ -58523,6 +58504,39 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
+"oSv" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/item/toy/figure/geneticist{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "oSy" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
@@ -58845,6 +58859,9 @@
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	name = "Science purple corner"
+	},
+/obj/machinery/camera{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/storage)
@@ -63044,6 +63061,12 @@
 /obj/structure/sign/departments/lawyer,
 /turf/closed/wall,
 /area/service/lawoffice)
+"qbw" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "qbx" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -66893,6 +66916,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"raa" = (
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "rag" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -67583,29 +67611,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"rhK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 23
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "rhM" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -68063,19 +68068,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"rmU" = (
-/obj/machinery/nanite_program_hub,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "rnj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -70129,23 +70121,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
-"rNX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/science/research)
 "rOf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -73272,11 +73247,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"sAR" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "sBb" = (
 /obj/structure/sign/departments/court,
 /turf/closed/wall,
@@ -73972,6 +73942,17 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/vault,
 /area/command/bridge)
+"sLe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "sLf" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase,
@@ -77265,6 +77246,29 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"tFK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 23
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "tFL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -77880,6 +77884,15 @@
 /obj/effect/turf_decal/tile/random,
 /turf/open/floor/iron,
 /area/maintenance/department/crew_quarters/dorms)
+"tQp" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/science/genetics)
 "tQx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -78421,14 +78434,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"tWs" = (
-/obj/structure/chair/office/light{
-	color = "#4D0067";
-	dir = 1
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "tWF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -82380,24 +82385,6 @@
 	},
 /turf/open/floor/plating,
 /area/service/lawoffice)
-"uXv" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "uXB" = (
 /obj/structure/closet/crate/silvercrate,
 /obj/effect/turf_decal/tile/blue{
@@ -83699,6 +83686,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"vnS" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "vod" = (
 /turf/open/floor/iron/white,
 /area/science/storage)
@@ -86870,9 +86861,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"wjZ" = (
-/turf/closed/indestructible/reinforced,
-/area/science/genetics)
 "wkh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -88026,6 +88014,24 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"wyh" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "wyr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 6
@@ -88288,6 +88294,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"wBm" = (
+/obj/machinery/nanite_program_hub,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "wBz" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/dark,
@@ -89152,6 +89171,9 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"wLv" = (
+/turf/closed/indestructible/reinforced,
+/area/security/checkpoint/science)
 "wLL" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
@@ -93326,12 +93348,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"xLV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/grille,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "xLZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -136840,8 +136856,8 @@ vfW
 qKx
 xgh
 hLk
-hnm
-fKk
+cJz
+bup
 mbf
 jHv
 kFT
@@ -137094,7 +137110,7 @@ pTC
 fSq
 pTC
 wOo
-aZe
+axh
 nbo
 bUp
 qds
@@ -138640,7 +138656,7 @@ mRy
 dNQ
 kCd
 jYO
-jXr
+jxb
 tVc
 mii
 wtM
@@ -139661,11 +139677,11 @@ uXQ
 itU
 mGu
 uXQ
-dXZ
-rmU
-oea
-rmU
-uXv
+baC
+wBm
+gXv
+wBm
+wyh
 pwf
 rGW
 qZP
@@ -139915,17 +139931,17 @@ euj
 xaG
 xaG
 uXQ
-mlc
-mlc
-mlc
+wLv
+wLv
+wLv
 xGn
 xGn
 xGn
 xGn
 xGn
-wjZ
+aBm
 jYO
-jXr
+jxb
 mTu
 dlm
 wEe
@@ -140175,12 +140191,12 @@ uPK
 bDJ
 rgl
 mGx
-wjZ
+aBm
 xmz
 doy
 pDN
 qTe
-sAR
+raa
 ljO
 cuK
 mTu
@@ -140432,14 +140448,14 @@ fOq
 mOX
 mOX
 lkM
-wjZ
+aBm
 nuY
 rzD
 eNu
 fTZ
-xLV
-rNX
-rhK
+qbw
+foT
+tFK
 mTu
 jBP
 yiK
@@ -140689,7 +140705,7 @@ sCJ
 vod
 vod
 oXj
-wjZ
+aBm
 mxU
 cSe
 iUO
@@ -140944,15 +140960,15 @@ qlS
 vod
 pHo
 cgO
-ojb
+vnS
 iAR
-wjZ
+aBm
 lcI
-tWs
+arH
 gZb
 cZH
 tiR
-bZy
+sLe
 fuz
 bsw
 ipU
@@ -141203,8 +141219,8 @@ jEZ
 qAC
 nYQ
 gwK
-wjZ
-hZk
+aBm
+oSv
 gZb
 leZ
 kAU
@@ -141460,10 +141476,10 @@ eIf
 vod
 vod
 fZv
-wjZ
+aBm
 pew
 gZb
-gXT
+tQp
 ord
 nWu
 jYO
@@ -141716,8 +141732,8 @@ dCc
 fXg
 hjy
 baH
-oXj
-wjZ
+jSb
+aBm
 sfR
 nJZ
 rcw
@@ -141972,8 +141988,8 @@ jba
 oYJ
 fRv
 oYJ
-bVZ
-jpO
+emW
+jBz
 xGn
 xGn
 xGn
@@ -142229,7 +142245,7 @@ qZz
 xcf
 pDY
 lIU
-cwC
+aVZ
 qoh
 ntY
 ppX

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -2038,6 +2038,19 @@
 /obj/item/flashlight,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"aAe" = (
+/obj/machinery/nanite_program_hub,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "aAj" = (
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -3823,26 +3836,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "baH" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/bodybags{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/item/storage/box/disks{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 4;
 	name = "Science purple corner"
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "baI" = (
 /obj/item/spear,
 /obj/structure/stone_tile/slab,
@@ -4161,9 +4161,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bgO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/rack,
+/obj/item/stack/sheet/iron{
+	amount = 50
 	},
+/obj/item/storage/toolbox/mechanical,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 1;
@@ -4174,11 +4176,12 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
-/obj/structure/sign/warning/chemdiamond{
-	pixel_y = 32
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
 	},
 /turf/open/floor/iron/white,
-/area/science/research)
+/area/science/storage)
 "bgT" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/iron,
@@ -6051,19 +6054,19 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "bDJ" = (
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "bEe" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -8100,6 +8103,9 @@
 	color = "#4D0067";
 	name = "Science purple corner"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/nanite)
 "cfe" = (
@@ -8195,15 +8201,9 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cgO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/holopad,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "cgQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -8740,6 +8740,11 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"cnE" = (
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "cnF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -8933,10 +8938,13 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cpG" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "cpR" = (
 /obj/machinery/holopad,
 /obj/machinery/duct,
@@ -9786,7 +9794,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "czA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -9796,6 +9803,12 @@
 	color = "#4D0067";
 	dir = 4;
 	name = "Science purple corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -9835,8 +9848,27 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cAz" = (
-/turf/open/floor/engine,
-/area/science/genetics)
+/obj/structure/rack,
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/clothing/glasses/welding,
+/obj/item/book/manual/wiki/toxins,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "cAJ" = (
 /obj/structure/window,
 /obj/machinery/door/firedoor/border_only,
@@ -10167,22 +10199,6 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/command)
-"cFn" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = -32
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "cFx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
 	dir = 8
@@ -10936,9 +10952,9 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "cSe" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/iron,
-/area/science/storage)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "cSj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -11194,7 +11210,6 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "cUR" = (
-/obj/machinery/computer/nanite_cloud_controller,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	name = "Science purple corner"
@@ -11202,11 +11217,6 @@
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
 	name = "Science purple corner"
 	},
 /turf/open/floor/iron/dark,
@@ -11553,13 +11563,14 @@
 	color = "#4D0067";
 	name = "Science purple corner"
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "cZX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -11739,28 +11750,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/starboard)
-"dbJ" = (
-/obj/machinery/door/airlock/research{
-	name = "Genetics Lab";
-	req_access_txt = "9"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "dbK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -12722,9 +12711,22 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "doy" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/iron,
-/area/science/storage)
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "doC" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -13662,7 +13664,6 @@
 /turf/open/floor/sepia,
 /area/maintenance/starboard/fore)
 "dCc" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
@@ -13670,10 +13671,7 @@
 	dir = 4;
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
+/obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 1;
@@ -13685,7 +13683,7 @@
 	name = "Science purple corner"
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "dCk" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/event_spawn,
@@ -14490,6 +14488,12 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"dLp" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "dLq" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -14652,6 +14656,9 @@
 	name = "Science purple corner"
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/nanite)
 "dNR" = (
@@ -15011,23 +15018,6 @@
 "dTZ" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
-"dUj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Genetics Lab Maintenance";
-	req_access_txt = "9"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
 /area/maintenance/starboard)
 "dUx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -15433,6 +15423,39 @@
 /obj/machinery/doppler_array/research/science,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"dYR" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/item/toy/figure/geneticist{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "dYW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -15921,11 +15944,6 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "efp" = (
@@ -16244,24 +16262,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"ejB" = (
-/obj/structure/closet/bombcloset,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "ejC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
@@ -17463,11 +17463,6 @@
 	dir = 1;
 	name = "Science purple corner"
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "eBF" = (
@@ -17908,16 +17903,14 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "eIf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "eIr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -18075,9 +18068,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
-"eKi" = (
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "eKy" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -18404,8 +18394,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/science/storage)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "eNv" = (
 /turf/open/floor/iron/white/side,
 /area/science/lab)
@@ -21526,6 +21517,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/restrooms)
+"fEu" = (
+/obj/structure/chair/office/light{
+	color = "#4D0067";
+	dir = 1
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "fEC" = (
 /obj/machinery/power/apc{
 	areastring = "/area/cargo/miningdock";
@@ -22116,6 +22115,28 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"fKn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "fKo" = (
 /obj/effect/turf_decal/siding{
 	color = "grey";
@@ -22411,16 +22432,9 @@
 	},
 /area/medical/abandoned)
 "fOq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "fOt" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/effect/decal/cleanable/blood/footprints,
@@ -22652,9 +22666,38 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "fRv" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/science/genetics)
+/obj/machinery/door/airlock/research{
+	name = "Toxins Storage";
+	req_access_txt = "8"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "fRz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -22893,11 +22936,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "fTZ" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/machinery/light_switch{
-	pixel_x = -5;
-	pixel_y = -25
-	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	name = "Science purple corner"
@@ -22907,15 +22946,13 @@
 	dir = 8;
 	name = "Science purple corner"
 	},
-/obj/machinery/button/door{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage Blast Door";
-	pixel_x = 5;
-	pixel_y = -25;
-	req_access_txt = "30"
+/obj/structure/chair/office/light{
+	color = "#4D0067";
+	dir = 8
 	},
+/obj/effect/landmark/start/geneticist,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "fUc" = (
 /obj/structure/table,
 /obj/item/food/salad/ricebowl,
@@ -23243,9 +23280,11 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "fXg" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -23253,7 +23292,7 @@
 	name = "Science purple corner"
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "fXj" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -23490,24 +23529,27 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "fZv" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 8;
 	name = "Science purple corner"
 	},
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/machinery/button/door{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage Blast Door";
+	pixel_x = 25;
+	pixel_y = -25;
+	req_access_txt = "30"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "fZy" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -24014,11 +24056,6 @@
 /turf/open/floor/plating,
 /area/construction)
 "ggv" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 1;
@@ -24495,6 +24532,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"gpa" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "gpb" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -24937,6 +24992,9 @@
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/nanite)
 "gvu" = (
@@ -24981,20 +25039,6 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"gwK" = (
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "gwQ" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/structure/extinguisher_cabinet{
@@ -25255,12 +25299,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/service/bar)
-"gzy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/storage)
 "gzG" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
@@ -26329,6 +26367,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
+"gMW" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/carbon/human/monkeybrain,
+/turf/open/floor/grass,
+/area/science/genetics)
 "gMY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -27201,9 +27248,8 @@
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
 "gZb" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron,
-/area/science/storage)
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "gZp" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/garbage_spawner,
@@ -27911,23 +27957,18 @@
 /turf/open/floor/plating/asteroid/basalt,
 /area/maintenance/fore)
 "hjy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
+/obj/structure/closet/bombcloset,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "hjD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -28363,15 +28404,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hpg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "hpm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -28522,6 +28554,9 @@
 /obj/machinery/light,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
+"hsC" = (
+/turf/closed/indestructible/reinforced,
+/area/science/genetics)
 "hta" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -30080,6 +30115,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -30155,9 +30191,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"hMU" = (
-/turf/closed/wall/r_wall,
-/area/science/storage)
 "hMX" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
@@ -33231,26 +33264,18 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "iAR" = (
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 8;
 	name = "Science purple corner"
 	},
-/obj/machinery/camera{
-	c_tag = "Research - Genetics";
-	dir = 1;
-	network = list("ss13", "rd")
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "iAX" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	name = "air mixer";
@@ -34570,11 +34595,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "iVg" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/central";
@@ -35064,6 +35087,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/science/nanite)
 "jaX" = (
@@ -35072,7 +35096,7 @@
 /area/maintenance/port/aft)
 "jba" = (
 /turf/closed/wall/r_wall,
-/area/science/genetics)
+/area/science/storage)
 "jbe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -36725,6 +36749,21 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
+"jwJ" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "jwT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -37387,24 +37426,14 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "jEZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/structure/sign/departments/science{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science/research)
+/area/science/storage)
 "jFd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -38553,36 +38582,6 @@
 /obj/structure/grille/broken,
 /turf/open/floor/iron,
 /area/maintenance/department/engine/atmos)
-"jSb" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 9;
-	pixel_y = 4
-	},
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "jSk" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -40379,6 +40378,14 @@
 /obj/structure/sign/directions/upload,
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain)
+"kro" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "krv" = (
 /obj/structure/table/wood,
 /obj/item/pen,
@@ -41038,21 +41045,19 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "kAU" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
 	dir = 8;
-	name = "Science purple corner"
+	layer = 3
 	},
-/obj/item/book/manual/wiki/toxins,
-/turf/open/floor/iron/white,
-/area/science/storage)
+/mob/living/carbon/human/monkeybrain,
+/turf/open/floor/grass,
+/area/science/genetics)
 "kAY" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -43356,19 +43361,19 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "lcI" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/computer/scan_consolenew,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "lcR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -43602,11 +43607,17 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "leZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 3
 	},
-/turf/open/floor/iron,
-/area/science/storage)
+/obj/machinery/door/window/northleft{
+	name = "Monkey Pen";
+	req_access_txt = "9"
+	},
+/turf/open/floor/grass,
+/area/science/genetics)
 "lfh" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -43903,14 +43914,15 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
+	dir = 8;
 	name = "Science purple corner"
 	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
+/obj/machinery/door/airlock/research{
+	name = "Genetics Lab";
+	req_access_txt = "9"
 	},
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "ljh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -44061,28 +44073,18 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "lkM" = (
-/obj/structure/table/glass,
-/obj/item/radio/headset/headset_sci{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/folder/blue,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 8;
 	name = "Science purple corner"
 	},
-/obj/machinery/light,
-/obj/item/toy/figure/geneticist,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "lkW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -44755,20 +44757,10 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "ltl" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
+/obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 1;
@@ -44780,7 +44772,7 @@
 	name = "Science purple corner"
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "lts" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -45074,7 +45066,12 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "lxO" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 8;
@@ -45090,12 +45087,8 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
-/obj/machinery/requests_console{
-	department = "Genetics";
-	pixel_x = -30
-	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "lxS" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -45198,6 +45191,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"lzG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/science/research)
 "lzT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -45511,6 +45521,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"lFj" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "lFm" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
 /obj/effect/turf_decal/tile/red{
@@ -45851,11 +45877,8 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "lIU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/sign/warning/chemdiamond{
+	pixel_x = -30
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -49199,23 +49222,22 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "mxU" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 4;
 	name = "Science purple corner"
 	},
-/obj/machinery/camera{
-	c_tag = "Research - Toxins Storage";
-	network = list("ss13", "rd")
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
 	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/obj/machinery/dna_scannernew,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "mxY" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
@@ -49879,19 +49901,10 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/engineering/atmos)
 "mGx" = (
-/obj/structure/table/glass,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = -8;
-	pixel_y = 10
-	},
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/dropper,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
+	dir = 1;
 	name = "Science purple corner"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -49901,11 +49914,10 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
-	dir = 1;
 	name = "Science purple corner"
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "mGK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50624,13 +50636,9 @@
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "mOX" = (
-/obj/structure/chair/office/light{
-	color = "#4D0067";
-	dir = 8
-	},
-/obj/effect/landmark/start/geneticist,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "mPa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -50892,6 +50900,9 @@
 /obj/machinery/requests_console{
 	department = "Nanites Lab";
 	pixel_x = 30
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/science/nanite)
@@ -51632,10 +51643,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nbg" = (
+/obj/effect/decal/cleanable/robot_debris/old,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "nbo" = (
@@ -53163,19 +53174,23 @@
 /turf/open/floor/iron,
 /area/security/office)
 "nuY" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/requests_console{
+	department = "Genetics";
+	name = "Genetics requests console";
+	pixel_y = 30
+	},
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "nvh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -53504,6 +53519,9 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"nAw" = (
+/turf/closed/indestructible/reinforced,
+/area/security/checkpoint/science)
 "nAK" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 1
@@ -54190,7 +54208,9 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "nJZ" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	name = "Science purple corner"
@@ -54200,14 +54220,9 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/dna_scannernew,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "nKe" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -55178,21 +55193,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "nWu" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
-	req_access_txt = "8"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
+/obj/structure/grille,
+/obj/effect/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "nXz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -55335,11 +55339,9 @@
 /turf/open/floor/iron,
 /area/security/office)
 "nYQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "nYZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -55560,6 +55562,9 @@
 "oct" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/science/nanite)
@@ -56747,22 +56752,12 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "ord" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron{
-	amount = 50
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
+/obj/item/food/grown/banana,
+/turf/open/floor/grass,
+/area/science/genetics)
 "orC" = (
 /obj/machinery/conveyor{
 	id = "packageSort2"
@@ -57559,7 +57554,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "oEi" = (
-/obj/machinery/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/nanite)
 "oEI" = (
@@ -58088,23 +58085,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"oMH" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "oMP" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -58809,20 +58789,17 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "oXj" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 8;
 	name = "Science purple corner"
 	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "oXs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -58875,8 +58852,8 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "oYJ" = (
-/turf/closed/wall,
-/area/science/genetics)
+/turf/closed/indestructible/reinforced,
+/area/science/storage)
 "oZi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -59277,19 +59254,23 @@
 /turf/open/floor/plating,
 /area/maintenance/solars)
 "pew" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/structure/chair/office/light{
+	color = "#4D0067";
+	dir = 4
+	},
+/obj/effect/landmark/start/geneticist,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "peB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -60076,12 +60057,6 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "ppX" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/research";
-	dir = 8;
-	name = "Misc Research APC";
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -60095,6 +60070,12 @@
 	color = "#4D0067";
 	dir = 1;
 	name = "Science purple corner"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/science/genetics";
+	dir = 4;
+	name = "Genetics Lab APC";
+	pixel_x = -24
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -60318,6 +60299,10 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"psh" = (
+/obj/structure/extinguisher_cabinet,
+/turf/closed/indestructible/reinforced,
+/area/science/genetics)
 "psk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -60679,6 +60664,29 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
+"pwG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 23
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "pwN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -61191,8 +61199,19 @@
 /turf/open/floor/iron/cafeteria,
 /area/maintenance/department/medical)
 "pDN" = (
-/turf/open/floor/iron,
-/area/science/storage)
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/dna_scannernew,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "pDO" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -61209,8 +61228,10 @@
 /turf/open/floor/iron,
 /area/maintenance/fore)
 "pDY" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -61220,11 +61241,8 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
-	dir = 4;
+	dir = 8;
 	name = "Science purple corner"
-	},
-/obj/structure/sign/warning/explosives/alt{
-	pixel_y = 32
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -61462,26 +61480,12 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "pHo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/window/northleft{
-	name = "Monkey Pen";
-	req_access_txt = "9"
-	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "pHz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -61608,6 +61612,29 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"pJl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/light,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "pJn" = (
 /obj/structure/sign/departments/restroom{
 	pixel_x = 32
@@ -62802,22 +62829,13 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
+/obj/structure/flora/ausbushes/grassybush,
+/mob/living/carbon/human/monkeybrain,
+/turf/open/floor/grass,
+/area/science/genetics)
 "pYu" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -63840,14 +63858,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qkD" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
-	areastring = "/area/science/genetics";
+	areastring = "/area/science/storage";
 	dir = 4;
-	name = "Genetics Lab APC";
+	name = "Toxins Storage APC";
 	pixel_x = 24
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "qkK" = (
@@ -64002,12 +64019,22 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "qlS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/science/genetics)
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "qlT" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/camera{
@@ -64144,11 +64171,6 @@
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
 	name = "Science purple corner"
 	},
 /turf/open/floor/iron/white,
@@ -64994,14 +65016,11 @@
 /turf/closed/wall,
 /area/commons/toilet/restrooms)
 "qAC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "qAV" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -65705,6 +65724,9 @@
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "qKz" = (
@@ -66237,7 +66259,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qTe" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	name = "Science purple corner"
@@ -66247,8 +66268,20 @@
 	dir = 8;
 	name = "Science purple corner"
 	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -25;
+	pixel_y = 5
+	},
+/obj/machinery/computer/scan_consolenew{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "qTi" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -67097,21 +67130,13 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "rcw" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
+/turf/open/floor/grass,
+/area/science/genetics)
 "rcR" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobio Pen Block B";
@@ -67401,22 +67426,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"rgl" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "rgs" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -67686,6 +67695,23 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"riL" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "riO" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -69085,9 +69111,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rzD" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/iron,
-/area/science/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "rzI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -69888,6 +69916,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/nanite)
 "rKW" = (
@@ -70317,17 +70348,11 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "rRu" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -6
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -70339,12 +70364,8 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "rRB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/engine,
@@ -71510,14 +71531,8 @@
 /turf/open/floor/iron,
 /area/maintenance/department/crew_quarters/dorms)
 "sfR" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
 	name = "Science purple corner"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -71525,8 +71540,16 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/computer/scan_consolenew{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "sfU" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -73315,24 +73338,11 @@
 /turf/open/floor/carpet/green,
 /area/service/library)
 "sCJ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "sCK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/hidden{
 	dir = 1
@@ -74068,6 +74078,17 @@
 	icon_state = "wood-broken7"
 	},
 /area/service/abandoned_gambling_den)
+"sNE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "sNL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark,
@@ -74817,19 +74838,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"tbs" = (
-/obj/machinery/nanite_program_hub,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "tbt" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/hangover,
@@ -75383,13 +75391,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"thc" = (
-/obj/structure/chair/office/light{
-	color = "#4D0067"
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "thp" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/tile/red{
@@ -75546,19 +75547,19 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
-	dir = 1;
 	name = "Science purple corner"
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
+	dir = 4;
 	name = "Science purple corner"
 	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
+/obj/machinery/door/airlock/research{
+	name = "Genetics Lab";
+	req_access_txt = "9"
 	},
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "tja" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -76669,10 +76670,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"txZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/engine,
-/area/science/genetics)
 "tyh" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Quarters";
@@ -77794,16 +77791,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/restrooms)
-"tPw" = (
-/obj/structure/chair/office/light{
-	color = "#4D0067"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "tPU" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -81843,30 +81830,19 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "uPK" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
+/obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "uPX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
@@ -82971,9 +82947,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	sortType = 23
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
@@ -83648,11 +83623,8 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "vod" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/storage)
 "vok" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -84426,6 +84398,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
+"vzU" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "vzX" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -84596,19 +84586,6 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/engineering/atmos)
 "vCG" = (
-/obj/machinery/nanite_programmer,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "vCQ" = (
@@ -84787,6 +84764,10 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/commons/locker)
+"vEM" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "vEN" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/dorms)
@@ -85399,6 +85380,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"vMF" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/science/research)
 "vMN" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
@@ -87741,19 +87726,19 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "wvm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 8;
 	name = "Science purple corner"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "wvr" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -90522,6 +90507,9 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/structure/sign/warning/explosives/alt{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "xcj" = (
@@ -90751,6 +90739,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/science/research)
 "xgk" = (
@@ -91390,10 +91379,9 @@
 /turf/open/floor/iron,
 /area/security/office)
 "xmz" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
-	dir = 1;
+	dir = 8;
 	name = "Science purple corner"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -91401,8 +91389,14 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/genetics)
 "xmG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -91802,12 +91796,6 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "xrb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -91818,6 +91806,8 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "xrH" = (
@@ -92862,24 +92852,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "xGn" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
+/turf/closed/wall/r_wall,
+/area/science/genetics)
 "xGo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -95284,6 +95258,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
+"yij" = (
+/obj/machinery/nanite_programmer,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "yik" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/chair/stool{
@@ -136806,8 +136796,8 @@ vfW
 qKx
 xgh
 hLk
-guT
-qBZ
+vMF
+pJl
 mbf
 jHv
 kFT
@@ -137060,7 +137050,7 @@ pTC
 fSq
 pTC
 wOo
-pTC
+jwJ
 nbo
 bUp
 qds
@@ -138606,7 +138596,7 @@ mRy
 dNQ
 kCd
 jYO
-qZP
+fKn
 tVc
 mii
 wtM
@@ -139371,9 +139361,9 @@ uOw
 nGc
 uXQ
 ggv
-tbs
 vCG
-tbs
+vCG
+vCG
 cUR
 pwf
 uBI
@@ -139627,11 +139617,11 @@ uXQ
 itU
 mGu
 uXQ
-pwf
-pwf
-pwf
-pwf
-pwf
+vzU
+aAe
+yij
+aAe
+gpa
 pwf
 rGW
 qZP
@@ -139879,19 +139869,19 @@ wZK
 ooc
 euj
 xaG
-jba
+xaG
 uXQ
-tVB
-tVB
-tVB
-hMU
+nAw
+nAw
+nAw
 xGn
-oMH
-cFn
-ejB
-hMU
+xGn
+xGn
+xGn
+xGn
+hsC
 jYO
-qZP
+fKn
 mTu
 dlm
 wEe
@@ -140133,21 +140123,21 @@ yju
 yju
 xBU
 vfe
-cpG
+rUs
 qkD
-dUj
+oYJ
 lxO
 uPK
 bDJ
-rgl
+uPK
 mGx
-hMU
+hsC
 xmz
 doy
 pDN
 qTe
-hMU
-pDY
+cnE
+ljO
 cuK
 mTu
 blG
@@ -140395,17 +140385,17 @@ jba
 jba
 rRu
 fOq
-eKi
+mOX
 mOX
 lkM
-hMU
+hsC
 nuY
 rzD
 eNu
 fTZ
-hMU
-jYO
-qZP
+dLp
+lzG
+pwG
 mTu
 jBP
 yiK
@@ -140650,12 +140640,12 @@ lTD
 rUs
 jba
 cAz
-cAz
+cpG
 sCJ
 vod
-tPw
+vod
 oXj
-hMU
+hsC
 mxU
 cSe
 iUO
@@ -140907,18 +140897,18 @@ iZj
 xBU
 jba
 qlS
-txZ
+vod
 pHo
 cgO
-eKi
+vEM
 iAR
-hMU
+hsC
 lcI
-cSe
-gzy
+fEu
+gZb
 cZH
 tiR
-jYO
+sNE
 fuz
 bsw
 ipU
@@ -141163,19 +141153,19 @@ wpj
 lTD
 fvA
 jba
-cAz
-cAz
-sCJ
+bgO
+baH
+jEZ
 qAC
 nYQ
-gwK
-hMU
-lcI
+iAR
+hsC
+dYR
 gZb
 leZ
 kAU
-hMU
-jEZ
+nWu
+jYO
 qZP
 fgL
 fGw
@@ -141423,16 +141413,16 @@ jba
 jba
 ltl
 eIf
-hpg
-thc
+vod
+vod
 fZv
-hMU
+psh
 pew
 gZb
-pDN
+gMW
 ord
-hMU
-bgO
+nWu
+jYO
 qZP
 mTu
 qTr
@@ -141682,8 +141672,8 @@ dCc
 fXg
 hjy
 baH
-jSb
-hMU
+oXj
+hsC
 sfR
 nJZ
 rcw
@@ -141937,15 +141927,15 @@ eUj
 jba
 oYJ
 fRv
-dbJ
-fRv
 oYJ
-hMU
-hMU
-hMU
-hMU
-hMU
-hMU
+riL
+lFj
+xGn
+xGn
+xGn
+xGn
+xGn
+xGn
 ljO
 dvc
 mTu
@@ -142193,9 +142183,9 @@ wpj
 wpj
 qZz
 xcf
-ntY
+pDY
 lIU
-ntY
+kro
 qoh
 ntY
 ppX

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1335,6 +1335,39 @@
 "asf" = (
 /turf/open/floor/iron/dark,
 /area/maintenance/port/aft)
+"asi" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/item/toy/figure/geneticist{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "ask" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/bot,
@@ -2038,19 +2071,6 @@
 /obj/item/flashlight,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aAe" = (
-/obj/machinery/nanite_program_hub,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "aAj" = (
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -6065,6 +6085,9 @@
 	dir = 8;
 	name = "Science purple corner"
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/storage)
 "bEe" = (
@@ -8740,11 +8763,6 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"cnE" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "cnF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -10828,6 +10846,22 @@
 /obj/structure/sign/departments/botany,
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"cQp" = (
+/obj/machinery/nanite_programmer,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "cQw" = (
 /turf/closed/wall,
 /area/commons/dorms)
@@ -14488,12 +14522,6 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"dLp" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/grille,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "dLq" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -15423,39 +15451,6 @@
 /obj/machinery/doppler_array/research/science,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"dYR" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/item/toy/figure/geneticist{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 7;
-	pixel_y = -4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "dYW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -16099,6 +16094,29 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"ehr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/light,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "eht" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -16423,6 +16441,23 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"elr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/science/research)
 "elC" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -19110,6 +19145,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"eXH" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/science/genetics)
 "eXX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -19816,6 +19860,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"fhR" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "fhW" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plating,
@@ -21517,14 +21576,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/restrooms)
-"fEu" = (
-/obj/structure/chair/office/light{
-	color = "#4D0067";
-	dir = 1
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "fEC" = (
 /obj/machinery/power/apc{
 	areastring = "/area/cargo/miningdock";
@@ -22115,28 +22166,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"fKn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "fKo" = (
 /obj/effect/turf_decal/siding{
 	color = "grey";
@@ -24532,24 +24561,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"gpa" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "gpb" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -25039,6 +25050,20 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"gwK" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/machinery/light,
+/turf/open/floor/iron/white,
+/area/science/storage)
 "gwQ" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/structure/extinguisher_cabinet{
@@ -25767,6 +25792,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"gGL" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "gGR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -26367,15 +26408,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
-"gMW" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/mob/living/carbon/human/monkeybrain,
-/turf/open/floor/grass,
-/area/science/genetics)
 "gMY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -27386,6 +27418,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hbu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "hby" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -27966,6 +28020,9 @@
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	name = "Science purple corner"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/storage)
@@ -28554,9 +28611,6 @@
 /obj/machinery/light,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
-"hsC" = (
-/turf/closed/indestructible/reinforced,
-/area/science/genetics)
 "hta" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -29090,6 +29144,24 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hyt" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "hyM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -33598,6 +33670,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"iFb" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "iFq" = (
 /obj/structure/window/reinforced,
 /obj/machinery/chem_dispenser,
@@ -36749,21 +36825,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
-"jwJ" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "jwT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -40378,14 +40439,6 @@
 /obj/structure/sign/directions/upload,
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain)
-"kro" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "krv" = (
 /obj/structure/table/wood,
 /obj/item/pen,
@@ -41055,7 +41108,7 @@
 	dir = 8;
 	layer = 3
 	},
-/mob/living/carbon/human/monkeybrain,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/science/genetics)
 "kAY" = (
@@ -43372,6 +43425,9 @@
 	name = "Science purple corner"
 	},
 /obj/machinery/computer/scan_consolenew,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "lcR" = (
@@ -44854,6 +44910,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/maintenance/department/science)
+"luq" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/science/research)
 "lus" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -45191,23 +45251,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"lzG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/science/research)
 "lzT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -45387,6 +45430,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"lCS" = (
+/turf/closed/indestructible/reinforced,
+/area/security/checkpoint/science)
 "lDb" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -45521,22 +45567,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"lFj" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "lFm" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
 /obj/effect/turf_decal/tile/red{
@@ -48559,6 +48589,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"mpm" = (
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "mps" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -53519,9 +53554,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"nAw" = (
-/turf/closed/indestructible/reinforced,
-/area/security/checkpoint/science)
 "nAK" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 1
@@ -55194,7 +55226,7 @@
 /area/security/checkpoint/medical)
 "nWu" = (
 /obj/structure/grille,
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "nXz" = (
@@ -56152,6 +56184,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/vault,
 /area/command/bridge)
+"oiC" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "oiG" = (
 /obj/machinery/holopad,
 /obj/item/beacon,
@@ -58460,6 +58498,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"oSc" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "oSn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -60299,10 +60354,6 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"psh" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/indestructible/reinforced,
-/area/science/genetics)
 "psk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -60664,29 +60715,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
-"pwG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 23
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "pwN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -61612,29 +61640,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"pJl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/machinery/light,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "pJn" = (
 /obj/structure/sign/departments/restroom{
 	pixel_x = 32
@@ -62833,7 +62838,7 @@
 	dir = 9
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/mob/living/carbon/human/monkeybrain,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/science/genetics)
 "pYu" = (
@@ -66280,6 +66285,9 @@
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "qTi" = (
@@ -67135,6 +67143,9 @@
 	dir = 1;
 	layer = 2.9
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/science/genetics)
 "rcR" = (
@@ -67426,6 +67437,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"rgl" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/white,
+/area/science/storage)
 "rgs" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -67695,23 +67720,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"riL" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "riO" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -70110,6 +70118,9 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
+"rOA" = (
+/turf/closed/indestructible/reinforced,
+/area/science/genetics)
 "rOD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -71547,6 +71558,9 @@
 	},
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
@@ -74078,17 +74092,6 @@
 	icon_state = "wood-broken7"
 	},
 /area/service/abandoned_gambling_den)
-"sNE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "sNL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark,
@@ -78628,6 +78631,19 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"tZC" = (
+/obj/machinery/nanite_program_hub,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "uad" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -83669,6 +83685,29 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"vpk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 23
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "vpq" = (
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
@@ -84398,24 +84437,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
-"vzU" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "vzX" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -84764,10 +84785,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/commons/locker)
-"vEM" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "vEN" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/dorms)
@@ -85380,10 +85397,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
-"vMF" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/science/research)
 "vMN" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
@@ -86439,6 +86452,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"wfe" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "wfk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
@@ -90512,6 +90543,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"xch" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "xcj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/purple{
@@ -94528,6 +94570,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
+"yaO" = (
+/obj/structure/chair/office/light{
+	color = "#4D0067";
+	dir = 1
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "yaV" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
@@ -95258,22 +95308,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
-"yij" = (
-/obj/machinery/nanite_programmer,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "yik" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/chair/stool{
@@ -95475,6 +95509,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
+"ylf" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "yls" = (
 /obj/structure/closet/crate,
 /obj/item/book/manual/random,
@@ -136796,8 +136838,8 @@ vfW
 qKx
 xgh
 hLk
-vMF
-pJl
+luq
+ehr
 mbf
 jHv
 kFT
@@ -137050,7 +137092,7 @@ pTC
 fSq
 pTC
 wOo
-jwJ
+fhR
 nbo
 bUp
 qds
@@ -138596,7 +138638,7 @@ mRy
 dNQ
 kCd
 jYO
-fKn
+hbu
 tVc
 mii
 wtM
@@ -139617,11 +139659,11 @@ uXQ
 itU
 mGu
 uXQ
-vzU
-aAe
-yij
-aAe
-gpa
+hyt
+tZC
+cQp
+tZC
+wfe
 pwf
 rGW
 qZP
@@ -139871,17 +139913,17 @@ euj
 xaG
 xaG
 uXQ
-nAw
-nAw
-nAw
+lCS
+lCS
+lCS
 xGn
 xGn
 xGn
 xGn
 xGn
-hsC
+rOA
 jYO
-fKn
+hbu
 mTu
 dlm
 wEe
@@ -140129,14 +140171,14 @@ oYJ
 lxO
 uPK
 bDJ
-uPK
+rgl
 mGx
-hsC
+rOA
 xmz
 doy
 pDN
 qTe
-cnE
+mpm
 ljO
 cuK
 mTu
@@ -140388,14 +140430,14 @@ fOq
 mOX
 mOX
 lkM
-hsC
+rOA
 nuY
 rzD
 eNu
 fTZ
-dLp
-lzG
-pwG
+oiC
+elr
+vpk
 mTu
 jBP
 yiK
@@ -140645,7 +140687,7 @@ sCJ
 vod
 vod
 oXj
-hsC
+rOA
 mxU
 cSe
 iUO
@@ -140900,15 +140942,15 @@ qlS
 vod
 pHo
 cgO
-vEM
+iFb
 iAR
-hsC
+rOA
 lcI
-fEu
+yaO
 gZb
 cZH
 tiR
-sNE
+xch
 fuz
 bsw
 ipU
@@ -141158,9 +141200,9 @@ baH
 jEZ
 qAC
 nYQ
-iAR
-hsC
-dYR
+gwK
+rOA
+asi
 gZb
 leZ
 kAU
@@ -141416,10 +141458,10 @@ eIf
 vod
 vod
 fZv
-psh
+rOA
 pew
 gZb
-gMW
+eXH
 ord
 nWu
 jYO
@@ -141673,7 +141715,7 @@ fXg
 hjy
 baH
 oXj
-hsC
+rOA
 sfR
 nJZ
 rcw
@@ -141928,8 +141970,8 @@ jba
 oYJ
 fRv
 oYJ
-riL
-lFj
+oSc
+gGL
 xGn
 xGn
 xGn
@@ -142185,7 +142227,7 @@ qZz
 xcf
 pDY
 lIU
-kro
+ylf
 qoh
 ntY
 ppX


### PR DESCRIPTION
## About The Pull Request

Swaps Genetics with Toxins storage, adding windows that the main halls can see.
Additionally, adds Sunglasses to the Toxins range area, to match with Heliostation, replaces the ancient heirloom toolbox in Engineering maint, with a regular non-heirloom toolbox, and fixes the disposal unit in the Nanite lab not being connected to disposals.

![image](https://user-images.githubusercontent.com/53777086/116962670-9e7b5a00-ac74-11eb-9e52-ae68eb051162.png)
![image](https://user-images.githubusercontent.com/53777086/116962674-a3400e00-ac74-11eb-93fd-623c411b49f1.png)


## Why It's Good For The Game

Probably isn't, I'm just biased and like it when people can ask me for genes, which they rarely do when they can never see the area I'm at.

## Changelog
:cl:
add: Sunglasses has been added to Toxins range on Selene.
qol: Genetics and Toxins storage areas have been swapped on Selene.
fix: The ancient toolbox in Engineering maints is no longer an heirloom.
/:cl: