### PR TITLE
Bug fix-oriontrail silicon

### DIFF
--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 
 /obj/machinery/computer/arcade/orion_trail/proc/newgame()
 	// Set names of settlers in crew
-	var/mob/living/carbon/player = usr
+	var/mob/living/player = usr
 	var/player_crew_name = player.first_name()
 	settlers = list()
 	for(var/i in 1 to ORION_STARTING_CREW_COUNT - 1) //one reserved to be YOU
@@ -190,7 +190,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 	if(.)
 		return
 
-	var/mob/living/carbon/gamer = usr
+	var/mob/living/gamer = usr
 	if(!istype(gamer))
 		return
 
@@ -347,7 +347,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 	event = null
 	reason = given_reason || death_reason(user)
 
-/obj/machinery/computer/arcade/orion_trail/proc/death_reason(mob/living/carbon/gamer)
+/obj/machinery/computer/arcade/orion_trail/proc/death_reason(mob/living/gamer)
 	var/reason
 	if(!settlers.len)
 		reason = "Your entire crew died, and your ship joins the fleet of ghost-ships littering the galaxy."
@@ -421,7 +421,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
  * Arguments:
  * * gamer: carbon that may need emag effects applied
  */
-/obj/machinery/computer/arcade/orion_trail/proc/execute_crewmember(mob/living/carbon/gamer, target)
+/obj/machinery/computer/arcade/orion_trail/proc/execute_crewmember(mob/living/gamer, target)
 	var/sheriff = remove_crewmember(target) //I shot the sheriff
 	if(target)
 		killed_crew += 1 //if there was no suspected lings, this is just plain murder

--- a/code/game/machinery/computer/arcade/orion_event.dm
+++ b/code/game/machinery/computer/arcade/orion_event.dm
@@ -52,7 +52,7 @@
  * * gamer_skill: skill of the gamer, because gamers gods can lessen the effects of the emagged machine
  * * gamer_skill_level: skill level of the gamer, another way to measure emag downside avoidance
  */
-/datum/orion_event/proc/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/carbon/gamer)
+/datum/orion_event/proc/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/gamer)
 	if(emag_message)
 		game.audible_message(emag_message)
 	if(emag_sound)
@@ -112,7 +112,7 @@
 	event_responses.Cut()
 	..()
 
-/datum/orion_event/electronic_part/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/carbon/gamer)
+/datum/orion_event/electronic_part/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/gamer)
 	playsound(game, 'sound/effects/empulse.ogg', 50, TRUE)
 	game.visible_message(span_danger("[src] malfunctions, randomizing in-game stats!"))
 	var/oldfood = game.food
@@ -156,7 +156,7 @@
 	event_responses.Cut()
 	..()
 
-/datum/orion_event/hull_part/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/carbon/gamer)
+/datum/orion_event/hull_part/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/gamer)
 	if(prob(10+gamer_skill))
 		game.say("Something slams into the floor around [src] - luckily, it didn't get through!")
 		playsound(game, 'sound/effects/bang.ogg', 50, TRUE)
@@ -189,7 +189,7 @@
 		return ..()
 	game.encounter_event(/datum/orion_event/exploring_derelict)
 
-/datum/orion_event/old_ship/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/carbon/gamer)
+/datum/orion_event/old_ship/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/gamer)
 	return //do nothing because this leads into an event where we actually will do something.
 
 #define BUTTON_WELCOME_ABOARD "Welcome aboard."
@@ -257,7 +257,7 @@
 	else
 		text += "Fortunately, you fended them off without any trouble."
 
-/datum/orion_event/raiders/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/carbon/gamer)
+/datum/orion_event/raiders/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/gamer)
 	if(prob(50-gamer_skill))
 		to_chat(usr, span_userdanger("You hear battle shouts. The tramping of boots on cold metal. Screams of agony. The rush of venting air. Are you going insane?"))
 		gamer.hallucination += 30
@@ -277,7 +277,7 @@
 	var/deadname = game.remove_crewmember()
 	text = "A deadly illness has been contracted! [deadname] was killed by the disease."
 
-/datum/orion_event/illness/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/carbon/gamer)
+/datum/orion_event/illness/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/gamer)
 	var/maxSeverity = 3
 	if(gamer_skill_level >= SKILL_LEVEL_EXPERT)
 		maxSeverity = 2 //part of gitting gud is rng mitigation
@@ -314,7 +314,7 @@
 		game.fuel -= 5
 		..()
 
-/datum/orion_event/flux/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/carbon/gamer)
+/datum/orion_event/flux/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/gamer)
 	if(prob(25 + gamer_skill))//withstand the wind with your GAMER SKILL
 		to_chat(gamer, span_userdanger("A violent gale blows past you, and you barely manage to stay standing!"))
 		return
@@ -432,7 +432,7 @@
 	game.set_game_over(usr, "You were swept away into the black hole.")
 	..()
 
-/datum/orion_event/black_hole_death/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/carbon/gamer)
+/datum/orion_event/black_hole_death/emag_effect(obj/machinery/computer/arcade/orion_trail/game, mob/living/gamer)
 	if(game.obj_flags & EMAGGED)
 		playsound(game.loc, 'sound/effects/supermatter.ogg', 100, TRUE)
 		game.say("A miniature black hole suddenly appears in front of [game], devouring [gamer] alive!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request

quick bug fix in order to allow silicons to play orion trail not just carbon players
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes a bug, and made people sad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Doctor Pope
fix. Fixed silicons not being able to play orion trail 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
