### PR TITLE
SeleneStation: Moving the wrench ,in the execution room closet, outside

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -24631,6 +24631,7 @@
 	dir = 8;
 	name = "Security red corner"
 	},
+/obj/item/crowbar/red,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "gqn" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -8234,6 +8234,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
+/obj/item/wrench,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "chr" = (
@@ -24603,10 +24604,8 @@
 	pixel_x = -3;
 	pixel_y = 1
 	},
-/obj/item/storage/box/bodybags,
 /obj/item/assembly/signaler,
 /obj/item/screwdriver,
-/obj/item/wrench,
 /obj/item/taperecorder{
 	pixel_x = -3
 	},
@@ -24631,7 +24630,6 @@
 	dir = 8;
 	name = "Security red corner"
 	},
-/obj/item/crowbar/red,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "gqn" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -24630,6 +24630,7 @@
 	dir = 8;
 	name = "Security red corner"
 	},
+/obj/item/bodybag,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "gqn" = (


### PR DESCRIPTION
I need mapping jobs, I'm going hungry

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moved the wrench outside

## Why It's Good For The Game

Officers can now wrench the canisters inside

## Changelog
:cl:

add: Wrench in execution room now accessible to officers

/:cl:

