### PR TITLE
[Heliostation] Fixes atmos from being sabotaged roundstart

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -58297,15 +58297,9 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"cFf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cFg" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -99803,7 +99797,7 @@ crj
 csA
 cCE
 cDT
-cFf
+cDW
 cGi
 cHq
 crh


### PR DESCRIPTION
## About The Pull Request

These pipes used to be blue, so it would connect to the pipe UNDER the gas pump, rather than to the gas pump.
![image](https://user-images.githubusercontent.com/53777086/123526682-7ffb7300-d6a7-11eb-8b4c-80fe9793fba0.png)

## Why It's Good For The Game

🚎 