### PR TITLE
Misdirection can no longer break the laws of physics

### DIFF
--- a/fulp_modules/features/lisa/joelgun.dm
+++ b/fulp_modules/features/lisa/joelgun.dm
@@ -191,7 +191,8 @@
 				span_hear("You hear aggressive shuffling!"),
 				COMBAT_MESSAGE_RANGE,
 			)
-			main_victims.Move(target)
+			main_victims.throw_at(target, 1, 1, user, FALSE)
+			main_victims.Knockdown(1 SECONDS)
 	// Everyone else will just notice it
 	for(var/mob/living/extra_victims in viewers(5, target))
 		extra_victims.face_atom(target)

--- a/fulp_modules/features/lisa/joelgun.dm
+++ b/fulp_modules/features/lisa/joelgun.dm
@@ -191,7 +191,7 @@
 				span_hear("You hear aggressive shuffling!"),
 				COMBAT_MESSAGE_RANGE,
 			)
-			main_victims.throw_at(target, 1, 1, user, FALSE)
+			step_towards(main_victims, target)
 			main_victims.Knockdown(1 SECONDS)
 	// Everyone else will just notice it
 	for(var/mob/living/extra_victims in viewers(5, target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request

This PR fixes the fact Joel's Gun's Misdirection ability could ~~put people inside objects, including but not limited to: 
scrubbers, vents, rolling chair and the nuke, from which they could not exit without admin intervention.
As far as I can tell, the actual intended part remains functionally the same as it used to be.~~
merge people together now, apparently?
This should fix that. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes a ~~pretty big~~ problem with the thing, hopefully without creating any larger ones. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Joel's Gun's misdirection now uses ~~.throw_at~~ step_towards rather than .Move to avoid previous glitches.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
