### PR TITLE
Re-cables the supermatter.

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1692,7 +1692,6 @@
 	name = "Supermatter Engine Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -2464,7 +2463,6 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Cooling Loop to Gas"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aIZ" = (
@@ -3697,6 +3695,8 @@
 	name = "Engineering yellow corner"
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "baf" = (
@@ -3913,15 +3913,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/carpet,
 /area/maintenance/fore)
-"bcA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "bcD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -5293,7 +5284,6 @@
 	name = "Laser Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -6781,7 +6771,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bPB" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -6795,6 +6784,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "bPJ" = (
@@ -7241,6 +7231,11 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat_interior)
+"bWf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bWh" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -7589,6 +7584,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter)
 "bZs" = (
@@ -8692,7 +8688,6 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -9237,7 +9232,6 @@
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
 "cwH" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
 	name = "Mix Bypass"
@@ -9386,7 +9380,6 @@
 /area/security/checkpoint/medical)
 "cyp" = (
 /obj/structure/rack,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
@@ -9431,6 +9424,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "cyE" = (
@@ -10315,7 +10309,6 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "cKe" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -11114,6 +11107,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "cVL" = (
@@ -11377,6 +11371,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "daq" = (
@@ -11773,6 +11768,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
+"deF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "deG" = (
 /obj/structure/table,
 /obj/machinery/light_switch/directional/north,
@@ -13180,7 +13188,6 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/central)
 "dxt" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
@@ -13192,6 +13199,7 @@
 	},
 /obj/structure/cable/layer1,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "dxV" = (
@@ -13758,6 +13766,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "dGD" = (
@@ -14677,7 +14686,6 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "dSy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -14818,7 +14826,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron,
 /area/engineering/main)
 "dVd" = (
@@ -14901,6 +14908,11 @@
 	},
 /turf/open/floor/wood,
 /area/service/library/printer)
+"dVM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "dVQ" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -15588,8 +15600,7 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "edQ" = (
-/obj/effect/decal/remains/human,
-/obj/item/organ/fly,
+/obj/effect/mob_spawn/human/skeleton,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
 "edR" = (
@@ -15710,6 +15721,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "efI" = (
@@ -16943,7 +16955,6 @@
 "exF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction)
 "exG" = (
@@ -18957,6 +18968,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction)
 "eZO" = (
@@ -19202,6 +19214,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction)
 "fcF" = (
@@ -20272,6 +20285,7 @@
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	name = "Output Release"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "frd" = (
@@ -20396,6 +20410,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/main)
 "fse" = (
@@ -20510,7 +20525,6 @@
 /area/maintenance/fore)
 "ftV" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
@@ -20522,6 +20536,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "fug" = (
@@ -20871,14 +20886,6 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "fyJ" = (
-/obj/structure/filingcabinet/chestdrawer,
-/mob/living/simple_animal/parrot/poly,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/command/heads_quarters/ce";
-	dir = 4;
-	name = "CE Office APC";
-	pixel_x = 24
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -20982,6 +20989,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"fAK" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "fAO" = (
 /obj/machinery/monkey_recycler,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -21257,7 +21268,7 @@
 	dir = 8;
 	name = "Security Delivery";
 	pixel_y = -7;
-	req_access_txt = "3"
+	req_access_txt = "63"
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -21471,14 +21482,6 @@
 /obj/structure/bed/maint,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"fHE" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/engineering/supermatter)
 "fHF" = (
 /turf/open/floor/iron,
 /area/maintenance/starboard)
@@ -21969,7 +21972,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "fOe" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -23059,11 +23061,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"gap" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "gay" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -23556,6 +23553,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "gif" = (
@@ -23989,9 +23987,8 @@
 /area/maintenance/fore)
 "gqe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/engineering/main)
 "gqk" = (
@@ -24060,7 +24057,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "gqx" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -24216,7 +24212,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gtm" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24367,6 +24362,11 @@
 /obj/structure/rack,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
+"gwj" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/engineering/main)
 "gwD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -24592,6 +24592,20 @@
 "gyy" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"gyz" = (
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "gyJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -25158,7 +25172,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "gHi" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
@@ -25843,7 +25856,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "gOH" = (
-/obj/structure/cable,
 /obj/item/crowbar,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -27261,6 +27273,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "hlg" = (
@@ -28279,17 +28292,16 @@
 /turf/open/floor/iron/dark,
 /area/commons/storage/art)
 "hyY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/cable/layer1,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "hzo" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
@@ -29157,6 +29169,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "hJP" = (
@@ -29731,6 +29744,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/main)
 "hSi" = (
@@ -30254,6 +30268,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "hZs" = (
@@ -30477,6 +30492,7 @@
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "icz" = (
@@ -31105,11 +31121,11 @@
 /turf/open/floor/engine,
 /area/medical/chemistry)
 "iiZ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "ijf" = (
@@ -31118,6 +31134,15 @@
 "ijn" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
+/area/maintenance/port/aft)
+"ijO" = (
+/obj/machinery/door/window/southleft{
+	dir = 4;
+	name = "Engineering Delivery";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
 /area/maintenance/port/aft)
 "ijP" = (
 /obj/effect/turf_decal/tile/green{
@@ -31234,7 +31259,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/medbay)
 "ikx" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -31517,14 +31541,8 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 1;
 	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "iom" = (
@@ -32647,6 +32665,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"iEg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "iEk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -33298,6 +33322,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -33557,6 +33582,7 @@
 	dir = 8;
 	network = list("ss13", "engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "iSA" = (
@@ -37278,6 +37304,11 @@
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/grimy,
 /area/maintenance/starboard/fore)
+"jPe" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/main)
 "jPh" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph{
 	pixel_y = 32
@@ -37696,7 +37727,6 @@
 	dir = 8;
 	name = "Atmos to Loop"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "jUj" = (
@@ -38221,7 +38251,6 @@
 	name = "Power Storage";
 	req_access_txt = "11"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
@@ -38231,6 +38260,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "kbb" = (
@@ -41129,6 +41159,24 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"kMK" = (
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "kMS" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/bed/maint,
@@ -41153,7 +41201,6 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "kNJ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -41423,7 +41470,6 @@
 	dir = 8;
 	name = "Mix to Gas"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "kRZ" = (
@@ -44057,7 +44103,6 @@
 /turf/open/floor/iron/grimy,
 /area/security/prison/rec)
 "lBo" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -44365,6 +44410,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "lGe" = (
@@ -45155,7 +45201,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "lPg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
@@ -46325,6 +46370,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"mcF" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/main)
 "mcI" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -48175,6 +48225,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "mAQ" = (
@@ -49724,7 +49775,6 @@
 /area/hallway/primary/central)
 "mSu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/obj/structure/cable,
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -49927,12 +49977,21 @@
 /turf/open/floor/iron,
 /area/security/office)
 "mWg" = (
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "Engineering Delivery";
-	req_one_access_txt = "10;24"
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "mWi" = (
@@ -50333,6 +50392,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "nbb" = (
@@ -50673,6 +50733,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "nfh" = (
@@ -50961,6 +51022,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "njK" = (
@@ -51093,6 +51155,10 @@
 	dir = 4
 	},
 /area/service/chapel)
+"nlg" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/main)
 "nlj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -51357,6 +51423,7 @@
 	c_tag = "Engineering - Foyer W";
 	network = list("ss13", "engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "npk" = (
@@ -51433,7 +51500,6 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/status_display/ai/directional/south,
-/obj/structure/cable,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
@@ -52349,7 +52415,6 @@
 /turf/open/floor/wood,
 /area/service/library)
 "nCR" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
@@ -54073,6 +54138,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "obm" = (
@@ -55389,7 +55455,6 @@
 	name = "SMES room APC";
 	pixel_x = 25
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 4;
@@ -55404,6 +55469,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "osB" = (
@@ -55715,6 +55781,11 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"oyK" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/engineering/atmospherics_engine)
 "oyY" = (
 /obj/structure/table/glass,
 /obj/item/slime_scanner,
@@ -56468,6 +56539,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"oIQ" = (
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "oJl" = (
 /obj/structure/chair/plastic{
 	dir = 1
@@ -56900,7 +56980,6 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "oQn" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -56997,6 +57076,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "oRK" = (
@@ -58736,7 +58816,6 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "prp" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -58751,6 +58830,7 @@
 	},
 /obj/structure/cable/layer1,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "pry" = (
@@ -59280,6 +59360,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"pyX" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Chief Engineer Office Maintenance";
+	req_access_txt = "56"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "pzc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 4
@@ -60252,6 +60340,20 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"pLd" = (
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/main)
 "pLm" = (
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/west,
@@ -60279,7 +60381,6 @@
 	name = "Engineering Maintenance";
 	req_one_access_txt = "10;24"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
@@ -60671,7 +60772,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "pQK" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -60688,6 +60788,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "pQT" = (
@@ -61155,7 +61256,6 @@
 /area/security/checkpoint/medical)
 "pWn" = (
 /obj/structure/closet/crate/solarpanel_small,
-/obj/structure/cable,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -61171,6 +61271,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "pWs" = (
@@ -61703,7 +61804,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/maintenance/department/science)
 "qdH" = (
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Engineering - SM Chamber";
 	dir = 9;
@@ -63000,7 +63100,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/restrooms)
 "qtD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -63308,7 +63407,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "qyh" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -64707,7 +64805,6 @@
 	name = "Engine Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -64723,6 +64820,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "qTq" = (
@@ -64825,6 +64923,7 @@
 /obj/structure/sign/warning/enginesafety{
 	pixel_y = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "qUE" = (
@@ -64879,7 +64978,6 @@
 /turf/open/floor/iron,
 /area/security/office)
 "qVi" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -65201,6 +65299,23 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"qZp" = (
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_y = 32
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "qZq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Boxing";
@@ -65860,6 +65975,7 @@
 	dir = 4;
 	name = "Output to Waste"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "rgC" = (
@@ -66203,6 +66319,11 @@
 "rjH" = (
 /turf/closed/wall/r_wall,
 /area/science/test_area)
+"rjX" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "rkd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -66297,6 +66418,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "rma" = (
@@ -66832,7 +66954,6 @@
 /turf/open/floor/wood,
 /area/service/library/artgallery)
 "rqT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -66846,6 +66967,7 @@
 	},
 /obj/structure/cable/layer1,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "rqV" = (
@@ -67393,6 +67515,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
+"ryH" = (
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "ryJ" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red{
@@ -67861,7 +67992,6 @@
 	pixel_x = -10;
 	req_access_txt = "10"
 	},
-/obj/structure/cable,
 /obj/machinery/keycard_auth{
 	pixel_y = -35
 	},
@@ -68224,7 +68354,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "rKw" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -68243,6 +68372,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "rKC" = (
@@ -68284,7 +68414,6 @@
 	name = "Engine Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -68298,6 +68427,7 @@
 	},
 /obj/structure/cable/layer1,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "rLu" = (
@@ -69149,7 +69279,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/service)
 "rXt" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -70414,7 +70543,6 @@
 	network = list("ss13", "engineering")
 	},
 /obj/machinery/status_display/evac/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "soi" = (
@@ -71092,7 +71220,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "swu" = (
@@ -71552,7 +71680,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
@@ -73057,6 +73184,13 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"tbB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/main)
 "tbC" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
@@ -73595,7 +73729,6 @@
 	name = "Engineering APC";
 	pixel_y = 23
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
@@ -73679,6 +73812,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"thZ" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/construction)
 "tig" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -73745,6 +73883,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "tjc" = (
@@ -74367,6 +74506,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "tsf" = (
@@ -74973,6 +75113,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "tAj" = (
@@ -75597,7 +75738,7 @@
 	dir = 8;
 	icon_state = "left";
 	name = "Security Delivery";
-	req_access_txt = "1"
+	req_access_txt = "12"
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -76396,6 +76537,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "tVt" = (
@@ -77466,6 +77608,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "uiB" = (
@@ -77995,8 +78138,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -78322,6 +78466,7 @@
 /area/cargo/miningoffice)
 "utE" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "utF" = (
@@ -79381,10 +79526,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"uKI" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "uKN" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
@@ -80109,6 +80250,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "uTc" = (
@@ -80759,7 +80901,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "vbw" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -80938,7 +81079,6 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "veD" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -82035,6 +82175,22 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/upper)
+"vtI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "vtM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -82363,7 +82519,6 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "vzJ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 8;
@@ -82373,6 +82528,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "vzM" = (
@@ -83231,7 +83387,6 @@
 /turf/closed/wall,
 /area/construction)
 "vKu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -83595,7 +83750,6 @@
 	dir = 8;
 	name = "Gas to Cooling Loop"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "vQx" = (
@@ -83783,7 +83937,6 @@
 	},
 /area/command/heads_quarters/rd)
 "vTc" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -84587,16 +84740,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
-"wgv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "wgN" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/plating,
@@ -84767,9 +84910,11 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "wjz" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "wjC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84990,6 +85135,21 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"wmB" = (
+/obj/machinery/shieldgen,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/main)
 "wmF" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -85412,6 +85572,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter)
 "wsM" = (
@@ -87046,6 +87207,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "wLL" = (
@@ -88541,20 +88703,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"xeU" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
 "xff" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -88844,6 +88992,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "xis" = (
@@ -89047,7 +89196,6 @@
 /turf/open/floor/iron,
 /area/medical/virology)
 "xkL" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -91000,7 +91148,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "xKV" = (
@@ -91648,6 +91795,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "xTx" = (
@@ -92078,9 +92226,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "xXn" = (
-/obj/structure/rack,
-/obj/item/rcl/pre_loaded,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
@@ -92090,6 +92235,8 @@
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/filingcabinet/chestdrawer,
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "xXq" = (
@@ -117433,10 +117580,10 @@ xRN
 qnP
 xRN
 iQW
-iQW
-iQW
-iQW
-iQW
+xRN
+xRN
+xRN
+xRN
 iQW
 xdv
 xdv
@@ -117452,7 +117599,7 @@ ouh
 nUz
 cpo
 vKu
-bcA
+pSa
 gHi
 idu
 uJk
@@ -117691,8 +117838,8 @@ wGD
 xRN
 xRN
 xRN
-xRN
-xRN
+yel
+gbW
 xRN
 iQW
 xdv
@@ -117717,9 +117864,9 @@ xCS
 mSI
 fHR
 tse
-dCs
+eJg
 rgs
-dCs
+eJg
 vWn
 ouh
 xdv
@@ -117949,7 +118096,7 @@ yel
 pFj
 yel
 yel
-gbW
+yel
 xRN
 iQW
 xdv
@@ -118205,8 +118352,8 @@ rLu
 xkn
 rTm
 frt
-yel
-yel
+xRN
+jII
 xRN
 iQW
 xdv
@@ -118221,7 +118368,7 @@ kOC
 kOC
 wzj
 sle
-rMR
+jIc
 kiF
 jRE
 hJs
@@ -118233,7 +118380,7 @@ vlZ
 uqr
 vlZ
 ogN
-dCs
+eJg
 xEJ
 ouh
 xdv
@@ -118463,8 +118610,8 @@ xRN
 xRN
 xRN
 yfc
-jII
-xRN
+ijO
+yfc
 mdH
 kOC
 kOC
@@ -118490,7 +118637,7 @@ qWw
 qiQ
 aQq
 wuD
-dCs
+eJg
 tzQ
 kOC
 iQW
@@ -118721,7 +118868,7 @@ ykH
 goo
 xcR
 mWg
-rxn
+kMK
 kOC
 vub
 sPD
@@ -118735,7 +118882,7 @@ rlH
 jsc
 ouh
 pre
-rMR
+jIc
 nau
 nZr
 nZr
@@ -118977,7 +119124,7 @@ hzG
 lLS
 opB
 xcR
-wSA
+fQh
 iok
 kOC
 tIO
@@ -118987,12 +119134,12 @@ pUS
 gMl
 kOC
 cyp
-uKI
+iJh
 gqx
 dSy
 avI
 lBo
-rMR
+jIc
 mSI
 jQD
 nFN
@@ -119232,7 +119379,7 @@ aTk
 oIe
 aTk
 mxz
-qEz
+thZ
 xcR
 lFZ
 pQK
@@ -119246,19 +119393,19 @@ qTp
 bPB
 neR
 iNT
-jsc
+pLd
 ouh
 xzl
 wSg
-mSI
+jPe
 wsF
-wLY
+qEy
 pAU
 kGk
 sAa
 tgc
 cXv
-wLY
+qEy
 bZn
 uix
 jRE
@@ -119491,7 +119638,7 @@ nio
 dbq
 exF
 sCa
-qko
+vtI
 oQn
 kOC
 qvo
@@ -119508,16 +119655,16 @@ oTS
 loO
 rMR
 gmQ
-fHE
+jQD
 qdH
 cJn
 kGk
 wLY
 tgc
 dOu
-qEy
-fHE
-wgv
+wLY
+jQD
+bmx
 dCs
 tja
 ouh
@@ -119748,7 +119895,7 @@ iQi
 eZz
 qvm
 xcR
-fQh
+gyz
 ikx
 dfB
 dfB
@@ -120519,7 +120666,7 @@ uqY
 wLL
 wLL
 xcR
-fQh
+gyz
 qVi
 tsy
 pVy
@@ -120535,7 +120682,7 @@ gwQ
 kOC
 xzl
 aMW
-gap
+lGh
 lGh
 lGh
 baQ
@@ -120781,8 +120928,8 @@ vTc
 dfB
 dfB
 ftV
-xel
-xel
+qAX
+qAX
 xXn
 tsy
 swk
@@ -120793,15 +120940,15 @@ kOC
 sGU
 qsr
 fOe
-eJg
+dCs
 gOH
-eJg
-eJg
+dCs
+dCs
 veD
-eJg
+dCs
 jUi
-eJg
-eJg
+dCs
+dCs
 kRY
 dCs
 njH
@@ -121033,20 +121180,20 @@ kOw
 gnP
 edw
 edw
-nEY
+oIQ
 cKe
 gwV
 tsy
 uSY
 xel
-qAX
+xel
 icr
 tsy
-swk
-mHl
-mHl
+wmB
+nlg
+nlg
 rlW
-kOC
+gwj
 uqd
 gqe
 oRG
@@ -121059,9 +121206,9 @@ hJO
 oaZ
 hkZ
 cyA
-lQL
-dCs
-dCs
+tbB
+eJg
+eJg
 hyj
 tID
 ouh
@@ -121290,7 +121437,7 @@ yfc
 dzi
 cxT
 aLF
-oNn
+ryH
 qtD
 qgI
 tsy
@@ -121303,8 +121450,8 @@ tSo
 pGW
 bOQ
 swb
-vVh
-vVh
+mcF
+iEg
 wjz
 ouh
 ouh
@@ -121552,7 +121699,7 @@ qyh
 gKe
 vVh
 vVh
-vVh
+pyX
 vVh
 vVh
 vVh
@@ -121563,7 +121710,7 @@ jhU
 vVh
 gKe
 gKe
-iQW
+ouh
 iQW
 iQW
 iQW
@@ -121804,12 +121951,12 @@ wzZ
 rSG
 vDJ
 rAB
-yeF
+qZp
 gtm
 pLK
-oEa
+bWf
 pkQ
-sdd
+fAK
 sdd
 uCP
 vVh
@@ -122061,7 +122208,7 @@ pOu
 pOu
 fiR
 wHs
-fQh
+gyz
 vbw
 gKe
 gKe
@@ -122321,9 +122468,9 @@ wLu
 hZq
 xkL
 rFk
-gKe
+dVM
 uva
-sdd
+fAK
 sdd
 sdd
 sdd
@@ -122578,9 +122725,9 @@ wHs
 fQh
 rXt
 uEQ
-gKe
+dVM
 uva
-sdd
+fAK
 sdd
 sdd
 gKe
@@ -122832,12 +122979,12 @@ vqS
 bIi
 vzJ
 kaY
-xeU
-rXt
+gyz
+deF
 xTt
-gKe
+rjX
 utE
-sdd
+fAK
 mJI
 lTr
 gKe
@@ -124382,7 +124529,7 @@ mHH
 fgq
 vSJ
 kvU
-kCb
+oyK
 sDN
 rgH
 aPN


### PR DESCRIPTION
## About The Pull Request

Replaces all cables for Selene's supermatter, removing the admin-only power teleporters which only makes repairing the SM nearly impossible and confuses the fuck out of literally everyone.
This was originally meant to be bigger but I got lazy, so I also had removed some spots where 4 walls were cornering eachother, and replaced the Brig maint door with the same access the windoor leading up to it used, as well changed the delivery windoor to security office instead of armory, because it's not the damn armory.


## Why It's Good For The Game

Selene sucks.
