### PR TITLE
Fix small atmos issue on Beeftology station.

### DIFF
--- a/fulp_modules/mapping/ruins/icemoon/beef_cytology.dmm
+++ b/fulp_modules/mapping/ruins/icemoon/beef_cytology.dmm
@@ -332,12 +332,12 @@
 /turf/open/floor/eighties,
 /area/ruin/powered/beefcyto)
 "ra" = (
-/turf/open/floor/plating/snowed,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
 "rc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/ice,
-/turf/open/floor/plating/snowed,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/powered/beefcyto)
 "sH" = (
 /obj/structure/grille,
@@ -446,7 +446,7 @@
 /area/ruin/powered/beefcyto)
 "wE" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/snowed,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
 "wZ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -714,7 +714,7 @@
 /area/icemoon/underground/explored)
 "Io" = (
 /obj/machinery/door/airlock/public/glass,
-/turf/open/floor/plating/snowed,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/powered/beefcyto)
 "It" = (
 /turf/open/floor/iron/kitchen_coldroom,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request
Just swap a few tiles to the icemoon version.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cut 3 tiles that are processing atmos at roundstart.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
fix: Buff Atmos techs by giving them a little bit of more CPU processing or something.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
