### PR TITLE
Fixes selene library airlock name

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -73346,11 +73346,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "tih" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel Library"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Art Gallery"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/service/library/artgallery)
 "tit" = (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/83892995/143299667-8a8816ce-5429-44ed-a3a4-d32ed85f16a7.png)
renames the airlock to the art gallery one so it stops showing up as this 