### PR TITLE
makes science actually have an APC

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -36204,6 +36204,7 @@
 /area/security/checkpoint/science/research)
 "bIq" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
 "bIr" = (
@@ -37336,7 +37337,6 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "bLd" = (
-/obj/structure/cable,
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -37451,6 +37451,7 @@
 	name = "security red"
 	},
 /obj/effect/landmark/start/depsec/science,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "bLt" = (
@@ -37955,7 +37956,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "bMO" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -38613,6 +38613,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
 "bOD" = (
@@ -39172,6 +39173,7 @@
 	color = "#FF0000";
 	name = "security red"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "bQb" = (
@@ -67545,6 +67547,7 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "iBu" = (
@@ -68878,6 +68881,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"llW" = (
+/obj/effect/turf_decal/siding/purple{
+	color = "#990099";
+	dir = 4;
+	name = "research purple"
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/research)
 "lmc" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/east,
@@ -75116,6 +75129,14 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xlO" = (
+/obj/effect/turf_decal/siding/purple/corner{
+	color = "#990099";
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/research)
 "xmX" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser{
@@ -123269,8 +123290,8 @@ bLc
 bNc
 bOS
 bQl
-bLc
-bJF
+llW
+xlO
 bUn
 bxx
 aak


### PR DESCRIPTION
## About The Pull Request

Science never actually had an APC which was why lights never went down and why the cell charger in science never actually worked and you had to move it to xenobio/techfab room.
