### PR TITLE
Removes deputy's mindshield

### DIFF
--- a/fulp_modules/main_features/jobs/deputy/code/deputy_clothing.dm
+++ b/fulp_modules/main_features/jobs/deputy/code/deputy_clothing.dm
@@ -21,7 +21,6 @@
 	id_trim = /datum/id_trim/job/deputy
 	box = /obj/item/storage/box/survival
 	pda_slot = ITEM_SLOT_RPOCKET
-	implants = list(/obj/item/implant/mindshield)
 
 /// Engineering Deputy
 /datum/outfit/job/deputy/engineering


### PR DESCRIPTION
## About The Pull Request

New Bloodsucker PR is gonna blacklist them from Bloodsuckers, the only antag they can roll now is obsessed and whatever else Security can roll.

Difference this makes:
- Security should hopefully be less trustful of Deputies looting Security gear they shouldnt have
- They cant be rolled as the Cult's target
- They, like the Quartermaster (except the QM isnt prepared with a stunbaton) can be converted to a revolutionary by a headrev (though cant roll headrev themselves)
- They are prone to brainwash/hypno grenade (they bowmans to counter it anyways)

![image](https://user-images.githubusercontent.com/53777086/130876837-5b43eeee-3863-4bef-8f05-2f8312473fa7.png)


Let's lie to the players and say deputies can be antag, the look on antag roller's faces when they don't roll antagonist and have to protect their departments will be awesome!
