### PR TITLE
Bloodsucker fixes (sleep is too strong)

### DIFF
--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -294,6 +294,7 @@
 
 /datum/antagonist/bloodsucker/proc/SpendRank()
 	set waitfor = FALSE
+
 	if(bloodsucker_level_unspent <= 0 || !owner || !owner.current || !owner.current.client)
 		return
 	//TODO: Make this into a radial, or perhaps a tgui next UI
@@ -321,8 +322,6 @@
 		var/datum/action/bloodsucker/P = options[choice]
 		BuyPower(new P)
 		to_chat(owner.current, "<span class='notice'>You have learned how to use [initial(P.name)]!</span>")
-		bloodsucker_level++
-		bloodsucker_level_unspent--
 	else
 		to_chat(owner.current, "<span class='notice'>You grow more ancient by the night!</span>")
 	/////////
@@ -337,6 +336,9 @@
 		S.punchdamagehigh += 0.5 // NOTE: This affects the hitting power of Brawn.
 	/// More Health
 	owner.current.setMaxHealth(owner.current.maxHealth + 10)
+	/// You're still levelling up, spend your Rank.
+	bloodsucker_level++
+	bloodsucker_level_unspent--
 	/// Vamp Stats
 	bloodsucker_regen_rate += 0.05 // Points of brute healed (starts at 0.3)
 	feed_amount += 2 // Increase how quickly I munch down vics (15)

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -133,6 +133,9 @@
 	/// Torpor revives the dead once complete.
 	if(C.stat == DEAD)
 		C.revive(full_heal = FALSE, admin_revive = FALSE)
+	for(var/i in C.all_wounds)
+		var/datum/wound/iter_wound = i
+		iter_wound.remove_wound()
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/fulp_modules/main_features/bloodsuckers/code/powers/cloak.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/cloak.dm
@@ -28,7 +28,7 @@
 	if(was_running)
 		user.toggle_move_intent()
 
-	while(bloodsuckerdatum && ContinueActive(user) && do_mob(user, user, 0.5 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE|IGNORE_HELD_ITEM|IGNORE_INCAPACITATED), progress = FALSE))
+	while(bloodsuckerdatum && ContinueActive(user))
 		// Pay Blood Toll (if awake)
 		owner.alpha = max(35, owner.alpha - min(75, 10 + 5 * level_current))
 		if(user.stat == CONSCIOUS)
@@ -37,6 +37,7 @@
 			user.toggle_move_intent()
 			to_chat(user, "<span class='warning'>You attempt to run, crushing yourself in the process.</span>")
 			user.adjustBruteLoss(rand(5,15))
+		sleep(5) // Check every few ticks
 
 /datum/action/bloodsucker/cloak/ContinueActive(mob/living/user, mob/living/target)
 	if(!..())

--- a/fulp_modules/main_features/bloodsuckers/code/powers/fortitude.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/fortitude.dm
@@ -27,7 +27,7 @@
 	was_running = (user.m_intent == MOVE_INTENT_RUN)
 	if(was_running)
 		user.toggle_move_intent()
-	while(B && ContinueActive(user) && do_mob(user, user, 2 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE|IGNORE_HELD_ITEM|IGNORE_INCAPACITATED), progress = FALSE))
+	while(B && ContinueActive(user))
 		if(user.m_intent != MOVE_INTENT_WALK) /// Prevents running while on Fortitude
 			user.toggle_move_intent()
 			to_chat(user, "<span class='warning'>You attempt to run, crushing yourself in the process.</span>")
@@ -38,6 +38,7 @@
 		if(owner.mind.has_antag_datum(/datum/antagonist/bloodsucker)) /// Prevents the Monster Hunter version from runtiming
 			if(user.stat == CONSCIOUS)
 				B.AddBloodVolume(-0.5)
+		sleep(20) // Check every few ticks that we haven't disabled this power
 
 /datum/action/bloodsucker/fortitude/DeactivatePower(mob/living/user = owner)
 	// Restore Traits & Effects

--- a/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
@@ -62,8 +62,9 @@
 	// Step One: Heatseek toward Target's Turf
 	walk_towards(owner, T, 0.1, 10) // NOTE: this runs in the background! to cancel it, you need to use walk(owner.current,0), or give them a new path.
 	var/safety = 10
-	while(get_turf(owner) != T && safety > 0 && !(isliving(target) && target.Adjacent(owner)) && do_mob(user, user, 0.1 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE|IGNORE_HELD_ITEM|IGNORE_INCAPACITATED), progress = FALSE))
+	while(get_turf(owner) != T && safety > 0 && !(isliving(target) && target.Adjacent(owner)))
 		ADD_TRAIT(user, TRAIT_IMMOBILIZED, BLOODSUCKER_TRAIT) // No Motion
+		sleep(1)
 		safety--
 
 		// Did I get knocked down?

--- a/fulp_modules/main_features/bloodsuckers/code/powers/masquerade.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/masquerade.dm
@@ -59,7 +59,7 @@
 
 	// WE ARE ALIVE! //
 	var/obj/item/organ/heart/vampheart/H = user.getorganslot(ORGAN_SLOT_HEART)
-	while(bloodsuckerdatum && ContinueActive(user) && do_mob(user, user, 2 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE|IGNORE_HELD_ITEM|IGNORE_INCAPACITATED), progress = FALSE))
+	while(bloodsuckerdatum && ContinueActive(user))
 		// HEART
 		if(istype(H))
 			H.FakeStart()
@@ -69,6 +69,7 @@
 		// Don't Heal
 		if(user.stat == CONSCIOUS) // Pay Blood Toll if awake.
 			bloodsuckerdatum.AddBloodVolume(-0.3) // Since we're removing all Bloodsucker abilities, they will regenerate blood like a normal human, so pay a lot.
+		sleep(20)
 
 /datum/action/bloodsucker/masquerade/ContinueActive(mob/living/user)
 	// Disable if unable to use power anymore.

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -13,7 +13,7 @@
 	var/mob/living/carbon/human/H
 	if(ishuman(owner))
 		H = owner
-	while(ContinueActive(owner) && do_mob(C, C, 2 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE|IGNORE_HELD_ITEM), progress = FALSE))
+	while(ContinueActive(owner))
 		C.adjustBruteLoss(-1.5)
 		C.adjustFireLoss(-0.5)
 		C.adjustToxLoss(-2, forced = TRUE)
@@ -25,6 +25,7 @@
 			for(var/obj/item/bodypart/part in H.bodyparts)
 				part.generic_bleedstacks--
 		C.Jitter(5)
+		sleep(10)
 	// DONE!
 	//DeactivatePower(owner)
 

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -8,21 +8,20 @@
 	cooldown = 100
 
 /datum/action/bloodsucker/recuperate/ActivatePower()
+	var/mob/living/carbon/human/C = owner
+
 	to_chat(owner, "<span class='notice'>Your muscles clench as your master's immortal blood mixes with your own, knitting your wounds.</span>")
-	var/mob/living/carbon/C = owner
-	var/mob/living/carbon/human/H
-	if(ishuman(owner))
-		H = owner
 	while(ContinueActive(owner))
 		C.adjustBruteLoss(-1.5)
 		C.adjustFireLoss(-0.5)
 		C.adjustToxLoss(-2, forced = TRUE)
 		C.adjustStaminaLoss(bloodcost * 1.1)
-		if(!HAS_TRAIT(C, NOBLOOD)) /// Plasmamen won't lose blood, whatever.
+		/// Plasmamen won't lose blood, they don't have any.
+		if(!HAS_TRAIT(C, NOBLOOD))
 			C.blood_volume -= bloodcost
-		// Stop Bleeding
-		if(istype(H) && H.is_bleeding())
-			for(var/obj/item/bodypart/part in H.bodyparts)
+		/// Stop Bleeding
+		if(istype(C) && C.is_bleeding())
+			for(var/obj/item/bodypart/part in C.bodyparts)
 				part.generic_bleedstacks--
 		C.Jitter(5)
 		sleep(10)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/veil.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/veil.dm
@@ -92,8 +92,9 @@
 
 	// Wait here til we deactivate power or go unconscious
 	var/datum/antagonist/bloodsucker/B = owner.mind.has_antag_datum(/datum/antagonist/bloodsucker)
-	while(B && ContinueActive(owner) && do_mob(H, H, 1 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE|IGNORE_HELD_ITEM|IGNORE_INCAPACITATED), progress = FALSE))
+	while(B && ContinueActive(owner))
 		B.AddBloodVolume(-0.2)
+		sleep(10)
 		// Wait for a moment if you fell unconscious...
 		if(owner && owner.stat > CONSCIOUS)
 			sleep(50)


### PR DESCRIPTION
## About The Pull Request

I hate sleep but I also dont know any other alternative I could use here.

Fixes #162 so thank you for opening that issue to bring this to my attention!

## Why It's Good For The Game

When the Antagonist is Playable ! 😳 

## Changelog
:cl:
fix: Bloodsucker passive abilities will no longer cancel if they get shove/stunned, will no longer drain immense amounts of Blood randomly, and will no longer prevent construction
fix: Bloodsuckers will no longer be able to infinitely buff themselves once they reach Rank 7
balance: Bloodsuckers can now remove their wounds by going through Torpor
fix: Recuperate now should work properly again.
/:cl:
