### PR TITLE
Fixes missing fire alarm in selene cryo

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -5706,6 +5706,7 @@
 	name = "Medical blue corner"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/cryo)
 "bAJ" = (
@@ -25582,10 +25583,10 @@
 	dir = 4;
 	name = "Medical blue corner"
 	},
-/obj/item/radio/intercom/directional/south,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "gLx" = (
@@ -134049,7 +134050,7 @@ fBs
 uRk
 psk
 pBp
-oOD
+oKi
 tdW
 oOD
 tlI
@@ -134306,7 +134307,7 @@ bmk
 aAq
 ezN
 qMb
-haw
+sPM
 wKX
 cTF
 ych
@@ -134563,7 +134564,7 @@ igF
 uRk
 psk
 pBp
-haw
+sPM
 lFw
 xgs
 jrh
@@ -134820,7 +134821,7 @@ ndu
 ndu
 urd
 uyD
-haw
+sPM
 eEN
 kEU
 bAn
@@ -135077,7 +135078,7 @@ kqZ
 seR
 psk
 tsl
-oOD
+oKi
 oOD
 wSM
 mOg


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request
Adds a fire alarm that was missing in selene station cryogenics, moved the intercom over a tile as i felt the fire alarm fit better in it's spot.
I also slightly adjusted the areas to prevent a firelock in the medbay halls from coming down when it shouldn't.
![image](https://user-images.githubusercontent.com/99276929/153473246-ffe9e3d2-6cd5-4ebc-b5eb-df843ae05425.png)
![image](https://user-images.githubusercontent.com/99276929/153473303-10bfaaa2-47fa-4615-9339-09b368f1b6eb.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rooms are supposed to have fire alarms in them.
 Prevents doctors getting stuck unable to turn the fire alarm off when they turn on environment as reservoir on their cooler and allows engineers to actually turn the alarm off when they fix it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: Fixes missing fire alarm in selene cryo
fix: Changes area placement to prevent firelocks coming down in medbay halls coming down when the cryo alarm is pulled

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
