### PR TITLE
SeleneStation: Crates stacked in engineering

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -87673,7 +87673,6 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "wtB" = (
-/obj/structure/closet/crate,
 /obj/item/stock_parts/subspace/analyzer,
 /obj/item/stock_parts/subspace/analyzer,
 /obj/item/stock_parts/subspace/analyzer,


### PR DESCRIPTION


## About The Pull Request

Removes a crate from engineering that was stacked on top of another.


## Why It's Good For The Game

Can actually let engineers open the crate without a hassle

## Changelog
:cl:

fix: Fixed the stacked crates in engineering

/:cl:


