### PR TITLE
Remove digitigrade shoes from some lockers.

### DIFF
--- a/fulp_modules/Z_edits/inititalize_edits/closet_init.dm
+++ b/fulp_modules/Z_edits/inititalize_edits/closet_init.dm
@@ -2,14 +2,6 @@
 /obj/structure/closet/secure_closet/security
 	req_access = list(ACCESS_WEAPONS, ACCESS_SECURITY)
 
-/obj/structure/closet/secure_closet/security/Initialize()
-	new /obj/item/clothing/shoes/jackboots/digitigrade(src)
-	. = ..()
-
-/obj/structure/closet/secure_closet/medical3/Initialize()
-	new /obj/item/clothing/shoes/brown/digitigrade(src)
-	. = ..()
-
 /obj/structure/closet/wardrobe/miner/Initialize()
 	new /obj/item/clothing/shoes/workboots/digitigrade(src)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request
Removes the roundstart digitigrade shoes that spawn on every sec and medical locker.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
They are almost never used, if a lizard loses their shoes they can be bought on the vendor, simply locker bloat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
qol: After some deep research on the subject, our economists realized that supplying digi shoes for sec and medical lockers is a waste of money for NT. This will increase the quality of life of workers that don't have to deal with spare shoes throw around on the floor every shift. This will decrease the quality of life of lizards that want a free shoe, or moths that are hungry so nothing of value was lost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
