### PR TITLE
Fixes admins giving Bloodsucker objectives & Adds monster hunters to admin list

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -970,7 +970,8 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		/datum/objective/bloodsucker/heartthief,
 		/datum/objective/bloodsucker/vassalhim,
 		/datum/objective/bloodsucker/gourmand,
-		/datum/objective/bloodsucker/survive, // Fulpstation edit ends
+		/datum/objective/bloodsucker/survive,
+		/datum/objective/bloodsucker/monsterhunter, // Fulpstation edit ends
 		/datum/objective/destroy,
 		/datum/objective/hijack,
 		/datum/objective/escape,

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -532,44 +532,38 @@
 	// Claim a Lair Objective
 	var/datum/objective/bloodsucker/lair/lair_objective = new
 	lair_objective.owner = owner
-	lair_objective.generate_objective()
-	add_objective(lair_objective)
+	objectives += lair_objective
 
 	// Objective 1: Vassalize a Head/Command, or Drink X amount of Blood.
 	switch(rand(0,1))
 		if(0) // Protege Objective
 			var/datum/objective/bloodsucker/protege/protege_objective = new
 			protege_objective.owner = owner
-			protege_objective.generate_objective()
 			protege_objective.objective_name = "Optional Objective"
-			add_objective(protege_objective)
+			objectives += protege_objective
 		if(1) // Drink Blood Objective
 			var/datum/objective/bloodsucker/gourmand/gourmand_objective = new
 			gourmand_objective.owner = owner
-			gourmand_objective.generate_objective()
 			gourmand_objective.objective_name = "Optional Objective"
-			add_objective(gourmand_objective)
+			objectives += gourmand_objective
 
 	// Objective 2: Steal X amount of hearts, or Vassalize a certain crewmate.
 	switch(rand(0,1))
 		if(0) // Heart Thief Objective
 			var/datum/objective/bloodsucker/heartthief/heartthief_objective = new
 			heartthief_objective.owner = owner
-			heartthief_objective.generate_objective()
 			heartthief_objective.objective_name = "Optional Objective"
-			add_objective(heartthief_objective)
+			objectives += heartthief_objective
 		if(1) // Vassalize Target Objective
 			var/datum/objective/bloodsucker/vassalhim/vassalhim_objective = new
 			vassalhim_objective.owner = owner
-			vassalhim_objective.find_target()
 			vassalhim_objective.objective_name = "Optional Objective"
-			add_objective(vassalhim_objective)
+			objectives += vassalhim_objective
 
 	// Survive Objective
 	var/datum/objective/bloodsucker/survive/survive_objective = new
 	survive_objective.owner = owner
