### PR TITLE
[Selene & Helio] Makes CO2 get filtered back into waste

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -67639,6 +67639,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"gSF" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gTl" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -67723,6 +67727,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hdk" = (
@@ -68521,6 +68526,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"iON" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "iSu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -71958,6 +71977,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"qFt" = (
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qGF" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
@@ -72355,6 +72383,19 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"ryn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rBY" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -72684,6 +72725,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"slg" = (
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "sly" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
@@ -100815,13 +100864,13 @@ cbY
 cbY
 cbY
 cbY
-jOg
-cmU
-imH
+iON
+cmY
+slg
 hcM
-vEO
-crj
-dJg
+qFt
+gSF
+ryn
 ctP
 cvb
 cwn

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -3140,6 +3140,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"aSl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aSw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/structure/cable,
@@ -12482,6 +12488,13 @@
 	icon_state = "wood-broken4"
 	},
 /area/commons/vacant_room/office)
+"dqE" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "dqP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18669,6 +18682,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay)
+"eYa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "eYc" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -23338,6 +23357,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -30752,7 +30774,7 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "ieh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -65380,10 +65402,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qZz" = (
@@ -66895,6 +66917,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -90939,6 +90964,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"xFq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	piping_layer = 2
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xFv" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -126525,7 +126567,7 @@ hms
 hZs
 bEf
 qZy
-wVc
+aSl
 qoC
 koK
 teM
@@ -126782,7 +126824,7 @@ mZh
 wIk
 wqd
 ieh
-wVc
+eYa
 kiB
 koK
 xBM
@@ -127038,7 +127080,7 @@ qoZ
 xCX
 xCX
 bSe
-wVc
+ieh
 wVc
 sCZ
 nVF
@@ -127295,7 +127337,7 @@ aje
 lpI
 xCX
 amX
-sSs
+dqE
 xFT
 nZB
 nVF
@@ -127552,7 +127594,7 @@ suj
 dtF
 xCX
 iQp
-wVc
+ieh
 utY
 uKu
 nVF
@@ -128323,7 +128365,7 @@ xhK
 pUi
 jgr
 xUN
-sAg
+xFq
 sAg
 sAg
 iwb

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -3140,12 +3140,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"aSl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "aSw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/structure/cable,
@@ -12488,13 +12482,6 @@
 	icon_state = "wood-broken4"
 	},
 /area/commons/vacant_room/office)
-"dqE" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "dqP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18682,12 +18669,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay)
-"eYa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "eYc" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -23357,9 +23338,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -29026,6 +29004,13 @@
 /obj/structure/reagent_dispensers/virusfood/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"hHE" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 8;
+	piping_layer = 2
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hHX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -30774,7 +30759,7 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "ieh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -45569,6 +45554,9 @@
 	},
 /obj/structure/cable,
 /obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lRk" = (
@@ -60665,9 +60653,6 @@
 /turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "pOL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -60680,6 +60665,9 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -62691,7 +62679,6 @@
 /turf/open/floor/engine,
 /area/science/genetics)
 "qlT" = (
-/obj/effect/landmark/xeno_spawn,
 /obj/machinery/camera{
 	c_tag = "Engineering - Air Tank";
 	dir = 8;
@@ -65402,10 +65389,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qZz" = (
@@ -66917,9 +66904,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -77766,6 +77750,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uix" = (
@@ -90964,23 +90951,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"xFq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
-	piping_layer = 2
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xFv" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -126567,7 +126537,7 @@ hms
 hZs
 bEf
 qZy
-aSl
+wVc
 qoC
 koK
 teM
@@ -126824,7 +126794,7 @@ mZh
 wIk
 wqd
 ieh
-eYa
+wVc
 kiB
 koK
 xBM
@@ -127080,7 +127050,7 @@ qoZ
 xCX
 xCX
 bSe
-ieh
+wVc
 wVc
 sCZ
 nVF
@@ -127337,7 +127307,7 @@ aje
 lpI
 xCX
 amX
-dqE
+sSs
 xFT
 nZB
 nVF
@@ -127594,7 +127564,7 @@ suj
 dtF
 xCX
 iQp
-ieh
+wVc
 utY
 uKu
 nVF
@@ -128365,7 +128335,7 @@ xhK
 pUi
 jgr
 xUN
-xFq
+sAg
 sAg
 sAg
 iwb
@@ -128875,7 +128845,7 @@ qju
 wnU
 qDv
 lRi
-ecg
+hHE
 mGw
 fDv
 mNG


### PR DESCRIPTION
## About The Pull Request

Selene:
![image](https://user-images.githubusercontent.com/53777086/123530315-d2985780-d6c6-11eb-8379-2d51926be553.png)
Helio:
![image](https://user-images.githubusercontent.com/53777086/123530319-d926cf00-d6c6-11eb-8f2f-a80617a44724.png)

## Why It's Good For The Game

CO2 is meant to be sent back into the waste pipes so there's always CO2 for the station's freezers to send heat to, every map but the Fulp ones have this.