### PR TITLE
[Selene & Helio] Small map fixes

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -38136,6 +38136,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"bNi" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "bNk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -54588,7 +54592,7 @@
 	name = "engineering yellow"
 	},
 /turf/open/floor/iron,
-/area/engineering/transit_tube)
+/area/maintenance/disposal/incinerator)
 "cza" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/transit_tube,
@@ -55692,17 +55696,13 @@
 	dir = 8;
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cBD" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
-"cBE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cBF" = (
@@ -56261,7 +56261,6 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cCU" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56291,6 +56290,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cCX" = (
@@ -56759,23 +56759,20 @@
 /area/maintenance/disposal/incinerator)
 "cEk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 8;
 	name = "engineering yellow"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cEl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "atmospherics mix pump"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -56784,11 +56781,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 10
 	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
-"cEn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cEo" = (
@@ -56870,9 +56862,7 @@
 /area/service/hydroponics/garden)
 "cEy" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cEz" = (
@@ -56954,11 +56944,8 @@
 	dir = 4;
 	name = "engineering yellow"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/atmos/upper";
-	dir = 4;
-	name = "Atmospherics Upper APC";
-	pixel_x = 25
+/obj/machinery/atmospherics/components/binary/thermomachine/heater{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -57191,30 +57178,22 @@
 /area/maintenance/disposal/incinerator)
 "cFr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 8;
 	name = "engineering yellow"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cFs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "Port Out"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
-"cFt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 4
+	name = "atmospherics mix pump"
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -57224,6 +57203,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cFv" = (
@@ -57449,6 +57429,7 @@
 	departmentType = 4;
 	name = "Atmos RC"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cFT" = (
@@ -57671,18 +57652,27 @@
 	dir = 8;
 	name = "engineering yellow"
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cGz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port Out"
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cGA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cGB" = (
@@ -57920,12 +57910,12 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cHb" = (
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 4;
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cHc" = (
@@ -59180,6 +59170,7 @@
 	name = "engineering yellow"
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cJp" = (
@@ -59287,6 +59278,13 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/power/apc{
+	areastring = "/area/engineering/atmos/upper";
+	dir = 4;
+	name = "Atmospherics Upper APC";
+	pixel_x = 25
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cJC" = (
@@ -61214,7 +61212,7 @@
 /area/engineering/main)
 "cOr" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent{
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 1
 	},
 /turf/open/space/basic,
@@ -65824,6 +65822,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/rec)
+"fak" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "faA" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -106601,8 +106605,8 @@ cAn
 mmv
 cBB
 cCS
+fak
 cEj
-cFq
 cFq
 cHO
 cxT
@@ -107370,10 +107374,10 @@ csI
 cxT
 czm
 cXO
-cBE
+bNi
 cCV
+bNi
 cEm
-cFt
 cGA
 cHR
 cIO
@@ -107629,7 +107633,7 @@ czn
 cAr
 cBF
 cCW
-cEn
+cBF
 cFu
 cGB
 cHS
@@ -107881,7 +107885,7 @@ cqv
 cug
 aak
 cXT
-cug
+cxT
 cyZ
 cAD
 cBY
@@ -108138,8 +108142,8 @@ bJe
 cug
 cug
 cug
-cug
-cug
+cxT
+cxT
 cxT
 cxT
 cKK

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -41781,6 +41781,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/camera/directional/east{
+	c_tag = "Public - Game Room Hall"
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "kVJ" = (
@@ -47985,14 +47988,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Public - Dorms Hall";
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/camera/directional/south{
+	c_tag = "Public - Dorms Hall"
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "mwM" = (
@@ -73474,10 +73476,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Public - Game Room Hall";
-	dir = 9
 	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";


### PR DESCRIPTION
## About The Pull Request

Selene: Repaths 2 cameras to update them to directionals
Helio: Fixes the SM waste pipe, makes incinerator SMES not connected to the grid, adds a thermomachine to its distro.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


