### PR TITLE
SeleneStation: Atmospheric room pump shift

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -43394,7 +43394,10 @@
 	name = "Prison Orange"
 	},
 /obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix Outlet Pump"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "loF" = (
@@ -62744,16 +62747,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/department/crew_quarters/dorms)
-"qnG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Plasma Outlet Pump"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qnJ" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -129622,7 +129615,7 @@ jpa
 jpa
 vEj
 eZx
-qnG
+mAu
 lop
 mjs
 reQ


### PR DESCRIPTION

## About The Pull Request

Moves a pump down to help atmospheric techs

## Why It's Good For The Game

I was told that it would possibly stop atmospheric technicians from being racist

## Changelog
:cl:

balance: atmospheric room tweaks

/:cl:
