### PR TITLE
Solitare: Sec buzz-in and runed metal removal

### DIFF
--- a/_maps/map_files/SolitaireStation/Solitairestation.dmm
+++ b/_maps/map_files/SolitaireStation/Solitairestation.dmm
@@ -41636,7 +41636,6 @@
 /area/hallway/primary/central/fore)
 "lSf" = (
 /obj/effect/spawner/random/entertainment/drugs,
-/obj/effect/spawner/random/engineering/material_rare,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lSi" = (
@@ -78831,6 +78830,14 @@
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000"
+	},
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
+	freqlock = 1;
+	frequency = 1359;
+	name = "Security Buzz-in";
+	pixel_x = -29;
+	pixel_y = 0
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)


### PR DESCRIPTION

## About The Pull Request

Adds a security buzz-in, right next to the entrance of brig. 

Removes a rare material spawn, which has the chance to spawn runed metal.

## Why It's Good For The Game

Security buzz-in is a nice quality of life that all stations would benefit from. 

Having 30 runed metal spawn in a fixed position, is a huge boon for cultists, which already thrive due to Solitare's large maintenance.

## Changelog
:cl:
add: Added security buzz-in
del: Removed rare material spawn
/:cl:
