### PR TITLE
[Solitaire] Minor fixes

### DIFF
--- a/_maps/map_files/SolitaireStation/Solitairestation.dmm
+++ b/_maps/map_files/SolitaireStation/Solitairestation.dmm
@@ -29380,6 +29380,7 @@
 "iiu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "iiC" = (
@@ -35714,7 +35715,7 @@
 "jVG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
-	req_one_access_txt = "10; 24"
+	req_one_access_txt = "10; 23"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -62286,6 +62287,7 @@
 /obj/effect/turf_decal/trimline/green/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "rYh" = (
@@ -65989,6 +65991,7 @@
 /obj/machinery/door/window/northleft{
 	req_access_txt = "35"
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plating,
 /area/service/hydroponics)
 "tfG" = (
@@ -82220,6 +82223,7 @@
 	dir = 4;
 	name = "Medical blue half"
 	},
+/obj/item/clothing/gloves/color/latex/nitrile,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "xSQ" = (
@@ -102746,7 +102750,7 @@ lAP
 vBV
 tLY
 ibI
-bNj
+lra
 sxz
 eMb
 lGU
@@ -104031,7 +104035,7 @@ oVk
 heY
 pEj
 oZs
-bNj
+lra
 bNj
 bNj
 bNj


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request
-Changes Maints Tech Storage airlock from Maintenance/Atmospherics to Maintenance/Tech Storage
![NVIDIA_Share_1ysocfIdui](https://user-images.githubusercontent.com/79607211/151450647-b5653510-952d-486b-93b1-568584626d92.png)
-Adds Nitrite Gloves to the pile of roundstart equipment for MDs in Medical Storage
![NVIDIA_Share_JjSoY33de7](https://user-images.githubusercontent.com/79607211/151450657-e38eb473-bf1b-42fc-8d3b-1e0fb0d20c7e.png)
-Fixes issue from the Solitaire feedback thread 
![NVIDIA_Share_npYmrQvmyU](https://user-images.githubusercontent.com/79607211/151450668-37411b8e-e0e7-460c-9200-c948f2c578bd.png)
-Minor facelift to Science EXPERIMENTER Testing Room
![NVIDIA_Share_aDiAV9kTwy](https://user-images.githubusercontent.com/79607211/151450680-de1b38e3-8414-4a91-a1b4-ad01ca3512b4.png)

## Why It's Good For The Game
Roundstart MDs having to rush their gloves or get stuck with the loser's latex isn't a good situation, considering other stations either have a pile or are designed for a smaller pop, while this is the maxpop map. 
Having the maints airlock for Tech Storage as an "atmosian backdoor" is an L. Ask your boss. 
Fixing issues as they come up in the thread is good.