### PR TITLE
Adds Cult Stun Nerf to Antagonist Tips

### DIFF
--- a/fulp_modules/features/antag_tips/html/cultist.html
+++ b/fulp_modules/features/antag_tips/html/cultist.html
@@ -9,7 +9,7 @@
 	<p><img src="sacrune.png"/>To begin, you should gather converts by placing them over an <b>Offering Rune.</b></p>
 	<p>There will be several other cultists on board, communicate with them using the commune button. Find a place to create a base, and keep cult structures hidden.</p>
 	<p>Before you can summon Nar'Sie, you must first sacrifice a target for her on an offering rune. Check the top right of your screen for information on your target.</p>
-	<p><font size="+1"><b>Note that your stun spell will not stun those with shielded minds-- consider alternative tactics for dealing with them.</b></font></p>
+	<p><b>NOTE: Your Cult Stun spell will not have full effect on Mindshielded people -- consider using alternative tactics when dealing with them.</b></p>
 	<p>Don't be afraid to ask <b>mentors</b> for help using the mentorhelp button.</p>
 	<p>For further information visit <b>https://tgstation13.org/wiki/Blood_Cult</b></p>
 	</center>

--- a/fulp_modules/features/antag_tips/html/cultist.html
+++ b/fulp_modules/features/antag_tips/html/cultist.html
@@ -9,6 +9,7 @@
 	<p><img src="sacrune.png"/>To begin, you should gather converts by placing them over an <b>Offering Rune.</b></p>
 	<p>There will be several other cultists on board, communicate with them using the commune button. Find a place to create a base, and keep cult structures hidden.</p>
 	<p>Before you can summon Nar'Sie, you must first sacrifice a target for her on an offering rune. Check the top right of your screen for information on your target.</p>
+	<p><font size="+1"><b>Note that your stun spell will not stun those with shielded minds-- consider alternative tactics for dealing with them.</b></font></p>
 	<p>Don't be afraid to ask <b>mentors</b> for help using the mentorhelp button.</p>
 	<p>For further information visit <b>https://tgstation13.org/wiki/Blood_Cult</b></p>
 	</center>


### PR DESCRIPTION
## About The Pull Request

Adds a new line to the cultist antag tips that details the stun nerf present on fulpstation

![image](https://user-images.githubusercontent.com/83368538/122088263-9239ff00-cdd3-11eb-9e65-5d8cd05a8214.png)


## Why It's Good For The Game

Better clarity for custom nerfs; provides information that isn't present on the referenced wiki

## Changelog
:cl:
qol: Cult antag tips now mention the stun nerf
/:cl: