### PR TITLE
Bloodsucker patch

### DIFF
--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -94,14 +94,14 @@
 /datum/antagonist/bloodsucker/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
 	RegisterSignal(owner.current, COMSIG_LIVING_BIOLOGICAL_LIFE, .proc/LifeTick)
+	RegisterSignal(owner.current, COMSIG_LIVING_DEATH, .proc/on_death)
 	handle_clown_mutation(M, mob_override ? null : "As a vampiric clown, you are no longer a danger to yourself. Your clownish nature has been subdued by your thirst for blood.")
-	return
 
 /datum/antagonist/bloodsucker/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
 	UnregisterSignal(owner.current, COMSIG_LIVING_BIOLOGICAL_LIFE)
+	UnregisterSignal(owner.current, COMSIG_LIVING_DEATH)
 	handle_clown_mutation(M, removing = FALSE)
-	return
 
 /datum/antagonist/bloodsucker/get_admin_commands()
 	. = ..()

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/vassal_datum.dm
@@ -89,14 +89,14 @@
 	to_chat(owner, span_boldannounce("The power of [master.owner.current.p_their()] immortal blood compels you to obey [master.owner.current.p_them()] in all things, even offering your own life to prolong theirs.\n\
 		You are not required to obey any other Bloodsucker, for only [master.owner.current] is your master. The laws of Nanotrasen do not apply to you now; only your vampiric master's word must be obeyed."))
 	owner.current.playsound_local(null, 'sound/magic/mutate.ogg', 100, FALSE, pressure_affected = FALSE)
-	antag_memory += "You became the mortal servant of <b>[master.owner.current]</b>, a bloodsucking vampire!<br>"
+	antag_memory += "You, becoming the mortal servant of <b>[master.owner.current]</b>, a bloodsucking vampire!<br>"
 	/// Message told to your Master.
 	to_chat(master.owner, span_userdanger("[owner.current] has become addicted to your immortal blood. [owner.current.p_they(TRUE)] [owner.current.p_are()] now your undying servant!"))
 	master.owner.current.playsound_local(null, 'sound/magic/mutate.ogg', 100, FALSE, pressure_affected = FALSE)
 
 /datum/antagonist/vassal/farewell()
 	owner.current.visible_message(
-		span_deconversion_message("[owner.current]'s eyes dart feverishly from side to side, and then stop. [owner.current.p_they(TRUE)] seem[owner.current.p_s()] calm,\
+		span_deconversion_message("[owner.current]'s eyes dart feverishly from side to side, and then stop. [owner.current.p_they(TRUE)] seem[owner.current.p_s()] calm, \
 		like [owner.current.p_they()] [owner.current.p_have()] regained some lost part of [owner.current.p_them()]self."),
 	)
 	to_chat(owner, span_deconversion_message("With a snap, you are no longer enslaved to [master.owner]! You breathe in heavily, having regained your free will."))

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -310,21 +310,21 @@
 	else
 		additional_regen = 0.5
 
-/*
-	# Torpor
-
-	Torpor is what deals with the Bloodsucker falling asleep, their healing, the effects, ect.
-	This is basically what Sol is meant to do to them, but they can also trigger it manually if they wish to heal, as Burn is only healed through Torpor.
-	You cannot manually exit Torpor, it is instead entered/exited by:
-
-	Torpor is triggered by:
-	- Being in a Coffin while Sol is on, dealt with by /HandleTorpor()
-	- Entering a Coffin with more than 10 combined Brute/Burn damage, dealt with by /closet/crate/coffin/close() [bloodsucker_coffin.dm]
-	- Death, dealt with by /HandleDeath()
-	Torpor is ended by:
-	- Having less than 10 Brute damage while OUTSIDE of your Coffin while it isnt Sol, dealt with by /HandleTorpor()
-	- Having less than 10 Brute & Burn Combined while INSIDE of your Coffin while it isnt Sol, dealt with by /HandleTorpor()
-	- Sol being over, dealt with by /sunlight/process() [bloodsucker_daylight.dm]
+/**
+ * # Torpor
+ *
+ * Torpor is what deals with the Bloodsucker falling asleep, their healing, the effects, ect.
+ * This is basically what Sol is meant to do to them, but they can also trigger it manually if they wish to heal, as Burn is only healed through Torpor.
+ * You cannot manually exit Torpor, it is instead entered/exited by:
+ *
+ * Torpor is triggered by:
+ * - Being in a Coffin while Sol is on, dealt with by /HandleTorpor()
+ * - Entering a Coffin with more than 10 combined Brute/Burn damage, dealt with by /closet/crate/coffin/close() [bloodsucker_coffin.dm]
+ * - Death, dealt with by /HandleDeath()
+ * Torpor is ended by:
+ * - Having less than 10 Brute damage while OUTSIDE of your Coffin while it isnt Sol, dealt with by /HandleTorpor()
+ * - Having less than 10 Brute & Burn Combined while INSIDE of your Coffin while it isnt Sol, dealt with by /HandleTorpor()
+ * - Sol being over, dealt with by /sunlight/process() [bloodsucker_daylight.dm]
 */
 
 /datum/antagonist/bloodsucker/proc/HandleTorpor()
@@ -394,21 +394,23 @@
 	ADD_TRAIT(owner.current, TRAIT_SLEEPIMMUNE, BLOODSUCKER_TRAIT)
 	HealVampireOrgans()
 
+/datum/antagonist/bloodsucker/proc/on_death()
+	SIGNAL_HANDLER
+
+	addtimer(CALLBACK(src, .proc/HandleDeath), 5 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE)
+
 /// Gibs the Bloodsucker, roundremoving them.
 /datum/antagonist/bloodsucker/proc/FinalDeath()
-	// Check for non carbons and end it early.
-	if(!iscarbon(owner.current))
-		owner.current.gib()
+	FreeAllVassals()
+	// If we have no body, end here.
+	if(!owner.current)
 		return
 
-	// End Bloodsucker processes
-	UnregisterSignal(owner.current, COMSIG_LIVING_BIOLOGICAL_LIFE)
-	FreeAllVassals()
 	DisableAllPowers()
 	// Drop anything in us and play a tune
+	var/mob/living/carbon/C = owner.current
 	owner.current.drop_all_held_items()
 	owner.current.unequip_everything()
-	var/mob/living/carbon/C = owner.current
 	C.remove_all_embedded_objects()
 	playsound(owner.current, 'sound/effects/tendril_destroyed.ogg', 40, TRUE)
 	// Elders get dusted, Fledglings get gibbed
@@ -552,7 +554,7 @@
 	mood_change = -5
 	timeout = 5 MINUTES
 
-/// Candelabrum
+///Candelabrum's mood event to non Bloodsucker/Vassals
 /datum/mood_event/vampcandle
 	description = "<span class='boldwarning'>Something is making your mind feel... loose.</span>\n"
 	mood_change = -15


### PR DESCRIPTION
## About The Pull Request

Bloodsuckers' constant processes are tied to the mob, which means it doesn't go on if the mob doesn't exist, like gibbing and incinerating.
Since incinerating is common use to kill Bloodsuckers, this really should be fixed.

## Changelog

:cl:
fix: Vassals will now get deconverted when a Bloodsucker goes through FinalDeath, regardless if it's from gibbing/incineration.
/:cl: