### PR TITLE
Restore mafia player identities

### DIFF
--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -577,6 +577,9 @@
 		RegisterSignal(H,COMSIG_ATOM_UPDATE_OVERLAYS,.proc/display_votes)
 		var/datum/action/innate/mafia_panel/mafia_panel = new(null,src)
 		mafia_panel.Grant(H)
+		var/client/player_client = GLOB.directory[role.player_key]
+		if(player_client)
+			player_client.prefs.copy_to(H)
 		role.body = H
 		player_role_lookup[H] = role
 		H.key = role.player_key


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows people in mafia to be their own characters again instead of random humans. Plasmamen safety is still intact as they have their breath and fire vars disabled so they don't instantly die, and can instead walk around the meager mafia rooms as funny purple skeletons.

I have tested this PR on my private testing server running Fulpcode as of 5/30/2021 and it works as intended with plasmamen and other races.

## Why It's Good For The Game

People in deadchat have asked for this, and getting to be your own character in mafia lines up with getting to be your own character in the main game. 

For any accusations that this would cause metagaming in mafia, you're a ghost, you can change your name/character with game preferences before you join if you are concerned about metagaming. In practice mafia doesn't get used all that much but the times I have participated in or spectated mafia the metagaming there is basically non-existent.

## Changelog
:cl:
add: You can be your own character in Mafia again. Don't worry plasmamen: you don't die from fire or lack of plasma in the mafia game, so you can be a funny purple skeleton in relative peace.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