-	survive_objective.generate_objective()
-	add_objective(survive_objective)
+	objectives += survive_objective
 
 
 /*

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/monsterhunter_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/monsterhunter_datum.dm
@@ -39,7 +39,6 @@
 		/// Give Hunter Objective
 		var/datum/objective/bloodsucker/monsterhunter/monsterhunter_objective = new
 		monsterhunter_objective.owner = owner
-		monsterhunter_objective.generate_objective()
 		objectives += monsterhunter_objective
 		/// Give Theft Objective
 		if(prob(35) && !(locate(/datum/objective/download) in objectives) && !(owner.assigned_role in list("Research Director", "Scientist", "Roboticist", "Geneticist")))

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
@@ -47,7 +47,6 @@
 	/// Give Objectives
 	var/datum/objective/bloodsucker/vassal/vassal_objective = new
 	vassal_objective.owner = owner
-	vassal_objective.generate_objective()
 	add_objective(vassal_objective)
 	/// Give Vampire Language & Hud
 	owner.current.grant_all_languages(FALSE, FALSE, TRUE)

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
@@ -47,7 +47,7 @@
 	/// Give Objectives
 	var/datum/objective/bloodsucker/vassal/vassal_objective = new
 	vassal_objective.owner = owner
-	add_objective(vassal_objective)
+	objectives += vassal_objective
 	/// Give Vampire Language & Hud
 	owner.current.grant_all_languages(FALSE, FALSE, TRUE)
 	owner.current.grant_language(/datum/language/vampiric)

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
@@ -8,10 +8,6 @@
 /datum/objective/bloodsucker
 	martyr_compatible = TRUE
 
-/// GENERATE!
-/datum/objective/bloodsucker/proc/generate_objective()
-	update_explanation_text()
-
 //////////////////////////////////////////////////////////////////////////////
 //	//							 PROCS 									//	//
 
@@ -36,6 +32,10 @@
 
 /datum/objective/bloodsucker/lair
 	name = "claimlair"
+
+/datum/objective/bloodsucker/lair/New()
+	update_explanation_text()
+	..()
 
 // EXPLANATION
 /datum/objective/bloodsucker/lair/update_explanation_text()
@@ -74,12 +74,15 @@
 		"Chief Medical Officer",
 	)
 
-
 	var/target_role	// Equals "HEAD" when it's not a department role.
 	var/department_string
 
+/datum/objective/bloodsucker/protege/New()
+	update_explanation_text()
+	..()
+
 // GENERATE!
-/datum/objective/bloodsucker/protege/generate_objective()
+/datum/objective/bloodsucker/protege/New()
 	// Choose between Command and a Department
 	switch(rand(0,2))
 		if(0) // Command
@@ -182,10 +185,10 @@
 	name = "blooddrinker"
 
 // GENERATE!
-/datum/objective/bloodsucker/gourmand/generate_objective()
+/datum/objective/bloodsucker/gourmand/New()
 	target_amount = rand(450,650)
 	update_explanation_text()
-	return target_amount
+	..()
 
 // EXPLANATION
 /datum/objective/bloodsucker/gourmand/update_explanation_text()
@@ -248,10 +251,10 @@
 	name = "heartthief"
 
 // GENERATE!
-/datum/objective/bloodsucker/heartthief/generate_objective()
+/datum/objective/bloodsucker/heartthief/New()
 	target_amount = rand(2,3)
 	update_explanation_text()
-	return target_amount
+	..()
 
 // EXPLANATION
 /datum/objective/bloodsucker/heartthief/update_explanation_text()
@@ -281,6 +284,10 @@
 /datum/objective/bloodsucker/vassalhim
 	name = "vassalhim"
 	var/target_role_type = FALSE
+
+/datum/objective/bloodsucker/vassalhim/New()
+	update_explanation_text()
+	..()
 
 // FIND TARGET/GENERATE OBJECTIVE
 /datum/objective/bloodsucker/vassalhim/find_target_by_role(role, role_type=FALSE, invert=FALSE)
@@ -313,6 +320,10 @@
 /datum/objective/bloodsucker/survive
 	name = "bloodsuckersurvive"
 
+/datum/objective/bloodsucker/survive/New()
+	update_explanation_text()
+	..()
+
 // EXPLANATION
 /datum/objective/bloodsucker/survive/update_explanation_text()
 	explanation_text = "Survive the entire shift without succumbing to Final Death."
@@ -332,8 +343,9 @@
 	name = "destroymonsters"
 
 // GENERATE!
-/datum/objective/bloodsucker/monsterhunter/generate_objective()
+/datum/objective/bloodsucker/monsterhunter/New()
 	update_explanation_text()
+	..()
 
 // EXPLANATION
 /datum/objective/bloodsucker/monsterhunter/update_explanation_text()
@@ -368,8 +380,9 @@
 /datum/objective/bloodsucker/vassal
 
 // GENERATE!
-/datum/objective/bloodsucker/vassal/generate_objective()
+/datum/objective/bloodsucker/vassal/New()
 	update_explanation_text()
+	..()
 
 // EXPLANATION
 /datum/objective/bloodsucker/vassal/update_explanation_text()

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
@@ -8,6 +8,11 @@
 /datum/objective/bloodsucker
 	martyr_compatible = TRUE
 
+// GENERATE
+/datum/objective/bloodsucker/New()
+	update_explanation_text()
+	..()
+
 //////////////////////////////////////////////////////////////////////////////
 //	//							 PROCS 									//	//
 
@@ -32,10 +37,6 @@
 
 /datum/objective/bloodsucker/lair
 	name = "claimlair"
-
-/datum/objective/bloodsucker/lair/New()
-	update_explanation_text()
-	..()
 
 // EXPLANATION
 /datum/objective/bloodsucker/lair/update_explanation_text()
@@ -76,10 +77,6 @@
 
 	var/target_role	// Equals "HEAD" when it's not a department role.
 	var/department_string
-
-/datum/objective/bloodsucker/protege/New()
-	update_explanation_text()
-	..()
 
 // GENERATE!
 /datum/objective/bloodsucker/protege/New()
@@ -187,7 +184,6 @@
 // GENERATE!
 /datum/objective/bloodsucker/gourmand/New()
 	target_amount = rand(450,650)
-	update_explanation_text()
 	..()
 
 // EXPLANATION
@@ -253,7 +249,6 @@
 // GENERATE!
 /datum/objective/bloodsucker/heartthief/New()
 	target_amount = rand(2,3)
-	update_explanation_text()
 	..()
 
 // EXPLANATION
@@ -285,10 +280,6 @@
 	name = "vassalhim"
 	var/target_role_type = FALSE
 
-/datum/objective/bloodsucker/vassalhim/New()
-	update_explanation_text()
-	..()
-
 // FIND TARGET/GENERATE OBJECTIVE
 /datum/objective/bloodsucker/vassalhim/find_target_by_role(role, role_type=FALSE, invert=FALSE)
 	if(!invert)
@@ -312,17 +303,10 @@
 		return TRUE
 	return FALSE
 
-/datum/objective/bloodsucker/vassalhim/admin_edit(mob/admin)
-	admin_simple_target_pick(admin)
-
 //////////////////////////////////////////////////////////////////////////////////////
 
 /datum/objective/bloodsucker/survive
 	name = "bloodsuckersurvive"
-
-/datum/objective/bloodsucker/survive/New()
-	update_explanation_text()
-	..()
 
 // EXPLANATION
 /datum/objective/bloodsucker/survive/update_explanation_text()
@@ -341,11 +325,6 @@
 
 /datum/objective/bloodsucker/monsterhunter
 	name = "destroymonsters"
-
-// GENERATE!
-/datum/objective/bloodsucker/monsterhunter/New()
-	update_explanation_text()
-	..()
 
 // EXPLANATION
 /datum/objective/bloodsucker/monsterhunter/update_explanation_text()
@@ -379,16 +358,10 @@
 
 /datum/objective/bloodsucker/vassal
 
-// GENERATE!
-/datum/objective/bloodsucker/vassal/New()
-	update_explanation_text()
-	..()
-
 // EXPLANATION
 /datum/objective/bloodsucker/vassal/update_explanation_text()
 	. = ..()
 	explanation_text = "Guarantee the success of your Master's mission!"
-
 
 // WIN CONDITIONS?
 /datum/objective/bloodsucker/vassal/check_completion()


### PR DESCRIPTION
## About The Pull Request

Admins giving Bloodsucker objectives will now no longer say 'Nothing', and they can now give the Monster hunter's objective to destroy all monsters.
