### PR TITLE
SeleneStation: Mining wardrobe stack fix

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -40175,7 +40175,6 @@
 /area/maintenance/department/crew_quarters/dorms)
 "kEL" = (
 /obj/structure/closet/wardrobe/miner,
-/obj/structure/closet/wardrobe/miner,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4


### PR DESCRIPTION


## About The Pull Request

Mining wardrobes were stacked in mining room

## Why It's Good For The Game

Stacked items suck 

## Changelog
:cl:

del: Removed one of the mining wardrobes stacked on another one


/:cl:


