### PR TITLE
Allows bodycams to be worn on any jumpsuit

### DIFF
--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -1,4 +1,3 @@
-// This is all useless for non Security jumpsuits.
 /obj/item/clothing/under
 	var/upgraded = FALSE
 	var/obj/machinery/camera/builtInCamera = null
@@ -12,9 +11,6 @@
 /// Modifying the Jumpsuit
 /obj/item/clothing/under/attackby(obj/item/W, mob/user, params)
 	. = ..()
-	// Are we a security jumpsuit? If not, we can't do anything special, so return here.
-	if(!istype(src, /obj/item/clothing/under/rank/security) && !istype(src, /obj/item/clothing/under/bodysash/security) && !istype(src, /obj/item/clothing/under/plasmaman/security))
-		return
 
 	// Using a bodycam on the jumpsuit, upgrading it
 	if(istype(W, /obj/item/bodycam_upgrade))
@@ -121,7 +117,7 @@
 /obj/item/bodycam_upgrade/examine_more(mob/user)
 	. = list(span_notice("<i>You examine [src]'s instruction tag...</i>"))
 	. += list(span_warning("How to use Body Cameras v3.5: EMP-proof Edition!"))
-	. += list(span_notice("Use the Body camera Upgrade on any SECURITY jumpsuit to upgrade it."))
+	. += list(span_notice("Use the Body camera Upgrade on any jumpsuit to upgrade it."))
 	. += list(span_notice("Use a Screwdriver to remove the upgrade once you're done with it."))
 	. += list(span_notice("While upgraded & equipped, use your ID card on the jumpsuit to turn the camera on."))
 	. += list(span_notice("Unequipping or using your ID on the Jumpsuit will disable its camera."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request
Allows the bodycams purchased from the sec vendor to be equipped on any jumpsuit, as opposed to the only Security jumpsuits from before.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fashion police. 
Adds the ability for Security to wear jumpsuits other than the standard few, for the Officers who want more variety in their looks or to go undercover without forfeiting the benefits of the bodycam. Halloween is coming up, and as of now Officers will have to decide between body cam or costume. Additional, functionality to spy on crewmembers by placing it on their jumpsuit.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed the check for a security jumpsuit on bodycams
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
