### PR TITLE
[Non-Modular] Beefmen Preferences Fix

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -426,6 +426,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["feature_moth_wings"], features["moth_wings"])
 	READ_FILE(S["feature_moth_antennae"], features["moth_antennae"])
 	READ_FILE(S["feature_moth_markings"], features["moth_markings"])
+	// [FULP EDIT START]
+	READ_FILE(S["feature_beefcolor"], features["beefcolor"])
+	READ_FILE(S["feature_beefeyes"], features["beefeyes"])
+	READ_FILE(S["feature_beefmouth"], features["beefmouth"])
+	// [FULP EDIT END]
 	READ_FILE(S["persistent_scars"] , persistent_scars)
 	if(!CONFIG_GET(flag/join_with_mutant_humans))
 		features["tail_human"] = "none"


### PR DESCRIPTION
## About The Pull Request

Changes load_preferences() to account for beefmen features. Not currently modular, but neither is the file in general. If asked, I will try my best to modularize it

## Why It's Good For The Game

Preferences good

## Changelog
:cl:
fix: Beefmen preferences now properly load
/:cl:
