### PR TITLE
[NON-MODULAR] Felinids are now as fragile as a cat

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -12,9 +12,10 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/felinid
 	disliked_food = GROSS | RAW | CLOTH
+	toxic_food = FRUIT | VEGETABLES //Fulpstation Felinid Edit
+	brutemod = 3 //Fulpstation Felinid Edit
 	var/original_felinid = TRUE //set to false for felinids created by mass-purrbation
 	payday_modifier = 0.75
-	brutemod = 3 //Fulpstation Felinid Edit
 	ass_image = 'icons/ass/asscat.png'
 	family_heirlooms = list(/obj/item/toy/cattoy)
 

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -13,7 +13,7 @@
 	species_language_holder = /datum/language_holder/felinid
 	disliked_food = GROSS | RAW | CLOTH
 	toxic_food = FRUIT | VEGETABLES //Fulpstation Felinid Edit
-	brutemod = 3 //Fulpstation Felinid Edit
+	brutemod = 2 //Fulpstation Felinid Edit
 	var/original_felinid = TRUE //set to false for felinids created by mass-purrbation
 	payday_modifier = 0.75
 	ass_image = 'icons/ass/asscat.png'

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -14,6 +14,7 @@
 	disliked_food = GROSS | RAW | CLOTH
 	var/original_felinid = TRUE //set to false for felinids created by mass-purrbation
 	payday_modifier = 0.75
+	brutemod = 3 //Fulpstation Felinid Edit
 	ass_image = 'icons/ass/asscat.png'
 	family_heirlooms = list(/obj/item/toy/cattoy)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Felinids are now Fragile. Cats can't eat fruit or vegetables, so I made them toxic to the cat.
These are both one line edits, so they can be added or removed at your pleasure
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This way, people will have disincentives to be playing an ERP race.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Made Felinids take 3x Brute
balance: Fruit and Vegetables are now toxic to cats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
