### PR TITLE
Fixing Race Code 2: Electric Boogaloo

### DIFF
--- a/fulp_modules/Z_edits/race_bans/bans.dm
+++ b/fulp_modules/Z_edits/race_bans/bans.dm
@@ -1,10 +1,19 @@
-
+/// Case 1: Mob Login. Species are set before mobs are given a mind so we cant just use on_species_gain()
 /mob/sync_mind()
 	. = ..()
-	var/mob/living/carbon/human/H = src
-	H?.dna?.species.check_banned(H)
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		H?.dna?.species.check_banned(H)
+
+/// Case 2: Species Change. People can change their species midgame so we have to add this check aswell. sync_mind() only happens on login
+/datum/species/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+	. = ..()
+	check_banned(C)
 
 /datum/species/proc/check_banned(mob/living/carbon/C)
+	if(!C.ckey) // Checking for the value instead of using C?.ckey since it's immediately sent to a proc
+		return
+
 	if(is_banned_from(C.ckey, id))
 		addtimer(CALLBACK(C, /mob/living/carbon/proc/banned_species_revert), 10 SECONDS)
 		return


### PR DESCRIPTION
## About The Pull Request

Race ban code is now officially a ship of theseus

## Changelog
:cl:
code: Improves the clarity of sync_mind by adding an ishuman check
code: Re-adds the check_banned call to on_species_gain so banned people cant use mutation toxin or a pride mirror to change to their banned species
code: Modifies check_banned to early return if the mob doesnt have a ckey
code: Adds some comments to the race ban code
/:cl: