### PR TITLE
Fixes Malkavian admin loggings

### DIFF
--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -43,7 +43,7 @@
 	if(my_clan == CLAN_MALKAVIAN)
 		if(prob(85) || owner.current.stat != CONSCIOUS || poweron_masquerade)
 			return
-		owner.current.say(pick(strings("malkavian_revelations.json", "revelations", "fulp_modules")))
+		owner.current.say(pick(strings("malkavian_revelations.json", "revelations", "fulp_modules")), forced = CLAN_MALKAVIAN)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request

Fixes Malkavian revelations not showing as being Forced when viewed thru ingame logs and game.log so I can't tell if I should bwoink or if John coded these slurs in, also makes it annoying to filter out game.log with Notepad++ when I should be able to hide lines containing "FORCED". Only works with Malkavian revelations that aren't whispered until my fix PR is merged on tg and we tgu but it wouldnt require any extra changes to this code once thats done so i might aswell PR this now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/25415050/133597747-d26516d2-bfac-4d71-b165-132d2efa5d9a.png)

Ugly and cannot be filtered out with Notepad++ easily, I will not read your game logs. 😢 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Malkavian revelations are now logged correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
