### PR TITLE
Bloodsucker patch - You can no longer use Powers on yourself

### DIFF
--- a/fulp_modules/main_features/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/_powers.dm
@@ -306,7 +306,9 @@
 
 /// Check if target is VALID (wall, turf, or character?)
 /datum/action/bloodsucker/targeted/proc/CheckValidTarget(atom/target_atom)
-	return FALSE // FALSE targets nothing.
+	if(target_atom == owner)
+		return FALSE
+	return TRUE // FALSE targets nothing.
 
 /// Check if valid target meets conditions
 /datum/action/bloodsucker/targeted/proc/CheckCanTarget(atom/target_atom, display_error)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/brawn.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/brawn.dm
@@ -172,6 +172,9 @@
 			target_airlock.open(2) // open(2) is like a crowbar or jaws of life.
 
 /datum/action/bloodsucker/targeted/brawn/CheckValidTarget(atom/target_atom)
+	. = ..()
+	if(!.)
+		return FALSE
 	return isliving(target_atom) || istype(target_atom, /obj/machinery/door) || istype(target_atom, /obj/structure/closet)
 
 /datum/action/bloodsucker/targeted/brawn/CheckCanTarget(atom/target_atom, display_error)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/haste.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/haste.dm
@@ -45,7 +45,10 @@
 
 /// Anything will do, if it's not me or my square
 /datum/action/bloodsucker/targeted/haste/CheckValidTarget(atom/target_atom)
-	return isturf(target_atom) || target_atom.loc != owner.loc
+	. = ..()
+	if(!.)
+		return FALSE
+	return target_atom.loc != owner.loc
 
 /datum/action/bloodsucker/targeted/haste/CheckCanTarget(atom/target_atom, display_error)
 	// DEFAULT CHECKS (Distance)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/lunge.dm
@@ -35,6 +35,9 @@
 
 /// Check: Are we lunging at a person?
 /datum/action/bloodsucker/targeted/lunge/CheckValidTarget(atom/target_atom)
+	. = ..()
+	if(!.)
+		return FALSE
 	return isliving(target_atom)
 
 /datum/action/bloodsucker/targeted/lunge/CheckCanTarget(atom/target_atom, display_error)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/mesmerize.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/mesmerize.dm
@@ -51,6 +51,9 @@
 	return TRUE
 
 /datum/action/bloodsucker/targeted/mesmerize/CheckValidTarget(atom/target_atom)
+	. = ..()
+	if(!.)
+		return FALSE
 	return isliving(target_atom)
 
 /datum/action/bloodsucker/targeted/mesmerize/CheckCanTarget(atom/target_atom, display_error)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/tremere/_powers_tremere.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/tremere/_powers_tremere.dm
@@ -67,6 +67,9 @@
 
 
 /datum/action/bloodsucker/targeted/tremere/CheckValidTarget(atom/target_atom)
+	. = ..()
+	if(!.)
+		return FALSE
 	return isliving(target_atom)
 
 /datum/action/bloodsucker/targeted/tremere/CheckCanTarget(atom/target_atom, display_error)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/tremere/auspex.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/tremere/auspex.dm
@@ -77,6 +77,9 @@
 
 
 /datum/action/bloodsucker/targeted/tremere/auspex/CheckValidTarget(atom/target_atom)
+	. = ..()
+	if(!.)
+		return FALSE
 	return isturf(target_atom)
 
 /datum/action/bloodsucker/targeted/tremere/auspex/ActivatePower()

--- a/fulp_modules/main_features/bloodsuckers/code/powers/tremere/dominate.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/tremere/dominate.dm
@@ -52,9 +52,6 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	// Check: Self
-	if(target_atom == owner)
-		return FALSE
 	var/mob/living/selected_target = target_atom
 	if(!selected_target.mind)
 		if(display_error)
@@ -97,14 +94,6 @@
 /datum/action/bloodsucker/targeted/tremere/dominate/advanced/CheckCanTarget(atom/target_atom, display_error)
 	. = ..()
 	if(!.)
-		return FALSE
-	// Check: Self
-	if(target_atom == owner)
-		return FALSE
-	var/mob/living/selected_target = target_atom
-	if(!selected_target.mind)
-		if(display_error)
-			owner.balloon_alert(owner, "[selected_target] is mindless")
 		return FALSE
 	if((IS_VASSAL(selected_target) || selected_target.stat >= SOFT_CRIT) && !owner.Adjacent(selected_target))
 		if(display_error)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/tremere/thaumaturgy.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/tremere/thaumaturgy.dm
@@ -84,12 +84,15 @@
 
 
 /datum/action/bloodsucker/targeted/tremere/thaumaturgy/CheckValidTarget(atom/target_atom)
+	. = ..()
+	if(!.)
+		return FALSE
 	return TRUE
 
 /datum/action/bloodsucker/targeted/tremere/thaumaturgy/CheckCanUse(display_error)
 	. = ..()
 	if(!.)
-		return
+		return FALSE
 	if(!active) // Only do this when first activating.
 		var/mob/living/user = owner
 		if(tremere_level >= 2) // Only if we're at least level 2.
@@ -132,7 +135,6 @@
  *
  *	This is the projectile this Power will fire.
  */
-
 /obj/projectile/magic/arcane_barrage/bloodsucker
 	name = "blood bolt"
 	icon_state = "mini_leaper"

--- a/fulp_modules/main_features/bloodsuckers/code/powers/trespass.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/trespass.dm
@@ -26,6 +26,9 @@
 
 
 /datum/action/bloodsucker/targeted/trespass/CheckValidTarget(atom/target_atom)
+	. = ..()
+	if(!.)
+		return FALSE
 	// Can't target my tile
 	if(target_atom == get_turf(owner) || get_turf(target_atom) == get_turf(owner))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

You cannot use Powers on yourself anymore. This caused things like Predatory Lunge to break the player until they used the Power again on someone else.
