### PR TITLE
Fixes all of the 375 roundstart active turfs on Selene Station

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1108,7 +1108,7 @@
 "aqj" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars/port/fore)
 "aqn" = (
 /obj/structure/disposalpipe/segment,
@@ -2585,9 +2585,7 @@
 	dir = 8;
 	name = "Security red corner"
 	},
-/turf/open/floor/iron/white{
-	initial_gas_mix = "n2=100;TEMP=293.15"
-	},
+/turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
 "aLF" = (
 /obj/structure/window/reinforced,
@@ -14103,7 +14101,7 @@
 "dLS" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars/starboard/fore)
 "dLY" = (
 /obj/effect/turf_decal/tile/green{
@@ -21111,7 +21109,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "fDx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -22525,7 +22523,7 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars/starboard/fore)
 "fUR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -27174,13 +27172,13 @@
 /obj/structure/closet/crate/science{
 	name = "MOD core crate"
 	},
-/obj/item/mod/construction/core{
+/obj/item/mod/core/standard{
 	pixel_x = -4
 	},
-/obj/item/mod/construction/core{
+/obj/item/mod/core/standard{
 	pixel_x = 4
 	},
-/obj/item/mod/construction/core{
+/obj/item/mod/core/standard{
 	pixel_y = 4
 	},
 /turf/open/floor/iron,
@@ -27736,7 +27734,7 @@
 	},
 /obj/machinery/holopad,
 /obj/structure/chair/office,
-/turf/open/floor/iron/white/side/airless,
+/turf/open/floor/iron/white/side,
 /area/command/heads_quarters/rd)
 "hqN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
@@ -29743,7 +29741,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "hQC" = (
 /obj/structure/chair{
@@ -31691,7 +31689,7 @@
 	id = "perma"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars)
 "iqQ" = (
 /obj/structure/closet/crate/secure/loot,
@@ -32867,7 +32865,7 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars/port/fore)
 "iJh" = (
 /turf/open/floor/iron,
@@ -38742,7 +38740,7 @@
 "khR" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars/port/aft)
 "khU" = (
 /obj/effect/landmark/start/ai,
@@ -40278,9 +40276,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/open/floor/iron/white{
-	initial_gas_mix = "n2=100;TEMP=293.15"
-	},
+/turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
 "kCL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
@@ -42409,9 +42405,7 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
-/turf/open/floor/iron/white{
-	initial_gas_mix = "n2=100;TEMP=293.15"
-	},
+/turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
 "led" = (
 /obj/machinery/airalarm/directional/north,
@@ -48795,7 +48789,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "mGx" = (
 /obj/structure/table/glass,
@@ -49269,7 +49263,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "mLq" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -49422,7 +49416,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "mNJ" = (
 /obj/machinery/door/airlock/command{
@@ -49627,7 +49621,7 @@
 	name = "Perma Solar Array"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars)
 "mQA" = (
 /obj/effect/landmark/start/librarian,
@@ -49783,7 +49777,7 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/water_vapor,
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "mRD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -51992,9 +51986,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
-/turf/open/floor/iron/white{
-	initial_gas_mix = "n2=100;TEMP=293.15"
-	},
+/turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
 "nuO" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -54309,9 +54301,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/turf/open/floor/iron/white{
-	initial_gas_mix = "n2=100;TEMP=293.15"
-	},
+/turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
 "obO" = (
 /obj/structure/cable,
@@ -59164,7 +59154,7 @@
 /area/maintenance/department/cargo)
 "pwq" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "pwz" = (
 /obj/structure/closet/crate,
@@ -60179,9 +60169,7 @@
 	dir = 8;
 	name = "dark corner"
 	},
-/turf/open/floor/iron/white{
-	initial_gas_mix = "n2=100;TEMP=293.15"
-	},
+/turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
 "pJC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -63922,9 +63910,7 @@
 	dir = 8;
 	name = "Command blue corner"
 	},
-/turf/open/floor/iron/white{
-	initial_gas_mix = "n2=100;TEMP=293.15"
-	},
+/turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
 "qIN" = (
 /obj/item/organ/ears/cat,
@@ -80185,9 +80171,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
-/turf/open/floor/iron/white{
-	initial_gas_mix = "n2=100;TEMP=293.15"
-	},
+/turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
 "uUO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -80505,10 +80489,6 @@
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"uZa" = (
-/obj/structure/grille,
-/turf/open/floor/engine,
-/area/engineering/atmos)
 "uZb" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -82530,7 +82510,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "vCG" = (
 /obj/effect/turf_decal/tile/purple{
@@ -83832,7 +83812,7 @@
 	id = "portsolar";
 	name = "Port Solar Array"
 	},
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars/port/aft)
 "vTI" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -89043,7 +89023,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "xkt" = (
 /obj/effect/turf_decal/tile/red{
@@ -91413,7 +91393,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engineering/main)
 "xPj" = (
 /obj/effect/spawner/random/vending/colavend,
@@ -132097,7 +132077,7 @@ gLy
 gLy
 gLy
 gLy
-uZa
+gLy
 gLy
 gLy
 gLy

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -77526,7 +77526,7 @@
 /area/ai_monitored/command/nuke_storage)
 "umL" = (
 /obj/machinery/airalarm/server{
-	dir = 4;
+	dir = 8;
 	pixel_x = -22
 	},
 /turf/open/floor/circuit/telecomms/server,


### PR DESCRIPTION
Sometimes when I played on Fulpstation server when they were running their famous map "Selene Station" I would see this:
![image](https://user-images.githubusercontent.com/25415050/150775767-4ffa2573-e57a-41c6-9dbb-2c58c319e643.png)
And think to myself: "Wow! This is certainly a 'Selene Station' moment!" but it has now come time for me to fix these issues that make us look bad on the lobby screen

Below are examples of things I fixed there were some more that i didnt screenshot but I think some of these are funny or what do you think

![image](https://user-images.githubusercontent.com/25415050/150775955-f8cdb6b7-e1c9-43f1-80b7-f49faa5dfc96.png)
![image](https://user-images.githubusercontent.com/25415050/150775969-7aba14ef-9969-4882-bcd7-81c656a60717.png)
(solars not using the airless subtypes were like 80% of them)
![image](https://user-images.githubusercontent.com/25415050/150775994-542fcf7b-cdb3-4174-8ed6-b8ede90c1112.png)
![image](https://user-images.githubusercontent.com/25415050/150776012-4ab9921f-b538-4bd4-85b2-6ee1cb99d863.png)
