### PR TITLE
Adds runtimestation to map rotation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -54,6 +54,8 @@ map tramstation
 endmap
 
 map runtimestation
+	minplayers 1
+	votable
 endmap
 
 map multiz_debug


### PR DESCRIPTION
## About The Pull Request

Adds runtimestation to the map rotation, being votable

## Why It's Good For The Game

Give me one (1) good reason why not.

## Changelog
:cl:
add: Added RuntimeStation brand stations to the station rotation.
/:cl: