### PR TITLE
[MDB IGNORE] A few pubby changes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1050,8 +1050,11 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "adU" = (
-/turf/open/space/basic,
-/area/cargo/warehouse/upper)
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security)
 "adV" = (
 /turf/open/space,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
@@ -1209,9 +1212,13 @@
 /turf/open/space,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "aeB" = (
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/cargo/warehouse/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security)
 "aeC" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -1944,6 +1951,7 @@
 /area/security)
 "agQ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security)
 "agR" = (
@@ -2214,9 +2222,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "ahN" = (
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/cargo/storage)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security)
 "ahP" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
@@ -2241,9 +2252,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/execution/transfer)
 "ahT" = (
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/execution/transfer)
 "ahU" = (
@@ -2253,6 +2266,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "ahW" = (
@@ -2818,6 +2832,7 @@
 	},
 /obj/structure/reagent_dispensers/peppertank/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security)
 "ajr" = (
@@ -3040,6 +3055,7 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security)
 "aka" = (
@@ -3427,14 +3443,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security)
 "akT" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
 "akU" = (
 /obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "akV" = (
@@ -3469,6 +3488,7 @@
 	id = "hos_spess_shutters";
 	name = "Space shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
 "ala" = (
@@ -3804,6 +3824,7 @@
 /area/security/warden)
 "amh" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
 "amk" = (
@@ -3817,6 +3838,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "amm" = (
@@ -3943,18 +3965,21 @@
 "amx" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "amy" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "amz" = (
 /obj/machinery/computer/security/hos{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "amA" = (
@@ -4145,11 +4170,8 @@
 /turf/open/floor/iron,
 /area/security)
 "anf" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
 /area/security)
 "ani" = (
 /obj/structure/chair/office{
@@ -4369,6 +4391,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "anS" = (
@@ -4451,7 +4474,9 @@
 	name = "Engineering";
 	req_one_access_txt = "10;24"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Engineering-passthrough"
+	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "aof" = (
@@ -4466,12 +4491,12 @@
 /area/maintenance/department/security/brig)
 "aoj" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
 	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Engineering-passthrough"
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -4518,6 +4543,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aot" = (
@@ -4580,6 +4607,7 @@
 /area/maintenance/fore)
 "aoA" = (
 /obj/effect/turf_decal/bot_white/right,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "aoB" = (
@@ -4587,6 +4615,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot_white,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "aoC" = (
@@ -4647,6 +4676,7 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/glasses/sunglasses,
 /obj/structure/table/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aoS" = (
@@ -4850,12 +4880,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apm" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apn" = (
@@ -4886,6 +4918,7 @@
 /area/command/gateway)
 "apr" = (
 /obj/machinery/gateway/centerstation,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "apt" = (
@@ -5024,6 +5057,7 @@
 /area/maintenance/fore)
 "apR" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apS" = (
@@ -5126,6 +5160,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "aqv" = (
@@ -5220,6 +5255,7 @@
 	id = "bridgespace";
 	name = "bridge external shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
 "aqL" = (
@@ -5506,6 +5542,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "arJ" = (
@@ -5560,6 +5597,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "arN" = (
@@ -5608,6 +5646,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "arR" = (
@@ -5676,6 +5715,7 @@
 /obj/item/flashlight,
 /obj/item/flashlight,
 /obj/item/flashlight,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/gateway)
 "asa" = (
@@ -6108,6 +6148,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "atA" = (
@@ -6123,6 +6164,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "atC" = (
@@ -6138,10 +6180,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "atE" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
 	name = "Brig";
@@ -6155,6 +6197,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "atF" = (
@@ -6162,7 +6207,6 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "atG" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
 	name = "Brig";
@@ -6175,6 +6219,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "atH" = (
@@ -6259,6 +6306,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "atT" = (
@@ -6268,6 +6317,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "atU" = (
@@ -6278,12 +6328,17 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "atV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "atW" = (
@@ -6486,6 +6541,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "auB" = (
@@ -6854,6 +6910,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "avu" = (
@@ -6885,6 +6942,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "avx" = (
@@ -6916,6 +6974,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "avA" = (
@@ -7086,6 +7145,7 @@
 "avX" = (
 /obj/structure/table/glass,
 /obj/item/storage/toolbox/emergency,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "avY" = (
@@ -7323,9 +7383,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "awL" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
 	name = "Brig";
@@ -7339,12 +7396,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "awN" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
 	name = "Brig";
@@ -7358,6 +7415,9 @@
 /obj/machinery/navbeacon/wayfinding/sec,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "awO" = (
@@ -7534,6 +7594,7 @@
 /area/maintenance/department/security/brig)
 "axh" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
 "axi" = (
@@ -7595,10 +7656,10 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "holodeck"
+	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "axB" = (
@@ -7743,6 +7804,7 @@
 	req_one_access_txt = "19; 65"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ayg" = (
@@ -8109,6 +8171,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "azp" = (
@@ -8575,6 +8638,7 @@
 	id = "datboidetective";
 	name = "privacy shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "aBf" = (
@@ -8716,12 +8780,14 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBy" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aBz" = (
@@ -10136,6 +10202,7 @@
 	name = "Privacy Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hop)
 "aFB" = (
@@ -10547,9 +10614,6 @@
 	name = "bridge blast door"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -10563,6 +10627,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aHe" = (
@@ -10570,15 +10637,15 @@
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aHg" = (
@@ -10587,9 +10654,6 @@
 	name = "bridge blast door"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -10600,6 +10664,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -10659,19 +10726,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aHu" = (
-/obj/structure/table,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "ShuttleUnload";
-	name = "Shuttle Unload";
-	pixel_x = 6;
-	pixel_y = 9
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "aHz" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
@@ -11258,6 +11322,7 @@
 /area/ai_monitored/command/storage/eva)
 "aKZ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/command/storage/eva)
 "aLa" = (
@@ -11285,6 +11350,7 @@
 /area/ai_monitored/command/storage/eva)
 "aLc" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/teleporter)
 "aLd" = (
@@ -11598,6 +11664,7 @@
 "aMj" = (
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aMk" = (
@@ -12220,6 +12287,7 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aOT" = (
@@ -13362,11 +13430,13 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "aTz" = (
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "aTA" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
@@ -13381,6 +13451,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aTH" = (
@@ -14561,6 +14632,7 @@
 	id = "papersplease";
 	name = "security shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
 "aXJ" = (
@@ -15136,6 +15208,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "aZJ" = (
@@ -15417,6 +15490,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "baS" = (
@@ -15437,6 +15511,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "baU" = (
@@ -15937,10 +16012,10 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "bcK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum,
-/turf/open/floor/plating,
-/area/cargo/storage)
+/obj/effect/turf_decal/bot_white/left,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/gateway)
 "bcL" = (
 /obj/item/toy/plush/lizard_plushie,
 /turf/open/floor/plating,
@@ -19141,6 +19216,7 @@
 /area/science/server)
 "bpc" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bpe" = (
@@ -19244,6 +19320,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"bpN" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgespace";
+	name = "bridge external shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "bpQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -19472,6 +19557,7 @@
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bqo" = (
@@ -19599,11 +19685,13 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "9;55"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-gene-passthrough"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -19698,8 +19786,10 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12; 55"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bqV" = (
@@ -20240,6 +20330,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"bsw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bsy" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
@@ -20524,9 +20621,6 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "btt" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
 	req_one_access_txt = "9;55"
@@ -20538,6 +20632,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-gene-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -20673,6 +20770,7 @@
 	id = "cmoprivacy";
 	name = "CMO Office"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
 "bug" = (
@@ -21269,11 +21367,11 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12; 55"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bwq" = (
@@ -22595,6 +22693,7 @@
 	id = "rdprivacy";
 	name = "Privacy shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
 "bAp" = (
@@ -22621,6 +22720,7 @@
 /area/command/heads_quarters/rd)
 "bAt" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
 "bAu" = (
@@ -22905,6 +23005,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "bBw" = (
@@ -22942,6 +23043,7 @@
 	departmentType = 5;
 	name = "Science Post Requests Console"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "bBB" = (
@@ -23282,6 +23384,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "bCK" = (
@@ -23319,6 +23422,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "bCN" = (
@@ -23575,6 +23679,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "bDK" = (
@@ -25661,6 +25766,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bLS" = (
@@ -25987,6 +26093,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bMW" = (
@@ -27598,6 +27705,7 @@
 	pixel_y = -32
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/lobby)
 "bSP" = (
@@ -27924,6 +28032,7 @@
 /area/engineering/storage/tech)
 "bTC" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "bTD" = (
@@ -27933,7 +28042,6 @@
 /turf/closed/wall,
 /area/engineering/main)
 "bTF" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/navbeacon/wayfinding/engineering,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -27944,6 +28052,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Engineering-passthrough"
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -28688,6 +28799,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bVQ" = (
@@ -28943,6 +29055,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bWC" = (
@@ -29051,6 +29164,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
+"bXe" = (
+/obj/machinery/camera/preset/ordnance{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation/bomb_site)
 "bXf" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/tile/yellow{
@@ -29143,9 +29262,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "bXp" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -29156,6 +29272,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Engineering-passthrough"
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -29291,6 +29410,7 @@
 	id = "ce_privacy";
 	name = "Privacy shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "bYa" = (
@@ -32395,6 +32515,7 @@
 "cnP" = (
 /obj/machinery/vending/security,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "cnQ" = (
@@ -35070,6 +35191,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security)
 "cUb" = (
@@ -35138,6 +35260,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/gateway)
 "dej" = (
@@ -35388,9 +35511,6 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "dqw" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics";
 	req_access_txt = "9"
@@ -35402,6 +35522,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-gene-passthrough"
 	},
 /turf/open/floor/plating,
 /area/science/genetics)
@@ -35627,11 +35750,13 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Library-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
@@ -35731,6 +35856,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "dKA" = (
@@ -35752,6 +35878,7 @@
 /area/engineering/storage_shared)
 "dMB" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "dMI" = (
@@ -35960,6 +36087,16 @@
 /obj/item/food/meat/slab/monkey,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dWo" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/space/basic,
+/area/space)
 "dWp" = (
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
@@ -37702,6 +37839,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "fwx" = (
@@ -37847,6 +37985,7 @@
 "fGa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "fGd" = (
@@ -37862,6 +38001,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fGk" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "fGo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -38108,6 +38254,10 @@
 "fRs" = (
 /turf/closed/wall,
 /area/command/heads_quarters/rd)
+"fRJ" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "fSx" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -38585,6 +38735,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "gtl" = (
@@ -40292,6 +40443,7 @@
 	id = "executionfireblast"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "iab" = (
@@ -40888,14 +41040,19 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "iIB" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "ShuttleUnload";
+	name = "Shuttle Unload";
+	pixel_x = 6;
+	pixel_y = 9
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/iron,
+/area/cargo/storage)
 "iIY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40952,6 +41109,7 @@
 	name = "Brig Control Desk";
 	req_access_txt = "63"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "iKi" = (
@@ -41106,6 +41264,24 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/engineering/atmos)
+"iWD" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
+	},
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "iWV" = (
 /obj/machinery/light{
 	dir = 4
@@ -41133,6 +41309,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "cargo-maint-passthrough"
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -41232,12 +41411,12 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Library-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
@@ -41325,6 +41504,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
+"jlA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "jng" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -41543,6 +41727,17 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/closet/firecloset{
+	name = "fire extinguishers"
+	},
+/obj/item/extinguisher{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/extinguisher{
+	pixel_x = 6;
+	pixel_y = 7
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -41969,6 +42164,14 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/cargo)
+"jZL" = (
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Conveyor Access";
+	req_access_txt = "31"
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "kaA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -42719,8 +42922,20 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/cargo/storage)
+/area/space/nearstation)
+"kLp" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
+	},
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "kLJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -42859,6 +43074,7 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "kSD" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "kSG" = (
@@ -43110,6 +43326,7 @@
 /area/maintenance/department/security/brig)
 "lcZ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/gateway)
 "ldb" = (
@@ -43355,10 +43572,12 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Library-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
@@ -43566,6 +43785,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "lDj" = (
@@ -44118,6 +44338,15 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/iron,
 /area/medical/cryo)
+"mhw" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "mhL" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -44190,6 +44419,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "mmv" = (
@@ -44353,6 +44583,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "mtu" = (
@@ -44469,9 +44700,6 @@
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -44487,6 +44715,9 @@
 	pixel_y = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "mzl" = (
@@ -44589,6 +44820,7 @@
 	id = "Engineering";
 	name = "engineering security door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "mDo" = (
@@ -44738,7 +44970,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mNN" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -44750,6 +44981,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -44916,6 +45150,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "mWQ" = (
@@ -44925,6 +45160,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "mXc" = (
@@ -45180,10 +45416,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "holodeck"
+	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "nih" = (
@@ -45233,6 +45469,16 @@
 "njS" = (
 /turf/closed/wall/r_wall,
 /area/engineering/transit_tube)
+"njW" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
 "nku" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Crematorium";
@@ -45294,7 +45540,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -45771,6 +46020,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"nLW" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "nMG" = (
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Monitoring";
@@ -46170,17 +46425,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/closet/firecloset{
-	name = "fire extinguishers"
-	},
-/obj/item/extinguisher{
-	pixel_x = 6;
-	pixel_y = 7
-	},
-/obj/item/extinguisher{
-	pixel_x = 6;
-	pixel_y = 7
-	},
+/obj/machinery/chem_master,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ofR" = (
@@ -46383,6 +46628,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"ooI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "ops" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -46473,11 +46723,9 @@
 "osv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -46585,6 +46833,7 @@
 "oxC" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "oxM" = (
@@ -47061,18 +47310,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "oSC" = (
-/obj/structure/table,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "ShuttleLoad";
-	name = "Shuttle Load";
-	pixel_x = -8;
-	pixel_y = 10
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/effect/turf_decal/bot_white,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/gateway)
 "oSI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -47825,6 +48066,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "pGF" = (
@@ -47856,6 +48098,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"pHh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "pHo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -49095,6 +49342,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"qKN" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "qLo" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -49336,6 +49588,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"qYF" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "qZa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -49348,7 +49607,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/cargo/storage)
+/area/space)
 "raF" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -49543,8 +49802,9 @@
 	c_tag = "Cargo Docking Arm";
 	dir = 8
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/cargo/storage)
+/area/space/nearstation)
 "rnm" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -51742,6 +52002,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "tdp" = (
@@ -52082,6 +52343,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"trf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "trt" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -52343,13 +52614,13 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Library-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
@@ -53005,6 +53276,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"uhk" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
 "uhn" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -53194,9 +53475,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ume" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
 	req_access_txt = "55"
@@ -53211,6 +53489,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-gene-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -53280,6 +53561,7 @@
 /area/medical/psychology)
 "uqJ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "urG" = (
@@ -53549,6 +53831,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "uAh" = (
@@ -53937,6 +54220,11 @@
 	},
 /turf/open/floor/iron,
 /area/security)
+"uSE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/lobby)
 "uSL" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck - Fore";
@@ -54013,6 +54301,7 @@
 	name = "brig shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
 "uVf" = (
@@ -54129,9 +54418,6 @@
 	name = "Containment Pen Access";
 	req_access_txt = "55"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
 	name = "containment blast door"
@@ -54148,6 +54434,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
+	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "uXX" = (
@@ -54340,9 +54629,6 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "vgp" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/research{
 	name = "Containment Pen";
 	req_access_txt = "55"
@@ -54356,6 +54642,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
+	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "vgR" = (
@@ -54821,6 +55110,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "cargo-maint-passthrough"
+	},
 /turf/open/floor/plating,
 /area/cargo/storage)
 "vHR" = (
@@ -55050,12 +55342,18 @@
 	},
 /area/maintenance/department/science)
 "vRk" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/conveyor_switch/oneway{
+	id = "ShuttleLoad";
+	name = "Shuttle Load";
+	pixel_x = -8;
+	pixel_y = 10
 	},
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "vRm" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
@@ -56641,6 +56939,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"wZB" = (
+/obj/structure/chair/comfy/black,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "xan" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -56743,6 +57046,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"xdb" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/space/basic,
+/area/space)
 "xdc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -56917,6 +57230,7 @@
 /area/security/detectives_office)
 "xjU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "xjZ" = (
@@ -57074,7 +57388,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "xoD" = (
@@ -57183,6 +57498,9 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "cargo-maint-passthrough"
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "xur" = (
@@ -57352,6 +57670,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xyr" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "xyB" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -57633,6 +57958,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"xMS" = (
+/obj/machinery/door/window/westleft{
+	dir = 1;
+	name = "Conveyor Access";
+	req_access_txt = "31"
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "xNx" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/junction/flip,
@@ -57861,6 +58194,7 @@
 /area/security/prison)
 "yat" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "ybu" = (
@@ -57978,6 +58312,7 @@
 /area/engineering/atmos)
 "yeL" = (
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "yfO" = (
@@ -76448,7 +76783,7 @@ sJp
 hZL
 mWI
 ahU
-ahU
+aHu
 aiw
 afU
 ajH
@@ -78776,7 +79111,7 @@ avB
 lUY
 ojJ
 asu
-apE
+pHh
 auy
 avs
 uUY
@@ -79032,7 +79367,7 @@ hdB
 hdB
 hdB
 hdB
-aoN
+hdB
 atw
 gta
 avt
@@ -79290,7 +79625,7 @@ wcf
 aqn
 wbs
 mJe
-apE
+pHh
 auz
 avu
 uUY
@@ -79804,7 +80139,7 @@ amh
 aqz
 wbs
 mJe
-apE
+pHh
 auy
 avv
 uUY
@@ -80060,7 +80395,7 @@ aoS
 amh
 aqq
 wbs
-aoN
+hdB
 atA
 auA
 avw
@@ -80318,7 +80653,7 @@ apK
 ark
 wbs
 mJe
-apE
+pHh
 auz
 avx
 uUY
@@ -80832,7 +81167,7 @@ amh
 aqz
 wbs
 mJe
-apE
+pHh
 auy
 avy
 uUY
@@ -81088,7 +81423,7 @@ aoW
 apM
 aqy
 arn
-aoN
+hdB
 atC
 auA
 avz
@@ -81340,13 +81675,13 @@ rEZ
 amk
 piI
 piI
-tla
+aTz
 aoX
 amh
 aqz
 vao
 mJe
-apE
+pHh
 auz
 avA
 uUY
@@ -81597,7 +81932,7 @@ afH
 amh
 amZ
 anJ
-tla
+aTz
 aoY
 amg
 sBA
@@ -82117,7 +82452,7 @@ agP
 aqz
 vao
 mJe
-apE
+pHh
 ark
 ark
 uUY
@@ -82612,7 +82947,7 @@ aaa
 aby
 aaa
 agQ
-ahd
+adU
 xou
 cnT
 aiq
@@ -82870,7 +83205,7 @@ aby
 aaa
 agQ
 ahd
-xou
+aeB
 aiq
 aiq
 ahd
@@ -83127,7 +83462,7 @@ aby
 abI
 agP
 cnN
-xou
+aeB
 cnT
 aiq
 ahd
@@ -83384,7 +83719,7 @@ aby
 aaa
 agQ
 ahd
-xou
+aeB
 aiq
 fQN
 aip
@@ -83641,7 +83976,7 @@ aby
 aaa
 agQ
 cnP
-xou
+aeB
 xjU
 xjU
 xjU
@@ -83649,7 +83984,7 @@ cTC
 ajq
 ajZ
 akR
-anf
+dcn
 amr
 dcn
 anO
@@ -83898,7 +84233,7 @@ aby
 aaa
 agQ
 cnQ
-fcK
+ahN
 cnV
 aiq
 air
@@ -84155,7 +84490,7 @@ aby
 aaa
 agP
 wtp
-aiq
+anf
 aiq
 ahQ
 ais
@@ -87770,7 +88105,7 @@ aaa
 aaa
 aqI
 arI
-asR
+qYF
 atS
 syK
 syK
@@ -88028,7 +88363,7 @@ aaa
 aqI
 arJ
 asR
-ayg
+fRJ
 fNn
 ayg
 qsk
@@ -88798,11 +89133,11 @@ aaa
 aaa
 aqI
 arM
-asR
+qYF
 atU
-auR
+wZB
 avX
-axb
+fGk
 yeL
 azj
 aAC
@@ -89570,7 +89905,7 @@ aaa
 aqI
 arP
 asR
-ayg
+fRJ
 dch
 ayg
 hpp
@@ -89826,7 +90161,7 @@ aaa
 aaa
 aqI
 arQ
-asR
+qYF
 atV
 axc
 axc
@@ -90091,7 +90426,7 @@ ayg
 ayg
 wyP
 ayg
-aBy
+kLp
 vRN
 vRN
 aEJ
@@ -90348,7 +90683,7 @@ axe
 azo
 aAD
 aAE
-mNN
+iWD
 wyP
 aDP
 aEK
@@ -90859,7 +91194,7 @@ atY
 auU
 atY
 iNH
-auK
+bpN
 auK
 aAH
 aBz
@@ -91116,7 +91451,7 @@ atZ
 auV
 awc
 ayg
-ayg
+fRJ
 azp
 aAH
 aBA
@@ -91182,7 +91517,7 @@ qXH
 jez
 jez
 qOx
-qzm
+uSE
 xGi
 bSN
 bTD
@@ -91381,8 +91716,8 @@ aCR
 aDU
 aEM
 aFA
-aGw
-awd
+qKN
+ooI
 aaf
 xPQ
 fei
@@ -91432,7 +91767,7 @@ bBp
 bvD
 bIx
 cqz
-qzm
+uSE
 bLR
 bMV
 bOd
@@ -91639,7 +91974,7 @@ aDU
 aEN
 aAH
 aGw
-awd
+ooI
 aHV
 xPQ
 aJW
@@ -91689,7 +92024,7 @@ bBp
 bHh
 bIx
 cqz
-qzm
+uSE
 bLS
 rnQ
 bSa
@@ -91896,7 +92231,7 @@ aDV
 aEO
 aAH
 aGw
-awd
+ooI
 aHV
 xPQ
 aJR
@@ -91946,7 +92281,7 @@ bBp
 bHi
 bIx
 cqz
-qzm
+uSE
 bLT
 rnQ
 fUc
@@ -92153,9 +92488,9 @@ bAB
 aEP
 aFA
 oxC
-awd
-aHV
-xPQ
+ooI
+bsw
+trf
 fei
 aLc
 aNx
@@ -92203,7 +92538,7 @@ bBp
 bHj
 bIx
 cqz
-qzm
+uSE
 bLU
 bMW
 bOe
@@ -93935,7 +94270,7 @@ aaa
 cBU
 aoB
 apr
-apq
+oSC
 lCb
 arY
 dda
@@ -94190,7 +94525,7 @@ ljT
 aJc
 aaa
 lcZ
-aoC
+bcK
 apq
 hOY
 aqS
@@ -102298,7 +102633,7 @@ ckK
 ckK
 cju
 cjx
-cjV
+bXe
 cnq
 cju
 cju
@@ -102702,7 +103037,7 @@ aet
 afj
 ecR
 tko
-ahN
+dUZ
 aVI
 dUZ
 aaa
@@ -103985,13 +104320,13 @@ aco
 lao
 ndd
 sZh
-sut
-aTy
+dWo
+jlA
 qof
 cCB
 mRD
 aTy
-aYF
+uhk
 baG
 sut
 aaa
@@ -104242,13 +104577,13 @@ aco
 adO
 nkE
 sZh
-sut
-bcK
-oSC
+xMS
 cCB
-aHu
-aTy
-aYF
+cCB
+cCB
+cCB
+cCB
+jZL
 baG
 sut
 aaa
@@ -104499,13 +104834,13 @@ uOe
 uOe
 ovf
 sZh
-sut
-aTz
+xdb
+aTy
 vRk
-aVI
+cCB
 iIB
-aTz
-aYF
+aTy
+njW
 baG
 sut
 aaa
@@ -104750,19 +105085,19 @@ aaa
 aaa
 aht
 cdm
-adU
-adU
-adU
-adU
-aeB
+aaa
+aaa
+aaa
+aaa
+aYF
 sZh
-rWE
-aht
-aYE
+sut
+nLW
+xyr
 aVI
-rWE
-aht
-aYE
+mhw
+nLW
+aYF
 baG
 rWE
 aht
@@ -105007,19 +105342,19 @@ aaa
 aaa
 aht
 cdm
-adU
-adU
-adU
-adU
-aeB
-sZh
-sut
 aaa
+aaa
+aaa
+aaa
+aYF
+sZh
+kKz
+aht
 rng
 aVI
 kKz
-aaa
-aYF
+aht
+aqG
 baG
 sut
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->This PR has quite a few changes to Pubby:

Adds electrified grilles to most of security, all head of staff offices, EVA, Teleporter, Gateway, outside of bridge, all the security posts, and outside engineering. The areas I added wire to was mostly based off if those areas had electrified grilles on Metastation.

Added a Chem Master to science inside Xenobiology. Every other map has one and they're pretty important for Cytology. I remember Pubby having one way back but I think it was lost when the circuits area was added in.

Added Windoors to the cargo Conveyors because I kept seeing people get trapped inside them.
![image](https://user-images.githubusercontent.com/74441292/131244490-38ea5a64-c6d8-4ea9-85f3-7cb427df5380.png)

Moved a bomb camera at the back of the toxins test area so it's connected to the wall and not floating.

Added multi cycle link helpers to a lot of doors on the station. I mostly referenced Metastation when looking for where I should place them.

Removed some area tiles that were in space near cargo because I'm pretty sure they can cause things like anomalies to spawn outside

Moved a disposals outlet one tile backwards in disposals because it would cause items sent through to be instantly destroyed, or if the recycler was emagged, instantly kill anyone that went through disposals.
![image](https://user-images.githubusercontent.com/74441292/131244693-8ee88ddf-820f-4210-980f-2ca737738949.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->The lack of electrified grilles can make a lot of high security areas very easy to break into and feels like an oversight.
The Chem Master being missing in science also feels like an oversight.
The windoors in cargo should hopefully make people getting trapped in the cargo conveyors and dying/getting shuttle gibbed less common.
disposals is often a really good last stop for detectives to check for evidence to crimes, important things are often flushed down accidently, and people can sometimes find use in junk that other players threw away.

## Changelog
:cl:

add: Added doors to Pubbystation cargo conveyors
qol: Pubbystation disposals will no longer instantly destroy objects sent to it when the conveyor belt is off.
fix: Pubbystation now has its missing science Chem Master back.
fix: Pubbystation now has electrified grilles in high security areas.


/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
