### PR TITLE
Fixes the best clan

### DIFF
--- a/fulp_modules/features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -28,7 +28,7 @@
 	if(my_clan == CLAN_MALKAVIAN)
 		if(prob(85) || owner.current.stat != CONSCIOUS || HAS_TRAIT(owner.current, TRAIT_MASQUERADE))
 			return
-		var/message = pick(strings("malkavian_revelations.json", "revelations", "fulp_modules"))
+		var/message = pick(strings("malkavian_revelations.json", "revelations", "fulp_modules/strings/bloodsuckers"))
 		INVOKE_ASYNC(owner.current, /atom/movable/proc/say, message, , , , , , CLAN_MALKAVIAN)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
i was trying to figure out why beefstation people spawned with human names instead of beefman ones and so I checked runtimes and this is when i spotted this
![image](https://user-images.githubusercontent.com/25415050/150984664-767ceda9-4afa-413e-9f26-8393a4fde1ea.png)

Its been an issue since like #407 and its caused malkavians to lose their cooler gimmick idk how this wasnt reported before also i still dont know whats up with beefmen spawners if someone knows that would be cool i think