### PR TITLE
Removes game breaking oversight.

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -21755,10 +21755,6 @@
 /turf/open/floor/wood,
 /area/maintenance/fore)
 "fMv" = (
-/mob/living/simple_animal/hostile/lizard{
-	name = "Wags-His-Tail";
-	real_name = "Wags-His-Tail"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6


### PR DESCRIPTION
## About The Pull Request

There were TWO Wags-His-Tail spawns in the Selene custodial closet. Now there is only ONE.

## Why It's Good For The Game

Janitors powergaming moodbuffs from petting TWO Wags-His-Tail (they should only get one moodbuff as only one Wags-His-Tail should spawn1!)

## Changelog
:cl:

fix: Removes lizard

/:cl:
