### PR TITLE
Race Ban Code Improvement [Not Modular... Yet?]

### DIFF
--- a/code/___fulp_defines/fulp_defines.dm
+++ b/code/___fulp_defines/fulp_defines.dm
@@ -10,9 +10,6 @@
 #define ROLE_BLOODSUCKER "Bloodsucker"
 /// Monster Hunters - Defines the role for preferences
 #define ROLE_MONSTERHUNTER "Monster Hunter"
-/// Used for banning people from playing certain races
-#define RACE_FELINID "Felinid Race"
-#define RACE_ETHEREAL "Ethereal Race"
 
 /*
  *	Source Trait Defines
@@ -86,6 +83,7 @@
  *	Misc Defines
  */
 /// Human sub-species defines
+#define SPECIES_BEEFMAN "beefman"
 #define isbeefman(A) (is_species(A,/datum/species/beefman))
 /// Defines the Mentorhelp's Mentorsay button
 #define COMSIG_KB_ADMIN_MSAY_DOWN "keybinding_mentor_msay_down"

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -293,12 +293,6 @@
 				ROLE_POSIBRAIN,
 				ROLE_SENTIENCE,
 			),
-			/// Fulp edit - Race bans
-			"Races" = list(
-				RACE_FELINID,
-				RACE_ETHEREAL,
-			),
-			/// Fulp edit ends - Race bans
 			"Antagonist Positions" = list(
 				ROLE_ABDUCTOR,
 				ROLE_ALIEN,
@@ -306,10 +300,6 @@
 				ROLE_BROTHER,
 				ROLE_CHANGELING,
 				ROLE_CULTIST,
-				/// Fulp edit - Bloodsuckers
-				ROLE_BLOODSUCKER,
-				ROLE_MONSTERHUNTER,
-				/// Fulp edit end - Bloodsuckers
 				ROLE_HERETIC,
 				ROLE_HIVE,
 				ROLE_INTERNAL_AFFAIRS,
@@ -326,6 +316,7 @@
 				ROLE_WIZARD,
 			),
 		)
+		long_job_lists.Add(GLOB.fulp_ban_list) // FULP EDIT - BANS
 		for(var/department in long_job_lists)
 			output += "<div class='column'><label class='rolegroup long [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_com\")'" : ""]>[department]</label><div class='content'>"
 			break_counter = 0

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -316,7 +316,6 @@
 				ROLE_WIZARD,
 			),
 		)
-		long_job_lists.Add(GLOB.fulp_ban_list) // FULP EDIT - BANS
 		for(var/department in long_job_lists)
 			output += "<div class='column'><label class='rolegroup long [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_com\")'" : ""]>[department]</label><div class='content'>"
 			break_counter = 0

--- a/fulp_modules/Z_edits/race_bans/races.dm
+++ b/fulp_modules/Z_edits/race_bans/races.dm
@@ -1,6 +1,5 @@
 /datum/species/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
-	//if(is_banned_from(C.ckey, src.id))
-	if(src.id != SPECIES_HUMAN)
+	if(is_banned_from(C.ckey, src.id))
 		addtimer(CALLBACK(C, /mob/living/carbon/proc/banned_species_revert), 5 SECONDS)
 		return
 	. = ..()

--- a/fulp_modules/Z_edits/race_bans/races.dm
+++ b/fulp_modules/Z_edits/race_bans/races.dm
@@ -1,5 +1,5 @@
 /datum/species/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
-	if(is_banned_from(C.ckey, src.id))
+	if(is_banned_from(C.ckey, id))
 		addtimer(CALLBACK(C, /mob/living/carbon/proc/banned_species_revert), 5 SECONDS)
 		return
 	. = ..()
@@ -7,4 +7,39 @@
 /// Made into an individual proc to ensure that the to_chat message would always show to users. Sometimes it would not appear during roundstart as it would be sent too soon.
 /mob/living/carbon/proc/banned_species_revert()
 	to_chat(src, span_alert("You are currently banned from playing this race. Please review any ban messages you have received, and contact admins if you believe this is a mistake."))
-	src.set_species(/datum/species/human)
+	set_species(/datum/species/human)
+
+/// Okay so this just overrides set_content for a browser datum so we can intercept banpanel content and just plop in what we need. God help us.
+/datum/browser/set_content(ncontent)
+	if(window_id == "banpanel") // Intercept ONLY the ban panel
+		if(findtext(ncontent, "Mirror edits to matching bans")) // Make sure we aren't intercepting the EDIT ban panel by finding the text. We sadly cannot access the href list that the old proc uses.
+			return ..()
+		var/list/output = list() // Variable that holds all the changes we make so we can add them all at once
+		var/break_counter = 0 // Variable used to insert a break if a category has more than 10 or so entries
+
+		// Literally copypasted code from sql_ban_system.dm apart from removing one variable that can't be noted. This has the side effect of not telling admins if someone is
+		// already banned from a fulp ban (I assume)
+		for(var/department in GLOB.fulp_ban_list) // For each list within the list...
+			output += "<div class='column'><label class='rolegroup long [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_com\")'" : ""]>[department]</label><div class='content'>"
+			break_counter = 0
+			for(var/job in GLOB.fulp_ban_list[department]) // Go to each element and add it with a little checkbox underneath the relevant "Department"
+				if(break_counter > 0 && (break_counter % 10 == 0))
+					output += "<br>"
+				output += {"<label class='inputlabel checkbox'>[job]
+							<input type='checkbox' name='[job]' class='[department]' value='1'>
+							<div class='inputbox'></div></label>
+				"}
+				break_counter++
+			output += "</div></div>"
+		output += "</div>"
+		output += "</form>"
+
+		var/closing_form_index = findlasttext(ncontent, "</form>") // We need to put our content before the closing /form so that it's a part of the form
+
+		ncontent = splicetext(ncontent, closing_form_index, 0, jointext(output, ""))
+	. = ..()
+
+
+
+
+

--- a/fulp_modules/Z_edits/race_bans/races.dm
+++ b/fulp_modules/Z_edits/race_bans/races.dm
@@ -1,15 +1,11 @@
-/datum/species/ethereal/spec_life(mob/living/carbon/human/H)
-	if(is_banned_from(H.ckey, RACE_ETHEREAL))
-		if(prob(50))
-			H.set_species(/datum/species/beefman)
-		else
-			H.set_species(/datum/species/human)
+/datum/species/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+	//if(is_banned_from(C.ckey, src.id))
+	if(src.id != SPECIES_HUMAN)
+		addtimer(CALLBACK(C, /mob/living/carbon/proc/banned_species_revert), 5 SECONDS)
+		return
 	. = ..()
 
-/datum/species/human/felinid/spec_life(mob/living/carbon/human/H)
-	if(is_banned_from(H.ckey, RACE_FELINID))
-		if(prob(50))
-			H.set_species(/datum/species/beefman)
-		else
-			H.set_species(/datum/species/human)
-	. = ..()
+/// Made into an individual proc to ensure that the to_chat message would always show to users. Sometimes it would not appear during roundstart as it would be sent too soon.
+/mob/living/carbon/proc/banned_species_revert()
+	to_chat(src, span_alert("You are currently banned from playing this race. Please review any ban messages you have received, and contact admins if you believe this is a mistake."))
+	src.set_species(/datum/species/human)

--- a/fulp_modules/global_vars.dm
+++ b/fulp_modules/global_vars.dm
@@ -12,4 +12,19 @@ GLOBAL_LIST_INIT(fulp_job_assignments, list(
 	"Deputy (Medical)",
 	"Deputy (Science)",
 	"Deputy (Service)",
-	))
+))
+
+GLOBAL_LIST_INIT(fulp_ban_list, list(
+	"Fulp Race Bans" = list(
+		SPECIES_FELINE,
+		SPECIES_MOTH,
+		SPECIES_ETHEREAL,
+		SPECIES_PLASMAMAN,
+		SPECIES_LIZARD,
+		SPECIES_BEEFMAN,
+	),
+	"Fulp Antagonist Positions" = list(
+		ROLE_BLOODSUCKER,
+		ROLE_MONSTERHUNTER,
+	),
+))

--- a/fulp_modules/main_features/beefmen/code/modules/mob/beefman.dm
+++ b/fulp_modules/main_features/beefmen/code/modules/mob/beefman.dm
@@ -5,7 +5,7 @@
 
 /datum/species/beefman
 	name = "Beefman"
-	id = "beefman"
+	id = SPECIES_BEEFMAN
 	limbs_id = "beefman"
 	say_mod = "gurgles"
 	sexes = FALSE


### PR DESCRIPTION
## About The Pull Request

I really wish these problems could have been addressed in the initial PR, but it was already merged. If a PR is gonna be treated like a meme during the review phase (Where problems are replied to with "Dont care") then it should be treated as a meme during the merge phase.

This frustrated me enough to make me want to fix it at midnight

## Why It's Good For The Game

Bans are no longer evaluated every time spec_life is called, fewer lines are modified in tg files, might be able to fully modularize it

![image](https://user-images.githubusercontent.com/83368538/126056550-a1c9efff-7b34-4144-b589-848b990f50b3.png)


## Changelog
:cl:
admin: More races can be banned, and it's easier to add even more (Ban for EVERY race????)
code: Added a global list of Fulp bans in the format of the job ban list in the sql ban code to more efficiently modularize ban code
code: Reduced the number of lines overridden in a TG file from 5 to 1... for now
code: Moved the ban evaluation code off of spec_life and onto on_species_gain
code: Added a beefman species id define (Sorry pucci, I needed it early)
/:cl:

Elephant in the Room: Fully Modularizable?

To be frank I dont know if this is fully modularizable. Given the entirety of the ban panel proc takes place within a SINGLE proc, wrapped in opening and closing form tags, Im not sure if it can be modified before or after its runtime. You can receive information from a form, but modifying it is the tough question. Im not adept enough with code or HTML to know if you can delete the concluding tags, add the content you need, then re-add them or what

Perhaps someone more familiar with the formatting of a browser can use get_content() to retroactively remove the closing tags, before copy-pasting the code from long_job_lists in a modular folder to add the content before closing it once again. I might try this later but dont get your hopes up.

Looking at the code, why the fuck does get content not directly provide you with the content variable, making it infinitely harder to modify the existing content