### PR TITLE
Changes how Torpor is dealt with

### DIFF
--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
@@ -175,10 +175,25 @@
 				switch(tgui_alert(user,"Do you wish to claim this as your coffin? [get_area(src)] will be your lair.","Claim Lair", list("Yes", "No")))
 					if("Yes")
 						ClaimCoffin(user)
-			/// Level up? Auto-Fails if not appropriate
-			if(bloodsuckerdatum.my_clan == CLAN_VENTRUE)
-				return TRUE
-			bloodsuckerdatum.SpendRank()
+			/// Level up? Auto-Fails if not appropriate - Ventrue cannot level up in a Coffin.
+			if(bloodsuckerdatum.my_clan != CLAN_VENTRUE)
+				bloodsuckerdatum.SpendRank()
+			var/total_brute = user.getBruteLoss_nonProsthetic()
+			var/total_burn = user.getFireLoss_nonProsthetic()
+			var/total_damage = total_brute + total_burn
+			/// You're in a Coffin, everything else is done, you're likely here to heal. Let's office them the oppertunity to do so.
+			if(!bloodsuckerdatum.clan.bloodsucker_sunlight.amDay && total_damage >= 10)
+				if(!HAS_TRAIT(user, TRAIT_NODEATH))
+					to_chat(user, "<span class='notice'>Do you wish to enter Torpor? You will sleep to heal quickly, but cannot exit Torpor until fully healed!</span>")
+					var/list/torpor_options = list(
+						"Yes" = image(icon = 'icons/hud/screen_alert.dmi', icon_state = "asleep"),
+						"No" = image(icon = 'icons/hud/screen_alert.dmi', icon_state = "drunk2")
+						)
+					var/torpor_response = show_radial_menu(user, src, torpor_options, radius = 36, require_near = TRUE)
+					switch(torpor_response)
+						if("Yes")
+							bloodsuckerdatum.Torpor_Begin()
+							return
 	return TRUE
 
 /// You cannot weld or deconstruct an owned coffin. Only the owner can destroy their own coffin.

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
@@ -178,22 +178,8 @@
 			/// Level up? Auto-Fails if not appropriate - Ventrue cannot level up in a Coffin.
 			if(bloodsuckerdatum.my_clan != CLAN_VENTRUE)
 				bloodsuckerdatum.SpendRank()
-			var/total_brute = user.getBruteLoss_nonProsthetic()
-			var/total_burn = user.getFireLoss_nonProsthetic()
-			var/total_damage = total_brute + total_burn
-			/// You're in a Coffin, everything else is done, you're likely here to heal. Let's office them the oppertunity to do so.
-			if(!bloodsuckerdatum.clan.bloodsucker_sunlight.amDay && total_damage >= 10)
-				if(!HAS_TRAIT(user, TRAIT_NODEATH))
-					to_chat(user, "<span class='notice'>Do you wish to enter Torpor? You will sleep to heal quickly, but cannot exit Torpor until fully healed!</span>")
-					var/list/torpor_options = list(
-						"Yes" = image(icon = 'icons/hud/screen_alert.dmi', icon_state = "asleep"),
-						"No" = image(icon = 'icons/hud/screen_alert.dmi', icon_state = "drunk2")
-						)
-					var/torpor_response = show_radial_menu(user, src, torpor_options, radius = 36, require_near = TRUE)
-					switch(torpor_response)
-						if("Yes")
-							bloodsuckerdatum.Torpor_Begin()
-							return
+			/// You're in a Coffin, everything else is done, you're likely here to heal. Let's offer them the oppertunity to do so.
+			bloodsuckerdatum.Check_Begin_Torpor()
 	return TRUE
 
 /// You cannot weld or deconstruct an owned coffin. Only the owner can destroy their own coffin.

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -347,14 +347,13 @@
 				to_chat(owner.current, "<span class='userdanger'>You are staked! Remove the offending weapon from your heart before sleeping.</span>")
 				return
 			/// Otherwise, check if it's Sol, to enter Torpor.
-			if(clan.bloodsucker_sunlight.amDay && !HAS_TRAIT(owner.current, TRAIT_NODEATH))
+			if(clan.bloodsucker_sunlight.amDay)
 				Check_Begin_Torpor(TRUE)
 		/// You are in Torpor, and in a Coffin. Check if it's not Daytime & you have less than 10 Brute/Burn combined to end Torpor.
 		else if(!clan.bloodsucker_sunlight.amDay && total_damage <= 10)
 			Check_End_Torpor()
-			return
 	/// You're not in a Coffin, but are in Torpor. Check if it's not Daytime, & you have less than 10 Brute (NOT Burn) to end Torpor.
-	if(!clan.bloodsucker_sunlight.amDay && total_brute <= 10 && HAS_TRAIT(owner.current, TRAIT_NODEATH))
+	else if(!clan.bloodsucker_sunlight.amDay && total_brute <= 10 && HAS_TRAIT(owner.current, TRAIT_NODEATH))
 		Check_End_Torpor()
 
 /datum/antagonist/bloodsucker/proc/Check_Begin_Torpor(CheckChecks = FALSE)

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -356,9 +356,9 @@
 	else if(!clan.bloodsucker_sunlight.amDay && total_brute <= 10 && HAS_TRAIT(owner.current, TRAIT_NODEATH))
 		Check_End_Torpor()
 
-/datum/antagonist/bloodsucker/proc/Check_Begin_Torpor(CheckChecks = FALSE)
+/datum/antagonist/bloodsucker/proc/Check_Begin_Torpor(SkipChecks = FALSE)
 	/// Are we entering Torpor via Sol/Death? Then entering it isnt optional!
-	if(CheckChecks)
+	if(SkipChecks)
 		Torpor_Begin()
 		return
 	var/mob/living/carbon/user = owner.current

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -238,7 +238,6 @@
 			if(HandleHealing(1))
 				to_chat(H, "<span class='danger'>Your immortal body will not yet relinquish your soul to the abyss. You enter Torpor.</span>")
 				Torpor_Begin()
-				return
 
 /*
  *	High: 	Faster Healing
@@ -330,9 +329,8 @@
 			if(owner.current.AmStaked())
 				to_chat(owner.current, "<span class='userdanger'>You are staked! Remove the offending weapon from your heart before sleeping.</span>")
 				return
-			/// Otherwise, check for Sol, or if injured enough to enter Torpor.
-			if(clan.bloodsucker_sunlight.amDay || total_damage >= 10)
-				to_chat(owner.current, "<span class='notice'>You enter the horrible slumber of deathless Torpor. You will heal until you are renewed.</span>")
+			/// Otherwise, check if it's Sol, to enter Torpor.
+			if(clan.bloodsucker_sunlight.amDay)
 				Torpor_Begin()
 	/// If it's not Sol and you have 0 Brute damage, check to End Torpor.
 	if(!clan.bloodsucker_sunlight.amDay && total_brute <= 10)
@@ -340,6 +338,7 @@
 			Check_End_Torpor()
 
 /datum/antagonist/bloodsucker/proc/Torpor_Begin()
+	to_chat(owner.current, "<span class='notice'>You enter the horrible slumber of deathless Torpor. You will heal until you are renewed.</span>")
 	/// Force them to go to sleep
 	REMOVE_TRAIT(owner.current, TRAIT_SLEEPIMMUNE, BLOODSUCKER_TRAIT)
 	/// Without this, you'll just keep dying while you recover.

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -393,6 +393,7 @@
 	ADD_TRAIT(owner.current, TRAIT_NODEATH, BLOODSUCKER_TRAIT)
 	ADD_TRAIT(owner.current, TRAIT_FAKEDEATH, BLOODSUCKER_TRAIT)
 	ADD_TRAIT(owner.current, TRAIT_DEATHCOMA, BLOODSUCKER_TRAIT)
+	ADD_TRAIT(owner.current, TRAIT_RESISTLOWPRESSURE, BLOODSUCKER_TRAIT)
 	owner.current.Jitter(0)
 	/// Disable ALL Powers
 	for(var/datum/action/bloodsucker/power in powers)
@@ -401,6 +402,7 @@
 
 /datum/antagonist/bloodsucker/proc/Torpor_End()
 	to_chat(owner.current, "<span class='warning'>You have recovered from Torpor.</span>")
+	REMOVE_TRAIT(owner.current, TRAIT_RESISTLOWPRESSURE, BLOODSUCKER_TRAIT)
 	REMOVE_TRAIT(owner.current, TRAIT_DEATHCOMA, BLOODSUCKER_TRAIT)
 	REMOVE_TRAIT(owner.current, TRAIT_FAKEDEATH, BLOODSUCKER_TRAIT)
 	REMOVE_TRAIT(owner.current, TRAIT_NODEATH, BLOODSUCKER_TRAIT)


### PR DESCRIPTION
## About The Pull Request

How Torpor works now
---

Torpor is triggered by:

- Being in a Coffin while Sol is on
- Entering a Coffin with more than 10 combined Brute/Burn damage
- Dying

Torpor is ended by:

- Having less than 10 Brute damage while OUTSIDE of your Coffin while it isnt Sol
- Having less than 10 Brute & Burn Combined while INSIDE of your Coffin while it isnt Sol
- Sol being over


Also, makes Torpor give you immunity to low pressure, so while flamethrowers/fire will still be an annoyance, you wont take damage to, for example, space. I've had 3 people complain already about being endlessly stuck in Torpor because they thought it would be a good idea to enter Torpor while in a depressurizing room.