### PR TITLE
Adds module duplicators to Selene/Helio

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -43371,6 +43371,7 @@
 	color = "#990099";
 	name = "research purple"
 	},
+/obj/machinery/module_duplicator,
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "bZn" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -2373,6 +2373,19 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"aHw" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/module_duplicator,
+/turf/open/floor/iron/white,
+/area/science/misc_lab/range)
 "aHM" = (
 /turf/open/floor/iron/freezer,
 /area/science/xenobiology)
@@ -136905,7 +136918,7 @@ diJ
 xcj
 fJz
 rKO
-nsV
+aHw
 pwf
 heQ
 efn


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Module duplicators were missing from Selene/Helio, unlike the official TG maps. Now they're not.

## Why It's Good For The Game

Module duplicators are supposed to be in every circuit lab.

## Changelog
:cl:
add: Added module duplicators to Selene/Helio 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
