### PR TITLE
Fixes beefman spawner names (name + role name)

### DIFF
--- a/code/___fulp_defines/fulp_defines.dm
+++ b/code/___fulp_defines/fulp_defines.dm
@@ -48,9 +48,9 @@
 ///Check if we are indeed a Beefman
 #define isbeefman(A) (is_species(A, /datum/species/beefman))
 ///Job define for the Beefmen Cytology (Icemoon) Spawner
-#define ROLE_BEEFMAN_CYTOLOGY "Beefman Cytology"
+#define ROLE_BEEFMAN_CYTOLOGY "Beefman Cytology Scientist"
 ///Job define for the Beefmen Station (Space) Spawner
-#define ROLE_BEEFMAN_STATION "Beefman Station"
+#define ROLE_BEEFMAN_STATION "Beefman Station Inhabitant"
 
 
 /**

--- a/fulp_modules/mapping/ruins/icemoon/beefman_cytology/beefcyto_spawner.dm
+++ b/fulp_modules/mapping/ruins/icemoon/beefman_cytology/beefcyto_spawner.dm
@@ -18,6 +18,10 @@
 	outfit = /datum/outfit/russian_beefman
 	spawner_job_path = /datum/job/fulp_cytology
 
+/obj/effect/mob_spawn/ghost_role/human/beefman/special(mob/living/carbon/human/spawned_human)
+	. = ..()
+	spawned_human.fully_replace_character_name(null, random_unique_beefman_name(gender))
+
 /datum/job/fulp_cytology
 	title = ROLE_BEEFMAN_CYTOLOGY
 


### PR DESCRIPTION
## About The Pull Request

pepsi couldn't figure out why it was broken so I said I'd do it.

- Beefman Cytology and Beefman space spawner now have proper job titles (as they end up on the round-end screen with hypnotism trauma)
- Beefmen spawners now spawn with unique Beefmen, rather than human ones.