### PR TITLE
Moves bodycamera to armor vests

### DIFF
--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -113,13 +113,13 @@
 	name = "body camera upgrade"
 	icon = 'fulp_modules/features/clothing/body_cameras/bodycamera.dmi'
 	icon_state = "bodycamera"
-	desc = "A Security Jumpsuit upgrade, it says to examine closer to understand how it works."
+	desc = "An armor vest upgrade, it says to examine closer to understand how it works."
 
 /obj/item/bodycam_upgrade/examine_more(mob/user)
 	. = list(span_notice("<i>You examine [src]'s instruction tag...</i>"))
 	. += list(span_warning("How to use Body Cameras v3.5: EMP-proof Edition!"))
-	. += list(span_notice("Use the Body camera Upgrade on any jumpsuit to upgrade it."))
-	. += list(span_notice("Use a Screwdriver to remove the upgrade once you're done with it."))
-	. += list(span_notice("While upgraded & equipped, use your ID card on the jumpsuit to turn the camera on."))
-	. += list(span_notice("Unequipping or using your ID on the Jumpsuit will disable its camera."))
-	. += list(span_notice("While active, the wearer will be visible to Security camera consoles."))
+	. += list(span_notice("Use [src] on an armor vest to install it."))
+	. += list(span_notice("Use a Screwdriver to remove it when needed."))
+	. += list(span_notice("While equipped, use your ID card on the vest to activate the camera."))
+	. += list(span_notice("Unequipping the vest or using your ID again will deactivate the camera."))
+	. += list(span_notice("While the camera is active, the wearer will be visible to camera consoles."))

--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -1,15 +1,15 @@
-/obj/item/clothing/under
+/obj/item/clothing/suit/armor
 	var/upgraded = FALSE
 	var/obj/machinery/camera/builtInCamera = null
 	var/registrant
 
-/obj/item/clothing/under/examine(mob/user)
+/obj/item/clothing/suit/armor/examine(mob/user)
 	. = ..()
 	if(builtInCamera)
 		. += "It appears to have an <b>active</b> body camera attached."
 
 /// Modifying the Jumpsuit
-/obj/item/clothing/under/attackby(obj/item/W, mob/user, params)
+/obj/item/clothing/suit/armor/attackby(obj/item/W, mob/user, params)
 	. = ..()
 
 	// Using a bodycam on the jumpsuit, upgrading it
@@ -54,22 +54,22 @@
 	register_body_camera(I, user)
 
 /// Manual Register via ID
-/obj/item/clothing/under/proc/register_body_camera(obj/item/card/id/I, mob/user)
-	if(!I)
+/obj/item/clothing/suit/armor/proc/register_body_camera(obj/item/card/id/id_card, mob/user)
+	if(!id_card)
 		return
 	var/mob/living/carbon/human/H = user
-	var/obj/item/clothing/under/S = H.get_item_by_slot(ITEM_SLOT_ICLOTHING)
+	var/obj/item/clothing/suit/armor/S = H.get_item_by_slot(ITEM_SLOT_OCLOTHING)
 	if(!istype(S))
 		to_chat(user, span_warning("You have to be wearing [src] to turn the body camera on!"))
 		return
-	var/id_name = I.registered_name
+	var/id_name = id_card.registered_name
 	if(id_name == registrant) //If already registered to the same person swiping the ID, we will 'toggle off' registration and unregister the body camera.
 		unregister_body_camera(user)
 		return
 
 	registrant = id_name
 
-	/*
+	/**
 	 *	# Body Camera
 	 *
 	 *	Due to how TG deals with moving cameras, they have to be set to a PERSON, rather than an ITEM, otherwise its a black screen.
@@ -82,7 +82,7 @@
 	builtInCamera.internal_light = FALSE
 	builtInCamera.network = list("ss13")
 
-	var/cam_name = "-Body Camera: [id_name] ([I.assignment])"
+	var/cam_name = "-Body Camera: [id_name] ([id_card.assignment])"
 	for(var/obj/machinery/camera/matching_camera in GLOB.cameranet.cameras)
 		if(cam_name == matching_camera.c_tag)
 			to_chat(user, span_notice("Matching registration found. Unregistering previously registered body camera."))
@@ -94,10 +94,11 @@
 
 	playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
 	if(user)
-		to_chat(user, span_notice("Security uniform body camera successfully registered to [id_name]."))
+		user.balloon_alert(user, "bodycamera activated")
+		to_chat(user, span_notice("[src] body camera successfully registered to [id_name]."))
 
 /// Unregistering the ID - Called when using your ID on an already claimed jumpsuit, or removing it.
-/obj/item/clothing/under/proc/unregister_body_camera(mob/user)
+/obj/item/clothing/suit/armor/proc/unregister_body_camera(mob/user)
 	if(!builtInCamera)
 		return
 	QDEL_NULL(builtInCamera)
@@ -105,7 +106,7 @@
 	registrant = null
 	if(user)
 		playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
-		to_chat(user, span_notice("Security uniform body camera successfully unregistered."))
+		user.balloon_alert(user, "bodycamera deactivated")
 
 /// Bodycamera upgrade
 /obj/item/bodycam_upgrade


### PR DESCRIPTION
## About The Pull Request

Bodycameras get installed in the armor vest instead of the jumpsuit

## Why It's Good For The Game

Antags dont have to disable sec's suit sensors to disable their body camera.
