### PR TITLE
Deputy access change & Bounty fix

### DIFF
--- a/fulp_modules/main_features/jobs/deputy/code/deputy.dm
+++ b/fulp_modules/main_features/jobs/deputy/code/deputy.dm
@@ -22,7 +22,7 @@
 	liver_traits = list(TRAIT_LAW_ENFORCEMENT_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_SECURITY_OFFICER
-	bounty_types = CIV_JOB_MED
+	bounty_types = CIV_JOB_SEC
 	departments = DEPARTMENT_SECURITY
 
 	mail_goodies = list(
@@ -43,8 +43,8 @@
 	assignment = "Deputy"
 	trim_icon = 'fulp_modules/main_features/jobs/cards.dmi'
 	trim_state = "trim_deputy"
-	full_access = list(ACCESS_FORENSICS_LOCKERS, ACCESS_SEC_DOORS, ACCESS_SECURITY, ACCESS_BRIG, ACCESS_MAINT_TUNNELS, ACCESS_MINERAL_STOREROOM)
-	minimal_access = list(ACCESS_FORENSICS_LOCKERS, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_MINERAL_STOREROOM)
+	full_access = list(ACCESS_SEC_DOORS, ACCESS_SECURITY, ACCESS_BRIG, ACCESS_MAINT_TUNNELS, ACCESS_MINERAL_STOREROOM)
+	minimal_access = list(ACCESS_SEC_DOORS, ACCESS_SECURITY, ACCESS_BRIG, ACCESS_MINERAL_STOREROOM)
 	config_job = "deputy"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOS, ACCESS_CHANGE_IDS)
 	/// Used to give the Departmental access


### PR DESCRIPTION
## About The Pull Request

I didnt want to do this, I really hate this entirely. Deltastation's departmental cells require this access to function, Deputies cant use their sechuds, they cant open their department's locker (even if there's nothing in there they need), TG maps have forced my hand. I dont WANT deputies setting timers in the Brig by themselves, but there's no other choice here.

I just wish there was a way to prevent them from opening the security office's lockers without all the other garbage that comes along with it.

## Changelog
:cl:
fix: Deputies now get Security bounties
balance: Deputies can now access Brig holding cells, Sechuds and Security lockers.
/:cl:
