### PR TITLE
Bloodsucker balancing changes

### DIFF
--- a/code/___fulp_defines/fulp_defines.dm
+++ b/code/___fulp_defines/fulp_defines.dm
@@ -40,6 +40,7 @@
 #define BLOODSUCKER_LEVEL_TO_EMBRACE 3
 /// Checks if the given mob is a Bloodsucker
 #define IS_BLOODSUCKER(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/bloodsucker))
+#define IS_MONSTERHUNTER(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/monsterhunter))
 
 /*
  *	Deputy Defines

--- a/code/___fulp_defines/fulp_defines.dm
+++ b/code/___fulp_defines/fulp_defines.dm
@@ -38,8 +38,9 @@
 #define COMSIG_LIVING_BIOLOGICAL_LIFE "biological_life"
 /// Unused define, kept here in case Swain wants to use it.
 #define BLOODSUCKER_LEVEL_TO_EMBRACE 3
-/// Checks if the given mob is a Bloodsucker
+/// Antagonist checks
 #define IS_BLOODSUCKER(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/bloodsucker))
+#define IS_VASSAL(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/vassal))
 #define IS_MONSTERHUNTER(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/monsterhunter))
 
 /*

--- a/code/game/objects/items/implants/implant_mindshield.dm
+++ b/code/game/objects/items/implants/implant_mindshield.dm
@@ -27,6 +27,9 @@
 			target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 			deconverted = TRUE
 
+		if(target.mind.has_antag_datum(/datum/antagonist/vassal)) // Fulpstation Bloodsuckers edit - Mindshielding unvassalizes!
+			target.mind.remove_antag_datum(/datum/antagonist/vassal)
+			deconverted = TRUE
 		if(target.mind.has_antag_datum(/datum/antagonist/rev/head)|| target.mind.unconvertable)
 			if(!silent)
 				target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel something interfering with your mental conditioning, but you resist it!</span>")

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -7,8 +7,6 @@
 	show_name_in_check_antagonists = TRUE
 	can_coexist_with_others = FALSE
 	hijack_speed = 0.5
-	/// Sunlight Timer. Created on first Bloodsucker assign. Destroyed on last removed Bloodsucker.
-	var/obj/effect/sunlight/bloodsucker_sunlight
 	/// List of all Antagonists that can't be vassalized.
 	var/list/vassal_banned_antags = list(
 		/datum/antagonist/bloodsucker, /datum/antagonist/vassal, /datum/antagonist/monsterhunter,
@@ -148,6 +146,9 @@
 /datum/team/vampireclan
 	name = "Clan" // Teravanni,
 
+	/// Sunlight Timer. Created on first Bloodsucker assign. Destroyed on last removed Bloodsucker.
+	var/obj/effect/sunlight/bloodsucker_sunlight
+
 /datum/antagonist/bloodsucker/create_team(datum/team/vampireclan/team)
 	if(!team)
 		for(var/datum/antagonist/bloodsucker/H in GLOB.antagonists)
@@ -213,25 +214,20 @@
  *	This is tied to the Vampire Clan team's datum, originally was tied to game_mode, which TG has since deleted, forcing us to use something else.
  */
 
-/// Start Sun, called when someone is assigned Bloodsucker.
+/// Start Sun, called when someone is assigned Bloodsucker
 /datum/team/vampireclan/proc/check_start_sunlight()
-	for(var/datum/team/vampireclan/mind in GLOB.antagonist_teams) // Don't think this is actually needed but I'm too scared to remove it.
-		if(members.len <= 1)
-			for(var/datum/mind/M in mind.members)
-				var/datum/antagonist/bloodsucker/bloodsuckerdatum = M.has_antag_datum(/datum/antagonist/bloodsucker)
-				message_admins("New Sol has been created due to Bloodsucker assignement.")
-				bloodsuckerdatum.bloodsucker_sunlight = new()
+	if(members.len <= 1)
+		for(var/datum/mind/M in members)
+			message_admins("New Sol has been created due to Bloodsucker assignement.")
+			bloodsucker_sunlight = new()
 
 /// End Sol, if you're the last Bloodsucker
 /datum/team/vampireclan/proc/check_cancel_sunlight()
-	/// This searches for the minds of the people in the team, requires to actually search for bloodsucker_sunlight.
-	for(var/datum/mind/M in members)
-		var/datum/antagonist/bloodsucker/bloodsuckerdatum = M.has_antag_datum(/datum/antagonist/bloodsucker)
-		/// No members left? Delete it.
-		if(!members.len)
-			message_admins("Sol has been deleted due to the lack of Bloodsuckers")
-			qdel(bloodsuckerdatum.bloodsucker_sunlight)
-//			bloodsuckerdatum.bloodsucker_sunlight = null
+	/// No minds in the clan? Delete Sol.
+	if(members.len <= 1)
+		message_admins("Sol has been deleted due to the lack of Bloodsuckers")
+		qdel(bloodsucker_sunlight)
+//		bloodsucker_sunlight = null // Note: Not sure what this is meant to do, but everything works without it.
 
 /// Buying powers
 /datum/antagonist/bloodsucker/proc/BuyPower(datum/action/bloodsucker/power)

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -11,11 +11,11 @@
 	var/obj/effect/sunlight/bloodsucker_sunlight
 	/// List of all Antagonists that can't be vassalized.
 	var/list/vassal_banned_antags = list(
-		/datum/antagonist/changeling, /datum/antagonist/abductor, /datum/antagonist/rev/head,
-		/datum/antagonist/nukeop, /datum/antagonist/obsessed, /datum/antagonist/cult,
-		/datum/antagonist/heretic, /datum/antagonist/wizard, /datum/antagonist/wizard/apprentice,
-		/datum/antagonist/xeno, /datum/antagonist/ninja, /datum/antagonist/monsterhunter,
-		/datum/antagonist/ert/safety_moth, /datum/antagonist/monkey, /datum/antagonist/wishgranter,
+		/datum/antagonist/bloodsucker, /datum/antagonist/vassal, /datum/antagonist/monsterhunter,
+		/datum/antagonist/changeling, /datum/antagonist/wizard, /datum/antagonist/wizard/apprentice,
+		/datum/antagonist/nukeop, /datum/antagonist/nukeop/clownop, /datum/antagonist/cult,
+		/datum/antagonist/xeno, /datum/antagonist/ninja, /datum/antagonist/obsessed,
+		/datum/antagonist/ert/safety_moth, /datum/antagonist/wishgranter,
 		)
 	/// Used for assigning your name
 	var/bloodsucker_name

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -98,6 +98,8 @@
 	* Bloodsucker Tip: You regenerate your health slowly, you're weak to fire, and you depend on blood to survive. Don't allow your blood to run too low!<br> \
 	* Bloodsucker Tip: Medical and Genetic Analyzers can sell you out, your Masquerade ability will forge results for you to prevent this.<br> \
 	* You can find an in-depth guide at : https://wiki.fulp.gg/en/Bloodsucker </span>")
+	if(bloodsucker_level_unspent >= 2)
+		to_chat(owner, "<span class='announce'>As a latejoiner, you have [bloodsucker_level_unspent] bonus Ranks, entering your claimed coffin allows you to spend a Rank.</span><br>")
 	owner.current.playsound_local(null, 'fulp_modules/main_features/bloodsuckers/sounds/BloodsuckerAlert.ogg', 100, FALSE, pressure_affected = FALSE)
 	antag_memory += "Although you were born a mortal, in undeath you earned the name <b>[fullname]</b>.<br>"
 

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -13,8 +13,7 @@
 	var/list/vassal_banned_antags = list(
 		/datum/antagonist/bloodsucker, /datum/antagonist/vassal, /datum/antagonist/monsterhunter,
 		/datum/antagonist/changeling, /datum/antagonist/wizard, /datum/antagonist/wizard/apprentice,
-		/datum/antagonist/nukeop, /datum/antagonist/nukeop/clownop, /datum/antagonist/cult,
-		/datum/antagonist/xeno, /datum/antagonist/ninja, /datum/antagonist/obsessed,
+		/datum/antagonist/cult, /datum/antagonist/xeno, /datum/antagonist/obsessed,
 		/datum/antagonist/ert/safety_moth, /datum/antagonist/wishgranter,
 		)
 	/// Used for assigning your name
@@ -41,15 +40,31 @@
 	var/obj/structure/closet/crate/coffin
 	/// Used in Bloodsucker huds
 	var/valuecolor
-	// TRACKING
-	var/foodInGut // How much food to throw up later. You shouldn't have eaten that.
-	var/warn_sun_locker // So we only get the locker burn message once per day.
-	var/warn_sun_burn // So we only get the sun burn message once per day.
-	var/passive_blood_drain = -0.1 //The amount of blood we loose each bloodsucker life tick LifeTick()
-	var/notice_healing //Var to see if you are healing for preventing spam of the chat message inform the user of such
-	var/AmFinalDeath = FALSE // Have we reached final death?
-	var/static/list/defaultTraits = list(TRAIT_NOBREATH, TRAIT_SLEEPIMMUNE, TRAIT_NOCRITDAMAGE, TRAIT_RESISTCOLD, TRAIT_RADIMMUNE, TRAIT_NIGHT_VISION, TRAIT_STABLEHEART, \
-		TRAIT_NOSOFTCRIT, TRAIT_NOHARDCRIT, TRAIT_AGEUSIA, TRAIT_NOPULSE, TRAIT_COLDBLOODED, TRAIT_VIRUSIMMUNE, TRAIT_TOXIMMUNE, TRAIT_HARDLY_WOUNDED)
+	/*
+	 *	# TRACKING
+	 *
+	 *	These are all used for Tracking Bloodsucker stats and such.
+	 */
+	/// How much food to throw up later. You shouldn't have eaten that.
+	var/foodInGut
+	/// So we only get the locker burn message once per day.
+	var/warn_sun_locker
+	/// So we only get the sun burn message once per day.
+	var/warn_sun_burn
+	/// The amount of blood we loose each bloodsucker life tick LifeTick()
+	var/passive_blood_drain = -0.1
+	/// Var to see if you are healing for preventing spam of the chat message inform the user of such
+	var/notice_healing
+	/// Have we reached final death?
+	var/AmFinalDeath = FALSE
+	/// Default traits ALL Bloodsuckers get.
+	var/static/list/defaultTraits = list(
+		TRAIT_NOBREATH, TRAIT_SLEEPIMMUNE, TRAIT_NOCRITDAMAGE,\
+		TRAIT_RESISTCOLD, TRAIT_RADIMMUNE, \
+		TRAIT_STABLEHEART, TRAIT_NOSOFTCRIT, TRAIT_NOHARDCRIT,\
+		TRAIT_AGEUSIA, TRAIT_NOPULSE, TRAIT_COLDBLOODED,\
+		TRAIT_VIRUSIMMUNE, TRAIT_TOXIMMUNE, TRAIT_HARDLY_WOUNDED,\
+		)
 /*
  *	TRAIT_HARDLY_WOUNDED can be swapped with TRAIT_NEVER_WOUNDED if it's too unbalanced.
  *	Remember that Fortitude gives NODISMEMBER when balancing Traits!
@@ -152,6 +167,29 @@
 			report += H.roundend_report()
 
 	return "<div class='panel redborder'>[report.Join("<br>")]</div>"
+
+/*
+ *	# Assigning Sol
+ *
+ *	Sol is the sunlight, during this period, all Bloodsuckers must be in their coffin, else they burn and die.
+ */
+
+/// Start Sun, called when someone is assigned Bloodsucker.
+/datum/antagonist/bloodsucker/proc/check_start_sunlight()
+	for(var/datum/team/vampireclan/mind in GLOB.antagonist_teams)
+		if(clan.members.len <= 1)
+			message_admins("New Sol has been created due to Bloodsucker assignement.")
+			bloodsucker_sunlight = new()
+
+/// End Sun (If you're the last) - This currently doesnt work...
+/datum/antagonist/bloodsucker/proc/check_cancel_sunlight()
+	/// No Sunlight
+	for(var/datum/team/vampireclan/mind in GLOB.antagonist_teams)
+		if(!clan.members.len)
+			message_admins("Sol has been deleted due to the lack of Bloodsuckers")
+			qdel(bloodsucker_sunlight)
+			bloodsucker_sunlight = null
+
 
 /// Individual roundend report
 /datum/antagonist/bloodsucker/roundend_report()
@@ -795,25 +833,3 @@
 /atom/movable/screen/bloodsucker/sunlight_counter/update_counter(value, valuecolor)
 	..()
 	maptext = "<div align='center' valign='bottom' style='position:relative; top:0px; left:6px'><font color='[valuecolor]'>[value]</font></div>"
-
-/*
- *	# Assigning Sol
- *
- *	Sol is the sunlight, during this period, all Bloodsuckers must be in their coffin, else they burn and die.
- */
-
-/// Start Sun, called when someone is assigned Bloodsucker.
-/datum/antagonist/bloodsucker/proc/check_start_sunlight()
-	for(var/datum/team/vampireclan/mind in GLOB.antagonist_teams)
-		if(clan.members.len <= 1)
-			message_admins("New Sol has been created due to Bloodsucker assignement.")
-			bloodsucker_sunlight = new()
-
-/// End Sun (If you're the last) - This currently doesnt work...
-/datum/antagonist/bloodsucker/proc/check_cancel_sunlight()
-	/// No Sunlight
-	for(var/datum/team/vampireclan/mind in GLOB.antagonist_teams)
-		if(!clan.members.len)
-			message_admins("Sol has been deleted due to the lack of Bloodsuckers")
-			qdel(bloodsucker_sunlight)
-			bloodsucker_sunlight = null

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -68,7 +68,7 @@
 /datum/antagonist/bloodsucker/on_gain()
 	forge_bloodsucker_objectives()
 	/// Start Sunlight if first Bloodsucker
-//	check_start_sunlight()
+	check_start_sunlight()
 	AssignStarterPowersAndStats()
 	/// Name & Title
 	SelectFirstName()
@@ -81,7 +81,7 @@
 /// Called by the remove_antag_datum() and remove_all_antag_datums() mind procs for the antag datum to handle its own removal and deletion.
 /datum/antagonist/bloodsucker/on_removal()
 	/// End Sunlight? (if last Vamp)
-	check_cancel_sunlight()
+//	check_cancel_sunlight()
 	ClearAllPowersAndStats()
 	update_bloodsucker_icons_removed(owner.current)
 	if(!LAZYLEN(owner.antag_datums))

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -65,7 +65,7 @@
 /datum/antagonist/bloodsucker/on_gain()
 	forge_bloodsucker_objectives()
 	/// Start Sunlight if first Bloodsucker
-	check_start_sunlight()
+//	check_start_sunlight()
 	AssignStarterPowersAndStats()
 	/// Name & Title
 	SelectFirstName()

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -9,10 +9,13 @@
 	hijack_speed = 0.5
 	/// Sunlight Timer. Created on first Bloodsucker assign. Destroyed on last removed Bloodsucker.
 	var/obj/effect/sunlight/bloodsucker_sunlight
-	/// List of all Antagonists that can be vassalized.
-	var/list/vassal_allowed_antags = list(/datum/antagonist/brother, /datum/antagonist/traitor, /datum/antagonist/traitor/internal_affairs, /datum/antagonist/nukeop/lone,
-		/datum/antagonist/fugitive, /datum/antagonist/fugitive_hunter, /datum/antagonist/separatist, /datum/antagonist/gang, /datum/antagonist/survivalist, /datum/antagonist/rev,
-		/datum/antagonist/pirate, /datum/antagonist/ert, /datum/antagonist/abductee, /datum/antagonist/valentine, /datum/antagonist/heartbreaker,
+	/// List of all Antagonists that can't be vassalized.
+	var/list/vassal_banned_antags = list(
+		/datum/antagonist/changeling, /datum/antagonist/abductor, /datum/antagonist/rev/head,
+		/datum/antagonist/nukeop, /datum/antagonist/obsessed, /datum/antagonist/cult,
+		/datum/antagonist/heretic, /datum/antagonist/wizard, /datum/antagonist/wizard/apprentice,
+		/datum/antagonist/xeno, /datum/antagonist/ninja, /datum/antagonist/monsterhunter,
+		/datum/antagonist/ert/safety_moth, /datum/antagonist/monkey, /datum/antagonist/wishgranter,
 		)
 	/// Used for assigning your name
 	var/bloodsucker_name

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -119,7 +119,7 @@
 /datum/antagonist/bloodsucker/farewell()
 	to_chat(owner.current, "<span class='userdanger'><FONT size = 3>With a snap, your curse has ended. You are no longer a Bloodsucker. You live once more!</FONT></span>")
 	/// Refill with Blood so they don't instantly die.
-	owner.current.blood_volume = max(owner.current.blood_volume, BLOOD_VOLUME_SAFE)
+	owner.current.blood_volume = max(owner.current.blood_volume, BLOOD_VOLUME_NORMAL)
 
 /datum/antagonist/bloodsucker/proc/add_objective(datum/objective/O)
 	objectives += O

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/monsterhunter_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/monsterhunter_datum.dm
@@ -127,87 +127,6 @@
 	owner.announce_objectives()
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//			Monster Hunter Abilities
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-/datum/action/bloodsucker/trackvamp
-	name = "Track Monster" // "Cellular Emporium"
-	desc = "Take a moment to look for clues of any nearby monsters.<br>These creatures are slippery, and often look like the crew."
-	button_icon = 'fulp_modules/main_features/bloodsuckers/icons/actions_bloodsucker.dmi' // This is the file for the BACKGROUND icon
-	background_icon_state = "vamp_power_off" // And this is the state for the background icon
-	icon_icon = 'fulp_modules/main_features/bloodsuckers/icons/actions_bloodsucker.dmi' // This is the file for the ACTION icon
-	button_icon_state = "power_hunter" // And this is the state for the action icon
-	amToggle = FALSE // Action-Related
-	cooldown = 300 // 10 ticks, 1 second.
-	bloodcost = 5
-	var/give_pinpointer = FALSE // Removed, set to TRUE to re-add -Willard
-
-/datum/action/bloodsucker/trackvamp/ActivatePower()
-	. = ..()
-	var/mob/living/carbon/user = owner
-	// Return text indicating direction
-	to_chat(user, "<span class='notice'>You look around, scanning your environment and discerning signs of any filthy, wretched affronts to the natural order.</span>")
-	if(!do_mob(user, owner, 80))
-		return
-	if(give_pinpointer)
-		user.apply_status_effect(STATUS_EFFECT_HUNTERPINPOINTER)
-	display_proximity()
-	PayCost()
-	// NOTE: DON'T DEACTIVATE!
-	//DeactivatePower()
-
-/datum/action/bloodsucker/trackvamp/proc/display_proximity()
-	// Pick target
-	var/turf/my_loc = get_turf(owner)
-	//var/list/mob/living/carbon/vamps = list()
-	var/best_dist = 9999
-	var/mob/living/best_vamp
-
-	// Track ALL MONSTERS in Game Mode
-	var/list/datum/mind/monsters = list()
-	for(var/mob/living/carbon/C in GLOB.alive_mob_list)
-		if(C.mind)
-			var/datum/mind/UM = C.mind
-			if(UM.has_antag_datum(/datum/antagonist/changeling))
-				monsters += UM
-			if(UM.has_antag_datum(/datum/antagonist/heretic))
-				monsters += UM
-			if(UM.has_antag_datum(/datum/antagonist/bloodsucker))
-				monsters += UM
-			if(UM.has_antag_datum(/datum/antagonist/cult))
-				monsters += UM
-			if(UM.has_antag_datum(/datum/antagonist/ashwalker))
-				monsters += UM
-			if(UM.has_antag_datum(/datum/antagonist/wizard))
-				monsters += UM
-			if(UM.has_antag_datum(/datum/antagonist/wizard/apprentice))
-				monsters += UM
-
-	for(var/datum/mind/M in monsters)
-		if(!M.current || M.current == owner) // || !get_turf(M.current) || !get_turf(owner))
-			continue
-		for(var/a in M.antag_datums)
-			var/datum/antagonist/antag_datum = a // var/datum/antagonist/antag_datum = M.has_antag_datum(/datum/antagonist/bloodsucker)
-			if(!istype(antag_datum))
-				continue
-			var/their_loc = get_turf(M.current)
-			var/distance = get_dist_euclidian(my_loc, their_loc)
-			// Found One: Closer than previous/max distance
-			if (distance < best_dist && distance <= HUNTER_SCAN_MAX_DISTANCE)
-				best_dist = distance
-				best_vamp = M.current
-				break // Stop searching through my antag datums and go to the next guy
-
-	// Found one!
-	if(best_vamp)
-		var/distString = best_dist <= HUNTER_SCAN_MAX_DISTANCE / 2 ? "<b>somewhere closeby!</b>" : "somewhere in the distance."
-		to_chat(owner, "<span class='warning'>You detect signs of monsters [distString]</span>")
-
-	// Will yield a "?"
-	else
-		to_chat(owner, "<span class='notice'>There are no monsters nearby.</span>")
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //			Monster Hunter Pinpointer
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -216,7 +135,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/agent_pinpointer/hunter_edition
 	minimum_range = HUNTER_SCAN_MIN_DISTANCE
 	tick_interval = HUNTER_SCAN_PING_TIME
-	duration = 160 // Lasts 10s
+	duration = 10 SECONDS // Lasts 10s
 	range_fuzz_factor = 5 // PINPOINTER_EXTRA_RANDOM_RANGE
 
 /atom/movable/screen/alert/status_effect/agent_pinpointer/hunter_edition

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/monsterhunter_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/monsterhunter_datum.dm
@@ -113,7 +113,7 @@
 /datum/antagonist/monsterhunter/proc/add_objective(datum/objective/O)
 	objectives += O
 
-/datum/antagonist/monsterhunter/proc/remove_objective(datum/objective/O)
+/datum/antagonist/monsterhunter/proc/remove_objectives(datum/objective/O)
 	objectives -= O
 
 /datum/antagonist/monsterhunter/greet()

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
@@ -6,12 +6,13 @@
 	name = "Vassal"
 	roundend_category = "vassals"
 	antagpanel_category = "Bloodsucker"
-	show_in_roundend = FALSE
 	job_rank = ROLE_BLOODSUCKER
+	show_in_roundend = FALSE
+	show_name_in_check_antagonists = TRUE
 	/// Who made me?
 	var/datum/antagonist/bloodsucker/master
-	/// Recuperate power
-	var/datum/action/bloodsucker/recuperate/new_Recuperate
+	/// Purchased powers, which in reality is just Recuperate.
+	var/list/datum/action/powers = list()
 
 /datum/antagonist/vassal/apply_innate_effects(mob/living/mob_override)
 	return
@@ -29,6 +30,8 @@
 	// Master Pinpointer
 	owner.current.apply_status_effect(/datum/status_effect/agent_pinpointer/vassal_edition)
 	/// Give Recuperate
+	var/datum/action/bloodsucker/recuperate/new_Recuperate = new()
+	powers += new_Recuperate
 	new_Recuperate.Grant(owner.current)
 	// Give Vassal Objective
 	var/datum/objective/bloodsucker/vassal/vassal_objective = new
@@ -50,7 +53,10 @@
 	// Master Pinpointer
 	owner.current.remove_status_effect(/datum/status_effect/agent_pinpointer/vassal_edition)
 	/// Remove Recuperate
-	new_Recuperate.Remove(owner.current)
+	while(powers.len)
+		var/datum/action/bloodsucker/power = pick(powers)
+		powers -= power
+		power.Remove(owner.current)
 	// Remove Hunter Objectives
 	remove_objective()
 	owner.current.remove_language(/datum/language/vampiric)
@@ -135,3 +141,9 @@
 /// Removing the Vassal antag datum, called by FreeAllVassals
 /datum/antagonist/bloodsucker/proc/remove_vassal(datum/mind/vassal)
 	vassal.remove_antag_datum(/datum/antagonist/vassal)
+
+/// Traitor Panel debugging
+/datum/mind/proc/remove_vassal()
+	var/datum/antagonist/vassal/C = has_antag_datum(/datum/antagonist/vassal)
+	if(C)
+		remove_antag_datum(/datum/antagonist/vassal)

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
@@ -80,9 +80,9 @@
 	master.owner.current.playsound_local(null, 'sound/magic/mutate.ogg', 100, FALSE, pressure_affected = FALSE)
 
 /datum/antagonist/vassal/farewell()
-	owner.current.visible_message("[owner.current]'s eyes dart feverishly from side to side, and then stop. [owner.current.p_they(TRUE)] seem[owner.current.p_s()] calm, \
-			like [owner.current.p_they()] [owner.current.p_have()] regained some lost part of [owner.current.p_them()]self.",\
-			"<span class='userdanger'><FONT size = 3>With a snap, you are no longer enslaved to [master.owner]! You breathe in heavily, having regained your free will.</FONT></span>")
+	owner.current.visible_message("<span class='deconversion_message'>[owner.current] eyes dart feverishly from side to side, and then stop. [owner.current.p_they(TRUE)] seem[owner.current.p_s()] calm,\
+			like [owner.current.p_they()] [owner.current.p_have()] regained some lost part of [owner.current.p_them()]self.</span>", null, null, null, owner.current)
+	to_chat(owner, "<span class ='deconversion_message bold'>With a snap, you are no longer enslaved to [master.owner]! You breathe in heavily, having regained your free will.</span>")
 	owner.current.playsound_local(null, 'sound/magic/mutate.ogg', 100, FALSE, pressure_affected = FALSE)
 	/// Message told to your (former) Master.
 	if(master && master.owner)

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
@@ -8,8 +8,10 @@
 	antagpanel_category = "Bloodsucker"
 	show_in_roundend = FALSE
 	job_rank = ROLE_BLOODSUCKER
-	var/datum/antagonist/bloodsucker/master // Who made me?
-	var/list/datum/action/powers = list() // Purchased powers
+	/// Who made me?
+	var/datum/antagonist/bloodsucker/master
+	/// Recuperate power
+	var/datum/action/bloodsucker/recuperate/new_Recuperate
 
 /datum/antagonist/vassal/apply_innate_effects(mob/living/mob_override)
 	return
@@ -26,15 +28,14 @@
 		owner.enslave_mind_to_creator(master.owner.current)
 	// Master Pinpointer
 	owner.current.apply_status_effect(/datum/status_effect/agent_pinpointer/vassal_edition)
-	// Powers
-	var/datum/action/bloodsucker/recuperate/new_Recuperate = new()
-	powers += new_Recuperate
+	/// Give Recuperate
 	new_Recuperate.Grant(owner.current)
 	// Give Vassal Objective
 	var/datum/objective/bloodsucker/vassal/vassal_objective = new
 	vassal_objective.owner = owner
 	vassal_objective.generate_objective()
 	objectives += vassal_objective
+
 	owner.current.grant_all_languages(FALSE, FALSE, TRUE)
 	owner.current.grant_language(/datum/language/vampiric)
 	update_vassal_icons_added(owner.current, "vassal")
@@ -48,11 +49,8 @@
 			owner.enslaved_to = null
 	// Master Pinpointer
 	owner.current.remove_status_effect(/datum/status_effect/agent_pinpointer/vassal_edition)
-	// Powers
-	while(powers.len)
-		var/datum/action/power = pick(powers)
-		powers -= power
-		power.Remove(owner.current)
+	/// Remove Recuperate
+	new_Recuperate.Remove(owner.current)
 	// Remove Hunter Objectives
 	remove_objective()
 	owner.current.remove_language(/datum/language/vampiric)
@@ -110,9 +108,6 @@
 /datum/status_effect/agent_pinpointer/vassal_edition/scan_for_target()
 	// DO NOTHING. We already have our target, and don't wanna do anything from agent_pinpointer
 
-/datum/antagonist/bloodsucker/proc/remove_vassal(datum/mind/vassal)
-	vassal.remove_antag_datum(/datum/antagonist/vassal)
-
 /datum/antagonist/vassal/proc/update_vassal_icons_added(mob/living/vassal, icontype = "vassal")
 	var/datum/atom_hud/antag/bloodsucker/hud = GLOB.huds[ANTAG_HUD_BLOODSUCKER]
 	hud.join_hud(vassal)
@@ -136,3 +131,7 @@
 /datum/antagonist/bloodsucker/proc/FreeAllVassals()
 	for(var/datum/antagonist/vassal/V in vassals)
 		remove_vassal(V.owner)
+
+/// Removing the Vassal antag datum, called by FreeAllVassals
+/datum/antagonist/bloodsucker/proc/remove_vassal(datum/mind/vassal)
+	vassal.remove_antag_datum(/datum/antagonist/vassal)

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
@@ -21,54 +21,51 @@
 	return
 
 /datum/antagonist/vassal/on_gain()
-	// Mindslave Add
+	/// Enslave them to their Master
 	if(master)
-		var/datum/antagonist/bloodsucker/B = master.owner.has_antag_datum(/datum/antagonist/bloodsucker)
-		if(B)
-			B.vassals |= src
+		var/datum/antagonist/bloodsucker/bloodsuckerdatum = master.owner.has_antag_datum(/datum/antagonist/bloodsucker)
+		if(bloodsuckerdatum)
+			bloodsuckerdatum.vassals |= src
 		owner.enslave_mind_to_creator(master.owner.current)
-	// Master Pinpointer
+	/// Give Vassal Pinpointer
 	owner.current.apply_status_effect(/datum/status_effect/agent_pinpointer/vassal_edition)
-	/// Give Recuperate
+	/// Give Recuperate Power
 	var/datum/action/bloodsucker/recuperate/new_Recuperate = new()
 	powers += new_Recuperate
 	new_Recuperate.Grant(owner.current)
-	// Give Vassal Objective
+	/// Give Objectives
 	var/datum/objective/bloodsucker/vassal/vassal_objective = new
 	vassal_objective.owner = owner
 	vassal_objective.generate_objective()
-	objectives += vassal_objective
-
+	add_objective(vassal_objective)
+	/// Give Vampire Language & Hud
 	owner.current.grant_all_languages(FALSE, FALSE, TRUE)
 	owner.current.grant_language(/datum/language/vampiric)
 	update_vassal_icons_added(owner.current, "vassal")
 	. = ..()
 
 /datum/antagonist/vassal/on_removal()
-	// Mindslave Remove
+	/// Free them from their Master
 	if(master && master.owner)
 		master.vassals -= src
 		if(owner.enslaved_to == master.owner.current)
 			owner.enslaved_to = null
-	// Master Pinpointer
+	/// Remove Pinpointer
 	owner.current.remove_status_effect(/datum/status_effect/agent_pinpointer/vassal_edition)
-	/// Remove Recuperate
+	/// Remove Recuperate Power
 	while(powers.len)
 		var/datum/action/bloodsucker/power = pick(powers)
 		powers -= power
 		power.Remove(owner.current)
-	// Remove Hunter Objectives
-	remove_objective()
+	/// Remove Language & Hud
 	owner.current.remove_language(/datum/language/vampiric)
-	// Clear Antag
-	owner.special_role = null
 	update_vassal_icons_removed(owner.current)
 	return ..()
 
 /datum/antagonist/vassal/proc/add_objective(datum/objective/O)
 	objectives += O
 
-/datum/antagonist/vassal/proc/remove_objective(datum/objective/O)
+/datum/antagonist/vassal/proc/remove_objectives(datum/objective/O)
 	objectives -= O
 
 /datum/antagonist/vassal/greet()
@@ -76,21 +73,67 @@
 	to_chat(owner, "<span class='boldannounce'>The power of [master.owner.current.p_their()] immortal blood compells you to obey [master.owner.current.p_them()] in all things, even offering your own life to prolong theirs.<br>\
 			You are not required to obey any other Bloodsucker, for only [master.owner.current] is your master. The laws of Nanotrasen do not apply to you now; only your vampiric master's word must be obeyed.<span>")
 	to_chat(owner, "<span class='userdanger'>Vassal Tip: Avoid being mindshielded at all costs!</span>")
-	/// Effects...
 	owner.current.playsound_local(null, 'sound/magic/mutate.ogg', 100, FALSE, pressure_affected = FALSE)
-	/// And to your new Master...
+	antag_memory += "You became the mortal servant of <b>[master.owner.current]</b>, a bloodsucking vampire!<br>"
+	/// Message told to your Master.
 	to_chat(master.owner, "<span class='userdanger'>[owner.current] has become addicted to your immortal blood. [owner.current.p_they(TRUE)] [owner.current.p_are()] now your undying servant!</span>")
 	master.owner.current.playsound_local(null, 'sound/magic/mutate.ogg', 100, FALSE, pressure_affected = FALSE)
-	antag_memory += "You became the mortal servant of <b>[master.owner.current]</b>, a bloodsucking vampire!<br>"
 
 /datum/antagonist/vassal/farewell()
 	owner.current.visible_message("[owner.current]'s eyes dart feverishly from side to side, and then stop. [owner.current.p_they(TRUE)] seem[owner.current.p_s()] calm, \
 			like [owner.current.p_they()] [owner.current.p_have()] regained some lost part of [owner.current.p_them()]self.",\
 			"<span class='userdanger'><FONT size = 3>With a snap, you are no longer enslaved to [master.owner]! You breathe in heavily, having regained your free will.</FONT></span>")
 	owner.current.playsound_local(null, 'sound/magic/mutate.ogg', 100, FALSE, pressure_affected = FALSE)
-	/// And to your former Master...
+	/// Message told to your (former) Master.
 	if(master && master.owner)
 		to_chat(master.owner, "<span class='userdanger'>You feel the bond with your vassal [owner.current] has somehow been broken!</span>")
+
+/// If we weren't created by a bloodsucker, then we cannot be a vassal (assigned from antag panel)
+/datum/antagonist/vassal/can_be_owned(datum/mind/new_owner)
+//	if(!master)
+//		return FALSE
+	return ..()
+
+/// Used for Admin removing Vassals.
+/datum/mind/proc/remove_vassal()
+	var/datum/antagonist/vassal/C = has_antag_datum(/datum/antagonist/vassal)
+	if(C)
+		remove_antag_datum(/datum/antagonist/vassal)
+
+/// When a Bloodsucker gets FinalDeath, all Vassals are freed - This is a Bloodsucker proc, not a Vassal one.
+/datum/antagonist/bloodsucker/proc/FreeAllVassals()
+	for(var/datum/antagonist/vassal/V in vassals)
+		remove_vassal(V.owner)
+
+/// Called by FreeAllVassals()
+/datum/antagonist/bloodsucker/proc/remove_vassal(datum/mind/vassal)
+	vassal.remove_antag_datum(/datum/antagonist/vassal)
+
+/*
+ *	# Vassal HUDs
+ *
+ *	We're basically coping Bloodsuckers here.
+ *	They share the same code, so most of it is dealt by Bloodsucker code.
+ */
+
+/datum/antagonist/vassal/proc/update_vassal_icons_added(mob/living/vassal, icontype = "vassal")
+	// This is a copy of Bloodsucker's hud.
+	var/datum/atom_hud/antag/bloodsucker/hud = GLOB.huds[ANTAG_HUD_BLOODSUCKER]
+	hud.join_hud(vassal)
+	set_antag_hud(vassal, icontype)
+	owner.current.hud_list[ANTAG_HUD].icon = image('fulp_modules/main_features/bloodsuckers/icons/bloodsucker_icons.dmi', owner.current, "bloodsucker")
+
+/datum/antagonist/vassal/proc/update_vassal_icons_removed(mob/living/vassal)
+	var/datum/atom_hud/antag/hud = GLOB.huds[ANTAG_HUD_BLOODSUCKER]
+	hud.leave_hud(vassal)
+	set_antag_hud(vassal, null)
+
+/*
+ *	# Vassal Pinpointer
+ *
+ *	Pinpointer that points to their Master's location at all times.
+ *	Unlike the Monster hunter one, this one is permanently active, and has no power needed to activate it.
+ */
 
 /datum/status_effect/agent_pinpointer/vassal_edition
 	id = "agent_pinpointer"
@@ -118,37 +161,3 @@
 	if(scan_target)
 		to_chat(owner, "<span class='notice'>You've lost your master's trail.</span>")
 	..()
-
-/datum/antagonist/vassal/proc/update_vassal_icons_added(mob/living/vassal, icontype = "vassal")
-	var/datum/atom_hud/antag/bloodsucker/hud = GLOB.huds[ANTAG_HUD_BLOODSUCKER]
-	hud.join_hud(vassal)
-	/// Located in icons/mob/hud.dmi
-	set_antag_hud(vassal, icontype)
-	/// FULP ADDITION! Check prepare_huds in mob.dm to see why.
-	owner.current.hud_list[ANTAG_HUD].icon = image('fulp_modules/main_features/bloodsuckers/icons/bloodsucker_icons.dmi', owner.current, "bloodsucker")
-
-/datum/antagonist/vassal/proc/update_vassal_icons_removed(mob/living/vassal)
-	var/datum/atom_hud/antag/hud = GLOB.huds[ANTAG_HUD_BLOODSUCKER]
-	hud.leave_hud(vassal)
-	set_antag_hud(vassal, null)
-
-/// If we weren't created by a bloodsucker, then we cannot be a vassal (assigned from antag panel)
-/datum/antagonist/vassal/can_be_owned(datum/mind/new_owner)
-	if(!master)
-		return FALSE
-	return ..()
-
-/// When a Bloodsucker gets FinalDeath.
-/datum/antagonist/bloodsucker/proc/FreeAllVassals()
-	for(var/datum/antagonist/vassal/V in vassals)
-		remove_vassal(V.owner)
-
-/// Removing the Vassal antag datum, called by FreeAllVassals
-/datum/antagonist/bloodsucker/proc/remove_vassal(datum/mind/vassal)
-	vassal.remove_antag_datum(/datum/antagonist/vassal)
-
-/// Traitor Panel debugging
-/datum/mind/proc/remove_vassal()
-	var/datum/antagonist/vassal/C = has_antag_datum(/datum/antagonist/vassal)
-	if(C)
-		remove_antag_datum(/datum/antagonist/vassal)

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
@@ -155,7 +155,7 @@
 	scan_target = antag_datum?.master?.owner?.current
 
 /datum/status_effect/agent_pinpointer/vassal_edition/scan_for_target()
-	return // DO NOTHING. We already have our target, and don't wanna do anything from agent_pinpointer
+	// DO NOTHING. We already have our target, and don't wanna do anything from agent_pinpointer
 
 /datum/status_effect/agent_pinpointer/vassal_edition/Destroy()
 	if(scan_target)

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
@@ -90,8 +90,8 @@
 
 /// If we weren't created by a bloodsucker, then we cannot be a vassal (assigned from antag panel)
 /datum/antagonist/vassal/can_be_owned(datum/mind/new_owner)
-//	if(!master)
-//		return FALSE
+	if(!master)
+		return FALSE
 	return ..()
 
 /// Used for Admin removing Vassals.

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
@@ -112,7 +112,12 @@
 	scan_target = antag_datum?.master?.owner?.current
 
 /datum/status_effect/agent_pinpointer/vassal_edition/scan_for_target()
-	// DO NOTHING. We already have our target, and don't wanna do anything from agent_pinpointer
+	return // DO NOTHING. We already have our target, and don't wanna do anything from agent_pinpointer
+
+/datum/status_effect/agent_pinpointer/vassal_edition/Destroy()
+	if(scan_target)
+		to_chat(owner, "<span class='notice'>You've lost your master's trail.</span>")
+	..()
 
 /datum/antagonist/vassal/proc/update_vassal_icons_added(mob/living/vassal, icontype = "vassal")
 	var/datum/atom_hud/antag/bloodsucker/hud = GLOB.huds[ANTAG_HUD_BLOODSUCKER]

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
@@ -1,4 +1,3 @@
-/// NOTE: This can be any "closet" that you are resting AND inside of.
 /datum/antagonist/bloodsucker/proc/ClaimCoffin(obj/structure/closet/crate/claimed)
 	// ALREADY CLAIMED
 	if(claimed.resident)
@@ -69,8 +68,8 @@
 
 //////////////////////////////////////////////
 
-/// NOTE: This can be any "closet" that you are resting AND inside of.
-/obj/structure/closet/crate/proc/ClaimCoffin(mob/living/claimant)
+/// NOTE: This can be any Coffin that you are resting AND inside of.
+/obj/structure/closet/crate/coffin/proc/ClaimCoffin(mob/living/claimant)
 	// Bloodsucker Claim
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = claimant.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	if(bloodsuckerdatum)

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_crypt.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_crypt.dm
@@ -106,17 +106,17 @@
 	if(!user.mind)
 		. += {"<span class='cult'>This is a vassal rack, which allows Bloodsuckers to thrall crewmembers into loyal minions.</span>"}
 		return
-	if(user.mind.has_antag_datum(/datum/antagonist/bloodsucker))
+	if(IS_BLOODSUCKER(user))
 		. += {"<span class='cult'>This is the vassal rack, which allows you to thrall crewmembers into loyal minions in your service.</span>"}
 		. += {"<span class='cult'>You need to first secure the vassal rack by clicking on it while it is in your lair.</span>"}
 		. += {"<span class='cult'>Simply click and hold on a victim, and then drag their sprite on the vassal rack. Alt click on the vassal rack to unbuckle them.</span>"}
 		. += {"<span class='cult'>Make sure that the victim is handcuffed, or else they can simply run away or resist, as the process is not instant.</span>"}
 		. += {"<span class='cult'>To convert the victim, simply click on the vassal rack itself. Sharp weapons work faster than other tools.</span>"}
 	if(user.mind.has_antag_datum(/datum/antagonist/vassal))
-		. += "<span class='notice'>This is the vassal rack, which allows your master to thrall crewmembers into his minions.</span>"
+		. += "<span class='notice'>This is the vassal rack, which allows your master to thrall crewmembers into their minions.</span>"
 		. += "<span class='notice'>Aid your master in bringing their victims here and keeping them secure.</span>"
 		. += "<span class='notice'>You can secure victims to the vassal rack by click dragging the victim onto the rack while it is secured.</span>"
-	if(user.mind.has_antag_datum(/datum/antagonist/monsterhunter))
+	if(IS_MONSTERHUNTER(user))
 		. += {"<span class='cult'>This is the vassal rack, which monsters use to brainwash crewmembers into their loyal slaves.</span>"}
 		. += {"<span class='cult'>They usually ensure that victims are handcuffed, to prevent them from running away.</span>"}
 		. += {"<span class='cult'>Their rituals take time, allowing us to disrupt it.</span>"}
@@ -126,6 +126,9 @@
 		return
 	if(!anchored && IS_BLOODSUCKER(user))
 		to_chat(user, "<span class='danger'>Until this rack is secured in place, it cannot serve its purpose.</span>")
+		return
+	if(issilicon(O))
+		to_chat(user, "<span class='danger'>You realize that Silicon cannot be vassalized, therefore it is useless to buckle them.</span>")
 		return
 	// PULL TARGET: Remember if I was pullin this guy, so we can restore this
 	var/waspulling = (O == owner.pulling)
@@ -410,12 +413,6 @@
 	anchored = FALSE
 	var/lit = FALSE
 
-/*
-/// From candle.dm
-/obj/structure/bloodsucker/candelabrum/is_hot()
-	return FALSE
-*/
-
 /obj/structure/bloodsucker/candelabrum/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
@@ -463,7 +460,7 @@
 		///We dont want vassals or vampires affected by this
 		if(H.mind.has_antag_datum(/datum/antagonist/vassal))
 			return
-		if(H.mind.has_antag_datum(/datum/antagonist/bloodsucker))
+		if(IS_BLOODSUCKER(H))
 			return
 		H.hallucination += 20
 		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "vampcandle", /datum/mood_event/vampcandle)

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_crypt.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_crypt.dm
@@ -122,30 +122,31 @@
 		. += {"<span class='cult'>Their rituals take time, allowing us to disrupt it.</span>"}
 
 /obj/structure/bloodsucker/vassalrack/MouseDrop_T(atom/movable/O, mob/user)
+	/// Default checks
 	if(!O.Adjacent(src) || O == user || !isliving(O) || !isliving(user) || useLock || has_buckled_mobs() || user.incapacitated())
 		return
-	if(!anchored && IS_BLOODSUCKER(user))
-		to_chat(user, "<span class='danger'>Until this rack is secured in place, it cannot serve its purpose.</span>")
-		return
+	/// Not anchored?
+	if(!anchored)
+		/// Let the Bloodsucker know the problem.
+		if(IS_BLOODSUCKER(user))
+			to_chat(user, "<span class='danger'>Until this rack is secured in place, it cannot serve its purpose. (Click with an empty hand)</span>")
+			return
+		/// Not a Bloodsucker? Not our problem.
+		else
+			to_chat(user, "<span class='danger'>You dont fully understand how this works, and you're too scared to move it around.</span>")
+			return
+	/// Don't buckle Silicon to it please.
 	if(issilicon(O))
 		to_chat(user, "<span class='danger'>You realize that Silicon cannot be vassalized, therefore it is useless to buckle them.</span>")
 		return
-	// PULL TARGET: Remember if I was pullin this guy, so we can restore this
-	var/waspulling = (O == owner.pulling)
-	var/wasgrabstate = owner.grab_state
-	// 		* MOVE! *
-	O.forceMove(drop_location())
-	// PULL TARGET: Restore?
-	if(waspulling)
-		owner.start_pulling(O, wasgrabstate, TRUE)
-		// NOTE: in lunge.dm, we use [target.grabbedby(owner)], which simulates doing a grab action. We don't want that though...we're cutting directly back to where we were in a grab.
+	/// Start buckling!
 	useLock = TRUE
 	if(do_mob(user, O, 5 SECONDS))
 		attach_victim(O,user)
 	useLock = FALSE
 
 /// Attempt Release (Owner vs Non Owner)
-/obj/structure/bloodsucker/vassalrack/AltClick(mob/user)
+/obj/structure/bloodsucker/vassalrack/AltClick(mob/user) // WILLARDTODO: Replace this with RightClickOn once we get it via TGU (And change the description!) // WILLARDTODO: Re-do the entire fucking persuasion rack god I hate it
 	if(!has_buckled_mobs() || !isliving(user) || useLock)
 		return
 	var/mob/living/carbon/C = pick(buckled_mobs)

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_crypt.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_crypt.dm
@@ -108,10 +108,10 @@
 		return
 	if(IS_BLOODSUCKER(user))
 		. += {"<span class='cult'>This is the vassal rack, which allows you to thrall crewmembers into loyal minions in your service.</span>"}
-		. += {"<span class='cult'>You need to first secure the vassal rack by clicking on it while it is in your lair.</span>"}
+		. += {"<span class='cult'>Clicking on the rack with an empty hand while it is in your lair will permanently secure it in place.</span>"}
 		. += {"<span class='cult'>Simply click and hold on a victim, and then drag their sprite on the vassal rack. Alt click on the vassal rack to unbuckle them.</span>"}
 		. += {"<span class='cult'>Make sure that the victim is handcuffed, or else they can simply run away or resist, as the process is not instant.</span>"}
-		. += {"<span class='cult'>To convert the victim, simply click on the vassal rack itself. Sharp weapons work faster than other tools.</span>"}
+		. += {"<span class='cult'>To convert into a Vassal, repeatedly click on the persuasion rack. The time required scales with the tool in your off hand.</span>"}
 	if(IS_VASSAL(user))
 		. += "<span class='notice'>This is the vassal rack, which allows your master to thrall crewmembers into their minions.</span>"
 		. += "<span class='notice'>Aid your master in bringing their victims here and keeping them secure.</span>"

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_crypt.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_crypt.dm
@@ -186,8 +186,13 @@
 							"<span class='danger'>You attempt to release yourself from the rack!</span>") //  For sound if not seen -->  "<span class='italics'>You hear a squishy wet noise.</span>")
 		else
 			M.visible_message("<span class='danger'>[user] tries to pull [M] rack!</span>") //  For sound if not seen -->  "<span class='italics'>You hear a squishy wet noise.</span>")
-		if(!do_mob(user, M, 45 SECONDS))
-			return
+		if(IS_MONSTERHUNTER(user))
+			/// Monster hunters are used to this sort of stuff.
+			if(!do_mob(user, M, 10 SECONDS))
+				return
+		else
+			if(!do_mob(user, M, 25 SECONDS))
+				return
 	..()
 	unbuckle_mob(M)
 
@@ -243,9 +248,9 @@
 	torture_victim(user, C)
 
 /*
- * 	// Step One:	Tick Down Conversion from 3 to 0
- *	// Step Two:	Break mindshielding/antag (on approve)
- *	// Step Three:	Blood Ritual
+ *	Step One: Tick Down Conversion from 3 to 0
+ *	Step Two: Break mindshielding/antag (on approve)
+ *	Step Three: Blood Ritual
  */
 
 /obj/structure/bloodsucker/vassalrack/proc/torture_victim(mob/living/user, mob/living/target)
@@ -258,7 +263,9 @@
 		if(!do_torture(user,target))
 			to_chat(user, "<span class='danger'><i>The ritual has been interrupted!</i></span>")
 		else
-			convert_progress-- // Ouch. Stop. Don't.
+			/// Prevent them from unbuckling themselves as long as we're torturing.
+			target.Paralyze(1 SECONDS)
+			convert_progress--
 			// All done!
 			if(convert_progress <= 0)
 				if(RequireDisloyalty(user,target))

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_daylight.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_daylight.dm
@@ -55,6 +55,8 @@
 				var/datum/antagonist/bloodsucker/bloodsuckerdatum = M.has_antag_datum(/datum/antagonist/bloodsucker)
 				if(!istype(bloodsuckerdatum))
 					continue
+				/// Sol is over? Give them a unique pass to end Torpor.
+				bloodsuckerdatum.Torpor_End()
 				bloodsuckerdatum.warn_sun_locker = FALSE
 				bloodsuckerdatum.warn_sun_burn = FALSE
 				for(var/datum/action/bloodsucker/P in bloodsuckerdatum.powers)

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
@@ -39,7 +39,7 @@
 /mob/living/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()
 	SEND_SIGNAL(src,COMSIG_LIVING_BIOLOGICAL_LIFE, delta_time, times_fired)
-	
+
 
 
 /// INTEGRATION: Adding Procs and Datums to existing "classes"

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
@@ -39,13 +39,7 @@
 /mob/living/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()
 	SEND_SIGNAL(src,COMSIG_LIVING_BIOLOGICAL_LIFE, delta_time, times_fired)
-
-/obj/item/implant/mindshield/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
-	. = ..()
-	if(..())
-		if(target.mind.has_antag_datum(/datum/antagonist/vassal))
-			target.mind.remove_antag_datum(/datum/antagonist/vassal)
-
+	
 
 
 /// INTEGRATION: Adding Procs and Datums to existing "classes"

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -128,8 +128,7 @@
 	/// Remove their husk first, so everything else can work
 	C.cure_husk()
 	/// Now repair their organs - Note that Bloodsuckers currently (if intended) don't regenerate lost organs.
-		// Giving them passive organ regeneration will cause Torpor to spam /datum/client_colour/monochrome at you!
-	for(var/O in C.internal_organs)
+	for(var/O in C.internal_organs) // NOTE: Giving them passive organ regeneration will cause Torpor to spam /datum/client_colour/monochrome at you!
 		var/obj/item/organ/organ = O
 		organ.setOrganDamage(0)
 	/// Torpor revives the dead once complete.
@@ -143,6 +142,16 @@
 	for(var/thing in C.diseases)
 		var/datum/disease/D = thing
 		D.cure()
+	/// Remove Body Eggs & Zombie tumors - From panacea.dm
+	var/list/bad_organs = list(
+		C.getorgan(/obj/item/organ/body_egg),
+		C.getorgan(/obj/item/organ/zombie_infection))
+	for(var/tumors in bad_organs)
+		var/obj/item/organ/yucky_organs = tumors
+		if(!istype(yucky_organs))
+			continue
+		yucky_organs.Remove(C)
+		yucky_organs.forceMove(get_turf(C))
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -265,7 +265,8 @@
 		return
 	/// We are dead now.
 	AmFinalDeath = TRUE
-	if(!iscarbon(owner.current)) //Check for non carbons.
+	/// Check for non carbons.
+	if(!iscarbon(owner.current))
 		owner.current.gib()
 		return
 	playsound(get_turf(owner.current), 'sound/effects/tendril_destroyed.ogg', 60, 1)
@@ -273,15 +274,15 @@
 	owner.current.unequip_everything()
 	var/mob/living/carbon/C = owner.current
 	C.remove_all_embedded_objects()
-	// Free my Vassals!
+	/// Free my Vassals!
 	FreeAllVassals()
-	// Elders get Dusted
+	/// Elders get Dusted
 	if(bloodsucker_level >= 4)
 		owner.current.visible_message("<span class='warning'>[owner.current]'s skin crackles and dries, their skin and bones withering to dust. A hollow cry whips from what is now a sandy pile of remains.</span>", \
 			 "<span class='userdanger'>Your soul escapes your withering body as the abyss welcomes you to your Final Death.</span>", \
 			 "<span class='italics'>You hear a dry, crackling sound.</span>")
 		addtimer(CALLBACK(owner.current, /mob/living/proc/dust), 5 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
-	// Fledglings get Gibbed
+	/// Fledglings get Gibbed
 	else
 		owner.current.visible_message("<span class='warning'>[owner.current]'s skin bursts forth in a spray of gore and detritus. A horrible cry echoes from what is now a wet pile of decaying meat.</span>", \
 			 "<span class='userdanger'>Your soul escapes your withering body as the abyss welcomes you to your Final Death.</span>", \

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -125,16 +125,24 @@
 
 /datum/antagonist/bloodsucker/proc/CureDisabilities()
 	var/mob/living/carbon/C = owner.current
+	/// Remove their husk first, so everything else can work
+	C.cure_husk()
+	/// Now repair their organs - Note that Bloodsuckers currently (if intended) don't regenerate lost organs.
+		// Giving them passive organ regeneration will cause Torpor to spam /datum/client_colour/monochrome at you!
 	for(var/O in C.internal_organs)
 		var/obj/item/organ/organ = O
 		organ.setOrganDamage(0)
-	C.cure_husk()
 	/// Torpor revives the dead once complete.
 	if(C.stat == DEAD)
 		C.revive(full_heal = FALSE, admin_revive = FALSE)
+	/// Clear all Wounds
 	for(var/i in C.all_wounds)
 		var/datum/wound/iter_wound = i
 		iter_wound.remove_wound()
+	/// Remove all diseases - In case you got one while on Masquerade, or disease has Inorganic Biology.
+	for(var/thing in C.diseases)
+		var/datum/disease/D = thing
+		D.cure()
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -172,10 +180,10 @@
 		for(var/datum/action/bloodsucker/masquerade/P in powers)
 			P.Deactivate()
 	*/
-	/// Temporary Death? Convert to Torpor
+	/// Temporary Death? Convert to Torpor.
 	if(owner.current.stat == DEAD)
 		var/mob/living/carbon/human/H = owner.current
-		/// We won't use the spam check if they're on masquerade, we want to spam them until they notice, else they'll cry about shit being broken.
+		/// We won't use the spam check if they're on masquerade, we want to spam them until they notice, else they'll cry to me about shit being broken.
 		if(poweron_masquerade)
 			to_chat(H, "<span class='warning'>Your wounds will not heal until you disable the <span class='boldnotice'>Masquerade</span> power.</span>")
 		else if(!HAS_TRAIT(H, TRAIT_NODEATH))

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -237,11 +237,11 @@
 				to_chat(owner.current, "<span class='userdanger'>You are staked! Remove the offending weapon from your heart before sleeping.</span>")
 				return
 			/// Otherwise, check for Sol, or if injured enough to enter Torpor.
-			if(bloodsucker_sunlight.amDay || total_damage >= 10)
+			if(clan.bloodsucker_sunlight.amDay || total_damage >= 10)
 				to_chat(owner.current, "<span class='notice'>You enter the horrible slumber of deathless Torpor. You will heal until you are renewed.</span>")
 				Torpor_Begin()
 	/// Used for ending Torpor.
-	if(!bloodsucker_sunlight.amDay && total_damage <= 0)
+	if(!clan.bloodsucker_sunlight.amDay && total_damage <= 0)
 		if(HAS_TRAIT(owner.current, TRAIT_NODEATH))
 			Torpor_End()
 			to_chat(owner.current, "<span class='warning'>You have recovered from Torpor.</span>")

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -90,15 +90,14 @@
 		var/costMult = 1 // Coffin makes it cheaper
 		var/bruteheal = min(C.getBruteLoss_nonProsthetic(), actual_regen) // BRUTE: Always Heal
 		var/fireheal = 0 // BURN: Heal in Coffin while Fakedeath, or when damage above maxhealth (you can never fully heal fire)
-		var/amInCoffinWhileTorpor = istype(C.loc, /obj/structure/closet/crate/coffin) && HAS_TRAIT(C, TRAIT_NODEATH)
-		if(amInCoffinWhileTorpor)
+		/// Checks if you're in a coffin here, additionally checks for Torpor right below it.
+		var/amInCoffinWhileTorpor = istype(C.loc, /obj/structure/closet/crate/coffin)
+		if(amInCoffinWhileTorpor && HAS_TRAIT(C, TRAIT_NODEATH))
 			fireheal = min(C.getFireLoss_nonProsthetic(), actual_regen)
 			mult *= 5 // Increase multiplier if we're sleeping in a coffin.
 			C.extinguish_mob()
 			C.remove_all_embedded_objects() // Remove Embedded!
 			CheckVampOrgans() // Heart
-			for(var/obj/item/organ/O in C.internal_organs)
-				O.setOrganDamage(0)
 			if(check_limbs(costMult))
 				return TRUE
 		/// Heal if Damaged

--- a/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
@@ -93,7 +93,7 @@
 	living_players -= M.mind
 	var/datum/antagonist/bloodsucker/sucker = new
 	M.mind.add_antag_datum(sucker)
-	sucker.bloodsucker_level_unspent = rand(2,4)
+	sucker.bloodsucker_level_unspent = rand(2,3)
 	message_admins("[ADMIN_LOOKUPFLW(M)] was selected by the [name] ruleset and has been made into a midround Bloodsucker.")
 	log_game("DYNAMIC: [key_name(M)] was selected by the [name] ruleset and has been made into a midround Bloodsucker.")
 	return TRUE
@@ -122,7 +122,7 @@
 	assigned += M.mind
 	var/datum/antagonist/bloodsucker/sucker = new
 	M.mind.add_antag_datum(sucker)
-	sucker.bloodsucker_level_unspent = rand(2,4)
+	sucker.bloodsucker_level_unspent = rand(2,3)
 	message_admins("[ADMIN_LOOKUPFLW(M)] was selected by the [name] ruleset and has been made into a latejoin Bloodsucker.")
 	log_game("DYNAMIC: [key_name(M)] was selected by the [name] ruleset and has been made into a latejoin Bloodsucker.")
 	return TRUE

--- a/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
@@ -193,9 +193,9 @@
 	// No List?
 	if(!islist(M.antag_datums) || M.antag_datums.len == 0)
 		return FALSE
-	// Does even ONE antag appear in this mind that isn't in the list? Then FAIL!
+	/// Checks if the person is an antag banned from being vassalized, stored in bloodsucker's datum.
 	for(var/datum/antagonist/antag_datum in M.antag_datums)
-		if(!(antag_datum.type in vassal_allowed_antags))  // vassal_allowed_antags is a list stored in Bloodsucker's datum, above.
+		if(antag_datum.type in vassal_banned_antags)
 			//message_admins("DEBUG VASSAL: Found Invalid: [antag_datum] // [antag_datum.type]")
 			return TRUE
 	//message_admins("DEBUG VASSAL: Valid Antags! (total of [M.antag_datums.len])")

--- a/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
@@ -89,11 +89,11 @@
 
 /datum/dynamic_ruleset/midround/bloodsucker/execute()
 	var/mob/M = pick(living_players)
-	assigned += M
-	living_players -= M
-	var/datum/antagonist/bloodsucker/Sucker = new
-	M.mind.add_antag_datum(Sucker)
-	Sucker.bloodsucker_level_unspent = rand(2,5)
+	assigned += M.mind
+	living_players -= M.mind
+	var/datum/antagonist/bloodsucker/sucker = new
+	M.mind.add_antag_datum(sucker)
+	sucker.bloodsucker_level_unspent = rand(2,4)
 	message_admins("[ADMIN_LOOKUPFLW(M)] was selected by the [name] ruleset and has been made into a midround Bloodsucker.")
 	log_game("DYNAMIC: [key_name(M)] was selected by the [name] ruleset and has been made into a midround Bloodsucker.")
 	return TRUE
@@ -116,6 +116,16 @@
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	/// We should preferably not just have several Bloodsucker midrounds, as they are nerfed hard due to missing Sols.
 	repeatable = FALSE
+
+/datum/dynamic_ruleset/latejoin/bloodsucker/execute()
+	var/mob/M = pick(candidates) // This should contain a single player, but in case.
+	assigned += M.mind
+	var/datum/antagonist/bloodsucker/sucker = new
+	M.mind.add_antag_datum(sucker)
+	sucker.bloodsucker_level_unspent = rand(2,4)
+	message_admins("[ADMIN_LOOKUPFLW(M)] was selected by the [name] ruleset and has been made into a latejoin Bloodsucker.")
+	log_game("DYNAMIC: [key_name(M)] was selected by the [name] ruleset and has been made into a latejoin Bloodsucker.")
+	return TRUE
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
@@ -16,26 +16,32 @@
 	scaling_cost = 9
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	antag_cap = list("denominator" = 24)
+	var/datum/team/vampireclan/bloodsucker_clan
+
+/datum/dynamic_ruleset/roundstart/bloodsucker/ready(population, forced = FALSE)
+	required_candidates = get_antag_cap(population)
+	. = ..()
 
 /datum/dynamic_ruleset/roundstart/bloodsucker/pre_execute(population)
 	. = ..()
 	var/num_bloodsuckers = get_antag_cap(population) * (scaled_times + 1)
-
 	for(var/i = 1 to num_bloodsuckers)
-		var/mob/picked_candidate = pick_n_take(candidates)
-		assigned += picked_candidate.mind
-		picked_candidate.mind.restricted_roles = restricted_roles
-		picked_candidate.mind.special_role = ROLE_BLOODSUCKER
-		GLOB.pre_setup_antags += picked_candidate.mind
+		if(candidates.len <= 0)
+			break
+		var/mob/M = pick_n_take(candidates)
+		assigned += M.mind
+		M.mind.special_role = ROLE_BLOODSUCKER
+		M.mind.restricted_roles = restricted_roles
+		GLOB.pre_setup_antags += M.mind
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/bloodsucker/execute()
-
-	for(var/c in assigned)
-		var/datum/mind/bloodsucker = c
+	bloodsucker_clan = new
+	for(var/datum/mind/M in assigned)
 		var/datum/antagonist/bloodsucker/new_antag = new antag_datum()
-		bloodsucker.add_antag_datum(new_antag)
-		GLOB.pre_setup_antags -= bloodsucker
+		new_antag.clan = bloodsucker_clan
+		M.add_antag_datum(new_antag)
+		GLOB.pre_setup_antags -= M
 	return TRUE
 
 //////////////////////////////////////////////

--- a/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
@@ -98,6 +98,25 @@
 	log_game("DYNAMIC: [key_name(M)] was selected by the [name] ruleset and has been made into a midround Bloodsucker.")
 	return TRUE
 
+//////////////////////////////////////////////
+//                                          //
+//          LATEJOIN BLOODSUCKER            //
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/latejoin/bloodsucker
+	name = "Bloodsucker Breakout"
+	antag_datum = /datum/antagonist/bloodsucker
+	antag_flag = ROLE_BLOODSUCKER
+	protected_roles = list("Captain", "Head of Personnel", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Quartermaster", "Warden", "Security Officer", "Detective", "Brig Physician", "Deputy",)
+	restricted_roles = list("AI","Cyborg")
+	required_candidates = 1
+	weight = 5
+	cost = 10
+	requirements = list(10,10,10,10,10,10,10,10,10,10)
+	/// We should preferably not just have several Bloodsucker midrounds, as they are nerfed hard due to missing Sols.
+	repeatable = FALSE
+
 //////////////////////////////////////////////////////////////////////////////
 
 /*

--- a/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
@@ -199,19 +199,19 @@
 		return FALSE
 	return TRUE
 
-/datum/antagonist/bloodsucker/proc/AmValidAntag(datum/mind/M)
-	// No List?
-	if(!islist(M.antag_datums) || M.antag_datums.len == 0)
-		return FALSE
-	// Am I NOT an invalid Antag? NOTE: We already excluded non-antags above. Don't worry about the "No List?" check in AmInvalidIntag()
-	return !AmInvalidAntag(M)
+/datum/antagonist/bloodsucker/proc/AmValidAntag(mob/M)
+	/// Check if they are an antag, if so, check if they're Invalid.
+	if(M.mind?.special_role || !isnull(M.mind?.antag_datums))
+		return !AmInvalidAntag(M)
+	/// Otherwise, just cancel out.
+	return FALSE
 
-/datum/antagonist/bloodsucker/proc/AmInvalidAntag(datum/mind/M)
-	// No List?
-	if(!islist(M.antag_datums) || M.antag_datums.len == 0)
+/datum/antagonist/bloodsucker/proc/AmInvalidAntag(mob/M)
+	/// Not an antag?
+	if(!M.mind?.special_role || isnull(M.mind?.antag_datums))
 		return FALSE
 	/// Checks if the person is an antag banned from being vassalized, stored in bloodsucker's datum.
-	for(var/datum/antagonist/antag_datum in M.antag_datums)
+	for(var/datum/antagonist/antag_datum in M.mind.antag_datums)
 		if(antag_datum.type in vassal_banned_antags)
 			//message_admins("DEBUG VASSAL: Found Invalid: [antag_datum] // [antag_datum.type]")
 			return TRUE

--- a/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
@@ -215,7 +215,7 @@
 
 /datum/antagonist/bloodsucker/proc/attempt_turn_vassal(mob/living/carbon/C)
 	C.silent = 0
-	return make_vassal(C,owner)
+	return make_vassal(C, owner)
 
 /datum/antagonist/bloodsucker/proc/make_vassal(mob/living/target, datum/mind/creator)
 	if(!can_make_vassal(target, creator))

--- a/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/gamemodes/bloodsucker_gamemode.dm
@@ -57,7 +57,7 @@
 	/// We should preferably not just have several Bloodsucker midrounds, as they are nerfed hard due to missing Sols.
 	repeatable = FALSE
 
-/datum/dynamic_ruleset/midround/autotraitor/acceptable(population = 0, threat = 0)
+/datum/dynamic_ruleset/midround/bloodsucker/acceptable(population = 0, threat = 0)
 	var/player_count = mode.current_players[CURRENT_LIVING_PLAYERS].len
 	var/antag_count = mode.current_players[CURRENT_LIVING_ANTAGS].len
 	var/max_suckers = round(player_count / 10) + 1
@@ -72,7 +72,7 @@
 
 	return ..()
 
-/datum/dynamic_ruleset/midround/autotraitor/trim_candidates()
+/datum/dynamic_ruleset/midround/bloodsucker/trim_candidates()
 	..()
 	for(var/mob/living/player in living_players)
 		if(issilicon(player)) // Your assigned role doesn't change when you are turned into a silicon.
@@ -82,39 +82,21 @@
 		else if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
 			living_players -= player // We don't allow people with roles already
 
-/datum/dynamic_ruleset/midround/autotraitor/ready(forced = FALSE)
+/datum/dynamic_ruleset/midround/bloodsucker/ready(forced = FALSE)
 	if (required_candidates > living_players.len)
 		return FALSE
 	return ..()
 
-/datum/dynamic_ruleset/midround/autotraitor/execute()
+/datum/dynamic_ruleset/midround/bloodsucker/execute()
 	var/mob/M = pick(living_players)
 	assigned += M
 	living_players -= M
 	var/datum/antagonist/bloodsucker/Sucker = new
 	M.mind.add_antag_datum(Sucker)
+	Sucker.bloodsucker_level_unspent = rand(2,5)
 	message_admins("[ADMIN_LOOKUPFLW(M)] was selected by the [name] ruleset and has been made into a midround Bloodsucker.")
 	log_game("DYNAMIC: [key_name(M)] was selected by the [name] ruleset and has been made into a midround Bloodsucker.")
 	return TRUE
-
-//////////////////////////////////////////////
-//                                          //
-//          LATEJOIN BLOODSUCKER            //
-//                                          //
-//////////////////////////////////////////////
-
-/datum/dynamic_ruleset/latejoin/bloodsucker
-	name = "Bloodsucker Breakout"
-	antag_datum = /datum/antagonist/bloodsucker
-	antag_flag = ROLE_BLOODSUCKER
-	protected_roles = list("Captain", "Head of Personnel", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Quartermaster", "Warden", "Security Officer", "Detective", "Brig Physician", "Deputy",)
-	restricted_roles = list("AI","Cyborg")
-	required_candidates = 1
-	weight = 5
-	cost = 10
-	requirements = list(10,10,10,10,10,10,10,10,10,10)
-	/// We should preferably not just have several Bloodsucker midrounds, as they are nerfed hard due to missing Sols.
-	repeatable = FALSE
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/fulp_modules/main_features/bloodsuckers/code/gamemodes/monsterhunter_gamemode.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/gamemodes/monsterhunter_gamemode.dm
@@ -9,49 +9,12 @@
  */
 
 
-/// The default, for Bloodsucker rounds.
-/datum/round_event_control/bloodsucker_hunters
-	name = "Spawn Monster Hunter - Bloodsucker"
-	typepath = /datum/round_event/bloodsucker_hunters
-	max_occurrences = 1
-	weight = 2000
-	min_players = 10
-	earliest_start = 30 MINUTES
-	alert_observers = FALSE
-
-/datum/round_event/bloodsucker_hunters
-	fakeable = FALSE
-
-/datum/round_event/bloodsucker_hunters/start()
-	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
-		if(!H.mind.has_antag_datum(/datum/antagonist/bloodsucker))
-			break
-		if(!H.client || !(ROLE_MONSTERHUNTER in H.client.prefs.be_special))
-			continue
-		if(H.stat == DEAD)
-			continue
-		if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions))
-			continue
-		if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.command_positions))
-			continue
-		if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.security_positions))
-			continue
-		if(H.mind.has_antag_datum(/datum/antagonist/vassal))
-			continue
-		if(H.mind.has_antag_datum(/datum/antagonist/bloodsucker))
-			continue
-		if(!H.getorgan(/obj/item/organ/brain))
-			continue
-		H.mind.add_antag_datum(/datum/antagonist/monsterhunter)
-		message_admins("BLOODSUCKER NOTICE: [H] has awoken as a Monster Hunter.")
-		break
-
-/// Randomly spawned Monster hunters during TraitorChangeling, Changeling, Heretic and Cult rounds.
+/// Spawns monster hunters.
 /datum/round_event_control/monster_hunters
-	name = "Spawn Monster Hunter - Misc"
+	name = "Spawn Monster Hunter"
 	typepath = /datum/round_event/monster_hunters
 	max_occurrences = 1
-	weight = 7
+	weight = 9
 	min_players = 10
 	earliest_start = 25 MINUTES
 	alert_observers = FALSE
@@ -61,15 +24,8 @@
 
 /datum/round_event/monster_hunters/start()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
-		if(!H.mind.has_antag_datum(/datum/antagonist/changeling))
-			break
-		if(!H.mind.has_antag_datum(/datum/antagonist/heretic))
-			break
-		if(!H.mind.has_antag_datum(/datum/antagonist/cult))
-			break
-		if(!H.mind.has_antag_datum(/datum/antagonist/wizard))
-			break
-		if(!H.mind.has_antag_datum(/datum/antagonist/wizard/apprentice))
+		/// Make sure there are monsters on the station, otherwise don't spawn them in.
+		if(!H.mind.has_antag_datum(/datum/antagonist/bloodsucker) || !H.mind.has_antag_datum(/datum/antagonist/changeling) || !H.mind.has_antag_datum(/datum/antagonist/heretic) || !H.mind.has_antag_datum(/datum/antagonist/cult) || !H.mind.has_antag_datum(/datum/antagonist/wizard))
 			break
 		if(!H.client || !(ROLE_MONSTERHUNTER in H.client.prefs.be_special))
 			continue

--- a/fulp_modules/main_features/bloodsuckers/code/gamemodes/monsterhunter_gamemode.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/gamemodes/monsterhunter_gamemode.dm
@@ -1,7 +1,7 @@
 /*
  * 		MONSTER HUNTERS:
  * 	Their job is to hunt Monsters.
- * 	I didnt know what better way to implement this, so they just cancel out if the antag is missing
+ * 	I didnt know what better way to implement this, so they just cancel out if there's no monsters.
  * 	They can also be used as Admin-only antags during rounds such as;
  * 	- Changeling murderboning rounds
  * 	- Lategame Cult round
@@ -27,6 +27,7 @@
 		/// Make sure there are monsters on the station, otherwise don't spawn them in.
 		if(!H.mind.has_antag_datum(/datum/antagonist/bloodsucker) || !H.mind.has_antag_datum(/datum/antagonist/changeling) || !H.mind.has_antag_datum(/datum/antagonist/heretic) || !H.mind.has_antag_datum(/datum/antagonist/cult) || !H.mind.has_antag_datum(/datum/antagonist/wizard))
 			break
+		/// From obsessed
 		if(!H.client || !(ROLE_MONSTERHUNTER in H.client.prefs.be_special))
 			continue
 		if(H.stat == DEAD)

--- a/fulp_modules/main_features/bloodsuckers/code/gamemodes/monsterhunter_gamemode.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/gamemodes/monsterhunter_gamemode.dm
@@ -1,30 +1,31 @@
 /*
  * 		MONSTER HUNTERS:
  * 	Their job is to hunt Monsters.
- * 	They spawn by default 35 minutes into a Bloodsucker round,
- * 	They also randomly spawn in other rounds, as some unique flavor.
+ * 	I didnt know what better way to implement this, so they just cancel out if the antag is missing
  * 	They can also be used as Admin-only antags during rounds such as;
  * 	- Changeling murderboning rounds
  * 	- Lategame Cult round
  * 	- Ect.
  */
 
+
 /// The default, for Bloodsucker rounds.
 /datum/round_event_control/bloodsucker_hunters
 	name = "Spawn Monster Hunter - Bloodsucker"
 	typepath = /datum/round_event/bloodsucker_hunters
-	max_occurrences = 1 // We have to see how Bloodsuckers are in game to decide if having more than 1 is beneficial.
+	max_occurrences = 1
 	weight = 2000
 	min_players = 10
-	earliest_start = 35 MINUTES
+	earliest_start = 30 MINUTES
 	alert_observers = FALSE
-	gamemode_whitelist = list("bloodsucker")
 
 /datum/round_event/bloodsucker_hunters
 	fakeable = FALSE
 
 /datum/round_event/bloodsucker_hunters/start()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
+		if(!H.mind.has_antag_datum(/datum/antagonist/bloodsucker))
+			break
 		if(!H.client || !(ROLE_MONSTERHUNTER in H.client.prefs.be_special))
 			continue
 		if(H.stat == DEAD)
@@ -54,13 +55,22 @@
 	min_players = 10
 	earliest_start = 25 MINUTES
 	alert_observers = FALSE
-	gamemode_whitelist = list("changeling","heresy","cult")
 
 /datum/round_event/monster_hunters
 	fakeable = FALSE
 
 /datum/round_event/monster_hunters/start()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
+		if(!H.mind.has_antag_datum(/datum/antagonist/changeling))
+			break
+		if(!H.mind.has_antag_datum(/datum/antagonist/heretic))
+			break
+		if(!H.mind.has_antag_datum(/datum/antagonist/cult))
+			break
+		if(!H.mind.has_antag_datum(/datum/antagonist/wizard))
+			break
+		if(!H.mind.has_antag_datum(/datum/antagonist/wizard/apprentice))
+			break
 		if(!H.client || !(ROLE_MONSTERHUNTER in H.client.prefs.be_special))
 			continue
 		if(H.stat == DEAD)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/brawn.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/brawn.dm
@@ -1,6 +1,6 @@
 /datum/action/bloodsucker/targeted/brawn
 	name = "Brawn"
-	desc = "Snap restraints with ease, or deal terrible damage with your bare hands."
+	desc = "Snap restraints, break lockers and doors, or deal terrible damage with your bare hands."
 	button_icon_state = "power_strength"
 	bloodcost = 8
 	cooldown = 90

--- a/fulp_modules/main_features/bloodsuckers/code/powers/brawn.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/brawn.dm
@@ -150,6 +150,19 @@
 		else
 			to_chat(user, "<span class='notice'>You are not strong enough to pry this open.</span>")
 			return FALSE
+	// Target Type: Locker
+	else if(istype(target, /obj/structure/closet))
+		if(level_current >= 2)
+			var/obj/structure/closet/C = target
+			to_chat(user, "<span class='notice'>You prepare to break [C] open.</span>")
+			if(do_mob(usr, target, 2.5 SECONDS))
+				C.visible_message("<span class='warning'>[C] breaks open as [user] bashes the locker!</span>")
+				to_chat(user, "<span class='warning'>We bash [C] wide open!</span>")
+				addtimer(CALLBACK(src, .proc/break_closet, user, C), 1)
+				playsound(get_turf(user), 'sound/effects/grillehit.ogg', 80, 1, -1)
+		else
+			to_chat(user, "<span class='notice'>You are not strong enough to break this open.</span>")
+			return FALSE
 
 /datum/action/bloodsucker/targeted/brawn/CheckValidTarget(atom/A)
 	return isliving(A) || istype(A, /obj/machinery/door) || istype(A, /obj/structure/closet)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/brawn.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/brawn.dm
@@ -67,7 +67,7 @@
 		var/obj/structure/closet/C = user.loc
 		if(!istype(C))
 			return FALSE
-		C.visible_message("<span class='warning'>[C] tears apart as [user] bashes the locker open from within!</span>")
+		C.visible_message("<span class='warning'>[C] tears apart as [user] bashes it open from within!</span>")
 		to_chat(user, "<span class='warning'>We bash [C] wide open!</span>")
 		addtimer(CALLBACK(src, .proc/break_closet, user, C), 1)
 		playsound(get_turf(user), 'sound/effects/grillehit.ogg', 80, 1, -1)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/cloak.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/cloak.dm
@@ -1,6 +1,6 @@
 /datum/action/bloodsucker/cloak
 	name = "Cloak of Darkness"
-	desc = "Blend into the shadows and become invisible to the untrained eye. Slows you down and you cannot dissapear while mortals watch you."
+	desc = "Blend into the shadows and become invisible to the untrained and Artificial eye. Slows you down and you cannot dissapear while mortals watch you."
 	button_icon_state = "power_cloak"
 	bloodcost = 5
 	cooldown = 50

--- a/fulp_modules/main_features/bloodsuckers/code/powers/cloak.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/cloak.dm
@@ -8,7 +8,6 @@
 	amToggle = TRUE
 	warn_constant_cost = TRUE
 	var/was_running
-	var/lum
 
 /// Must have nobody around to see the cloak
 /datum/action/bloodsucker/cloak/CheckCanUse(display_error)
@@ -27,10 +26,11 @@
 	was_running = (user.m_intent == MOVE_INTENT_RUN)
 	if(was_running)
 		user.toggle_move_intent()
+	user.AddElement(/datum/element/digitalcamo)
 
 	while(bloodsuckerdatum && ContinueActive(user))
 		// Pay Blood Toll (if awake)
-		owner.alpha = max(35, owner.alpha - min(75, 10 + 5 * level_current))
+		owner.alpha = max(25, owner.alpha - min(75, 10 + 5 * level_current))
 		if(user.stat == CONSCIOUS)
 			bloodsuckerdatum.AddBloodVolume(-0.2)
 		if(user.m_intent != MOVE_INTENT_WALK) // Prevents running while on Fortitude
@@ -50,6 +50,6 @@
 /datum/action/bloodsucker/cloak/DeactivatePower(mob/living/user = owner, mob/living/target)
 	..()
 	user.alpha = 255
-
+	user.RemoveElement(/datum/element/digitalcamo)
 	if(was_running && user.m_intent == MOVE_INTENT_WALK)
 		user.toggle_move_intent()

--- a/fulp_modules/main_features/bloodsuckers/code/powers/haste.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/haste.dm
@@ -94,3 +94,13 @@
 			L.Knockdown(10 + level_current * 5)
 			L.Paralyze(0.1)
 			L.spin(10, 1)
+			if(IS_MONSTERHUNTER(L) && HAS_TRAIT(L, TRAIT_STUNIMMUNE))
+				to_chat(L, "<span class='warning'>The spinning causes you to lose focus on Flow!</span>")
+				for(var/datum/action/bloodsucker/power in L.actions)
+					if(power.active)
+						power.DeactivatePower()
+				L.Jitter(20)
+				L.set_confusion(max(8, L.get_confusion()))
+				L.stuttering = max(8, L.stuttering)
+				L.Knockdown(10 + level_current * 5) // Re-knock them down, the first one didn't work due to stunimmunity
+

--- a/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
@@ -90,9 +90,12 @@
 		else
 			if(target.stat == DEAD)
 				var/obj/item/organ/heart/myheart_now = locate() in target.internal_organs
-				myheart_now.Remove(target)
-				user.put_in_hands(myheart_now)
-				to_chat(owner, "<span class='warning'>You tear [myheart_now] out of [target]!</span>")
+				if(myheart_now)
+					myheart_now.Remove(target)
+					user.put_in_hands(myheart_now)
+					to_chat(owner, "<span class='warning'>You tear [myheart_now] out of [target]!</span>")
+				else
+					to_chat(user, "<span class='notice'>[target] doesn't have a heart to rip out!</span>")
 			target.grabbedby(owner) // Taken from mutations.dm under changelings
 			target.grippedby(owner, instant = TRUE) //instant aggro grab
 		REMOVE_TRAIT(user, TRAIT_IMMOBILIZED, BLOODSUCKER_TRAIT)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
@@ -89,6 +89,13 @@
 			target.grabbedby(owner)
 		else
 			if(target.stat == DEAD)
+				var/obj/item/bodypart/chest = target.get_bodypart(BODY_ZONE_CHEST)
+				var/datum/wound/slash/moderate/crit_wound = new
+				crit_wound.apply_wound(chest)
+				user.visible_message(
+					"<span class='warning'>[owner] tears into [target]'s chest!</span>",
+					"<span class='warning'>You tear into [target]'s chest!</span>"
+				)
 				var/obj/item/organ/heart/myheart_now = locate() in target.internal_organs
 				if(myheart_now)
 					myheart_now.Remove(target)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
@@ -79,17 +79,22 @@
 	if(target.Adjacent(owner))
 		// LEVEL 2: If behind target, mute or unconscious!
 		if(do_knockdown) // && level_current >= 1)
-			if(!target.mind || !target.mind.has_antag_datum(/datum/antagonist/monsterhunter))
+			if(!IS_MONSTERHUNTER(target))
 				target.Paralyze(15 + 10 * level_current,1)
 		// Cancel Walk (we were close enough to contact them)
 		walk(owner,0)
 		//target.Paralyze(10,1)
-		if(!target.mind || !target.mind.has_antag_datum(/datum/antagonist/monsterhunter))
-			target.grabbedby(owner) // Taken from mutations.dm under changelings
-			target.grippedby(owner, instant = TRUE) //instant aggro grab
-		else
+		if(IS_MONSTERHUNTER(target))
 			to_chat(owner, "<span class='warning'>You get pushed away as you advance, and fail to get a strong grasp!</span>")
 			target.grabbedby(owner)
+		else
+			if(target.stat == DEAD)
+				var/obj/item/organ/heart/myheart_now = locate() in target.internal_organs
+				myheart_now.Remove(target)
+				user.put_in_hands(myheart_now)
+				to_chat(owner, "<span class='warning'>You tear [myheart_now] out of [target]!</span>")
+			target.grabbedby(owner) // Taken from mutations.dm under changelings
+			target.grippedby(owner, instant = TRUE) //instant aggro grab
 		REMOVE_TRAIT(user, TRAIT_IMMOBILIZED, BLOODSUCKER_TRAIT)
 		//	UNCONSCIOUS or MUTE!
 		//owner.start_pulling(target,GRAB_AGGRESSIVE) // GRAB_PASSIVE, GRAB_AGGRESSIVE, GRAB_NECK, GRAB_KILL

--- a/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
@@ -5,7 +5,7 @@
 
 /datum/action/bloodsucker/targeted/lunge
 	name = "Predatory Lunge"
-	desc = "Spring at your target and aggressively grapple them without warning. Attacks from concealment or the rear may even knock them down."
+	desc = "Spring at your target to grapple them without warning, or tear the dead's heart out. Attacks from concealment or the rear may even knock them down."
 	button_icon_state = "power_lunge"
 	bloodcost = 10
 	cooldown = 100

--- a/fulp_modules/main_features/bloodsuckers/code/powers/mesmerize.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/mesmerize.dm
@@ -96,7 +96,7 @@
 		var/power_time = 90 + level_current * 15
 		if(iscarbon(target))
 			var/mob/living/carbon/mesmerized = target
-			if(mesmerized.mind && mesmerized.mind.has_antag_datum(/datum/antagonist/monsterhunter))
+			if(mesmerized.mind && IS_MONSTERHUNTER(mesmerized))
 				to_chat(mesmerized, "<span class='notice'>You feel your eyes burn for a while, but it passes.</span>")
 				return
 			ADD_TRAIT(mesmerized, TRAIT_MUTE, BLOODSUCKER_TRAIT)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/mesmerize.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/mesmerize.dm
@@ -96,7 +96,7 @@
 		var/power_time = 90 + level_current * 15
 		if(iscarbon(target))
 			var/mob/living/carbon/mesmerized = target
-			if(mesmerized.mind && IS_MONSTERHUNTER(mesmerized))
+			if(IS_MONSTERHUNTER(mesmerized))
 				to_chat(mesmerized, "<span class='notice'>You feel your eyes burn for a while, but it passes.</span>")
 				return
 			ADD_TRAIT(mesmerized, TRAIT_MUTE, BLOODSUCKER_TRAIT)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/monstertrack.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/monstertrack.dm
@@ -1,0 +1,78 @@
+/// From 'Cellular Emporium'... somehow?
+/datum/action/bloodsucker/trackvamp
+	name = "Track Monster"
+	desc = "Take a moment to look for clues of any nearby monsters.<br>These creatures are slippery, and often look like the crew."
+	button_icon = 'fulp_modules/main_features/bloodsuckers/icons/actions_bloodsucker.dmi'
+	background_icon_state = "vamp_power_off"
+	icon_icon = 'fulp_modules/main_features/bloodsuckers/icons/actions_bloodsucker.dmi'
+	button_icon_state = "power_hunter"
+	amToggle = FALSE
+	cooldown = 300
+	bloodcost = 5
+	/// Removed, set to TRUE to re-add, either here to be a default function, or in-game through VV for neat Admin stuff -Willard
+	var/give_pinpointer = FALSE
+
+/datum/action/bloodsucker/trackvamp/ActivatePower()
+	. = ..()
+	var/mob/living/carbon/user = owner
+	/// Return text indicating direction
+	to_chat(user, "<span class='notice'>You look around, scanning your environment and discerning signs of any filthy, wretched affronts to the natural order.</span>")
+	if(!do_mob(user, owner, 80))
+		return
+	if(give_pinpointer)
+		user.apply_status_effect(STATUS_EFFECT_HUNTERPINPOINTER)
+	display_proximity()
+	PayCost()
+	// NOTE: DON'T DEACTIVATE!
+	//DeactivatePower()
+
+/datum/action/bloodsucker/trackvamp/proc/display_proximity()
+	/// Pick target
+	var/turf/my_loc = get_turf(owner)
+	var/best_dist = 9999
+	var/mob/living/best_vamp
+
+	/// Track ALL living Monsters.
+	var/list/datum/mind/monsters = list()
+	for(var/mob/living/carbon/C in GLOB.alive_mob_list)
+		if(C.mind)
+			var/datum/mind/UM = C.mind
+			if(UM.has_antag_datum(/datum/antagonist/changeling))
+				monsters += UM
+			if(UM.has_antag_datum(/datum/antagonist/heretic))
+				monsters += UM
+			if(UM.has_antag_datum(/datum/antagonist/bloodsucker))
+				monsters += UM
+			if(UM.has_antag_datum(/datum/antagonist/cult))
+				monsters += UM
+			if(UM.has_antag_datum(/datum/antagonist/ashwalker))
+				monsters += UM
+			if(UM.has_antag_datum(/datum/antagonist/wizard))
+				monsters += UM
+			if(UM.has_antag_datum(/datum/antagonist/wizard/apprentice))
+				monsters += UM
+
+	for(var/datum/mind/M in monsters)
+		if(!M.current || M.current == owner) // || !get_turf(M.current) || !get_turf(owner))
+			continue
+		for(var/a in M.antag_datums)
+			var/datum/antagonist/antag_datum = a
+			if(!istype(antag_datum))
+				continue
+			var/their_loc = get_turf(M.current)
+			var/distance = get_dist_euclidian(my_loc, their_loc)
+			/// Found One: Closer than previous/max distance
+			if (distance < best_dist && distance <= HUNTER_SCAN_MAX_DISTANCE)
+				best_dist = distance
+				best_vamp = M.current
+				/// Stop searching through my antag datums and go to the next guy
+				break
+
+	/// Found one!
+	if(best_vamp)
+		var/distString = best_dist <= HUNTER_SCAN_MAX_DISTANCE / 2 ? "<b>somewhere closeby!</b>" : "somewhere in the distance."
+		to_chat(owner, "<span class='warning'>You detect signs of monsters [distString]</span>")
+
+	/// Will yield a "?"
+	else
+		to_chat(owner, "<span class='notice'>There are no monsters nearby.</span>")

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -39,4 +39,4 @@
 	return TRUE
 
 /datum/action/bloodsucker/recuperate/ContinueActive(mob/living/user)
-	return ..() && user.stat <= DEAD && user.blood_volume > 0 && user.getBruteLoss() > 0
+	return ..() && user.stat <= DEAD && user.blood_volume > 0

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -13,12 +13,13 @@
 	to_chat(owner, "<span class='notice'>Your muscles clench as your master's immortal blood mixes with your own, knitting your wounds.</span>")
 	while(ContinueActive(owner))
 		C.adjustBruteLoss(-1.5)
-		C.adjustFireLoss(-0.5)
 		C.adjustToxLoss(-2, forced = TRUE)
 		C.adjustStaminaLoss(bloodcost * 1.1)
-		/// Plasmamen won't lose blood, they don't have any.
+		/// Plasmamen won't lose blood, they don't have any, so they don't heal from Burn.
 		if(!HAS_TRAIT(C, NOBLOOD))
 			C.blood_volume -= bloodcost
+		else
+			C.adjustFireLoss(-0.5)
 		/// Stop Bleeding
 		if(istype(C) && C.is_bleeding())
 			for(var/obj/item/bodypart/part in C.bodyparts)
@@ -32,11 +33,13 @@
 /*	. = ..()
 	if(!.) // Vassals use this, not Bloodsuckers, so we don't want them using these checks.
 		return */
-	if(!owner.stat)
+	if(owner.stat >= DEAD)
+		to_chat(owner, "<span class='notice'>You are unable to use Recuperate in your state.</span>")
 		return FALSE
 	return TRUE
 
 /datum/action/bloodsucker/recuperate/ContinueActive(mob/living/user)
-	if(user.stat >= HARD_CRIT)
+	if(user.stat >= DEAD)
+		to_chat(user, "<span class='notice'>You lost the ability to keep using Recuperate.</span>")
 		return FALSE
 	return ..()

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -39,4 +39,4 @@
 	return TRUE
 
 /datum/action/bloodsucker/recuperate/ContinueActive(mob/living/user)
-	return ..() && user.stat <= DEAD && user.blood_volume > 0
+	return ..() && user.stat <= DEAD && user.blood_volume > 0 && user.getBruteLoss() > 0

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -39,4 +39,4 @@
 	return TRUE
 
 /datum/action/bloodsucker/recuperate/ContinueActive(mob/living/user)
-	return ..() && user.stat <= DEAD && user.blood_volume > 0 && user.getBruteLoss() > 0
+	return ..() && user.stat <= DEAD && user.blood_volume > 0 && user.getBruteLoss() > 0 && user.getFireLoss() > 0

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -18,12 +18,12 @@
 		C.adjustStaminaLoss(bloodcost * 1.1)
 		/// Plasmamen won't lose blood, they don't have any, so they don't heal from Burn.
 		if(!(NOBLOOD in C.dna.species.species_traits))
-			var/datum/antagonist/bloodsucker/bloodsuckerdatum = vassaldatum.master.owner.has_antag_datum(/datum/antagonist/bloodsucker)
-			if(bloodsuckerdatum)
-				C.blood_volume -= bloodcost
-				C.adjustFireLoss(-0.5)
-			/// Take blood from their Master, too.
-			var/mob/living/carbon/human/H = vassaldatum.master.owner
+			C.blood_volume -= bloodcost
+			C.adjustFireLoss(-0.5)
+		/// Take bloodcost from their Master.
+		var/datum/antagonist/bloodsucker/bloodsuckerdatum = vassaldatum.master.owner.has_antag_datum(/datum/antagonist/bloodsucker)
+		if(bloodsuckerdatum)
+			var/mob/living/carbon/human/H = bloodsuckerdatum.owner
 			H.blood_volume -= bloodcost
 		/// Stop Bleeding
 		if(istype(C) && C.is_bleeding())

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -29,14 +29,14 @@
 	//DeactivatePower(owner)
 
 /datum/action/bloodsucker/recuperate/CheckCanUse(display_error)
-/*	. = ..() /// Vassals use this, not Bloodsuckers, so we don't want them using these checks.
-	if(!.)
+/*	. = ..()
+	if(!.) // Vassals use this, not Bloodsuckers, so we don't want them using these checks.
 		return */
 	if(!owner.stat)
 		return FALSE
 	return TRUE
 
 /datum/action/bloodsucker/recuperate/ContinueActive(mob/living/user)
-	if(user.stat <= DEAD)
+	if(user.stat >= HARD_CRIT)
 		return FALSE
 	return ..()

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -34,12 +34,9 @@
 	if(!.) // Vassals use this, not Bloodsuckers, so we don't want them using these checks.
 		return */
 	if(owner.stat >= DEAD)
-		to_chat(owner, "<span class='notice'>You are unable to use Recuperate in your state.</span>")
+		to_chat(owner, "<span class='notice'>You cannot use Recuperate while incapacitated.</span>")
 		return FALSE
 	return TRUE
 
 /datum/action/bloodsucker/recuperate/ContinueActive(mob/living/user)
-	if(user.stat >= DEAD)
-		to_chat(user, "<span class='notice'>You lost the ability to keep using Recuperate.</span>")
-		return FALSE
-	return ..()
+	return ..() && user.stat <= DEAD && user.blood_volume > 0 && user.getBruteLoss() > 0

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -4,11 +4,12 @@
 	desc = "Slowly heals you overtime using your master's blood, in exchange for some of your own blood and effort."
 	button_icon_state = "power_recup"
 	amToggle = TRUE
-	bloodcost = 5 // Increments every 5 seconds; damage increases over time
+	bloodcost = 3.5 // Increments every 5 seconds; damage increases over time
 	cooldown = 100
 
 /datum/action/bloodsucker/recuperate/ActivatePower()
 	var/mob/living/carbon/human/C = owner
+	var/datum/antagonist/vassal/vassaldatum = owner.mind.has_antag_datum(/datum/antagonist/vassal)
 
 	to_chat(owner, "<span class='notice'>Your muscles clench as your master's immortal blood mixes with your own, knitting your wounds.</span>")
 	while(ContinueActive(owner))
@@ -17,8 +18,13 @@
 		C.adjustStaminaLoss(bloodcost * 1.1)
 		/// Plasmamen won't lose blood, they don't have any, so they don't heal from Burn.
 		if(!(NOBLOOD in C.dna.species.species_traits))
-			C.blood_volume -= bloodcost
-			C.adjustFireLoss(-0.5)
+			var/datum/antagonist/bloodsucker/bloodsuckerdatum = vassaldatum.master.owner.has_antag_datum(/datum/antagonist/bloodsucker)
+			if(bloodsuckerdatum)
+				C.blood_volume -= bloodcost
+				C.adjustFireLoss(-0.5)
+			/// Take blood from their Master, too.
+			var/mob/living/carbon/human/H = vassaldatum.master.owner
+			H.blood_volume -= bloodcost
 		/// Stop Bleeding
 		if(istype(C) && C.is_bleeding())
 			for(var/obj/item/bodypart/part in C.bodyparts)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -16,9 +16,8 @@
 		C.adjustToxLoss(-2, forced = TRUE)
 		C.adjustStaminaLoss(bloodcost * 1.1)
 		/// Plasmamen won't lose blood, they don't have any, so they don't heal from Burn.
-		if(!HAS_TRAIT(C, NOBLOOD))
+		if(!(NOBLOOD in C.dna.species.species_traits))
 			C.blood_volume -= bloodcost
-		else
 			C.adjustFireLoss(-0.5)
 		/// Stop Bleeding
 		if(istype(C) && C.is_bleeding())
@@ -36,7 +35,17 @@
 	if(owner.stat >= DEAD)
 		to_chat(owner, "<span class='notice'>You cannot use Recuperate while incapacitated.</span>")
 		return FALSE
+	if(owner.incapacitated())
+		to_chat(owner, "<span class='notice'>You cannot use Recuperate while incapacitated.</span>")
+		return FALSE
 	return TRUE
 
 /datum/action/bloodsucker/recuperate/ContinueActive(mob/living/user)
-	return ..() && user.stat <= DEAD && user.blood_volume > 0 && user.getBruteLoss() > 0 && user.getFireLoss() > 0
+	if(user.stat >= DEAD)
+		to_chat(owner, "<span class='notice'>You are dead.</span>")
+		return FALSE
+	if(user.incapacitated())
+		to_chat(owner, "<span class='notice'>You are too exhausted to keep recuperating...</span>")
+		return FALSE
+	return TRUE
+

--- a/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/recuperate.dm
@@ -8,7 +8,7 @@
 	cooldown = 100
 
 /datum/action/bloodsucker/recuperate/ActivatePower()
-	var/mob/living/carbon/human/C = owner
+	var/mob/living/carbon/C = owner
 	var/datum/antagonist/vassal/vassaldatum = owner.mind.has_antag_datum(/datum/antagonist/vassal)
 
 	to_chat(owner, "<span class='notice'>Your muscles clench as your master's immortal blood mixes with your own, knitting your wounds.</span>")
@@ -21,9 +21,7 @@
 			C.blood_volume -= bloodcost
 			C.adjustFireLoss(-0.5)
 		/// Take bloodcost from their Master.
-		var/datum/antagonist/bloodsucker/bloodsuckerdatum = vassaldatum.master.owner.has_antag_datum(/datum/antagonist/bloodsucker)
-		if(bloodsuckerdatum)
-			var/mob/living/carbon/human/H = bloodsuckerdatum.owner
+			var/mob/living/carbon/H = vassaldatum.master
 			H.blood_volume -= bloodcost
 		/// Stop Bleeding
 		if(istype(C) && C.is_bleeding())

--- a/fulp_modules/main_features/bloodsuckers/code/powers/trespass.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/trespass.dm
@@ -1,6 +1,6 @@
 /datum/action/bloodsucker/targeted/trespass
 	name = "Trespass"
-	desc = "Become mist and advance two tiles in one direction, ignoring all obstacles except for walls. Useful for skipping past doors and barricades."
+	desc = "Become mist and advance two tiles in one direction, ignoring all obstacles. Useful for skipping past doors and barricades."
 	button_icon_state = "power_tres"
 	bloodcost = 10
 	cooldown = 80

--- a/fulp_modules/main_features/bloodsuckers/readme.MD
+++ b/fulp_modules/main_features/bloodsuckers/readme.MD
@@ -12,6 +12,7 @@
 - code/game/gamemodes/objective.dm > Added Bloodsucker objectives to the list of objectives Admins can make
 - code/game/objects/items/devices/scanners.dm > Falsifies health analyzers if you're on Masquerade
 - code/modules/mob/living/carbon/human/examine.dm > Added Bloodsucker examine text
+- code/game/objects/items/implants/implant_mindshield.dm > Mindshielding removes Vassalization
 
 ## TG proc overwrites:
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3612,6 +3612,7 @@
 #include "fulp_modules\main_features\bloodsuckers\code\powers\lunge.dm"
 #include "fulp_modules\main_features\bloodsuckers\code\powers\masquerade.dm"
 #include "fulp_modules\main_features\bloodsuckers\code\powers\mesmerize.dm"
+#include "fulp_modules\main_features\bloodsuckers\code\powers\monstertrack.dm"
 #include "fulp_modules\main_features\bloodsuckers\code\powers\recuperate.dm"
 #include "fulp_modules\main_features\bloodsuckers\code\powers\trespass.dm"
 #include "fulp_modules\main_features\bloodsuckers\code\powers\veil.dm"


### PR DESCRIPTION
## About The Pull Request

This PR aims to balance Bloodsucker's powers, there's too strong of a meta to get Brawn/Fortitude first because they're just too good compared to the rest.

## Changelog
:cl:
balance: Latejoining Bloodsuckers now get bonus Rank points to spend by entering their claimed Coffin.
code: The list of antag_allowed_vassals has been replaced with antag_banned_vassals
fix: Brawn now breaks open lockers.
fix: Recuperate should now work again.
balance: Cloak of Darkness now hides you from the AI, and hides you even better.
balance: Lunge will now tear the heart out of dead people.
balance: Immortal Haste will now mess with Monster hunters using Flow.
balance: It is now easier to break out of the persuasion rack, torturing the victim will prevent this.
fix: You no longer stop grabbing someone when dragging them onto a persuasion rack.
/:cl:
