### PR TITLE
SeleneStation: Moved camera in SM chamber so users can interact with the air alarm

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -33669,6 +33669,17 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"iSn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - SM Room NE";
+	dir = 8;
+	network = list("ss13", "engineering")
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "iSA" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -76681,11 +76692,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/camera{
-	c_tag = "Engineering - SM Room NE";
-	dir = 8;
-	network = list("ss13", "engineering")
-	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -121402,7 +121408,7 @@ hJO
 tVs
 hJO
 hJO
-hJO
+iSn
 hJO
 oaZ
 hkZ


### PR DESCRIPTION

## About The Pull Request

Moves camera in SM chamber so users can interact with the air alarm

## Why It's Good For The Game

Help A.I mains do their job

## Changelog
:cl:

fix: Moved AI chamber Camera down; can now be reached

/:cl:

