### PR TITLE
[Selene] Edits (buffs) Chef's CQC

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -824,7 +824,7 @@
 "alJ" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "alL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -1540,7 +1540,7 @@
 	},
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "aul" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1732,7 +1732,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "aws" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat)
@@ -1749,7 +1749,7 @@
 "axd" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "axf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -1932,7 +1932,7 @@
 	pixel_x = 5
 	},
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "azt" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -2044,7 +2044,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "aAO" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -3046,7 +3046,7 @@
 /area/command/heads_quarters/cmo)
 "aRM" = (
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "aRO" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -4009,7 +4009,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "bgz" = (
 /obj/structure/table,
 /obj/item/stack/sheet/rglass{
@@ -4461,7 +4461,7 @@
 "blH" = (
 /obj/structure/chair,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "blJ" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -5222,7 +5222,7 @@
 "bvh" = (
 /obj/machinery/gibber,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "bvA" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -5405,7 +5405,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "bxG" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -6425,7 +6425,7 @@
 	},
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "bLm" = (
 /turf/open/floor/iron,
 /area/security/prison)
@@ -9646,7 +9646,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "cBI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -10474,7 +10474,7 @@
 	pixel_y = 22
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "cPj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -10635,7 +10635,7 @@
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "cRF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -10733,7 +10733,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/glass/reinforced,
-/area/service/bar)
+/area/service/bar/atrium)
 "cSP" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -12546,7 +12546,7 @@
 /area/construction/mining/aux_base)
 "drB" = (
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "drK" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/tubes,
@@ -13246,7 +13246,7 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "dAV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
@@ -13399,7 +13399,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "dDL" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -13680,7 +13680,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "dHX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14169,7 +14169,7 @@
 "dMI" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "dML" = (
 /obj/structure/cable,
 /turf/open/floor/wood{
@@ -14781,7 +14781,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "dWi" = (
 /obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/purple{
@@ -15124,7 +15124,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "eaB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -16754,7 +16754,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "exv" = (
 /obj/item/instrument/bikehorn,
 /obj/item/instrument/recorder,
@@ -17612,7 +17612,7 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
-/area/service/bar)
+/area/service/bar/atrium)
 "eKh" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -17895,7 +17895,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "eMT" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -18948,7 +18948,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "fbt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -19134,7 +19134,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "feX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -19438,7 +19438,7 @@
 /obj/item/radio/intercom/directional/south,
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "fjX" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -19971,7 +19971,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "fpF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -21261,7 +21261,7 @@
 "fHh" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "fHk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -21683,7 +21683,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "fLs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -22555,7 +22555,7 @@
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "fWn" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/tile{
@@ -22884,7 +22884,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "fZd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -25445,7 +25445,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "gKy" = (
 /obj/structure/table,
 /obj/item/gun/energy/laser/practice,
@@ -25554,7 +25554,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "gLM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
 	dir = 8
@@ -25802,7 +25802,7 @@
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "gOb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -26739,7 +26739,7 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "hcu" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/turf_decal/tile/green{
@@ -29354,7 +29354,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "hLj" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -29684,7 +29684,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "hQD" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /turf/open/floor/engine,
@@ -32212,7 +32212,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "iwI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -34923,7 +34923,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "jlm" = (
 /obj/structure/table/wood,
 /obj/item/trash/can/food/peaches,
@@ -35902,7 +35902,7 @@
 	},
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "jwT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -36025,7 +36025,7 @@
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/restaurant_portal/bar,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "jyI" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile{
@@ -36247,7 +36247,7 @@
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "jBK" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -37885,7 +37885,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "jUK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip{
@@ -39394,7 +39394,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "kpp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -41422,7 +41422,7 @@
 "kPu" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/glass/reinforced,
-/area/service/bar)
+/area/service/bar/atrium)
 "kPy" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -42264,7 +42264,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "lbf" = (
 /obj/structure/table/glass,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -44962,7 +44962,7 @@
 "lJI" = (
 /obj/machinery/icecream_vat,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "lJS" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab/range)
@@ -46352,7 +46352,7 @@
 	},
 /obj/effect/landmark/start/mime,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "maG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -46462,7 +46462,7 @@
 	location = "Kitchen"
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "mcq" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
@@ -47429,7 +47429,7 @@
 "mny" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "mnF" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -47505,7 +47505,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "mph" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -48371,7 +48371,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "mAJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -48562,7 +48562,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "mCV" = (
 /obj/effect/spawner/randomcolavend,
 /obj/effect/turf_decal/siding/thinplating,
@@ -48930,7 +48930,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/glass/reinforced,
-/area/service/bar)
+/area/service/bar/atrium)
 "mHH" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -49358,6 +49358,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"mMA" = (
+/turf/closed/wall,
+/area/service/kitchen/coldroom)
 "mMD" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -49684,7 +49687,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "mQH" = (
 /obj/machinery/bluespace_vendor/east,
 /turf/open/floor/carpet,
@@ -51566,7 +51569,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "npr" = (
 /obj/structure/chair,
 /turf/open/floor/iron/white,
@@ -52428,7 +52431,7 @@
 "nBb" = (
 /obj/effect/spawner/lootdrop/gambling,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "nBq" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets/donkpockethonk,
@@ -53265,7 +53268,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "nMC" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -56376,7 +56379,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "oEY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -59813,7 +59816,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "pCS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -60374,7 +60377,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "pKa" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -61174,7 +61177,7 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "pUS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -62016,7 +62019,7 @@
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "qfT" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/grimy,
@@ -62132,7 +62135,7 @@
 /obj/structure/table/wood,
 /obj/item/instrument/saxophone,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "qgS" = (
 /obj/structure/grille/broken,
 /turf/open/floor/iron,
@@ -64635,7 +64638,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "qOB" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -65634,7 +65637,7 @@
 "rbx" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "rbz" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
@@ -66668,7 +66671,7 @@
 "rnP" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "rnT" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
@@ -66866,7 +66869,7 @@
 /area/commons/fitness)
 "rpE" = (
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "rpL" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -66917,7 +66920,7 @@
 	network = list("ss13", "service")
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "rpY" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile{
@@ -67315,7 +67318,7 @@
 	network = list("ss13", "service")
 	},
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "rvr" = (
 /obj/structure/table,
 /obj/item/paper/pamphlet/gateway,
@@ -67531,7 +67534,7 @@
 	name = "CondiMaster Neo"
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "rxX" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /turf/open/floor/iron,
@@ -69017,7 +69020,7 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "rTN" = (
 /obj/structure/chair/plastic{
 	dir = 1
@@ -69998,7 +70001,7 @@
 "sfF" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "sfO" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -71541,7 +71544,7 @@
 /obj/structure/table/wood,
 /obj/item/toy/figure/bartender,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "szw" = (
 /obj/machinery/vending/boozeomat,
 /obj/structure/sign/plaques/deempisi{
@@ -73476,6 +73479,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"tdo" = (
+/turf/closed/wall,
+/area/service/bar/atrium)
 "tdu" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -74704,7 +74710,7 @@
 	},
 /obj/effect/landmark/start/clown,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "tsD" = (
 /obj/structure/table/glass,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -74730,7 +74736,7 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
-/area/service/bar)
+/area/service/bar/atrium)
 "tsK" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
@@ -74898,7 +74904,7 @@
 	},
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "tvJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space/basic,
@@ -75211,7 +75217,7 @@
 	},
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "tAw" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/eighties,
@@ -75706,7 +75712,7 @@
 /obj/item/kirbyplants/potty,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "tGD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -75872,7 +75878,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "tJl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -76385,7 +76391,7 @@
 "tRI" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/glass/reinforced,
-/area/service/bar)
+/area/service/bar/atrium)
 "tRY" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/bookmanagement,
@@ -76572,7 +76578,7 @@
 /obj/effect/landmark/start/cook,
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "tUv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -78108,7 +78114,7 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
-/area/service/bar)
+/area/service/bar/atrium)
 "unK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -78945,7 +78951,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "uxj" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -81662,7 +81668,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "vkU" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
@@ -81828,7 +81834,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "vnm" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -82006,7 +82012,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "vpX" = (
 /obj/item/circuitboard/computer/teleporter,
 /obj/item/circuitboard/machine/teleporter_hub,
@@ -82473,7 +82479,7 @@
 	layer = 2.9
 	},
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "vxo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -83200,7 +83206,7 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "vGu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -83419,7 +83425,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/service/bar)
+/area/service/bar/atrium)
 "vJf" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -84503,7 +84509,7 @@
 "vZR" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "wai" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -84888,7 +84894,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "whS" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/nanite";
@@ -88394,7 +88400,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "wZx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -89422,7 +89428,7 @@
 "xlJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/service/bar)
+/area/service/bar/atrium)
 "xlK" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -89835,7 +89841,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "xpG" = (
 /obj/machinery/power/emitter,
 /obj/machinery/camera{
@@ -90004,7 +90010,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "xsk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -91117,7 +91123,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/bar/atrium)
 "xIm" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/disposal/bin,
@@ -91966,7 +91972,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
-/area/service/theater)
+/area/service/bar/atrium)
 "xTt" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/tile/yellow{
@@ -113283,7 +113289,7 @@ jsk
 utO
 tPU
 vFC
-wFW
+tdo
 qDN
 fZE
 dWD
@@ -114060,14 +114066,14 @@ xOl
 stK
 fpl
 xbE
-wFW
-wFW
-wFW
-wFW
-wFW
-wFW
-wFW
-wFW
+tdo
+tdo
+tdo
+tdo
+tdo
+tdo
+tdo
+tdo
 vgm
 uOg
 xWG
@@ -114317,14 +114323,14 @@ fAi
 lZh
 irO
 hGi
-wFW
+tdo
 qgN
 gNY
 aRM
 rvn
 aRM
 azk
-wFW
+tdo
 ojJ
 cZX
 hcX
@@ -114581,7 +114587,7 @@ xTr
 feS
 bgv
 aRM
-wFW
+tdo
 ueV
 dBP
 wIa
@@ -114831,14 +114837,14 @@ nNS
 fTa
 eSY
 kvi
-wFW
+tdo
 jwy
 aRM
 tsA
 mak
 pJV
 fjR
-wFW
+tdo
 kiC
 sCQ
 uLy
@@ -115086,16 +115092,16 @@ fDA
 fDA
 fDA
 fDA
-fDA
-fDA
-fDA
+tdo
+tdo
+tdo
 dMI
 aRM
 aRM
 aRM
 pJV
 rnP
-fDA
+tdo
 xWG
 eCI
 fRC
@@ -118176,12 +118182,12 @@ gxq
 fkM
 jTk
 uYK
-fDA
-fDA
-fDA
-fDA
-fDA
-fDA
+tdo
+tdo
+tdo
+tdo
+tdo
+tdo
 hZp
 mYH
 aAj
@@ -118677,8 +118683,8 @@ hJf
 qhe
 gJI
 dHX
-uYK
-uYK
+mMA
+mMA
 uYK
 kzj
 aWL
@@ -118936,11 +118942,11 @@ lRd
 dHX
 mcp
 qfQ
-uYK
-uYK
+mMA
+mMA
 vpW
-uYK
-uYK
+mMA
+mMA
 hZp
 hZp
 hZp
@@ -119191,7 +119197,7 @@ ssW
 icE
 tXz
 uvW
-uYK
+mMA
 rpE
 pCx
 vZR
@@ -119448,7 +119454,7 @@ gMY
 qLm
 gQC
 fUd
-uYK
+mMA
 cPc
 mpf
 tUj
@@ -119705,7 +119711,7 @@ pJy
 pzQ
 agr
 pxv
-uYK
+mMA
 bvh
 kpm
 mny
@@ -119962,11 +119968,11 @@ lBt
 rAh
 lVC
 fOD
-uYK
-uYK
+mMA
+mMA
 mAH
-uYK
-uYK
+mMA
+mMA
 fhJ
 lJI
 hZp
@@ -120223,9 +120229,9 @@ peT
 blg
 xGP
 udo
-uYK
-uYK
-uYK
+mMA
+mMA
+mMA
 hZp
 ubl
 vwb

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -25122,11 +25122,14 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "gHg" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenhydro";
 	name = "Service Shutter"
+	},
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_one_access_txt = "28;35"
 	},
 /turf/open/floor/iron/white,
 /area/service/kitchen)

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1539,6 +1539,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/randomcolavend,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "aul" = (
@@ -1731,6 +1732,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "aws" = (
@@ -39396,6 +39398,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "kpp" = (
@@ -47507,6 +47510,7 @@
 	dir = 6
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "mph" = (
@@ -48373,6 +48377,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "mAJ" = (
@@ -59818,6 +59823,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "pCS" = (
@@ -64691,6 +64697,11 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/iron,
 /area/maintenance/department/science)
+"qQL" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/service/kitchen/coldroom)
 "qQO" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green{
@@ -74738,6 +74749,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "tsK" = (
@@ -75713,7 +75725,8 @@
 	dir = 1
 	},
 /obj/item/kirbyplants/potty,
-/obj/item/radio/intercom/directional/west,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "tGD" = (
@@ -81670,6 +81683,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "vkU" = (
@@ -88906,6 +88920,20 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"xfE" = (
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 4;
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 1;
+	name = "dark corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "xfL" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/atmos)
@@ -91087,6 +91115,7 @@
 	dir = 1
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "xGT" = (
@@ -93542,6 +93571,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"ykj" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/bar/atrium)
 "ykl" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -116390,9 +116427,9 @@ lbc
 cBt
 xIh
 xIh
-xIh
+ykj
 tsG
-xjz
+xfE
 kMx
 aAj
 soC
@@ -119201,7 +119238,7 @@ icE
 tXz
 uvW
 mMA
-rpE
+qQL
 pCx
 vZR
 mQG

--- a/_maps/selenestation.json
+++ b/_maps/selenestation.json
@@ -11,7 +11,7 @@
 	},
 	"job_changes": {
 		"cook": {
-			"additional_cqc_areas": ["/area/service/bar", "/area/service/kitchen/coldroom"]
+			"additional_cqc_areas": ["/area/service/bar/atrium", "/area/service/hydroponics"]
 		}
 	}
 }


### PR DESCRIPTION
## About The Pull Request

In black - old version
In magenta - new version
![image](https://user-images.githubusercontent.com/53777086/121244590-083ae500-c86d-11eb-9ab9-9d39752fc7c4.png)

yes it works in Botany now.

## Why It's Good For The Game

I dont like Bartenders being shot in their own bar, or CQC not working in the bar's atrium because glass panes are meant to show that this is actually the theatre, but I'm also biased against Botanists because I just hate them all for making nothing but deathnettle.

Also there was no bar atrium or kitchen coldroom (despite that being an additional CQC area (why is it an additional area its done automatically)) so those have been added.

## Changelog
:cl:
balance: The chef's CQC in Selene works in the bar's full atrium and botany, but no longer in the bar itself.
balance: The table between the Kitchen and Botany has been replaced with a door.
/:cl: