### PR TITLE
Secure coffin armour buff

### DIFF
--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
@@ -40,7 +40,7 @@
 
 /obj/structure/closet/crate/coffin/securecoffin
 	name = "secure coffin"
-	desc = "For insecure suckers to safely slumber in their secure sleeping space, surprisingly, this shelter's spacious sepulchre offers somewhat superior security."
+	desc = "For those too scared of having their place of rest disturbed."
 	icon_state = "securecoffin"
 	icon = 'fulp_modules/main_features/bloodsuckers/icons/vamp_obj.dmi'
 	open_sound = 'fulp_modules/main_features/bloodsuckers/sounds/coffin_open.ogg'

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
@@ -40,7 +40,7 @@
 
 /obj/structure/closet/crate/coffin/securecoffin
 	name = "secure coffin"
-	desc = "How can you tell if a vampire is sick? By how much hes coffin."
+	desc = "For insecure suckers to safely slumber in their secure sleeping space."
 	icon_state = "securecoffin"
 	icon = 'fulp_modules/main_features/bloodsuckers/icons/vamp_obj.dmi'
 	open_sound = 'fulp_modules/main_features/bloodsuckers/sounds/coffin_open.ogg'

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
@@ -40,7 +40,7 @@
 
 /obj/structure/closet/crate/coffin/securecoffin
 	name = "secure coffin"
-	desc = "For insecure suckers to safely slumber in their secure sleeping space."
+	desc = "For insecure suckers to safely slumber in their secure sleeping space, surprisingly, this shelter's spacious sepulchre offers somewhat superior security"
 	icon_state = "securecoffin"
 	icon = 'fulp_modules/main_features/bloodsuckers/icons/vamp_obj.dmi'
 	open_sound = 'fulp_modules/main_features/bloodsuckers/sounds/coffin_open.ogg'

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
@@ -40,7 +40,7 @@
 
 /obj/structure/closet/crate/coffin/securecoffin
 	name = "secure coffin"
-	desc = "For those too scared of having their place of rest disturbed."
+	desc = "How can you tell if a vampire is sick? By how much hes coffin."
 	icon_state = "securecoffin"
 	icon = 'fulp_modules/main_features/bloodsuckers/icons/vamp_obj.dmi'
 	open_sound = 'fulp_modules/main_features/bloodsuckers/sounds/coffin_open.ogg'

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
@@ -47,10 +47,10 @@
 	close_sound = 'fulp_modules/main_features/bloodsuckers/sounds/coffin_close.ogg'
 	breakout_time = 35 SECONDS
 	pryLidTimer = 35 SECONDS
-	resistance_flags = NONE
+	resistance_flags = FIRE_PROOF | LAVA_PROOF | ACID_PROOF
 	material_drop = /obj/item/stack/sheet/iron
 	material_drop_amount = 2
-	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 100, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 35, BULLET = 20, LASER = 20, ENERGY = 0, BOMB = 100, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 
 /obj/structure/closet/crate/coffin/meatcoffin
 	name = "meat coffin"
@@ -62,7 +62,6 @@
 	close_sound = 'sound/effects/footstep/slime1.ogg'
 	breakout_time = 25 SECONDS
 	pryLidTimer = 20 SECONDS
-	resistance_flags = NONE
 	material_drop = /obj/item/food/meat/slab/human
 	material_drop_amount = 3
 	armor = list(MELEE = 70, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 70, BIO = 0, RAD = 0, FIRE = 70, ACID = 60)

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
@@ -40,7 +40,7 @@
 
 /obj/structure/closet/crate/coffin/securecoffin
 	name = "secure coffin"
-	desc = "For insecure suckers to safely slumber in their secure sleeping space, surprisingly, this shelter's spacious sepulchre offers somewhat superior security"
+	desc = "For insecure suckers to safely slumber in their secure sleeping space, surprisingly, this shelter's spacious sepulchre offers somewhat superior security."
 	icon_state = "securecoffin"
 	icon = 'fulp_modules/main_features/bloodsuckers/icons/vamp_obj.dmi'
 	open_sound = 'fulp_modules/main_features/bloodsuckers/sounds/coffin_open.ogg'


### PR DESCRIPTION
## About The Pull Request

Before, secure coffins took 4 (four) welder hits to break open, as fun as it is to shit talk this coffin, I want to see a crazy lava coffin gimmick.

## Why It's Good For The Game

Armour sucked and coffin didn't have resistance flags, I wanna see more people using this sprite and design idea. New coffin should have just under the armour of the metal coffin, with lava acid, explosion and fire resistance 

## Changelog
:cl:
balance: Makes the secure coffin more secure, increasing its armour
/:cl: