### PR TITLE
Minor changes on the cytology spawner

### DIFF
--- a/fulp_modules/mapping/ruins/icemoon/beefman_cytology/beef_cytology.dmm
+++ b/fulp_modules/mapping/ruins/icemoon/beefman_cytology/beef_cytology.dmm
@@ -478,7 +478,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/item/pickaxe,
 /obj/item/flashlight/seclite,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
@@ -690,6 +689,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/item/slimecross/stabilized/pink,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "Hd" = (
@@ -724,6 +724,7 @@
 /area/icemoon/underground/explored)
 "Js" = (
 /obj/structure/table/reinforced,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/powered/beefcyto)
 "Jy" = (
@@ -782,6 +783,7 @@
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/item/wrench,
+/obj/item/slimecross/stabilized/pink,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "MU" = (

--- a/fulp_modules/mapping/ruins/icemoon/beefman_cytology/beef_cytology.dmm
+++ b/fulp_modules/mapping/ruins/icemoon/beefman_cytology/beef_cytology.dmm
@@ -1,248 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"af" = (
-/obj/effect/mob_spawn/human/beefman/cytology,
-/turf/open/floor/iron/white,
+"ag" = (
+/mob/living/simple_animal/hostile/blob/blobbernaut/independent,
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered/beefcyto)
-"al" = (
-/obj/structure/marker_beacon,
-/turf/open/floor/plating/asteroid/snow/atmosphere,
-/area/icemoon/underground/explored)
-"bl" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/beefcyto)
-"bx" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/item/defibrillator/loaded,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"bC" = (
-/obj/machinery/button/door{
-	id = "blobbernaut door";
-	name = "blobbernaut door bolt";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/powered/beefcyto)
-"bI" = (
-/turf/closed/wall/r_wall,
-/area/ruin/powered/beefcyto)
-"bZ" = (
-/obj/machinery/light,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"cx" = (
-/obj/machinery/jukebox,
+"av" = (
 /turf/open/floor/eighties,
 /area/ruin/powered/beefcyto)
-"cz" = (
-/obj/machinery/door/airlock/vault{
-	id_tag = "migo door";
-	name = "migo door"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/fans/tiny,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/powered/beefcyto)
-"cD" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/snowed,
-/area/icemoon/underground/explored)
-"cY" = (
-/obj/machinery/door/airlock/public,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"dr" = (
-/obj/structure/table/glass,
-/obj/item/hatchet,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/seeds/chanter/jupitercup,
-/obj/item/seeds/chanter/jupitercup,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"dI" = (
-/obj/item/book/manual/wiki/cytology,
-/obj/machinery/smartfridge/petri/preloaded,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"dW" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"ee" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/structure/fence/post,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"ef" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/beefcyto)
-"eh" = (
-/obj/structure/moisture_trap,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/ruin/powered/beefcyto)
-"el" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/turf/open/floor/eighties,
-/area/ruin/powered/beefcyto)
-"et" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"ey" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/ruin/powered/beefcyto)
-"fn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/powered/beefcyto)
-"fu" = (
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"fB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/chem_master,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"fU" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"fY" = (
-/obj/structure/marker_beacon,
-/obj/structure/flora/ash/chilly,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"ga" = (
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/ruin/powered/beefcyto)
-"gN" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/closet/crate,
-/obj/item/borg/upgrade/modkit/damage,
-/obj/item/borg/upgrade/modkit/damage,
-/obj/item/borg/upgrade/modkit/range,
-/obj/item/borg/upgrade/modkit/cooldown,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"hn" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/plating/asteroid/snow/atmosphere,
-/area/icemoon/underground/explored)
-"hL" = (
-/turf/open/floor/grass,
-/area/ruin/powered/beefcyto)
-"hU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/chem_dispenser,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"hX" = (
-/obj/machinery/vending/boozeomat/all_access{
-	onstation = 0
-	},
-/turf/open/floor/iron/cafeteria,
-/area/ruin/powered/beefcyto)
-"ie" = (
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/powered/beefcyto)
-"if" = (
-/obj/structure/window,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/ruin/powered/beefcyto)
-"ii" = (
-/turf/open/floor/plating/asteroid/snow/atmosphere,
-/area/icemoon/underground/explored)
-"iA" = (
-/obj/structure/marker_beacon,
-/obj/structure/flora/grass/both,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"iT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"jn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"jR" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"lr" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/ruin/powered/beefcyto)
-"lv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"lQ" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"mn" = (
-/obj/machinery/griddle,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/powered/beefcyto)
-"mD" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"mV" = (
-/obj/machinery/button/door{
-	id = "carp door";
-	name = "carp door bolt";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/powered/beefcyto)
-"mY" = (
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"nd" = (
+"aI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -255,87 +20,184 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"ng" = (
-/obj/structure/fans/tiny/invisible,
-/turf/open/floor/plating/asteroid/snow/atmosphere,
-/area/icemoon/underground/explored)
-"nh" = (
-/obj/item/wallframe/extinguisher_cabinet,
-/turf/closed/wall/r_wall,
-/area/ruin/powered/beefcyto)
-"nH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"nP" = (
-/obj/structure/fence{
-	dir = 4
-	},
+"aX" = (
+/obj/structure/flora/rock/pile/icy,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"os" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/light,
+"bg" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"oY" = (
+"bk" = (
+/turf/open/floor/iron/cafeteria,
+/area/ruin/powered/beefcyto)
+"by" = (
+/obj/structure/sign/departments/xenobio,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/beefcyto)
+"bA" = (
 /obj/structure/closet/crate/wooden,
 /obj/item/stack/sheet/mineral/wood{
 	amount = 10
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"pr" = (
-/mob/living/simple_animal/mouse/white,
-/turf/open/floor/plating,
+"bB" = (
+/turf/open/floor/plating/asteroid/snow/atmosphere,
+/area/icemoon/underground/explored)
+"bM" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"pG" = (
-/mob/living/simple_animal/hostile/retaliate/goat,
-/obj/effect/turf_decal/siding/blue/end{
+"co" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/structure/table/reinforced,
+/obj/item/construction/plumbing,
+/obj/item/storage/box/beakers/bluespace,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"cp" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/beefcyto)
+"cP" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/beefcyto)
+"cQ" = (
+/mob/living/simple_animal/chick,
+/turf/open/floor/grass,
+/area/ruin/powered/beefcyto)
+"dB" = (
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron/kitchen_coldroom,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"pT" = (
-/obj/structure/grille,
+"eo" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"eP" = (
+/mob/living/simple_animal/mouse/gray,
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
-"qf" = (
+"fj" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"fT" = (
+/obj/structure/closet/l3closet/virology,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"fU" = (
+/obj/machinery/door/airlock/survival_pod,
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/powered/beefcyto)
+"gh" = (
 /obj/structure/marker_beacon,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/snow/atmosphere,
 /area/icemoon/underground/explored)
-"qp" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/cafeteria,
+"gG" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
-"rg" = (
-/obj/machinery/microwave,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/cafeteria,
+"gV" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/light,
+/turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"rj" = (
+"il" = (
+/obj/machinery/door/window/westleft,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/ruin/powered/beefcyto)
+"iB" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"rY" = (
-/obj/structure/marker_beacon,
-/obj/structure/fence,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"sc" = (
-/obj/structure/flora/tree/pine,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"sn" = (
-/obj/structure/closet/crate/trashcart,
+"js" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"jx" = (
+/obj/machinery/door/airlock/vault{
+	id_tag = "migo door";
+	name = "migo door"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/powered/beefcyto)
+"jy" = (
+/obj/structure/closet/l3closet/virology,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/light,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"jz" = (
+/obj/item/wallframe/extinguisher_cabinet,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/beefcyto)
+"jX" = (
+/obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
-"sy" = (
+"kI" = (
+/obj/machinery/door/airlock/vault{
+	id_tag = "carp door";
+	name = "carp door"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/powered/beefcyto)
+"lO" = (
+/obj/machinery/light,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/ruin/powered/beefcyto)
+"mj" = (
+/obj/structure/moisture_trap,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/ruin/powered/beefcyto)
+"mu" = (
 /obj/structure/closet/secure_closet/cytology{
 	req_access = null
 	},
@@ -345,13 +207,50 @@
 /obj/item/clothing/suit/toggle/labcoat/science,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"sz" = (
-/obj/structure/fence/door{
+"mH" = (
+/obj/structure/fence{
 	dir = 4
 	},
+/obj/structure/fence/post,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"tb" = (
+"nl" = (
+/mob/living/simple_animal/pet/penguin/emperor/shamebrero,
+/turf/open/floor/plating/asteroid/snow/atmosphere,
+/area/icemoon/underground/explored)
+"nt" = (
+/obj/structure/chair/sofa/corp{
+	dir = 1
+	},
+/turf/open/floor/eighties,
+/area/ruin/powered/beefcyto)
+"nP" = (
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"nS" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"ol" = (
+/obj/machinery/jukebox,
+/turf/open/floor/eighties,
+/area/ruin/powered/beefcyto)
+"on" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/turf/open/floor/eighties,
+/area/ruin/powered/beefcyto)
+"op" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"oB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -363,44 +262,61 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"ts" = (
-/obj/machinery/light,
+"oI" = (
+/obj/machinery/chem_master/condimaster,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/ruin/powered/beefcyto)
-"tt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"tA" = (
-/obj/structure/fireplace,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"tF" = (
-/mob/living/simple_animal/pet/penguin/emperor,
-/turf/open/floor/plating/asteroid/snow/atmosphere,
-/area/icemoon/underground/explored)
-"tN" = (
-/obj/effect/turf_decal/caution{
+"oM" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"tW" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+"oW" = (
+/obj/structure/flora/tree/pine,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"pg" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"ph" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/chem_master,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"pm" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"ug" = (
-/turf/open/floor/plating/asteroid/snow/icemoon,
+"ps" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plating/asteroid/snow/atmosphere,
 /area/icemoon/underground/explored)
-"uq" = (
+"pv" = (
+/turf/closed/wall/r_wall,
+/area/ruin/powered/beefcyto)
+"pD" = (
+/mob/living/simple_animal/cow,
+/turf/open/floor/grass,
+/area/ruin/powered/beefcyto)
+"pS" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"pW" = (
+/obj/machinery/door/airlock/public,
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"qG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
@@ -409,215 +325,145 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"ux" = (
-/obj/structure/closet/crate/bin,
-/obj/item/clothing/shoes/clown_shoes,
-/obj/item/food/breadslice/moldy,
-/obj/item/food/pizzaslice/moldy,
-/turf/open/floor/iron/white,
+"qP" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
+	},
+/turf/open/floor/eighties,
 /area/ruin/powered/beefcyto)
-"uV" = (
-/obj/machinery/door/airlock/public/glass,
+"ra" = (
+/turf/open/floor/plating/snowed,
+/area/icemoon/underground/explored)
+"rc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/ice,
 /turf/open/floor/plating/snowed,
 /area/ruin/powered/beefcyto)
-"va" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/obj/structure/table/wood,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"vX" = (
-/obj/structure/moisture_trap,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"wj" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"ww" = (
+"sH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/ice,
 /turf/open/space/basic,
 /area/ruin/powered/beefcyto)
-"xf" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
+"sR" = (
+/obj/machinery/biogenerator,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"xg" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/beefcyto)
-"xl" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"xo" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"xD" = (
-/obj/structure/fence/corner,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+"sY" = (
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating/asteroid/snow/atmosphere,
 /area/icemoon/underground/explored)
-"xF" = (
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"yi" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"yD" = (
-/obj/machinery/door/airlock/survival_pod,
-/obj/structure/fans/tiny,
+"sZ" = (
+/mob/living/simple_animal/hostile/netherworld/migo,
+/obj/machinery/light/floor,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered/beefcyto)
-"yE" = (
-/obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+"ta" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck,
+/obj/item/lighter,
+/turf/open/floor/eighties,
+/area/ruin/powered/beefcyto)
+"tb" = (
+/turf/open/lava/plasma,
+/area/icemoon/underground/explored)
+"tA" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/blood/ethereal,
+/obj/item/reagent_containers/blood/ethereal,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/item/reagent_containers/blood/ethereal,
+/obj/item/reagent_containers/blood/ethereal,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"yQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/wrench,
-/obj/item/wrench,
+"tD" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/structure/table/wood,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"yV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+"tT" = (
+/obj/structure/table/glass,
+/obj/item/hatchet,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/seeds/chanter/jupitercup,
+/obj/item/seeds/chanter/jupitercup,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"us" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"ut" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"yX" = (
+"uy" = (
 /mob/living/simple_animal/chicken,
 /turf/open/floor/grass,
 /area/ruin/powered/beefcyto)
-"zl" = (
+"uO" = (
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"uZ" = (
+/mob/living/simple_animal/hostile/carp,
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/powered/beefcyto)
+"ve" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/chem_dispenser,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"vA" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"vY" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"wf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder/constructed,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"wn" = (
 /obj/machinery/vending/hydronutrients{
 	onstation = 0
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"zO" = (
-/obj/structure/flora/ash/chilly,
-/turf/open/floor/plating/asteroid/snow/atmosphere,
+"wE" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/snowed,
 /area/icemoon/underground/explored)
-"AE" = (
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/powered/beefcyto)
-"AM" = (
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/obj/structure/table/wood,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"AZ" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
-	},
-/turf/open/floor/eighties,
-/area/ruin/powered/beefcyto)
-"Ba" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
+"wZ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"BB" = (
-/mob/living/simple_animal/chick,
-/turf/open/floor/grass,
-/area/ruin/powered/beefcyto)
-"BP" = (
-/mob/living/simple_animal/cow,
-/turf/open/floor/grass,
-/area/ruin/powered/beefcyto)
-"BT" = (
-/obj/machinery/gibber,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/ruin/powered/beefcyto)
-"BU" = (
-/turf/open/floor/iron/kitchen_coldroom,
-/area/ruin/powered/beefcyto)
-"Cc" = (
-/turf/closed/mineral/snowmountain/cavern/icemoon,
-/area/icemoon/underground/explored)
-"CC" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"CU" = (
-/mob/living/simple_animal/hostile/tree{
-	health = 100
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"DB" = (
-/obj/structure/fence/corner{
-	dir = 6
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"Fm" = (
-/obj/structure/sign/warning/xeno_mining,
-/turf/closed/wall/r_wall,
-/area/ruin/powered/beefcyto)
-"Fv" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"FR" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"Gb" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"Gn" = (
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/grass,
-/area/ruin/powered/beefcyto)
-"Go" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/turf/open/floor/eighties,
-/area/ruin/powered/beefcyto)
-"Hg" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/powered/beefcyto)
-"HR" = (
+"xA" = (
 /obj/machinery/door/airlock/vault{
-	id_tag = "carp door";
-	name = "carp door"
+	id_tag = "blobbernaut door";
+	name = "blobbernaut door"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered/beefcyto)
-"In" = (
+"xF" = (
 /obj/structure/table/wood,
 /obj/item/gun/energy/kinetic_accelerator,
 /obj/item/kitchen/knife/combat/survival,
@@ -636,164 +482,21 @@
 /obj/item/flashlight/seclite,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"Ip" = (
-/obj/machinery/deepfryer,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/powered/beefcyto)
-"Is" = (
-/mob/living/simple_animal/pet/penguin/emperor/shamebrero,
-/turf/open/floor/plating/asteroid/snow/atmosphere,
-/area/icemoon/underground/explored)
-"IO" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"IT" = (
-/mob/living/simple_animal/mouse/gray,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"IU" = (
-/turf/open/floor/iron/cafeteria,
-/area/ruin/powered/beefcyto)
-"Jp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/obj/structure/table/reinforced,
-/obj/item/construction/plumbing,
-/obj/item/storage/box/beakers/bluespace,
+"xJ" = (
+/obj/structure/fireplace,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"JF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ice,
-/turf/open/floor/plating/snowed,
-/area/ruin/powered/beefcyto)
-"JH" = (
-/mob/living/simple_animal/hostile/blob/blobbernaut/independent,
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/powered/beefcyto)
-"JZ" = (
-/turf/open/floor/eighties,
-/area/ruin/powered/beefcyto)
-"Kz" = (
-/obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"KT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/machinery/chem_heater,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"KU" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"Lt" = (
-/obj/item/slimecross/chilling/gold,
-/obj/item/slimecross/chilling/gold,
-/obj/item/slimecross/chilling/gold,
-/obj/item/slimecross/chilling/gold,
-/obj/item/slimecross/chilling/gold,
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"LM" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"LP" = (
-/obj/structure/chair/sofa/corp/corner{
+"xS" = (
+/obj/structure/fence{
 	dir = 8
 	},
-/turf/open/floor/eighties,
-/area/ruin/powered/beefcyto)
-"Mk" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"MA" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"MC" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/moisture_trap,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"ME" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/fans/tiny,
+"yq" = (
+/obj/structure/closet/crate/trashcart,
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
-"ML" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/ruin/powered/beefcyto)
-"Ne" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"Nu" = (
-/obj/machinery/button/door{
-	id = "migo door";
-	name = "migo door bolt";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/powered/beefcyto)
-"Oh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"On" = (
-/turf/open/floor/plating/snowed,
-/area/icemoon/underground/explored)
-"Ox" = (
-/mob/living/simple_animal/pet/penguin/baby,
-/turf/open/floor/plating/asteroid/snow/atmosphere,
-/area/icemoon/underground/explored)
-"Pk" = (
-/obj/structure/geyser,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"Pp" = (
-/obj/structure/fireplace{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"Py" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"PB" = (
+"yA" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -807,191 +510,287 @@
 /obj/machinery/light,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"PC" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
+"yD" = (
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"yT" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/powered/beefcyto)
+"zc" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
-/obj/item/storage/box/syringes,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"Qk" = (
+"zg" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/chem_heater,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"zv" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"zQ" = (
+/mob/living/simple_animal/pet/penguin/baby,
+/turf/open/floor/plating/asteroid/snow/atmosphere,
+/area/icemoon/underground/explored)
+"Ag" = (
+/obj/structure/fireplace{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"Av" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"Ay" = (
+/turf/open/floor/grass,
+/area/ruin/powered/beefcyto)
+"AP" = (
+/mob/living/simple_animal/hostile/retaliate/goat,
+/obj/effect/turf_decal/siding/blue/end{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/ruin/powered/beefcyto)
+"AQ" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/beefcyto)
+"AV" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/powered/beefcyto)
+"BL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/clothing/head/chicken,
+/turf/open/floor/grass,
+/area/ruin/powered/beefcyto)
+"Cc" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/item/borg/upgrade/modkit/damage,
+/obj/item/borg/upgrade/modkit/damage,
+/obj/item/borg/upgrade/modkit/range,
+/obj/item/borg/upgrade/modkit/cooldown,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"Cj" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/powered/beefcyto)
+"Cu" = (
+/obj/structure/fence/corner{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"CD" = (
+/obj/structure/geyser,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"CJ" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"CM" = (
+/mob/living/simple_animal/mouse/white,
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"De" = (
+/obj/effect/turf_decal/caution{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"Ds" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"DP" = (
+/obj/machinery/button/door{
+	id = "carp door";
+	name = "carp door bolt";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/beefcyto)
+"DW" = (
+/obj/structure/marker_beacon,
 /obj/structure/flora/ash/chilly,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"Qy" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"QJ" = (
-/mob/living/simple_animal/mouse/brown,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"Rq" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"Ru" = (
-/obj/machinery/door/window/westleft,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/ruin/powered/beefcyto)
-"Sp" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"Su" = (
+"Ea" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"Sv" = (
+"Ed" = (
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"Ef" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"Ek" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"Em" = (
+/obj/effect/mob_spawn/human/beefman/cytology,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"EW" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"FM" = (
+/obj/structure/fence/door{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"GL" = (
+/obj/structure/flora/ash/chilly,
+/turf/open/floor/plating/asteroid/snow/atmosphere,
+/area/icemoon/underground/explored)
+"GX" = (
+/obj/item/slimecross/chilling/gold,
+/obj/item/slimecross/chilling/gold,
+/obj/item/slimecross/chilling/gold,
+/obj/item/slimecross/chilling/gold,
+/obj/item/slimecross/chilling/gold,
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"Sx" = (
+"Hd" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"HZ" = (
+/obj/structure/marker_beacon,
+/obj/structure/fence,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"Ib" = (
+/mob/living/simple_animal/hostile/tree{
+	health = 100
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"Ic" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"Io" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/plating/snowed,
+/area/ruin/powered/beefcyto)
+"It" = (
+/turf/open/floor/iron/kitchen_coldroom,
+/area/ruin/powered/beefcyto)
+"Iz" = (
+/turf/closed/mineral/snowmountain/cavern/icemoon,
+/area/icemoon/underground/explored)
+"Js" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/powered/beefcyto)
+"Jy" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"JG" = (
+/mob/living/simple_animal/mouse/brown,
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"JT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/powered/beefcyto)
+"Ku" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"Kz" = (
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/grass,
+/area/ruin/powered/beefcyto)
+"KK" = (
+/obj/structure/fence/door{
+	open = 1
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"Lo" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"Lt" = (
 /obj/machinery/vending/hydroseeds{
 	onstation = 0
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"SG" = (
-/obj/structure/fence,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"To" = (
-/mob/living/simple_animal/hostile/netherworld/migo,
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/powered/beefcyto)
-"TJ" = (
-/obj/machinery/door/airlock/vault{
-	id_tag = "blobbernaut door";
-	name = "blobbernaut door"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
+"LA" = (
+/obj/machinery/door/airlock/public/glass,
 /obj/structure/fans/tiny,
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
-"TQ" = (
-/obj/structure/sign/departments/xenobio,
-/turf/closed/wall/r_wall,
-/area/ruin/powered/beefcyto)
-"Ue" = (
-/obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/machinery/light,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"Uj" = (
-/obj/structure/fence/door{
-	open = 1
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"Up" = (
-/turf/closed/wall,
-/area/ruin/powered/beefcyto)
-"UA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder/constructed,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"Vs" = (
-/mob/living/simple_animal/hostile/carp,
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/powered/beefcyto)
-"Vu" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"Vv" = (
+"LV" = (
 /obj/structure/flora/grass/both,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"VI" = (
-/obj/structure/flora/ash/chilly,
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"Wh" = (
-/obj/structure/chair/sofa/corp/left{
+"LX" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/wrench,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"MU" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/mob/living/simple_animal/pet/dog/pug,
-/turf/open/floor/eighties,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered/beefcyto)
-"Wn" = (
-/obj/machinery/vending/dinnerware{
-	default_price = null;
-	extra_price = null;
-	fair_market_price = null;
-	onstation = 0
-	},
-/turf/open/floor/iron/cafeteria,
-/area/ruin/powered/beefcyto)
-"WR" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/blood/ethereal,
-/obj/item/reagent_containers/blood/ethereal,
-/obj/item/reagent_containers/blood/o_minus,
-/obj/item/reagent_containers/blood/o_minus,
-/obj/item/reagent_containers/blood/o_minus,
-/obj/item/reagent_containers/blood/ethereal,
-/obj/item/reagent_containers/blood/ethereal,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"Xf" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck,
-/obj/item/lighter,
-/turf/open/floor/eighties,
-/area/ruin/powered/beefcyto)
-"Xv" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"Xw" = (
-/obj/structure/closet/secure_closet/freezer/fridge{
-	req_access = null
-	},
-/obj/item/storage/box/papersack/meat,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/powered/beefcyto)
-"XC" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/iron/white,
-/area/ruin/powered/beefcyto)
-"XH" = (
+"Nf" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -1004,1159 +803,2112 @@
 /obj/item/clothing/suit/toggle/labcoat/science,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"Yk" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/clothing/head/chicken,
-/turf/open/floor/grass,
+"NV" = (
+/turf/closed/wall,
 /area/ruin/powered/beefcyto)
-"YF" = (
+"OJ" = (
+/obj/structure/fence/corner,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"OK" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/obj/item/storage/box/syringes,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"Pc" = (
+/obj/structure/window,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/ruin/powered/beefcyto)
+"Pg" = (
+/obj/structure/marker_beacon,
+/obj/structure/flora/grass/both,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"PN" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"PY" = (
+/obj/structure/flora/ash/chilly,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"Qx" = (
+/obj/machinery/vending/boozeomat/all_access{
+	onstation = 0
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/powered/beefcyto)
+"QA" = (
 /obj/structure/table/reinforced,
 /obj/structure/microscope,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"Zx" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
+"QC" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/moisture_trap,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"ZI" = (
-/obj/machinery/light{
-	dir = 4
+"QD" = (
+/obj/machinery/button/door{
+	id = "blobbernaut door";
+	name = "blobbernaut door bolt";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/beefcyto)
+"Rd" = (
+/obj/item/book/manual/wiki/cytology,
+/obj/machinery/smartfridge/petri/preloaded,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"Rp" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"Rx" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"RF" = (
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/powered/beefcyto)
+"RK" = (
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/structure/table/wood,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"RQ" = (
+/mob/living/simple_animal/pet/penguin/emperor,
+/turf/open/floor/plating/asteroid/snow/atmosphere,
+/area/icemoon/underground/explored)
+"Sh" = (
+/obj/structure/closet/crate/bin,
+/obj/item/clothing/shoes/clown_shoes,
+/obj/item/food/breadslice/moldy,
+/obj/item/food/pizzaslice/moldy,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"Si" = (
+/obj/machinery/vending/dinnerware{
+	default_price = null;
+	extra_price = null;
+	fair_market_price = null;
+	onstation = 0
 	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/powered/beefcyto)
+"Sj" = (
+/obj/machinery/light,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"Sn" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/green,
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"SG" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1
+	},
+/turf/open/floor/eighties,
+/area/ruin/powered/beefcyto)
+"SN" = (
+/obj/machinery/button/door{
+	id = "migo door";
+	name = "migo door bolt";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/beefcyto)
+"Tw" = (
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"Tx" = (
+/obj/structure/sign/warning/xeno_mining,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/beefcyto)
+"UH" = (
+/obj/structure/flora/ash/chilly,
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"UI" = (
+/obj/structure/moisture_trap,
+/turf/open/floor/plating,
+/area/ruin/powered/beefcyto)
+"UW" = (
+/obj/machinery/computer/pandemic,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"Vc" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/beefcyto)
+"Vk" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/ruin/powered/beefcyto)
+"Wk" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"WQ" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"Yc" = (
+/obj/machinery/microwave,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/powered/beefcyto)
+"Yo" = (
+/obj/machinery/door/window{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/beefcyto)
+"YC" = (
+/obj/machinery/gibber,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/ruin/powered/beefcyto)
+"YH" = (
+/obj/machinery/griddle,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/powered/beefcyto)
+"YN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"YW" = (
+/obj/structure/fence,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"Zs" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
+/obj/item/storage/box/papersack/meat,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/powered/beefcyto)
+"ZX" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/mob/living/simple_animal/pet/dog/pug,
+/turf/open/floor/eighties,
+/area/ruin/powered/beefcyto)
 
 (1,1,1) = {"
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
 "}
 (2,1,1) = {"
-Cc
-Vv
-ug
-ug
-wj
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-Vv
-ug
-ug
-ug
-ug
-CC
-Cc
+Iz
+Iz
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+Iz
 "}
 (3,1,1) = {"
-Cc
-ug
-mY
-SG
-SG
-SG
-SG
-SG
-SG
-SG
-SG
-SG
-SG
-SG
-SG
-SG
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-ug
-ug
-ug
-ug
-Cc
+Iz
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+Iz
 "}
 (4,1,1) = {"
-Cc
-ug
-nP
-ug
-ug
-ug
-ug
-Qk
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-bI
-vX
-xF
-QJ
-pT
-Xv
-sn
-vX
-et
-KU
-yV
-uq
-yV
-yV
-Zx
-bI
-ug
-ug
-ug
-sc
-Cc
+Iz
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+Iz
 "}
 (5,1,1) = {"
-Cc
-ug
-ee
-ug
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-ug
-ug
-Vv
-ug
-ug
-bI
-xF
-xF
-xF
-xF
-xF
-xF
-tN
-ME
-Sv
-fu
-fu
-fu
-fu
-os
-bI
-ug
-ug
-ug
-Vv
-Cc
+Iz
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+Iz
 "}
 (6,1,1) = {"
-Cc
-ug
-nP
-ug
-bI
-JH
-bI
-To
-bI
-Vs
-bI
-ug
-ug
-ug
-ug
-ug
-lr
-xl
-xF
-bI
-bI
-bI
-bI
-TQ
-nh
-Sv
-fu
-fu
-fu
-fu
-tt
-bI
-ug
-ug
-ug
-ug
-Cc
+Iz
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+Iz
 "}
 (7,1,1) = {"
-Cc
-ug
-nP
-ug
-ML
-TJ
-Nu
-cz
-mV
-HR
-ML
-ug
-ug
-ug
-ug
-ug
-bI
-FR
-et
-bI
-ii
-ii
-ii
-al
-JF
-Lt
-fu
-fu
-fu
-fu
-tt
-bI
-Qk
-ug
-ug
-sc
-Cc
+Iz
+tb
+tb
+tb
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+tb
+tb
+tb
+Iz
 "}
 (8,1,1) = {"
-Cc
-ug
-nP
-CC
-bC
-ie
-ie
-ie
-ie
-AE
-bI
-ug
-ug
-ug
-bI
-bI
-bI
-rj
-Gb
-bI
-nh
-bI
-ii
-tF
-JF
-yQ
-fu
-fu
-fu
-fu
-tt
-bI
-ug
-ug
-ug
-ug
-Cc
+Iz
+tb
+tb
+tb
+Iz
+LV
+yD
+yD
+aX
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+LV
+yD
+yD
+yD
+yD
+Ic
+Iz
+tb
+tb
+tb
+Iz
 "}
 (9,1,1) = {"
-Cc
-ug
-ee
-qf
+Iz
+tb
+tb
+tb
+Iz
 yD
-ie
-ie
-fn
-ie
-ie
+Tw
+YW
+YW
+YW
+YW
+YW
+YW
+YW
+YW
+YW
+YW
+YW
+YW
+YW
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
 yD
-qf
-ug
-bI
-bI
-MC
-mD
-Vu
-Ba
-iT
-tW
-bI
-bI
-ii
-JF
-Lt
-fu
-fu
-fu
-fu
-os
-bI
-ug
-ug
-ug
-Qk
-Cc
+yD
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (10,1,1) = {"
-Cc
-ug
-nP
-ug
-bI
-bI
-bI
-Fm
-bI
-bI
-bI
-ug
-ug
-ww
-WR
-Vu
-fu
-fu
-fu
-fu
-Ba
-Jp
-JF
-ii
-JF
-Oh
-jR
-Rq
-jR
-jR
-Ne
-bI
-ug
-ug
-ug
-CU
-Cc
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+yD
+yD
+yD
+PY
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+pv
+UI
+uO
+JG
+Rp
+CJ
+yq
+UI
+Ds
+bM
+fj
+qG
+fj
+fj
+wZ
+pv
+yD
+yD
+yD
+oW
+Iz
+tb
+tb
+tb
+Iz
 "}
 (11,1,1) = {"
-Cc
-ug
+Iz
+tb
+tb
+tb
+Iz
+yD
+mH
+yD
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+yD
+yD
+LV
+yD
+yD
+pv
+uO
+uO
+uO
+uO
+uO
+uO
+De
+LA
+Rx
 nP
-ug
-qf
-ug
-qf
-ug
-qf
-ug
-qf
-ug
-ug
-ww
-rj
-fu
-fu
-dI
-YF
-fu
-fu
-fB
-JF
-ii
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-ug
-ug
-ug
-ug
-Cc
+nP
+nP
+nP
+gV
+pv
+yD
+yD
+yD
+LV
+Iz
+tb
+tb
+tb
+Iz
 "}
 (12,1,1) = {"
-Cc
-wj
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+pv
+ag
+pv
+sZ
+pv
+uZ
+pv
+yD
+yD
+yD
+yD
+yD
+cP
+jX
+uO
+pv
+pv
+pv
+pv
+by
+jz
+Rx
 nP
-Qk
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ww
-Kz
-fu
-fu
-YF
-Fv
-fu
-fu
-hU
-JF
-ii
-MA
-ug
-ug
-ug
-ug
-ug
-ug
-MA
-ug
-ug
-ug
-ug
-Cc
+nP
+nP
+nP
+eo
+pv
+yD
+yD
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (13,1,1) = {"
-Cc
-ug
-ee
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-Qk
-ww
-PC
-fu
-fu
-Su
-UA
-fu
-fu
-nH
-JF
-ii
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-ug
-ug
-ug
-sc
-Cc
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+AQ
+xA
+SN
+jx
+DP
+kI
+AQ
+yD
+yD
+yD
+yD
+yD
+pv
+Hd
+Ds
+pv
+bB
+bB
+bB
+gh
+rc
+GX
+nP
+nP
+nP
+nP
+eo
+pv
+PY
+yD
+yD
+oW
+Iz
+tb
+tb
+tb
+Iz
 "}
 (14,1,1) = {"
-Cc
-ug
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+Ic
+QD
+yT
+yT
+yT
+yT
+RF
+pv
+yD
+yD
+yD
+pv
+pv
+pv
+iB
+pg
+pv
+jz
+pv
+bB
+RQ
+rc
+LX
 nP
-ug
-fY
-ug
-ug
-ug
-Qk
-ug
-Pk
-ug
-ug
-ww
-xf
-Mk
-fu
-fu
-fu
-fu
-XC
-KT
-JF
-ii
-bI
-yX
-Yk
-Gn
-LM
-lv
-xo
-bI
-ug
-ug
-ug
-ug
-Cc
+nP
+nP
+nP
+eo
+pv
+yD
+yD
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (15,1,1) = {"
-Cc
-ug
+Iz
+tb
+tb
+tb
+Iz
+yD
+mH
+Ed
+fU
+yT
+yT
+MU
+yT
+yT
+fU
+Ed
+yD
+pv
+pv
+QC
+ut
+oM
+zc
+Jy
+op
+pv
+pv
+bB
+rc
+GX
 nP
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-mY
-bI
-bI
-XH
-sy
-Mk
-XC
-yE
-Ue
-bI
-bI
-ii
-JF
-BB
-BP
-Gn
-zl
-fu
-xo
-bI
-ug
-ug
-ug
-ug
-Cc
+nP
+nP
+nP
+gV
+pv
+yD
+yD
+yD
+PY
+Iz
+tb
+tb
+tb
+Iz
 "}
 (16,1,1) = {"
-Cc
-ug
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+pv
+pv
+pv
+Tx
+pv
+pv
+pv
+yD
+yD
+sH
+tA
+oM
 nP
-ug
-iA
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-dW
-ng
-bI
-bI
-bI
-rj
-Gb
-bI
-bI
-bI
-ii
-ii
-JF
-BB
-hL
-Gn
-dr
-fu
-lQ
-bI
-ug
-ug
-ug
-sc
-Cc
+nP
+nP
+nP
+zc
+co
+rc
+bB
+rc
+pm
+nS
+Wk
+nS
+nS
+zv
+pv
+yD
+yD
+yD
+Ib
+Iz
+tb
+tb
+tb
+Iz
 "}
 (17,1,1) = {"
-Cc
-ug
-ee
-SG
-sz
-SG
-SG
-SG
-bI
-bI
-bI
-bI
-bI
-ii
-ii
-hn
-bI
-fU
-et
-bI
-ii
-ii
-ii
-ii
-Up
-xg
-ef
-bl
-Sx
-fu
-xo
-bI
-ug
-VI
-ug
-ug
-Cc
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+Ed
+yD
+Ed
+yD
+Ed
+yD
+Ed
+yD
+yD
+sH
+iB
+nP
+nP
+Rd
+QA
+nP
+nP
+ph
+rc
+bB
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+yD
+yD
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (18,1,1) = {"
-Cc
-ug
+Iz
+tb
+tb
+tb
+Iz
+aX
+vA
+PY
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+sH
+UW
 nP
-ug
-ug
-ug
-ug
-ug
-JF
-af
-Qy
-In
-JF
-ii
-ii
-ii
-lr
-xl
-xF
-bI
-ii
-Ox
-ii
-ii
-JF
-fu
-fu
-fu
-fu
-fu
-xo
-bI
-ug
-ug
-ug
-ug
-Cc
+nP
+QA
+Ku
+nP
+nP
+ve
+rc
+bB
+WQ
+yD
+yD
+yD
+yD
+yD
+yD
+WQ
+yD
+yD
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (19,1,1) = {"
-Cc
-ug
-Uj
-ug
-ug
-ug
-ug
-qf
-JF
-fu
-nd
-gN
-JF
-ii
-Is
-ii
-bI
-xF
-xF
-bI
-ii
-zO
-ii
-ii
-JF
-fu
-Wh
-AZ
-cx
-fu
-Pp
-bI
-ug
-ug
-ug
-ug
-Cc
+Iz
+tb
+tb
+tb
+Iz
+yD
+mH
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+PY
+sH
+OK
+nP
+nP
+Ea
+wf
+nP
+nP
+Ek
+rc
+bB
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+yD
+yD
+yD
+oW
+Iz
+tb
+tb
+tb
+Iz
 "}
 (20,1,1) = {"
-Cc
-ug
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+DW
+yD
+yD
+yD
+PY
+yD
+CD
+yD
+yD
+sH
+pS
+Ef
 nP
-ug
-ug
-On
-bI
-bI
-bI
-bx
-nd
-PB
-bI
-bI
-bI
-bI
-bI
-IT
-xF
-bI
-ii
-ii
-ii
-ii
-Up
-tA
-Xf
-el
-JZ
-fu
-bZ
-bI
-ug
-ug
-ug
-ug
-Cc
+nP
+nP
+nP
+Lo
+zg
+rc
+bB
+pv
+uy
+BL
+Kz
+sR
+bg
+Sn
+pv
+yD
+yD
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (21,1,1) = {"
-Cc
-ug
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+Tw
+pv
+pv
+Nf
+mu
+Ef
+Lo
+fT
+jy
+pv
+pv
+bB
+rc
+cQ
+pD
+Kz
+wn
 nP
-ug
-qf
-On
-uV
-xF
-ME
-fu
-nd
-yi
-ME
-xF
-IT
-xF
-fU
-xl
-IO
-bI
-ii
-tF
-tF
-ii
-JF
-fu
-Go
-LP
-JZ
-fu
-fu
-bI
-bI
-bI
-bI
-ug
-Cc
+Sn
+pv
+yD
+yD
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (22,1,1) = {"
-Cc
-ug
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+Pg
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+xS
+sY
+pv
+pv
+pv
+iB
+pg
+pv
+pv
+pv
+bB
+bB
+rc
+cQ
+Ay
+Kz
+tT
 nP
-ug
-ug
-cD
-bI
-bI
-bI
-Sp
-nd
-PB
-bI
-bI
-bI
-bI
-bI
-xF
-xF
-bI
-ii
-ii
-ii
-al
-JF
-fu
-fu
-fu
-fu
-fu
-fu
-cY
-if
-pG
-bI
-ug
-Cc
+us
+pv
+yD
+yD
+yD
+oW
+Iz
+tb
+tb
+tb
+Iz
 "}
 (23,1,1) = {"
-Cc
-ug
-Uj
-ug
-ug
-ug
-ug
-qf
-JF
-fu
-nd
-gN
-JF
-ug
-ug
-ug
-bI
-Py
-xF
-bI
-bI
-bI
-bI
-bI
-bI
-ux
-fu
-fu
-qp
-IU
-rg
-Up
-BU
-Ru
-bI
-ug
-Cc
+Iz
+tb
+tb
+tb
+Iz
+yD
+mH
+YW
+FM
+YW
+YW
+YW
+pv
+pv
+pv
+pv
+pv
+bB
+bB
+ps
+pv
+Av
+Ds
+pv
+bB
+bB
+bB
+bB
+NV
+Vc
+Yo
+cp
+Lt
+nP
+Sn
+pv
+yD
+UH
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (24,1,1) = {"
-Cc
-ug
-nP
-ug
-fY
-ug
-ug
-ug
-JF
-af
+Iz
 tb
-In
-JF
-wj
-ug
-ug
-bI
-vX
-pr
+tb
+tb
+Iz
+yD
+vA
+yD
+yD
+yD
+yD
+yD
+rc
+Em
+oB
 xF
-xF
-xF
-xF
-xl
-ME
-fu
-fu
-fu
-mn
-IU
-Hg
-Up
-ga
-ts
-bI
-ug
-Cc
+rc
+bB
+bB
+bB
+cP
+jX
+uO
+pv
+bB
+zQ
+bB
+bB
+rc
+nP
+nP
+nP
+nP
+nP
+Sn
+pv
+yD
+yD
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (25,1,1) = {"
-Cc
-ug
+Iz
+tb
+tb
+tb
+Iz
+yD
+KK
+yD
+yD
+yD
+yD
+Ed
+rc
 nP
-ug
-ug
-ug
-ug
-ug
-bI
-bI
-bI
-bI
-bI
-ug
-ug
-ug
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-va
-fu
-fu
-Ip
-IU
-Xw
-Up
-ey
-BU
-bI
-ug
+aI
 Cc
+rc
+bB
+nl
+bB
+pv
+uO
+uO
+pv
+bB
+GL
+bB
+bB
+rc
+nP
+ZX
+SG
+ol
+nP
+Ag
+pv
+yD
+yD
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (26,1,1) = {"
-Cc
-ug
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+yD
+ra
+pv
+pv
+pv
+vY
+aI
+yA
+pv
+pv
+pv
+pv
+pv
+eP
+uO
+pv
+bB
+bB
+bB
+bB
+NV
+xJ
+ta
+nt
+av
 nP
-ug
-Qk
-ug
-ug
-oY
-nP
-ug
-ug
-ug
-ug
-ug
-ug
-Qk
-ug
-ug
-ug
-ug
-wj
-ug
-ug
-Pk
-bI
-AM
-jn
-fu
-hX
-ZI
-Wn
-Up
-BT
-eh
-bI
-Vv
-Cc
+Sj
+pv
+yD
+yD
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (27,1,1) = {"
-Cc
-Vv
-DB
-SG
-rY
-SG
-SG
-SG
-xD
-ug
-ug
-ug
-ug
-ug
-ug
-Vv
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-bI
-ug
-Cc
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+Ed
+ra
+Io
+uO
+LA
+nP
+aI
+js
+LA
+uO
+eP
+uO
+Av
+jX
+gG
+pv
+bB
+RQ
+RQ
+bB
+rc
+nP
+on
+qP
+av
+nP
+nP
+pv
+pv
+pv
+pv
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (28,1,1) = {"
-Cc
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-ug
-Cc
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+yD
+wE
+pv
+pv
+pv
+PN
+aI
+yA
+pv
+pv
+pv
+pv
+pv
+uO
+uO
+pv
+bB
+bB
+bB
+gh
+rc
+nP
+nP
+nP
+nP
+nP
+nP
+pW
+Pc
+AP
+pv
+yD
+Iz
+tb
+tb
+tb
+Iz
 "}
 (29,1,1) = {"
+Iz
+tb
+tb
+tb
+Iz
+yD
+KK
+yD
+yD
+yD
+yD
+Ed
+rc
+nP
+aI
 Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
-Cc
+rc
+yD
+yD
+yD
+pv
+EW
+uO
+pv
+pv
+pv
+pv
+pv
+pv
+Sh
+nP
+nP
+Js
+bk
+Yc
+NV
+It
+il
+pv
+yD
+Iz
+tb
+tb
+tb
+Iz
+"}
+(30,1,1) = {"
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+DW
+yD
+yD
+yD
+rc
+Em
+dB
+xF
+rc
+aX
+yD
+yD
+pv
+UI
+CM
+uO
+uO
+uO
+uO
+jX
+LA
+nP
+nP
+nP
+YH
+bk
+JT
+NV
+oI
+lO
+pv
+yD
+Iz
+tb
+tb
+tb
+Iz
+"}
+(31,1,1) = {"
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+yD
+yD
+yD
+yD
+pv
+pv
+pv
+pv
+pv
+yD
+yD
+yD
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+tD
+nP
+nP
+AV
+bk
+Zs
+NV
+Vk
+It
+pv
+yD
+Iz
+tb
+tb
+tb
+Iz
+"}
+(32,1,1) = {"
+Iz
+tb
+tb
+tb
+Iz
+yD
+vA
+yD
+PY
+yD
+yD
+bA
+vA
+yD
+yD
+yD
+yD
+yD
+yD
+PY
+yD
+yD
+yD
+yD
+aX
+yD
+yD
+CD
+pv
+RK
+YN
+nP
+Qx
+Cj
+Si
+NV
+YC
+mj
+pv
+LV
+Iz
+tb
+tb
+tb
+Iz
+"}
+(33,1,1) = {"
+Iz
+tb
+tb
+tb
+Iz
+LV
+Cu
+YW
+HZ
+YW
+YW
+YW
+OJ
+yD
+yD
+yD
+yD
+yD
+yD
+LV
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+pv
+yD
+Iz
+tb
+tb
+tb
+Iz
+"}
+(34,1,1) = {"
+Iz
+tb
+tb
+tb
+Iz
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+Iz
+tb
+tb
+tb
+Iz
+"}
+(35,1,1) = {"
+Iz
+tb
+tb
+tb
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+tb
+tb
+tb
+Iz
+"}
+(36,1,1) = {"
+Iz
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+Iz
+"}
+(37,1,1) = {"
+Iz
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+Iz
+"}
+(38,1,1) = {"
+Iz
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+Iz
+"}
+(39,1,1) = {"
+Iz
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+tb
+Iz
+"}
+(40,1,1) = {"
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Minor changes to the cyto spanwer 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds a moat around the cytology spawner. The pickaxes have also been removed. Stabilized pink extracts have been added to the testing room. This should (hopefully) keep the miners out and keep the beefyboys in. I keep hearing that they're abandoning the base and joining the station, which is kinda not the point of a tutorial spawner. The pink extracts should also make accidentally spawning a hostile mob a little more forgiving.  ![cytofix](https://user-images.githubusercontent.com/69338705/129433218-484c4908-f5b8-422d-b35c-10649f0c5dff.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

balance: adds moat and stabilized pink extracts/ removes pickaxes

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->


