### PR TITLE
[Selenestation] Adds coffee vendors

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -9091,10 +9091,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"csd" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plating,
-/area/construction)
 "csg" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -17734,6 +17730,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/cytology)
+"eFu" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/service/library)
 "eFP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -22569,6 +22569,10 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
+"fPV" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plating,
+/area/construction)
 "fQh" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -30462,6 +30466,7 @@
 	c_tag = "Command - Meeting Room E";
 	dir = 8
 	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
 "hRm" = (
@@ -45639,6 +45644,7 @@
 	c_tag = "Command - Meeting Room W";
 	dir = 4
 	},
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
 "lGr" = (
@@ -60767,10 +60773,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"pzb" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/service/library)
 "pzc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 4
@@ -70192,10 +70194,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hop)
-"rPQ" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "rPT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -76860,6 +76858,10 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/grimy,
 /area/service/bar)
+"tAo" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "tAw" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/eighties,
@@ -116226,7 +116228,7 @@ tfD
 tfD
 csg
 tfD
-rPQ
+tAo
 xPj
 wFW
 fAi
@@ -122714,7 +122716,7 @@ yel
 qNi
 vKs
 vwu
-csd
+fPV
 afr
 lzc
 wLL
@@ -129838,7 +129840,7 @@ krv
 uso
 gWf
 bFb
-pzb
+eFu
 ueM
 kFb
 cjA

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -17730,10 +17730,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/cytology)
-"eFu" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/service/library)
 "eFP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -22569,10 +22565,6 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
-"fPV" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plating,
-/area/construction)
 "fQh" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -45500,6 +45492,10 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"lEQ" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/service/library)
 "lEW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -54837,6 +54833,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"nRa" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plating,
+/area/construction)
 "nRM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73519,6 +73519,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"sEA" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "sEZ" = (
 /obj/structure/frame/computer{
 	dir = 1
@@ -76858,10 +76862,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/grimy,
 /area/service/bar)
-"tAo" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "tAw" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/eighties,
@@ -81569,7 +81569,7 @@
 "uNd" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
-	name = "Captain's Desk";
+	name = "Command Desk";
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -116228,7 +116228,7 @@ tfD
 tfD
 csg
 tfD
-tAo
+sEA
 xPj
 wFW
 fAi
@@ -122716,7 +122716,7 @@ yel
 qNi
 vKs
 vwu
-fPV
+nRa
 afr
 lzc
 wLL
@@ -129840,7 +129840,7 @@ krv
 uso
 gWf
 bFb
-eFu
+lEQ
 ueM
 kFb
 cjA

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -7569,6 +7569,7 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron/white,
 /area/science/research)
 "bXG" = (
@@ -9090,6 +9091,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"csd" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plating,
+/area/construction)
 "csg" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -49741,6 +49746,7 @@
 	dir = 1;
 	network = list("ss13", "service")
 	},
+/obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/service/library/printer)
 "mFp" = (
@@ -60761,6 +60767,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"pzb" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/service/library)
 "pzc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 4
@@ -62927,12 +62937,12 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/structure/closet,
-/obj/item/vending_refill/cigarette,
 /obj/machinery/camera{
 	c_tag = "Service - Bar Backroom";
 	dir = 1;
 	network = list("ss13", "service")
 	},
+/obj/item/vending_refill/cola,
 /turf/open/floor/wood,
 /area/service/bar)
 "qai" = (
@@ -70182,6 +70192,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hop)
+"rPQ" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "rPT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -116212,7 +116226,7 @@ tfD
 tfD
 csg
 tfD
-xPj
+rPQ
 xPj
 wFW
 fAi
@@ -122700,7 +122714,7 @@ yel
 qNi
 vKs
 vwu
-opB
+csd
 afr
 lzc
 wLL
@@ -129824,7 +129838,7 @@ krv
 uso
 gWf
 bFb
-esi
+pzb
 ueM
 kFb
 cjA


### PR DESCRIPTION
## About The Pull Request

There's like, 2 coffee vendors throughout the entire map. Science doesnt even have one, when they do on all other maps do.
Adds several coffee vending machines, including in the Bridge
Adds a cigarette vending machine in the Bridge
Renames the windoor in the bridge to Command Desk (Was Captain's Desk)
Replaces the cigarette refill vendor from the Bar's backroom with a cola refill.

## Why It's Good For The Game

Step 1) Cover your target in frost oil
Step 2) Watch as they die due to no coffee being anywhere on the map, and the bar being on the complete other end of the station
Step 3)

And yes, this is i ded.

## Changelog
:cl:
qol: Coffee vendors has been placed around Selenestation.
/:cl:
