### PR TITLE
Syriniver shot for Helios and Selene (Removing mentions of toxins)

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -42544,7 +42544,7 @@
 /obj/machinery/power/apc{
 	areastring = "/area/science/mixing/chamber";
 	dir = 1;
-	name = "Toxins Chamber APC";
+	name = "Ordnance Chamber APC";
 	pixel_y = 24
 	},
 /obj/structure/cable,
@@ -42587,7 +42587,7 @@
 /obj/machinery/power/apc{
 	areastring = "/area/science/mixing";
 	dir = 8;
-	name = "Toxins Lab APC";
+	name = "Ordnance Lab APC";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -44198,7 +44198,7 @@
 "cbK" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Toxins Lab NE";
-	name = "Toxins Mixing Camera";
+	name = "Ordnance Mixing Camera";
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/siding/purple{
@@ -44342,7 +44342,7 @@
 	},
 /obj/machinery/button/door/directional/east{
 	id = "toxinsrd";
-	name = "Toxins Shield Button";
+	name = "Ordnance Shield Button";
 	pixel_x = 37;
 	pixel_y = -5;
 	req_access_txt = "30"
@@ -44715,7 +44715,7 @@
 /area/science/mixing)
 "ccY" = (
 /obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
+	name = "Ordnance Lab";
 	req_access_txt = "7"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -44758,7 +44758,7 @@
 /area/science/mixing)
 "cdc" = (
 /obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room";
+	name = "Ordnance Launch Room";
 	req_access_txt = "7"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -45538,7 +45538,7 @@
 /area/maintenance/starboard)
 "ceE" = (
 /obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
+	name = "Ordnance Lab";
 	req_access_txt = "7"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45664,7 +45664,7 @@
 	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Toxins Launch";
-	name = "Toxins Launch Camera";
+	name = "Ordnance Launch Camera";
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/siding/purple{
@@ -46007,7 +46007,7 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/camera/directional/west{
 	c_tag = "Toxins Storage";
-	name = "Toxins Storage Camera";
+	name = "Ordnance Storage Camera";
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/siding/purple{
@@ -46091,7 +46091,7 @@
 /obj/machinery/power/apc{
 	areastring = "/area/science/storage";
 	dir = 4;
-	name = "Toxins Storage APC";
+	name = "ORdnance Storage APC";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -46105,7 +46105,7 @@
 /area/maintenance/starboard)
 "cfX" = (
 /obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
+	name = "Ordnance Lab";
 	req_access_txt = "7"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -46637,7 +46637,7 @@
 "chh" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Toxins Lab SW";
-	name = "Toxins Lab Camera";
+	name = "Ordnance Lab Camera";
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/siding/purple{
@@ -46861,7 +46861,7 @@
 /obj/machinery/light/directional/west,
 /obj/machinery/requests_console/directional/west{
 	department = "Toxins Lab";
-	name = "Toxins RC";
+	name = "Ordnance RC";
 	receive_ore_updates = 1
 	},
 /turf/open/floor/iron/white,
@@ -47892,7 +47892,7 @@
 "cke" = (
 /obj/machinery/door/poddoor{
 	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
+	name = "Ordnance Secure Storage"
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -47909,7 +47909,7 @@
 "ckf" = (
 /obj/machinery/door/poddoor{
 	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
+	name = "Ordnance Secure Storage"
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -47926,7 +47926,7 @@
 "ckg" = (
 /obj/machinery/door/poddoor{
 	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
+	name = "Ordnance Secure Storage"
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -47941,7 +47941,7 @@
 /area/science/storage)
 "ckh" = (
 /obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
+	name = "Ordnance Storage";
 	req_access_txt = "8"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -64421,7 +64421,7 @@
 "cXc" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Toxins Hallway";
-	name = "Toxins Lab Camera";
+	name = "Ordnance Lab Camera";
 	network = list("ss13","rd")
 	},
 /obj/structure/closet/emcloset,
@@ -64528,7 +64528,7 @@
 	},
 /obj/machinery/button/door/directional/south{
 	id = "toxinsstorage";
-	name = "Toxins Secure Storage Blast Door";
+	name = "Ordnance Secure Storage Blast Door";
 	req_access_txt = "30"
 	},
 /turf/open/floor/iron/dark,
@@ -64693,7 +64693,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "toxinsrd";
-	name = "Toxins Shield RD Office"
+	name = "Ordnance Shield RD Office"
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1172,7 +1172,7 @@
 	},
 /obj/machinery/requests_console/directional/north{
 	department = "Toxins Lab";
-	name = "Toxins RC";
+	name = "Ordnance RC";
 	receive_ore_updates = 1
 	},
 /turf/open/floor/iron/white,
@@ -5038,7 +5038,7 @@
 /area/service/chapel/dock)
 "bsw" = (
 /obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
+	name = "Ordnance Lab";
 	req_access_txt = "8"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -22452,7 +22452,7 @@
 	},
 /obj/machinery/button/door/directional/south{
 	id = "toxinsstorage";
-	name = "Toxins Secure Storage Blast Door";
+	name = "Ordnance Secure Storage Blast Door";
 	pixel_x = 5;
 	req_access_txt = "30"
 	},
@@ -27369,7 +27369,7 @@
 /obj/machinery/power/apc{
 	areastring = "/area/science/mixing/chamber";
 	dir = 1;
-	name = "Toxins Chamber APC";
+	name = "Ordnance Chamber APC";
 	pixel_y = 24
 	},
 /obj/structure/cable,
@@ -37823,7 +37823,7 @@
 /area/maintenance/central)
 "jVN" = (
 /obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room";
+	name = "Ordnance Launch Room";
 	req_access_txt = "8"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -42796,7 +42796,7 @@
 	},
 /obj/machinery/door/poddoor{
 	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
+	name = "Ordnance Secure Storage"
 	},
 /turf/open/floor/iron/white,
 /area/science/storage)
@@ -53904,7 +53904,7 @@
 /area/security/checkpoint/medical)
 "nWu" = (
 /obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
+	name = "Ordnance Storage";
 	req_access_txt = "8"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -72860,7 +72860,7 @@
 /obj/machinery/power/apc{
 	areastring = "/area/science/mixing";
 	dir = 4;
-	name = "Toxins Lab APC";
+	name = "Ordnance Lab APC";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -73414,7 +73414,7 @@
 	},
 /obj/machinery/door/poddoor{
 	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
+	name = "Ordnance Secure Storage"
 	},
 /turf/open/floor/iron/white,
 /area/science/storage)
@@ -87226,7 +87226,7 @@
 /area/cargo/qm)
 "wPR" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Toxins Lab Maintenance";
+	name = "Ordnance Lab Maintenance";
 	req_access_txt = "8"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request

Renames most (hopefully all) cameras, airlocks and APCs from Selene and Helios that are still named after toxins to instead be named after ordnance.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Toxins is old and bad.
Ordnance is new and good.
The prosecution rests. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Removes mentions of toxins in airlocks and cameras of Selene and Helios in favour of Ordnance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
