### PR TITLE
solitiare arrivals re-make

### DIFF
--- a/_maps/map_files/SolitaireStation/Solitairestation.dmm
+++ b/_maps/map_files/SolitaireStation/Solitairestation.dmm
@@ -65906,7 +65906,6 @@
 /area/maintenance/starboard/fore)
 "urx" = (
 /obj/structure/lattice,
-/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
 "urP" = (

--- a/_maps/map_files/SolitaireStation/Solitairestation.dmm
+++ b/_maps/map_files/SolitaireStation/Solitairestation.dmm
@@ -31551,7 +31551,6 @@
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/secure_closet/security/cargo,
-/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "iPv" = (
@@ -50476,7 +50475,6 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "out" = (
-/obj/structure/closet/secure_closet/security/engine,
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
 	dir = 5;
@@ -50494,6 +50492,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/structure/closet/secure_closet/security/med,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "ouN" = (
@@ -51008,13 +51007,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oFt" = (
-/obj/structure/closet/secure_closet/security/engine,
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
 	dir = 8;
 	name = "security red"
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/closet/secure_closet/security/science,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "oFy" = (
@@ -62323,9 +62322,6 @@
 "sZS" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/closet/secure_closet/security/engine,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/red/anticorner{
 	color = "#FF0000";

--- a/_maps/map_files/SolitaireStation/Solitairestation.dmm
+++ b/_maps/map_files/SolitaireStation/Solitairestation.dmm
@@ -159,12 +159,11 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "aeC" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	name = "manual outlet valve"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "aeJ" = (
 /obj/structure/reflector/double/anchored{
 	dir = 6
@@ -436,6 +435,22 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"aiT" = (
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/science/research)
 "aiZ" = (
 /turf/open/floor/wood,
 /area/security/prison/workout)
@@ -505,6 +520,16 @@
 "akd" = (
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"akg" = (
+/obj/effect/turf_decal/tile/purple/anticorner{
+	color = "#4D0067";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "akq" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -710,6 +735,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"anB" = (
+/obj/effect/turf_decal/tile/green/half,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/service/hydroponics/garden)
 "anG" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -812,6 +843,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
+"apJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "apO" = (
 /obj/structure/rack,
 /obj/item/storage/box/flashes{
@@ -943,26 +984,20 @@
 /obj/item/clothing/suit/armor/riot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"arg" = (
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/engineering/atmos/upper)
 "ary" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"arK" = (
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/science/research)
 "arQ" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -30
@@ -973,6 +1008,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"arS" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "aso" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1135,15 +1174,23 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "aus" = (
-/obj/effect/turf_decal/tile/purple/anticorner{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/computer/atmos_control/ordnancemix{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/airalarm/mixingchamber{
+	dir = 8;
+	pixel_x = -25
 	},
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/mixing)
 "auy" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -1221,12 +1268,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
-"awb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/slot_machine,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
 "awk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1238,6 +1279,11 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"awn" = (
+/obj/structure/training_machine,
+/obj/item/target,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "awq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -1418,6 +1464,13 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"axW" = (
+/obj/machinery/newscaster/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/grimy,
+/area/commons/dorms)
 "axZ" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -1469,13 +1522,11 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "azc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/anticorner{
 	color = "#4D0067";
 	dir = 8
 	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -1664,16 +1715,6 @@
 /obj/machinery/power/supermatter_crystal,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"aCi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "aCj" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -1860,22 +1901,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"aEc" = (
-/obj/structure/rack,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/shovel,
-/obj/item/shovel,
-/obj/item/shovel,
-/obj/item/shovel,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "aEi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 5
@@ -2183,14 +2208,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"aJW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "aJZ" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -2301,13 +2318,12 @@
 /area/engineering/supermatter/room)
 "aLF" = (
 /obj/effect/landmark/start/scientist,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
+	dir = 8
 	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
+/turf/open/floor/iron/white/side{
+	dir = 8
 	},
 /area/science/research)
 "aLK" = (
@@ -2550,10 +2566,6 @@
 /obj/structure/table,
 /turf/open/floor/carpet/neon/simple,
 /area/hallway/primary/central/fore)
-"aOU" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "aPb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -2651,7 +2663,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
-/area/maintenance/port/aft)
+/area/service/abandoned_gambling_den)
 "aPH" = (
 /obj/structure/sign/poster/contraband/clown{
 	pixel_x = 32
@@ -2877,14 +2889,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"aSB" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/storage)
 "aSC" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -3085,6 +3089,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
+"aVz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "aVA" = (
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
@@ -3165,14 +3174,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"aWr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "aWu" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/head/helmet/space/plasmaman/engineering,
@@ -3329,6 +3330,13 @@
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/iron/white/smooth_large,
 /area/maintenance/department/science/xenobiology)
+"aXJ" = (
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Dorm 2"
+	},
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "aXK" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/status_display/evac/directional/north,
@@ -3440,9 +3448,7 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "aZc" = (
-/obj/item/toy/plush/awakenedplushie{
-	pixel_x = -5
-	},
+/obj/item/toy/plush/chica,
 /turf/open/indestructible/permalube,
 /area/maintenance/starboard/fore)
 "aZe" = (
@@ -3692,10 +3698,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/engineering/main)
-"bgm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/maintenance/department/crew_quarters/dorms)
 "bgs" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -4049,15 +4051,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
-"bkA" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Dock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "bkB" = (
 /turf/closed/wall,
 /area/commons/vacant_room/commissary)
@@ -4248,6 +4241,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/toilet)
+"bmb" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "bmh" = (
 /obj/machinery/power/smes/engineering{
 	charge = 5e+006
@@ -4408,6 +4407,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"boW" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "bpg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4586,6 +4593,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
+"bqT" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "bqW" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -4847,6 +4857,13 @@
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"buG" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 25
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "buK" = (
 /obj/structure/table,
 /obj/item/storage/photo_album/ce,
@@ -5285,6 +5302,14 @@
 	dir = 4
 	},
 /area/command/heads_quarters/ce)
+"bAZ" = (
+/obj/structure/rack,
+/obj/item/rack_parts,
+/obj/item/rack_parts,
+/obj/item/relic,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "bBc" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -5376,6 +5401,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"bCL" = (
+/obj/structure/sign/warning/docking{
+	pixel_y = 30
+	},
+/turf/open/space/basic,
+/area/space)
 "bCQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5386,18 +5417,6 @@
 /obj/item/clothing/mask/surgical,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
-"bCZ" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "bDc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5429,14 +5448,6 @@
 	dir = 8
 	},
 /area/hallway/primary/central/fore)
-"bDO" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "bEi" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -5963,10 +5974,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"bMx" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "bMC" = (
 /obj/item/tape,
 /obj/item/tape,
@@ -6121,19 +6128,14 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
-"bQh" = (
-/obj/effect/turf_decal/tile/purple/anticorner{
-	color = "#4D0067";
-	dir = 1
-	},
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/white/side{
-	dir = 9
-	},
-/area/science/research)
 "bQo" = (
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
+"bQx" = (
+/obj/structure/closet/crate/internals,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "bQG" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
@@ -6148,13 +6150,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
-"bQW" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/commons/fitness)
 "bQZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6874,6 +6869,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"bZI" = (
+/obj/machinery/light/small/directional/east,
+/obj/machinery/computer/shuttle/mining/common{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"bZQ" = (
+/obj/machinery/newscaster/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "cac" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
@@ -6886,6 +6895,15 @@
 	},
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
+"can" = (
+/obj/item/trash/energybar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/aft)
 "cat" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 4
@@ -6928,6 +6946,12 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"caN" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "caS" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -7455,16 +7479,14 @@
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "ciD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/ai/directional/west,
-/obj/effect/turf_decal/tile/purple/half{
+/obj/effect/turf_decal/tile/purple/anticorner{
 	color = "#4D0067";
-	dir = 8
+	dir = 1
 	},
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron/white/side{
-	dir = 8
+	dir = 9
 	},
 /area/science/research)
 "ciG" = (
@@ -7507,6 +7529,12 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"cje" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/storage)
 "cjr" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -7621,7 +7649,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/science/test_area)
 "ckN" = (
 /mob/living/carbon/human/species/monkey,
@@ -7888,6 +7916,9 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "coT" = (
@@ -7943,6 +7974,10 @@
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
+"cpo" = (
+/obj/machinery/vending/modularpc,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "cpA" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -8331,14 +8366,16 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
 "cuQ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/tile/blue/full{
+	color = "#4169E1";
+	name = "Command blue full"
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "cuS" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -8451,8 +8488,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "cwa" = (
-/obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "cwd" = (
@@ -8506,33 +8542,18 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"cwE" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "cwG" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Public Mining Dock"
+	name = "South Port Hallway"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "publicmining";
-	name = "Public Mining Lockdown"
-	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "cwJ" = (
 /turf/closed/wall/r_wall,
 /area/construction)
@@ -8902,17 +8923,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"cAK" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	dir = 8
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Cryosleepers";
-	name = "Recreation Camera - East"
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "cAU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -9029,6 +9039,7 @@
 	},
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/upper)
 "cCl" = (
@@ -9215,14 +9226,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"cFb" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/obj/structure/ore_box,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "cFk" = (
 /obj/structure/sign/warning/pods{
 	pixel_x = -30
@@ -9856,6 +9859,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"cMd" = (
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Dock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/space/basic,
+/area/hallway/primary/port)
 "cMk" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/yellow{
@@ -10003,6 +10013,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/upper)
 "cNW" = (
@@ -10362,6 +10373,18 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"cRk" = (
+/obj/structure/table,
+/obj/item/food/grown/cannabis{
+	pixel_x = 6
+	},
+/obj/item/food/grown/cannabis{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/obj/item/storage/fancy/rollingpapers,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "cRv" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -10412,15 +10435,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"cSf" = (
-/obj/machinery/computer/shuttle/mining/common{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "cSg" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "Mix 1 Output"
@@ -10471,12 +10485,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"cTn" = (
-/obj/structure/closet/wardrobe/miner,
-/obj/item/storage/backpack/satchel/explorer,
-/obj/effect/turf_decal/tile/brown/half,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "cTp" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "N2O Outlet"
@@ -10524,12 +10532,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"cTR" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/half,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "cUc" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half{
@@ -10720,10 +10722,22 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cWV" = (
-/obj/effect/turf_decal/tile/brown/half,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
+/obj/effect/turf_decal/tile/blue/anticorner{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/obj/structure/safe,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c500,
+/obj/item/stack/spacecash/c500,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/clothing/head/bearpelt,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "cXc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10739,6 +10753,20 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"cXB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "cXF" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
@@ -10750,6 +10778,10 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
+"cXG" = (
+/obj/structure/sign/warning/xeno_mining,
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "cXK" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -10761,6 +10793,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/upper)
 "cXL" = (
@@ -10824,11 +10857,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/upper)
-"cYo" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/tile/brown/half,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "cYq" = (
 /obj/structure/table,
 /obj/item/stack/rods/fifty,
@@ -10893,7 +10921,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "cZm" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/brown/filled/line,
@@ -11098,6 +11126,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"dbp" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "rdxeno";
+	name = "Xenobiology Containment Door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Lab";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "dbM" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -11144,6 +11189,10 @@
 /obj/item/bedsheet/ce,
 /turf/open/floor/carpet/orange,
 /area/command/heads_quarters/ce)
+"dcu" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/iron/grimy,
+/area/commons/dorms)
 "dcP" = (
 /obj/machinery/light_switch/directional/east,
 /obj/structure/dresser,
@@ -11303,6 +11352,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dfw" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "dfz" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 4;
@@ -11358,6 +11413,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/upper)
 "dgN" = (
@@ -11848,6 +11904,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"dmF" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "dmM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -11901,6 +11961,7 @@
 "dnI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dnJ" = (
@@ -11916,6 +11977,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dnO" = (
@@ -11936,6 +11998,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "dnQ" = (
@@ -11951,6 +12014,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/upper)
 "dnS" = (
@@ -12008,6 +12072,13 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"dpf" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/service/abandoned_gambling_den)
 "dpl" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/generator,
@@ -12305,6 +12376,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
+"dto" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "dtq" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -12357,7 +12432,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/hallway/primary/starboard)
 "dux" = (
 /obj/structure/table/reinforced,
@@ -12462,6 +12537,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dvP" = (
@@ -12605,6 +12681,10 @@
 /obj/machinery/vending/custom,
 /turf/open/floor/wood,
 /area/service/bar/atrium)
+"dxy" = (
+/obj/structure/closet/secure_closet,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "dxO" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/grassybush{
@@ -12641,6 +12721,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/processing)
+"dyk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "dyE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13040,6 +13126,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dDE" = (
@@ -13050,6 +13137,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dDP" = (
@@ -13072,6 +13160,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dEi" = (
@@ -13197,6 +13286,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"dFf" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "dFl" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -13648,13 +13743,10 @@
 /area/engineering/atmos)
 "dKB" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/medical/treatment_center";
-	name = "Medbay Treatment Room APC"
-	},
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "dKG" = (
@@ -13676,6 +13768,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dLo" = (
@@ -13709,7 +13802,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "dMe" = (
 /obj/structure/sink{
 	dir = 4;
@@ -13896,6 +13989,10 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/service/chapel)
+"dNX" = (
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "dOb" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
@@ -14520,6 +14617,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dWo" = (
@@ -14881,6 +14979,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/aft)
 "ebk" = (
@@ -15078,24 +15177,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"edl" = (
-/obj/structure/table,
-/obj/item/food/grown/cannabis{
-	pixel_x = -7;
-	pixel_y = 16
-	},
-/obj/item/food/grown/cannabis,
-/obj/item/food/grown/cannabis{
-	pixel_x = 9;
-	pixel_y = 12
-	},
-/obj/item/seeds/cannabis{
-	pixel_x = -6
-	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/maintenance/port/aft)
 "edq" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -15164,7 +15245,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/maintenance/port/aft)
+/area/service/abandoned_gambling_den)
 "eea" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/directional/east,
@@ -15179,6 +15260,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"eec" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "eed" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/rack,
@@ -15392,10 +15477,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos)
-"egz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "egC" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8;
@@ -15445,6 +15526,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"ehD" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "ehJ" = (
 /obj/machinery/computer/atmos_control/incinerator,
 /obj/effect/turf_decal/siding/green{
@@ -15898,8 +15986,9 @@
 	req_access_txt = "1"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "eoj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -15977,22 +16066,6 @@
 /obj/item/toy/figure/engineer,
 /turf/open/floor/carpet/orange,
 /area/engineering/lobby)
-"epv" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
-"epA" = (
-/obj/structure/bed,
-/obj/machinery/newscaster/directional/north,
-/obj/item/bedsheet/cult,
-/turf/open/floor/carpet/black,
-/area/commons/dorms)
 "epF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -16103,8 +16176,9 @@
 "eqU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "eqV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -16179,13 +16253,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"eso" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Rage Cage"
+"esd" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/commons/fitness)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms)
 "esz" = (
 /obj/effect/turf_decal/tile/yellow/full{
 	color = "#FFD700"
@@ -16198,7 +16275,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "esL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16231,13 +16308,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "etF" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 4
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/hallway/primary/port)
 "etK" = (
 /obj/machinery/door/window/brigdoor/westright{
 	name = "Atmospherics Monitoring";
@@ -16305,6 +16379,16 @@
 	dir = 8
 	},
 /area/science/research)
+"euv" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "euJ" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/atmospheric_technician,
@@ -16318,6 +16402,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos)
+"evb" = (
+/turf/open/floor/iron/grimy,
+/area/commons/dorms)
 "evf" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	name = "Atmoshperics Monitoring";
@@ -16342,11 +16429,17 @@
 	dir = 4
 	},
 /area/engineering/atmos)
-"evn" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/rack,
+"evt" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Maintenance";
+	req_one_access_txt = "47"
+	},
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/port/fore)
 "evx" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000";
@@ -16391,6 +16484,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "evX" = (
@@ -16461,6 +16555,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"exc" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/commons/dorms)
 "exf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 10
@@ -16493,7 +16595,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/central/aft)
 "exW" = (
 /obj/machinery/atmospherics/components/trinary/filter,
 /obj/structure/cable,
@@ -16644,6 +16746,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ezF" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
+"ezJ" = (
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 6;
+	name = "security red"
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron,
+/area/security/checkpoint)
 "ezO" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -16773,6 +16898,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"eBK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/service/abandoned_gambling_den)
 "eBR" = (
 /obj/machinery/computer/exoscanner_control,
 /turf/open/floor/iron/dark,
@@ -17001,7 +17132,6 @@
 /area/engineering/lobby)
 "eEw" = (
 /obj/machinery/light/small/directional/south,
-/obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	name = "engineering yellow"
@@ -17068,10 +17198,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"eER" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/science/storage)
 "eEX" = (
 /obj/structure/holohoop,
 /turf/open/floor/wood,
@@ -17147,6 +17273,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"eFQ" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "eFW" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -17330,6 +17463,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"eJi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "eJk" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/closed/wall/r_wall,
@@ -17349,6 +17488,9 @@
 	pixel_y = -3
 	},
 /obj/item/reagent_containers/food/drinks/shaker,
+/obj/structure/window{
+	dir = 8
+	},
 /turf/open/floor/carpet/black,
 /area/service/abandoned_gambling_den)
 "eJz" = (
@@ -17420,6 +17562,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eKj" = (
@@ -17549,6 +17692,13 @@
 /obj/machinery/recharger,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"eLw" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "manual outlet valve"
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "eLN" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/conveyor{
@@ -17723,13 +17873,20 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"eOp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+"eOj" = (
+/obj/structure/chair{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"eOp" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17851,6 +18008,7 @@
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/evac/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "eQU" = (
@@ -17957,6 +18115,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"eSk" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/soap/nanotrasen,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "eSn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18171,13 +18337,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"eUW" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "eVe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 8
@@ -18280,14 +18439,9 @@
 /turf/open/floor/plating,
 /area/security/prison/mess)
 "eWf" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Post - Medbay";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/checkpoint)
 "eWi" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18434,21 +18588,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"eXT" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
-"eYb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "eYk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -18700,6 +18839,13 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"fbV" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "South Port Hallway"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "fci" = (
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 4
@@ -18982,15 +19128,17 @@
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/medical)
 "fhd" = (
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/power/apc/auto_name/directional/west{
+	name = "Arrivals Security Checkpoint APC"
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
-	dir = 1;
+	dir = 9;
 	name = "security red"
 	},
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/secure_closet/security,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "fhp" = (
@@ -19039,6 +19187,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"fiw" = (
+/obj/structure/table,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/bedsheetbin,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms)
 "fix" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19065,14 +19227,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/security/warden)
-"fiZ" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/commons/fitness/recreation";
-	name = "Recreation Area APC"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "fjc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19185,6 +19339,14 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"fko" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Ordnance Maintenance";
+	req_access_txt = "8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "fkt" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -19205,12 +19367,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"flc" = (
-/obj/effect/mob_spawn/corpse/human/assistant,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/maintenance/port/aft)
 "flf" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/turf_decal/stripes/white/line,
@@ -19354,18 +19510,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "fnw" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	dir = 8;
-	id = "CellArr";
-	name = "Cell - Arrivals"
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "security red"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron,
 /area/security/checkpoint)
 "fnA" = (
 /obj/structure/chair/comfy/black{
@@ -20097,11 +20249,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"fzl" = (
-/obj/effect/spawner/random/maintenance/two,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "fzt" = (
 /obj/structure/table,
 /obj/item/clothing/suit/hazardvest,
@@ -20292,8 +20439,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "fAV" = (
@@ -20408,14 +20554,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse/upper)
-"fDg" = (
-/obj/effect/landmark/start/assistant,
-/obj/machinery/camera/autoname/directional/west{
-	c_tag = "Rec-Room Rage Cage W"
-	},
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "fDp" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/entertainment/wallet_lighter,
@@ -20476,9 +20614,9 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "fEr" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/hallway/primary/port)
 "fEs" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -20657,13 +20795,29 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
-/area/tcommsat/server)
+/area/tcommsat/computer)
 "fHq" = (
 /obj/machinery/computer/cargo{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"fHr" = (
+/obj/machinery/door/window/northright,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "fHt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20699,6 +20853,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
+"fHZ" = (
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "fIf" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating{
@@ -20760,10 +20918,11 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "fIV" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/commons/dorms)
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/holodeck/rec_center)
 "fJm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20920,6 +21079,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"fMI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "fMT" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxToilet3";
@@ -20961,10 +21124,6 @@
 	dir = 1
 	},
 /area/engineering/gravity_generator)
-"fNZ" = (
-/obj/structure/chair,
-/turf/open/floor/iron/white/side,
-/area/hallway/primary/port)
 "fOb" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east{
 	pixel_x = -29
@@ -21231,7 +21390,7 @@
 	},
 /obj/structure/tank_holder/oxygen/red,
 /turf/open/floor/iron,
-/area/tcommsat/server)
+/area/tcommsat/computer)
 "fRD" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -21361,7 +21520,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/tcommsat/server)
+/area/tcommsat/computer)
 "fSp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21518,15 +21677,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/security/prison/workout)
-"fUV" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -30
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/commons/fitness)
 "fVf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21540,6 +21690,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
+"fVn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "fVF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/east,
@@ -21565,11 +21720,16 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
 "fVR" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/machinery/meter,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "fVY" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -21584,6 +21744,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"fWk" = (
+/turf/open/space/basic,
+/area/maintenance/port/aft)
 "fWp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21871,6 +22034,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"gaG" = (
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "gaK" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -21991,6 +22159,10 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
+"gdn" = (
+/obj/machinery/vending/autodrobe/all_access,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "gdq" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -22315,6 +22487,15 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
+"ggv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "ggA" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -22380,6 +22561,7 @@
 	},
 /obj/item/multitool,
 /obj/machinery/light/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "ghq" = (
@@ -22516,7 +22698,7 @@
 /obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
-/area/tcommsat/server)
+/area/tcommsat/computer)
 "gjo" = (
 /obj/machinery/computer/telecomms/server{
 	dir = 1;
@@ -22534,7 +22716,10 @@
 "gjA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
+"gjN" = (
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "gka" = (
 /obj/machinery/announcement_system,
 /turf/open/floor/circuit,
@@ -22568,6 +22753,11 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
+"gks" = (
+/obj/structure/table/wood,
+/obj/item/storage/book/bible,
+/turf/open/floor/iron/grimy,
+/area/commons/dorms)
 "gku" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -22819,11 +23009,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"gna" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "gnk" = (
 /obj/machinery/door/poddoor/incinerator_ordmix,
 /obj/effect/turf_decal/stripes/full,
@@ -22917,6 +23102,13 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"gol" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "gon" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -23087,6 +23279,10 @@
 	},
 /turf/open/floor/grass,
 /area/service/chapel/monastery)
+"gqo" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "gqp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
@@ -23141,13 +23337,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
-"gqR" = (
-/obj/machinery/door/airlock{
-	id_tag = "ToiletA";
-	name = "Toilet A"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "gqT" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000"
@@ -23513,6 +23702,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"gvq" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "gvy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -23656,11 +23851,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/bar/atrium)
-"gxL" = (
-/obj/structure/table,
-/obj/item/pinpointer/wayfinding,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "gxW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23712,7 +23902,8 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "gyR" = (
-/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/side,
 /area/hallway/primary/port)
 "gze" = (
@@ -23913,17 +24104,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"gBK" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "gCh" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -23939,6 +24119,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"gCk" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "gCt" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -23962,6 +24146,21 @@
 	dir = 8
 	},
 /area/security/checkpoint/engineering)
+"gCH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "gCO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23976,10 +24175,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
-"gCP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "gCS" = (
 /turf/closed/wall,
 /area/commons/dorms)
@@ -23997,6 +24192,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"gDF" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "gDH" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -24141,12 +24345,6 @@
 	},
 /turf/open/floor/grass,
 /area/service/chapel/monastery)
-"gFR" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "gFT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -24327,6 +24525,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"gJK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "gJQ" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Space Burial";
@@ -24664,6 +24869,18 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
+"gOm" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/full{
+	alpha = 255
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "gOr" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -24725,7 +24942,6 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/iron/dark,
 /area/science/storage)
@@ -24734,6 +24950,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"gPj" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/service/abandoned_gambling_den)
 "gPm" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -24774,6 +24997,12 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
+"gQf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "gQm" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -25004,16 +25233,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"gUa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
+"gTZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/service/abandoned_gambling_den)
 "gUg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -25036,6 +25260,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_large,
 /area/maintenance/department/science/xenobiology)
+"gUP" = (
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "gUT" = (
 /obj/structure/cable,
 /obj/item/cigbutt,
@@ -25432,10 +25664,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"haK" = (
-/obj/structure/closet/crate/internals,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "haS" = (
 /obj/structure/flora/ausbushes/grassybush{
 	pixel_y = 17
@@ -25671,6 +25899,13 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
+"hdk" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "hdt" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -25807,6 +26042,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"heZ" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "hfa" = (
 /obj/machinery/telecomms/server/presets/command,
 /obj/effect/turf_decal/tile/blue/full{
@@ -25840,11 +26079,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
-"hfx" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "hfC" = (
 /obj/machinery/ntnet_relay,
 /turf/open/floor/iron/dark/telecomms,
@@ -25901,13 +26135,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"hgF" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/under/misc/pj/blue,
-/obj/item/clothing/under/suit/navy,
-/obj/item/clothing/glasses/regular,
-/turf/open/floor/carpet/blue,
-/area/commons/dorms)
 "hgH" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -26061,6 +26288,15 @@
 	},
 /turf/open/floor/wood,
 /area/cargo/qm)
+"hhT" = (
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Dock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "hhV" = (
 /obj/machinery/door/airlock/engineering{
 	id_tag = "EngiAccessOuter";
@@ -26079,17 +26315,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"hib" = (
-/obj/item/shard/plasma,
-/obj/item/stack/rods,
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/obj/item/stack/cable_coil/five,
-/obj/item/clothing/neck/tie/black,
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "hin" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "CellEngi";
@@ -26263,7 +26488,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "hnN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -26280,6 +26505,15 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos)
+"hog" = (
+/obj/effect/turf_decal/tile/blue/full{
+	color = "#73c2fb";
+	name = "Medical blue full"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "hoC" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/closet,
@@ -26312,6 +26546,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"hoN" = (
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "hoQ" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -26354,12 +26593,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"hpK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/blue,
-/area/commons/dorms)
 "hpU" = (
 /obj/item/mining_voucher,
 /turf/open/floor/plating,
@@ -26573,13 +26806,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"hsU" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/carpet/blue,
-/area/commons/dorms)
 "hsZ" = (
 /obj/structure/chair{
 	dir = 8
@@ -26633,19 +26859,6 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"htT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/south{
-	id = "Blue Dorm";
-	name = "Blue Dorm Bolts";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/carpet/blue,
-/area/commons/dorms)
 "htZ" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/iron/dark/telecomms,
@@ -26768,12 +26981,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hvy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/purple,
-/area/commons/dorms)
 "hvz" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/turf_decal/stripes/white/line{
@@ -26833,16 +27040,12 @@
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"hwa" = (
-/obj/structure/bedsheetbin,
-/obj/structure/table,
-/obj/machinery/camera/directional/south{
-	c_tag = "Dorms - Laundry";
-	name = "Dorms Camera"
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/white,
-/area/commons/toilet)
+"hwf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "hwr" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/cargo)
@@ -26931,7 +27134,7 @@
 	name = "Dear Ian 3"
 	},
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "hyi" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -27207,18 +27410,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hCz" = (
-/obj/structure/toilet,
-/obj/machinery/light/small/directional/north,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/button/door/directional/south{
-	id = "ToiletB";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_y = 24;
-	specialfunctions = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/item/trash/boritos,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "hCA" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/item/bedsheet/ian,
@@ -27498,21 +27692,19 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
+"hFU" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/service/abandoned_gambling_den)
 "hGf" = (
 /obj/structure/sign/poster/contraband/missing_gloves{
 	pixel_y = 30
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hGg" = (
-/obj/machinery/door/airlock{
-	id_tag = "Purple Dorm";
-	name = "Purple Dorm"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/purple,
-/area/commons/dorms)
 "hGi" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kanyewest";
@@ -27531,15 +27723,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"hGE" = (
-/obj/machinery/door/airlock{
-	id_tag = "Blue Dorm";
-	name = "Blue Dorm"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/blue,
-/area/commons/dorms)
 "hGL" = (
 /obj/item/beacon,
 /turf/open/floor/iron/dark/side{
@@ -27571,16 +27754,14 @@
 	name = "Dear Dan"
 	},
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "hHl" = (
-/obj/machinery/door/airlock{
-	id_tag = "Black Dorm";
-	name = "Black Dorm"
-	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/black,
-/area/commons/dorms)
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "hHL" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Research - Xenobiology Central";
@@ -27610,11 +27791,6 @@
 /obj/item/food/badrecipe/moldy,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"hIq" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "hIt" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -27686,6 +27862,19 @@
 	},
 /turf/closed/wall,
 /area/security/courtroom)
+"hJT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/hydroponics/soil{
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/service/hydroponics/garden)
 "hJW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28014,24 +28203,24 @@
 /turf/open/floor/iron/dark/side,
 /area/security/range)
 "hPo" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/hangover,
-/obj/item/radio/intercom/directional/west,
-/obj/item/bedsheet/random,
-/turf/open/floor/carpet/green,
-/area/commons/dorms)
-"hPs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/button/door/directional/south{
-	id = "Green Dorm";
-	name = "Green Dorm Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = 27;
-	pixel_y = 0;
-	specialfunctions = 4
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = -4
 	},
-/turf/open/floor/carpet/green,
-/area/commons/dorms)
+/obj/item/lighter/greyscale{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/storage/fancy/cigarettes{
+	pixel_y = 8
+	},
+/obj/item/survivalcapsule,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"hPs" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "hPu" = (
 /obj/machinery/door/poddoor{
 	id = "cargoload";
@@ -28079,6 +28268,8 @@
 "hPT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
@@ -28135,6 +28326,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"hQJ" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "hQL" = (
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
@@ -28211,6 +28407,15 @@
 "hRZ" = (
 /turf/closed/wall,
 /area/cargo/qm)
+"hSa" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/primary/port)
 "hSb" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
@@ -28378,20 +28583,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
-"hUk" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/under/rank/civilian/curator/treasure_hunter,
-/turf/open/floor/carpet/green,
-/area/commons/dorms)
-"hUo" = (
-/obj/machinery/door/airlock{
-	id_tag = "Green Dorm";
-	name = "Green Dorm"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/green,
-/area/commons/dorms)
 "hUq" = (
 /obj/structure/closet/bombcloset/white,
 /turf/open/floor/plating,
@@ -28538,6 +28729,13 @@
 /obj/machinery/computer/mechpad,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"hXc" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
+"hXq" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/port/fore)
 "hXB" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -28621,11 +28819,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"hYP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "hZb" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Xenobiology - Pen #4";
@@ -28669,12 +28862,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"hZP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "hZS" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -28684,6 +28871,24 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/genetics)
+"ial" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Laundry Room"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms)
+"iat" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "iax" = (
 /obj/item/bikehorn/airhorn,
 /turf/open/indestructible/permalube,
@@ -28703,6 +28908,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"ibr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "ibA" = (
 /obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
@@ -28783,11 +28992,13 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "icv" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/lounge)
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "icz" = (
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/dark/corner{
@@ -28867,16 +29078,6 @@
 /obj/effect/spawner/random/techstorage/arcade_boards,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
-"idw" = (
-/obj/machinery/duct,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "idC" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -29171,22 +29372,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"iiu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"iii" = (
+/obj/structure/chair/comfy{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/research)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "iiC" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"iiL" = (
-/obj/effect/spawner/random/maintenance/four,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "iiR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/engine,
@@ -29338,6 +29538,7 @@
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ikR" = (
@@ -29367,6 +29568,20 @@
 	icon_state = "chapel"
 	},
 /area/service/chapel/office)
+"ilk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/side,
+/area/hallway/primary/port)
 "ilr" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29416,6 +29631,16 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"ilN" = (
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "ilV" = (
 /turf/open/floor/iron{
 	dir = 1;
@@ -29445,11 +29670,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/prison/workout)
-"imw" = (
-/obj/effect/spawner/random/maintenance/two,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "imF" = (
 /obj/item/toy/plush/moth,
 /obj/structure/sign/poster/contraband/clown{
@@ -29603,13 +29823,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ipg" = (
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "ipj" = (
@@ -29777,10 +29993,9 @@
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
 "isK" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/lounge)
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "isP" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 1
@@ -29870,11 +30085,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"itR" = (
-/obj/structure/table,
-/obj/item/paper,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "itV" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
@@ -30155,23 +30365,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ixg" = (
-/obj/effect/turf_decal/tile/purple/anticorner{
-	color = "#4D0067";
-	dir = 4
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white/side{
-	dir = 5
-	},
-/area/science/research)
 "ixl" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
@@ -30197,24 +30390,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/fore)
-"ixO" = (
-/obj/item/clothing/neck/scarf/yellow{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 15
-	},
-/obj/structure/dresser,
-/turf/open/floor/carpet/orange,
-/area/commons/dorms)
-"ixS" = (
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/light_switch/directional/east,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet/orange,
-/area/commons/dorms)
 "ixX" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/security_officer,
@@ -30241,17 +30416,9 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "iym" = (
-/obj/structure/table,
-/obj/item/training_toolbox,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"iyr" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron,
-/area/commons/lounge)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "iyy" = (
 /obj/structure/chair/comfy/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -30278,12 +30445,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "iyS" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "publicmining";
-	name = "Public Mining Lockdown"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/cargo/miningoffice)
 "iyX" = (
 /obj/structure/bodycontainer/morgue{
@@ -30545,7 +30710,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/security/checkpoint/supply)
+/area/maintenance/department/cargo)
 "iBI" = (
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 8
@@ -30554,6 +30719,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"iBJ" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "iBK" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	color = "#FF6700";
@@ -30639,6 +30810,12 @@
 /obj/effect/turf_decal/tile/green/half,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"iEp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "iEw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30721,11 +30898,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
-"iGd" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "iGe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30774,14 +30946,6 @@
 /obj/effect/spawner/random/techstorage/ai_all,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"iHc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "iHh" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = -30
@@ -30829,17 +30993,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "iHA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/button/door/directional/north{
-	id = "Orange Dorm";
-	name = "Orange Dorm Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = 27;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/orange,
-/area/commons/dorms)
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "iHN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -30921,37 +31079,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
-"iJm" = (
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_y = 6
-	},
-/obj/structure/table,
+"iJp" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/computer/holodeck,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/commons/lounge)
+/area/commons/fitness/recreation)
 "iJE" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -30997,9 +31130,10 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "iJM" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/commons/lounge)
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "iJQ" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -31013,25 +31147,10 @@
 	dir = 4
 	},
 /area/hallway/primary/central/fore)
-"iJR" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"iJV" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "iJY" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "iKb" = (
 /obj/machinery/computer/security/telescreen/research{
 	dir = 1;
@@ -31073,6 +31192,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"iKQ" = (
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side,
+/area/hallway/primary/port)
 "iKY" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
@@ -31459,6 +31591,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"iPX" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iQm" = (
 /obj/machinery/gulag_teleporter,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -31476,6 +31615,9 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
+"iQp" = (
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "iQr" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser/high,
@@ -31571,6 +31713,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"iSb" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Post";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint)
 "iSi" = (
 /obj/structure/table,
 /obj/item/ai_module/supplied/freeform,
@@ -31622,20 +31774,6 @@
 "iSH" = (
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"iSI" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"iSO" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "iSS" = (
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 8
@@ -31805,11 +31943,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"iUK" = (
-/obj/structure/closet/cardboard,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "iUM" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -31870,6 +32003,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
+"iVE" = (
+/obj/structure/closet/athletic_mixed,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "iVJ" = (
 /obj/item/book/random,
 /obj/structure/closet,
@@ -32104,11 +32241,11 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "iZt" = (
-/obj/structure/chair,
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/commons/lounge)
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/holodeck/rec_center)
 "iZy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -32397,31 +32534,18 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/service/library)
+"jea" = (
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/bar/atrium)
 "jeh" = (
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"jej" = (
-/turf/open/floor/iron/white,
-/area/science/storage)
 "jer" = (
 /obj/structure/cable,
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
-"jes" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap/nanotrasen,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
-"jey" = (
-/obj/machinery/status_display/evac/directional/north,
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/hallway/primary/port)
 "jez" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -32507,6 +32631,10 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
+"jfO" = (
+/obj/effect/spawner/random/entertainment/drugs,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jfX" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -32585,12 +32713,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
-"jgU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "jhb" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 7;
@@ -32612,6 +32734,13 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/grass/jungle,
 /area/maintenance/starboard/fore)
+"jhj" = (
+/obj/machinery/newscaster/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/commons/dorms)
 "jhl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33067,12 +33196,9 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "jmX" = (
-/obj/machinery/door/airlock{
-	id_tag = "ToiletB";
-	name = "Toilet B"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/item/trash/syndi_cakes,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jnb" = (
 /obj/structure/sign/plaques/kiddie/badger{
 	pixel_y = 32
@@ -33207,6 +33333,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"joT" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Port South Hallway - Arrivals";
+	name = "South Port Hallway Camera"
+	},
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/primary/port)
 "joU" = (
 /obj/structure/flora/ausbushes/fullgrass{
 	pixel_y = -5
@@ -33378,12 +33513,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
-"jrl" = (
-/obj/machinery/status_display/evac/directional/north,
-/obj/item/toy/beach_ball/holoball,
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "jrs" = (
 /obj/structure/table,
 /obj/item/storage/box/trackimp{
@@ -33629,21 +33758,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"jvm" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
+"jvh" = (
+/obj/machinery/shower{
+	dir = 4
 	},
-/obj/structure/dresser,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 15
-	},
-/obj/item/clothing/neck/scarf/red{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/red,
-/area/commons/dorms)
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "jvp" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/table,
@@ -33671,14 +33791,6 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plating/grass/jungle,
 /area/maintenance/starboard/fore)
-"jvq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/red,
-/area/commons/dorms)
 "jvJ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33725,12 +33837,6 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/grass/jungle,
 /area/maintenance/starboard/fore)
-"jwn" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "jws" = (
 /obj/machinery/button/door/directional/east{
 	id = "xenobio6";
@@ -33765,15 +33871,17 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "jwH" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/commons/lounge)
+/area/hallway/secondary/entry)
 "jwI" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Cargo - Mining Shuttle Access";
 	name = "cargo camera"
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "jxd" = (
@@ -33852,17 +33960,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"jyx" = (
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"jyy" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "jyF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -33970,10 +34067,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
-"jAz" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "jAG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34095,6 +34188,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"jBU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/closed/wall,
+/area/cargo/miningoffice)
 "jCa" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow,
@@ -34136,25 +34235,25 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/plating/grass/jungle,
 /area/maintenance/starboard/fore)
+"jCG" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "jCO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/carpet/red,
 /area/service/lawoffice)
 "jDf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/button/door/directional/north{
-	id = "Red Dorm";
-	name = "Red Dorm Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = 27;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/red,
-/area/commons/dorms)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "jDr" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/smooth,
@@ -34289,12 +34388,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"jFO" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "jFS" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plating,
@@ -34398,6 +34491,11 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"jHk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "jHo" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -34469,11 +34567,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"jHZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "jIc" = (
 /obj/structure/destructible/cult/item_dispenser/archives/library,
 /obj/item/book/codex_gigas,
@@ -34600,11 +34693,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
-"jIY" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "jJd" = (
 /obj/structure/flora/junglebush/large,
 /obj/machinery/airalarm/directional/east,
@@ -34622,7 +34710,7 @@
 "jJq" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "jJs" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -34817,6 +34905,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "jMP" = (
@@ -34908,7 +34997,6 @@
 /area/security/prison)
 "jNI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -34916,14 +35004,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/maintenance/port/aft)
-"jNQ" = (
-/obj/structure/sign/warning/docking{
-	pixel_x = -30
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/commons/storage/mining)
+/area/service/abandoned_gambling_den)
 "jNU" = (
 /obj/structure/closet/wardrobe/miner,
 /obj/item/storage/backpack/satchel/explorer,
@@ -34999,11 +35080,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"jOD" = (
-/obj/effect/turf_decal/tile/brown/anticorner,
-/obj/structure/ore_box,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "jOV" = (
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 1
@@ -35212,18 +35288,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
-"jRu" = (
-/obj/item/clothing/neck/scarf/red,
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/suit/jacket/miljacket,
-/obj/item/clothing/shoes/jackboots,
-/turf/open/floor/carpet/red,
-/area/commons/dorms)
-"jRz" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/carpet/red,
-/area/commons/dorms)
 "jRA" = (
 /obj/effect/turf_decal/tile/green/half,
 /turf/open/floor/iron,
@@ -35276,17 +35340,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"jSj" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Dorms";
-	name = "Dorms Camera - South"
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/lounge)
+"jSm" = (
+/obj/structure/bed,
+/obj/item/toy/plush/bubbleplush,
+/obj/item/bedsheet/cosmos,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jSo" = (
 /obj/machinery/light/directional/east,
 /obj/structure/closet/secure_closet/personal/patient,
@@ -35308,7 +35367,6 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "jTa" = (
@@ -35439,6 +35497,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
+"jUo" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/wood,
+/area/commons/dorms)
 "jUt" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/crew_quarters/dorms)
@@ -35478,12 +35540,6 @@
 /obj/machinery/computer/bookmanagement,
 /turf/open/floor/carpet/green,
 /area/service/library)
-"jUS" = (
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/lounge)
 "jUW" = (
 /obj/structure/flora/ausbushes/fullgrass{
 	pixel_x = 17
@@ -35539,8 +35595,11 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jVB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/commons/lounge)
+/area/hallway/secondary/entry)
 "jVG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
@@ -35759,15 +35818,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"jYI" = (
-/obj/structure/sink{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = -8
-	},
-/obj/structure/mirror/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "jYT" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -35784,7 +35834,7 @@
 	name = "Given-As-Compensation"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "jZj" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -35997,20 +36047,16 @@
 "kcr" = (
 /turf/open/water/jungle,
 /area/service/hydroponics/garden/abandoned)
-"kcF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
-"kcJ" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Port South Hallway - Holodeck Entrance";
-	name = "South Port Hallway Camera"
+"kcZ" = (
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067"
 	},
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/area/hallway/primary/port)
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "kdd" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/medical{
@@ -36061,6 +36107,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating/grass/jungle,
 /area/service/hydroponics/garden/abandoned)
+"kdX" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "keb" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/grass/jungle,
@@ -36104,6 +36154,13 @@
 	icon_state = "chapel"
 	},
 /area/ai_monitored/turret_protected/ai_upload)
+"kew" = (
+/obj/machinery/requests_console/directional/south{
+	department = "Dormitories";
+	name = "Dorms Requests Console"
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "keM" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/grass/jungle,
@@ -36113,24 +36170,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"kfg" = (
-/obj/machinery/navbeacon/wayfinding/dorms,
-/obj/machinery/door/airlock/public/glass{
-	name = "Recreation Lounge"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"kfi" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Recreation Lounge"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "kfj" = (
 /turf/closed/wall,
 /area/cargo/sorting)
@@ -36149,10 +36188,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"kfz" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/commons/dorms)
 "kfE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36170,6 +36205,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"kfS" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "kfW" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -36196,7 +36240,7 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/structure/closet,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "kgg" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
@@ -36389,6 +36433,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"kji" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "kjn" = (
 /turf/open/floor/iron{
 	dir = 4;
@@ -36466,12 +36516,10 @@
 /turf/open/floor/plating/grass/jungle,
 /area/service/hydroponics/garden/abandoned)
 "kkG" = (
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "kkN" = (
 /obj/structure/flora/grass/jungle/b,
 /mob/living/simple_animal/butterfly,
@@ -36755,18 +36803,6 @@
 	icon_state = "chapel"
 	},
 /area/service/chapel)
-"kpu" = (
-/obj/structure/closet/wardrobe/green,
-/obj/effect/landmark/start/hangover/closet,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"kpA" = (
-/obj/structure/closet/wardrobe/pjs,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "kpI" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -36865,11 +36901,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"krm" = (
-/obj/structure/closet/wardrobe/grey,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "kro" = (
 /obj/effect/landmark/start/librarian,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36993,16 +37024,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "kth" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Office";
-	req_one_access_txt = "48"
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/closed/wall/r_wall,
 /area/cargo/miningoffice)
 "ktk" = (
 /obj/machinery/biogenerator,
@@ -37070,10 +37095,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/command/nuke_storage)
-"kud" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "kuf" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
@@ -37082,11 +37103,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"kug" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "kuj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar,
@@ -37099,18 +37115,6 @@
 /obj/structure/cable,
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/ai)
-"kuw" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/white,
-/area/commons/toilet)
-"kuM" = (
-/obj/machinery/washing_machine,
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/commons/toilet)
 "kuQ" = (
 /obj/machinery/computer/libraryconsole,
 /obj/structure/table/wood,
@@ -37136,11 +37140,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/range)
-"kuU" = (
-/obj/effect/landmark/start/hangover,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "kvg" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water/jungle,
@@ -37164,6 +37163,7 @@
 	},
 /obj/effect/spawner/structure/window,
 /obj/structure/sign/directions/vault{
+	dir = 8;
 	pixel_y = -40
 	},
 /turf/open/floor/plating,
@@ -37348,24 +37348,12 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/iron,
 /area/security/prison)
-"kxB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "kxE" = (
 /obj/structure/closet/crate,
 /obj/item/chisel,
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"kxT" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "kyd" = (
 /obj/effect/turf_decal/tile/green/anticorner{
 	dir = 8
@@ -37445,16 +37433,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"kzg" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Locker Room"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "kzi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37563,15 +37541,6 @@
 "kAo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"kAs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -37728,17 +37697,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/library)
-"kCo" = (
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/science/research)
 "kCu" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -37761,15 +37719,6 @@
 /mob/living/simple_animal/butterfly,
 /turf/open/water/jungle,
 /area/service/hydroponics/garden/abandoned)
-"kCK" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "kDB" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes,
@@ -37795,12 +37744,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kET" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/commons/toilet)
 "kEX" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Prosecution Office";
@@ -37821,22 +37764,6 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"kFg" = (
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/power/apc/auto_name/directional/west{
-	name = "Arrivals Security Checkpoint APC"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 9;
-	name = "security red"
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint)
 "kFj" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067"
@@ -37902,23 +37829,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"kFI" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/warning/docking{
-	pixel_x = -30
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
-"kFJ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Arrivals NE";
-	name = "Hallway Camera"
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
+"kFG" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/iron/grimy,
+/area/commons/dorms)
 "kFR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -37926,22 +37841,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/bar/atrium)
-"kFU" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Cargo - Public Mining Shuttle Access";
-	name = "cargo camera"
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
-"kFV" = (
-/obj/item/storage/firstaid/regular,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "kGh" = (
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -37999,13 +37898,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/security/processing)
-"kGV" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "kGY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment,
@@ -38024,6 +37916,17 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"kHx" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "security red"
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/security/checkpoint)
 "kHA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38036,12 +37939,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
-"kHI" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "kHL" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Fore Primary Hallway"
@@ -38193,6 +38090,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"kKg" = (
+/obj/item/trash/energybar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kKs" = (
 /obj/effect/turf_decal/tile/green/anticorner{
 	dir = 1
@@ -38363,12 +38267,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"kMk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "kMu" = (
 /obj/machinery/button/door/directional/west{
 	id = "xenobio3";
@@ -38409,6 +38307,16 @@
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"kNg" = (
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Holodeck - Fore";
+	dir = 2;
+	name = "Holodeck Camera"
+	},
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/holodeck/rec_center)
 "kNl" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -38483,52 +38391,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
-"kOk" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 10;
-	name = "security red"
-	},
-/obj/structure/filingcabinet,
-/turf/open/floor/iron,
-/area/security/checkpoint)
-"kOq" = (
-/obj/item/radio/off,
-/obj/item/screwdriver,
-/obj/structure/table,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 10;
-	name = "security red"
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Security";
-	departmentType = 5;
-	name = "Sec Outpost - Arrivals"
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/security/checkpoint)
-"kOt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "kOx" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/navbeacon/wayfinding,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "kOA" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -38540,9 +38410,18 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "kOB" = (
-/obj/item/trash/candy,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "kOD" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -38672,9 +38551,6 @@
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
 "kPT" = (
-/obj/item/toy/plush/awakenedplushie{
-	pixel_x = -5
-	},
 /obj/machinery/light/small/directional/east,
 /obj/structure/window{
 	dir = 8;
@@ -38700,7 +38576,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/central/aft)
 "kPX" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -38803,14 +38679,6 @@
 	dir = 10
 	},
 /area/construction/mining/aux_base)
-"kRL" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/commons/storage/tools";
-	name = "Tool Storage APC"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "kRX" = (
 /obj/structure/rack,
 /obj/structure/window{
@@ -38938,29 +38806,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"kTJ" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "kTR" = (
 /obj/item/beacon,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"kTT" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
-"kUd" = (
-/obj/structure/ore_box,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "kUe" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "kUh" = (
 /obj/item/stack/package_wrap,
 /obj/structure/table,
@@ -38971,7 +38824,6 @@
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/office)
@@ -39076,11 +38928,6 @@
 /obj/machinery/computer/teleporter,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
-"kWA" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/side,
-/area/hallway/primary/port)
 "kWJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -39236,10 +39083,19 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/science/mixing)
+"kYk" = (
+/obj/effect/turf_decal/siding/yellow/corner{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/engineering/atmos/upper)
 "kYm" = (
 /obj/item/stack/arcadeticket,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "kYo" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 4
@@ -39305,10 +39161,6 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
-"kZu" = (
-/obj/effect/turf_decal/tile/brown/half,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "kZz" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -39319,6 +39171,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/cargo/office)
 "kZB" = (
@@ -39660,13 +39513,24 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ldu" = (
-/obj/effect/spawner/random/entertainment/drugs,
+/obj/effect/spawner/structure/window/hollow/reinforced/directional,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/service/abandoned_gambling_den)
+"ldx" = (
+/obj/item/trash/chips,
+/obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ldy" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/mixing)
+"ldO" = (
+/obj/structure/rack,
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "ldP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -39730,13 +39594,6 @@
 /obj/item/gun/energy/e_gun/dragnet,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"leC" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "leD" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "EVAC SW";
@@ -39856,14 +39713,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"lgE" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Activity Rooms"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "lgL" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 4
@@ -39884,23 +39733,6 @@
 "lgW" = (
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"lhe" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "rdxeno";
-	name = "Xenobiology Containment Door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Lab";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/science/research)
 "lho" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -40034,12 +39866,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central/fore)
-"ljp" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "ljv" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
@@ -40162,10 +39988,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"lkS" = (
-/obj/item/trash/boritos,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "lkU" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/grass/jungle/b,
@@ -40186,13 +40008,11 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
 "lkZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/side{
-	dir = 10
+/obj/structure/chair{
+	dir = 4
 	},
-/area/commons/fitness)
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "lla" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000";
@@ -40217,12 +40037,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"llq" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "llw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40405,12 +40219,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"loc" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "loj" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -40522,7 +40330,7 @@
 "lpK" = (
 /obj/structure/janitorialcart,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "lpN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40556,7 +40364,7 @@
 "lqp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "lqr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -40595,10 +40403,6 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Central Hallway NW Crossroad";
 	name = "North West Central Hallway Camera"
-	},
-/obj/structure/sign/directions/vault{
-	pixel_x = -32;
-	pixel_y = 37
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
@@ -40648,7 +40452,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "lrJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40742,6 +40546,11 @@
 	dir = 1
 	},
 /area/hallway/primary/central/fore)
+"ltk" = (
+/obj/structure/chair/stool/bar/directional/west,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/bar/atrium)
 "ltF" = (
 /mob/living/simple_animal/mouse/brown/tom,
 /obj/machinery/duct,
@@ -40754,6 +40563,10 @@
 /obj/item/banner/cargo/mundane,
 /turf/open/floor/wood,
 /area/cargo/qm)
+"ltU" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/commons/dorms)
 "ltW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/half{
@@ -40791,11 +40604,6 @@
 	dir = 1
 	},
 /area/hallway/primary/starboard)
-"lui" = (
-/obj/machinery/status_display/evac/directional/north,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "luo" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white/side{
@@ -40966,7 +40774,7 @@
 	name = "South West Central Hallway Camera"
 	},
 /obj/structure/sign/directions/vault{
-	dir = 8;
+	dir = 1;
 	pixel_x = -32;
 	pixel_y = 40
 	},
@@ -40998,10 +40806,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"lxA" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint)
 "lxI" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/purple/half{
@@ -41022,12 +40826,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"lxO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
-	dir = 6
-	},
-/area/commons/fitness)
 "lxT" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41059,12 +40857,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
-"lyE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/commons/fitness)
 "lyH" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -41191,6 +40983,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"lAm" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "lAz" = (
 /obj/structure/chair/comfy/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41284,6 +41082,17 @@
 /obj/item/beacon,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"lBJ" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"lBP" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "lBX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -41384,20 +41193,6 @@
 	dir = 1
 	},
 /area/hallway/primary/central/fore)
-"lDv" = (
-/obj/machinery/light/directional/west,
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"lDA" = (
-/obj/structure/chair/stool/directional/west{
-	pixel_y = 8
-	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/cable,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "lDB" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -41466,12 +41261,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"lEC" = (
-/obj/item/trash/cheesie,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/maintenance/port/aft)
 "lEE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment{
@@ -41505,13 +41294,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
-"lEV" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "lFa" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -41641,17 +41423,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
-"lHc" = (
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "lHn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41838,6 +41609,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
+"lKo" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067"
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "lKy" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Research Directors Office";
@@ -42120,6 +41899,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"lNj" = (
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "lNl" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
@@ -42173,20 +41960,6 @@
 	dir = 1
 	},
 /area/hallway/primary/starboard)
-"lNG" = (
-/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "security red"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/security/checkpoint)
 "lNH" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -42439,13 +42212,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"lQB" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "lQK" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet,
@@ -42703,6 +42469,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"lVh" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/washing_machine,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms)
 "lVi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42785,6 +42561,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"lWI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms)
 "lWJ" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -42839,17 +42625,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
-"lXV" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"lXZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/commons/fitness)
 "lYo" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -42928,13 +42703,6 @@
 	dir = 1
 	},
 /area/science/research)
-"lZF" = (
-/obj/structure/chair/stool/directional/west{
-	pixel_y = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "lZO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -43061,12 +42829,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
-"mbP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
 "mca" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark/side{
@@ -43136,6 +42898,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"mcQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "mdg" = (
 /turf/open/floor/iron/dark/side{
 	dir = 6
@@ -43158,6 +42927,13 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"mdY" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "mdZ" = (
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 8
@@ -43172,11 +42948,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"met" = (
-/obj/item/trash/boritos,
-/obj/effect/mob_spawn/corpse/human/assistant,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "mev" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -43193,6 +42964,12 @@
 "meC" = (
 /turf/open/space/basic,
 /area/space)
+"meQ" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "meT" = (
 /obj/machinery/vending/custom,
 /turf/open/floor/iron/dark/side{
@@ -43310,6 +43087,12 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/hallway/primary/central/fore)
+"mfZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "mgc" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/side,
@@ -43333,6 +43116,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"mgo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/commons/dorms)
 "mgu" = (
 /turf/closed/wall,
 /area/hallway/primary/port)
@@ -43356,6 +43143,10 @@
 "mgL" = (
 /turf/closed/wall,
 /area/science/misc_lab)
+"mgP" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/maintenance/port/aft)
 "mhh" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000";
@@ -43390,6 +43181,13 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"mhq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "mhK" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Starboard North Hallway - Jungle Room E";
@@ -43488,30 +43286,10 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"mji" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance";
-	req_one_access_txt = "47"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
 "mjk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/auxiliary)
-"mjs" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 25
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science)
 "mjt" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/glass/reinforced,
@@ -43531,11 +43309,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"mjR" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "mkh" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -43692,10 +43465,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"mms" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "mmu" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -43746,10 +43515,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"mne" = (
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Holodeck - Fore";
+	name = "Holodeck Camera"
+	},
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/holodeck/rec_center)
 "mnh" = (
 /obj/item/toy/plush/supermatter,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "mnj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43783,13 +43561,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white/side,
 /area/science/research)
-"moa" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "moc" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -43797,20 +43568,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"mol" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/corner{
-	dir = 8
-	},
-/area/science/research)
 "moq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43928,14 +43685,18 @@
 /turf/open/floor/iron,
 /area/maintenance/department/crew_quarters/bar)
 "mpM" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
+"mpN" = (
+/obj/structure/chair/comfy{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "mqe" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Service - Auxiliary Restrooms";
@@ -43960,12 +43721,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
-"mqE" = (
-/obj/effect/spawner/random/contraband/permabrig_weapon,
-/obj/effect/spawner/random/contraband/permabrig_gear,
-/obj/effect/spawner/random/contraband/prison,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "mrc" = (
 /obj/structure/table,
 /obj/item/storage/photo_album/prison,
@@ -44105,10 +43860,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"mtB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/service/library/abandoned)
 "mtK" = (
 /obj/item/storage/box/lights/mixed,
 /obj/item/toy/mecha/deathripley{
@@ -44251,14 +44002,13 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "mwp" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/light/small/directional/east,
+/obj/structure/toilet{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "mwz" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 8;
@@ -44291,11 +44041,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/service/library)
-"mwK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/maintenance/port/aft)
 "mwM" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -44390,18 +44135,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/crew_quarters/bar)
-"myB" = (
-/obj/item/trash/boritos{
-	pixel_y = 14
-	},
-/obj/item/trash/boritos,
-/obj/item/trash/candy{
-	pixel_x = -12
-	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/maintenance/port/aft)
 "myH" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#73c2fb";
@@ -44413,13 +44146,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"myM" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "myV" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 4
@@ -44457,19 +44183,12 @@
 	dir = 8
 	},
 /area/command/gateway)
-"mzs" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/east,
-/obj/structure/chair/stool/directional/west{
-	pixel_y = 8
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "mzF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "mAa" = (
 /obj/machinery/duct,
 /obj/machinery/status_display/evac/directional/west,
@@ -44782,13 +44501,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/medical/pharmacy)
-"mEv" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "mEw" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
@@ -44804,16 +44516,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "mFk" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"mFo" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/obj/structure/table/wood/poker,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "mFq" = (
 /obj/machinery/computer/security/labor{
 	dir = 8
@@ -44850,27 +44556,12 @@
 /obj/item/weldingtool,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"mGi" = (
-/obj/item/storage/firstaid/regular,
-/obj/structure/table,
-/obj/structure/sign/poster/contraband/syndicate_recruitment{
-	pixel_y = 32
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "mGp" = (
 /obj/structure/table,
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/bar/atrium)
-"mGv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "mGx" = (
 /obj/structure/rack,
 /obj/item/stock_parts/water_recycler,
@@ -44970,12 +44661,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"mIe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science)
 "mIh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -45214,24 +44899,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
-"mLf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/computer/atmos_control/ordnancemix{
-	dir = 4
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 8
-	},
-/obj/machinery/airalarm/mixingchamber{
-	dir = 8;
-	pixel_x = -25
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing/chamber)
 "mLC" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -45324,19 +44991,22 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white/side,
 /area/science/research)
+"mMW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "mMY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/carpet/lone/star,
 /area/medical/psychology)
-"mMZ" = (
-/obj/structure/training_machine,
-/obj/item/target,
-/obj/item/target,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "mNi" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 10
@@ -45357,6 +45027,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"mNA" = (
+/obj/structure/closet/lasertag/blue,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "mND" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/structure/table,
@@ -45404,6 +45078,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"mOr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "mOR" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Service Maintenance Access";
@@ -45463,20 +45143,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"mPU" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "rdxeno";
-	name = "Xenobiology Containment Door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Lab";
-	req_access_txt = "47"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/science/research)
 "mPV" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -45848,6 +45514,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"mUT" = (
+/obj/machinery/door/airlock{
+	name = "Unit 2"
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "mVa" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -45904,10 +45576,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/auxiliary)
-"mVZ" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "mWa" = (
 /obj/machinery/button/door/directional/south{
 	id = "AuxToilet3";
@@ -46158,10 +45826,12 @@
 /turf/open/space/basic,
 /area/space)
 "mZH" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/commons/fitness/recreation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "mZW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46182,10 +45852,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
-"naf" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+"nai" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Arrivals SE";
+	name = "Hallway Camera"
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "nan" = (
 /obj/effect/turf_decal/tile/bar/half{
 	dir = 1
@@ -46310,19 +45984,6 @@
 "nbh" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central/fore)
-"nbk" = (
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/random{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "nbq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half{
@@ -46381,11 +46042,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"ncd" = (
-/obj/machinery/firealarm/directional/south,
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/iron/white/side,
-/area/hallway/primary/port)
 "ncz" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -46418,17 +46074,6 @@
 	icon_state = "chapel"
 	},
 /area/service/chapel/office)
-"ncK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/meter,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/iron/dark,
-/area/science/storage)
 "ncQ" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -46465,7 +46110,7 @@
 /obj/item/stack/sheet/cardboard,
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "ndK" = (
 /obj/structure/closet/secure_closet/brig/genpop,
 /obj/effect/turf_decal/bot,
@@ -46664,6 +46309,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"nfU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "ngi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46697,6 +46351,16 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/crew_quarters/bar)
+"ngB" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms)
 "ngC" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -46778,18 +46442,10 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/crew_quarters/bar)
-"niP" = (
-/obj/structure/table,
-/obj/item/food/grown/cannabis{
-	pixel_x = 6
-	},
-/obj/item/food/grown/cannabis{
-	pixel_x = -5;
-	pixel_y = 12
-	},
-/obj/item/storage/fancy/rollingpapers,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+"niH" = (
+/obj/structure/closet/lasertag/red,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "niV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -46906,13 +46562,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"nkZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron/white,
-/area/science/storage)
 "nle" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 30
@@ -46961,8 +46610,15 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/carpet/purple,
 /area/command/heads_quarters/rd)
+"nnR" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "nnV" = (
-/obj/item/trash/chips,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "nnX" = (
@@ -47011,6 +46667,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
+"noF" = (
+/obj/item/wheelchair,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "noV" = (
 /obj/machinery/rnd/production/protolathe/department/science,
 /obj/effect/turf_decal/stripes/line,
@@ -47075,17 +46735,12 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"npK" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/aft";
-	dir = 8;
-	name = "Port Quarter Maintenance APC";
-	pixel_x = -25
-	},
+"npW" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/service/bar/atrium)
 "nqg" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -47130,6 +46785,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
+"nrd" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "nrg" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -47188,6 +46850,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"nsm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/cargo/miningoffice)
 "nsp" = (
 /obj/structure/fermenting_barrel,
 /obj/machinery/light/directional/north,
@@ -47230,6 +46898,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "nsK" = (
@@ -47266,6 +46935,12 @@
 "nta" = (
 /turf/open/floor/iron/dark/side,
 /area/hallway/primary/starboard)
+"ntb" = (
+/obj/item/trash/cheesie,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
+/area/maintenance/port/fore)
 "ntf" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/wood/parquet,
@@ -47382,6 +47057,16 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"nve" = (
+/obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/camera/directional/east{
+	c_tag = "Dormitories Cyborg Recharger"
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "nvi" = (
 /obj/machinery/computer/crew,
 /obj/effect/turf_decal/bot,
@@ -47563,12 +47248,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"nxF" = (
-/obj/item/trash/candy,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/maintenance/port/aft)
 "nxG" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -47587,6 +47266,16 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
+"nyp" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "security red"
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/security/checkpoint)
 "nyE" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -47713,6 +47402,11 @@
 	dir = 4
 	},
 /area/science/research)
+"nAM" = (
+/obj/structure/cable,
+/obj/machinery/newscaster/security_unit/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "nAN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -47749,11 +47443,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/purple,
 /area/command/heads_quarters/rd)
-"nBG" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
 "nBH" = (
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 1
@@ -47763,6 +47452,13 @@
 "nBI" = (
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"nBJ" = (
+/obj/machinery/door/airlock{
+	id_tag = "Dorm1";
+	name = "Dorm 1"
+	},
+/turf/open/floor/wood,
+/area/commons/dorms)
 "nBL" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/brown/half{
@@ -47881,11 +47577,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
-"nDj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "nDm" = (
 /obj/machinery/iv_drip,
 /obj/machinery/light/small/directional/north,
@@ -47980,7 +47671,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/carpet/black,
-/area/maintenance/port/aft)
+/area/service/abandoned_gambling_den)
 "nEh" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre B";
@@ -48210,10 +47901,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"nFL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/maintenance/department/crew_quarters/dorms)
 "nFP" = (
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 5;
@@ -48237,15 +47924,10 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/security/warden)
-"nGr" = (
-/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
-/obj/item/reagent_containers/blood/random,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"nGt" = (
-/obj/machinery/light/small/directional/north,
+"nGb" = (
+/obj/machinery/bluespace_vendor/directional/south,
 /turf/open/floor/iron,
-/area/cargo/miningoffice)
+/area/commons/dorms)
 "nGw" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -48276,10 +47958,12 @@
 /turf/open/floor/iron,
 /area/security/range)
 "nHl" = (
-/obj/item/grenade/smokebomb,
-/obj/structure/closet,
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/service/abandoned_gambling_den)
 "nHs" = (
 /obj/structure/table/wood,
 /obj/item/candle,
@@ -48289,10 +47973,12 @@
 	},
 /area/service/chapel)
 "nHz" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "nHR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
@@ -48587,9 +48273,7 @@
 "nMr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/wood{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "nMv" = (
@@ -48636,13 +48320,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"nNe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "nNg" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/belt/medical,
@@ -48686,19 +48363,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"nNn" = (
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/science/research)
 "nNz" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Morgue S";
@@ -48779,10 +48443,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
-"nOD" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "nOK" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -48799,13 +48459,12 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "nOP" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/item/trash/popcorn,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/iron,
+/area/commons/dorms)
 "nPe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -49045,7 +48704,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "nSQ" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 1
@@ -49095,6 +48754,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/poker,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "nTk" = (
@@ -49102,13 +48762,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/poker,
 /obj/item/storage/wallet/random,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"nTp" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
-/area/science/storage)
 "nTv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49130,12 +48786,14 @@
 /turf/open/floor/plating/elevatorshaft,
 /area/service/theater)
 "nTD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	color = "#4D0067";
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white/side{
+	dir = 9
+	},
 /area/science/research)
 "nTE" = (
 /obj/machinery/light/directional/north,
@@ -49256,10 +48914,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "nWu" = (
+/obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "nWJ" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 4
@@ -49312,12 +48971,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/service/janitor)
-"nXl" = (
-/obj/structure/bed,
-/obj/item/toy/plush/bubbleplush,
-/obj/item/bedsheet/cosmos,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "nXv" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/bar,
@@ -49371,9 +49024,6 @@
 "nXL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/wood{
-	dir = 4
-	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
@@ -49461,10 +49111,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
-"nYR" = (
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "nZd" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -49915,35 +49561,13 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "ofT" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"ofU" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency{
-	pixel_y = -4
-	},
-/obj/item/lighter/greyscale{
-	pixel_x = 6;
-	pixel_y = 7
-	},
-/obj/item/storage/fancy/cigarettes{
-	pixel_y = 8
-	},
-/obj/item/survivalcapsule,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "ofY" = (
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
-"oge" = (
-/obj/machinery/space_heater,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 30
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ogw" = (
@@ -49994,6 +49618,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
+"ohb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "ohg" = (
 /obj/structure/window{
 	dir = 1
@@ -50381,6 +50011,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/stone,
 /area/service/chapel/monastery)
+"omJ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067"
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "omT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -50461,19 +50099,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"ooa" = (
-/obj/structure/table,
-/obj/item/food/grown/cannabis{
-	pixel_y = 20
-	},
-/obj/item/food/grown/cannabis{
-	pixel_x = -6
-	},
-/obj/item/food/grown/cannabis{
-	pixel_y = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ooh" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -50489,30 +50114,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"ook" = (
-/obj/machinery/door/airlock/hatch,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
-"oon" = (
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle/large/empty{
-	pixel_x = 7;
-	pixel_y = 22
-	},
-/obj/structure/dresser,
-/turf/open/floor/carpet/blue,
-/area/commons/dorms)
-"oot" = (
-/obj/structure/bed,
-/obj/item/toy/plush,
-/obj/machinery/newscaster/directional/north,
-/obj/item/bedsheet/wiz,
-/turf/open/floor/carpet/blue,
-/area/commons/dorms)
 "oow" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Courtroom Judge";
@@ -50526,53 +50127,33 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"ooy" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/under/suit/tan,
-/obj/item/clothing/head/kitty,
-/obj/item/clothing/under/costume/maid,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
-/turf/open/floor/carpet/purple,
-/area/commons/dorms)
 "ooz" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/newscaster/directional/north,
-/obj/item/bedsheet/random,
-/turf/open/floor/carpet/purple,
-/area/commons/dorms)
-"ooE" = (
-/obj/item/toy/eightball{
-	pixel_x = 5;
-	pixel_y = 10
-	},
-/obj/structure/dresser,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 15
-	},
-/turf/open/floor/carpet/purple,
-/area/commons/dorms)
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/maintenance/port/fore)
 "ooG" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "ooI" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/under/misc/assistantformal,
-/obj/item/clothing/under/pants/blackjeans,
-/obj/item/clothing/head/ushanka,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
+/obj/machinery/door/airlock/maintenance{
+	name = "Ordnance Lab Maintenance";
+	req_access_txt = "8"
 	},
-/turf/open/floor/carpet/black,
-/area/commons/dorms)
-"ooM" = (
-/obj/structure/closet/cardboard,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor/preopen{
+	id = "toxinsrd";
+	name = "Toxins Shield RD Office"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/port/fore)
+"ooM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/maintenance/port/fore)
 "ooN" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre A";
@@ -50591,6 +50172,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"opd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "ope" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
@@ -50630,6 +50216,13 @@
 	dir = 1
 	},
 /area/science/research)
+"oqC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "oqF" = (
 /obj/effect/turf_decal/tile/yellow/full,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -50953,12 +50546,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/security/processing)
-"owc" = (
-/obj/structure/closet/crate{
-	name = "Excess Manuals"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "owg" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -50981,6 +50568,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"owT" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "oxd" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/grass/jungle/b,
@@ -50991,19 +50584,9 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "oxe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/button/door/directional/north{
-	id = "Purple Dorm";
-	name = "Purple Dorm Bolts";
-	normaldoorcontrol = 1;
-	pixel_y = -27;
-	specialfunctions = 4
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/carpet/purple,
-/area/commons/dorms)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/maintenance/port/fore)
 "oxg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51015,37 +50598,18 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "oxo" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/carpet/purple,
-/area/commons/dorms)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "oxr" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "oxz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/black,
-/area/commons/dorms)
-"oxK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/button/door/directional/south{
-	id = "Black Dorm";
-	name = "Black Dorm Bolts";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/carpet/black,
-/area/commons/dorms)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "oxU" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000"
@@ -51056,10 +50620,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"oyd" = (
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/carpet/black,
-/area/commons/dorms)
 "oyf" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/closed/wall,
@@ -51379,7 +50939,6 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/iron/dark,
 /area/science/storage)
@@ -51415,12 +50974,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"oEo" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "oEr" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
@@ -51437,6 +50990,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
+"oEJ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "oEL" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 30
@@ -51444,36 +51001,12 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"oFf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
+"oFh" = (
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
-"oFh" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
-/obj/item/toy/sword{
-	pixel_x = 14;
-	pixel_y = 17
-	},
-/obj/structure/dresser,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 15
-	},
-/turf/open/floor/carpet/green,
-/area/commons/dorms)
-"oFn" = (
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/carpet/green,
-/area/commons/dorms)
+/area/maintenance/port/fore)
 "oFt" = (
 /obj/structure/closet/secure_closet/security/engine,
 /obj/effect/turf_decal/siding/red{
@@ -51579,11 +51112,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "oHf" = (
-/obj/structure/cable,
+/obj/machinery/holopad,
+/obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "oHm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -51681,6 +51216,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"oJq" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "oJv" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -51703,6 +51242,12 @@
 	},
 /turf/open/floor/iron,
 /area/service/janitor)
+"oJE" = (
+/obj/structure/chair/comfy{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "oJP" = (
 /obj/machinery/duct,
 /turf/closed/wall,
@@ -51775,10 +51320,9 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "oKx" = (
-/obj/effect/turf_decal/tile/random{
+/turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "oKH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51827,15 +51371,6 @@
 /area/medical/storage)
 "oLO" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/random{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
-	},
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#73c2fb";
 	dir = 4;
@@ -51847,11 +51382,12 @@
 	name = "Patrol Beacon"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/hallway/primary/central/aft)
 "oLP" = (
 /obj/effect/turf_decal/siding/green{
@@ -52053,15 +51589,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"oPx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "oQm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half{
@@ -52118,13 +51645,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"oQE" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "oQQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -52173,25 +51693,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet,
 /area/security/courtroom)
-"oSm" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"oSn" = (
-/obj/item/toy/figure/assistant{
-	pixel_y = 15
-	},
-/obj/machinery/computer/arcade,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "oSC" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Dorms";
-	name = "Dorms Camera - North"
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/commons/lounge)
+/obj/structure/closet/crate/internals,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "oSJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/purple{
@@ -52201,12 +51706,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
-"oSL" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 30
-	},
-/turf/open/floor/iron,
-/area/commons/lounge)
 "oSR" = (
 /obj/structure/table,
 /obj/item/relic,
@@ -52217,23 +51716,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"oTd" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"oTg" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -4
-	},
-/obj/item/toy/cards/deck,
-/obj/item/toy/foamblade,
-/obj/item/toy/foamfinger,
-/obj/item/toy/ammo/gun,
-/obj/effect/landmark/start/hangover/closet,
-/obj/structure/closet/crate,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "oTv" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/knife,
@@ -52256,6 +51738,15 @@
 /obj/effect/spawner/random/maintenance/eight,
 /turf/open/floor/iron/white/smooth_large,
 /area/maintenance/department/science/xenobiology)
+"oUA" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "oUB" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/white,
@@ -52274,19 +51765,16 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/service/library)
-"oVd" = (
-/obj/item/toy/plush/moth,
-/obj/item/toy/katana,
-/obj/item/toy/cards/deck/tarot,
-/obj/item/toy/beach_ball,
-/obj/item/toy/sword,
-/obj/item/gun/ballistic/shotgun/toy/crossbow,
-/obj/machinery/light/directional/east,
+"oUM" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/closet/crate,
-/turf/open/floor/iron,
-/area/commons/lounge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "oVh" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -52337,6 +51825,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
+"oVY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"oWb" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/wood,
+/area/commons/dorms)
 "oWm" = (
 /obj/structure/cable,
 /obj/machinery/icecream_vat,
@@ -52373,6 +51872,11 @@
 	dir = 8
 	},
 /area/science/research)
+"oXk" = (
+/obj/machinery/duct,
+/obj/item/toy/plush/awakenedplushie,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "oXF" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -52418,15 +51922,6 @@
 /area/service/theater)
 "oYt" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/random{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
-	},
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#73c2fb";
 	dir = 4;
@@ -52438,7 +51933,9 @@
 	dir = 1;
 	sortType = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/hallway/primary/central/aft)
 "oYG" = (
 /obj/structure/cable,
@@ -52473,6 +51970,8 @@
 "oZa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/poker,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "oZj" = (
@@ -52617,6 +52116,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"pat" = (
+/obj/machinery/door/airlock{
+	id_tag = "Dorm3";
+	name = "Dorm 3"
+	},
+/turf/open/floor/iron/grimy,
+/area/commons/dorms)
 "pax" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -52703,6 +52209,13 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"pbC" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "pbI" = (
 /turf/closed/wall,
 /area/security/prison/toilet)
@@ -52868,6 +52381,30 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"pfG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
+"pgb" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/service/abandoned_gambling_den)
 "pgl" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/multiver,
@@ -52888,14 +52425,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"pgy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/green,
-/area/commons/dorms)
 "pgB" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks{
@@ -52948,12 +52477,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "pgU" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/lounge)
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "pgW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -52968,6 +52496,8 @@
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "pip" = (
@@ -53155,6 +52685,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"pmQ" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "pmT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -53235,11 +52769,7 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "poA" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "security red"
-	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -53575,11 +53105,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"pvS" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "pvT" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -53592,10 +53117,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"pwa" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "pwb" = (
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -53622,29 +53143,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/research)
-"pwH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/lounge)
-"pwV" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"pwZ" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/lounge)
 "pxf" = (
-/obj/structure/chair,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/commons/lounge)
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"pxJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "pyd" = (
 /turf/open/floor/iron/white,
 /area/science/breakroom)
@@ -53839,13 +53347,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
-"pDt" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Rec-room - Gym";
-	name = "Recreation Camera - East"
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "pEa" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -54043,15 +53544,11 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"pGB" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "pGC" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/duct,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "pGO" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -54174,11 +53671,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"pJh" = (
-/obj/structure/closet/wardrobe/black,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "pJi" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/station_engineer,
@@ -54434,13 +53926,6 @@
 /obj/structure/closet/secure_closet/injection,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"pOd" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "pOu" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 1
@@ -54627,6 +54112,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"pRF" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "South Port Hallway"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "pRJ" = (
 /obj/structure/window,
 /obj/structure/chair/stool/directional/west,
@@ -54810,6 +54308,10 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/cmo)
+"pTQ" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/side,
+/area/hallway/primary/port)
 "pUa" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
@@ -54860,14 +54362,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"pUZ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "pVd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54895,6 +54389,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"pWg" = (
+/turf/open/indestructible/permalube,
+/area/maintenance/starboard/fore)
 "pWj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54914,12 +54411,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
-"pWL" = (
-/obj/structure/bed,
-/obj/item/radio/intercom/directional/west,
-/obj/item/bedsheet/random,
-/turf/open/floor/carpet/orange,
-/area/commons/dorms)
 "pXe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54932,11 +54423,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/security/courtroom)
-"pXo" = (
-/obj/structure/table,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "pXp" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple/half{
@@ -54966,25 +54452,9 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "pYp" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen{
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_y = -6
-	},
-/obj/item/pen,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"pYs" = (
-/obj/item/bikehorn/rubberducky,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/landmark/event_spawn,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "pYw" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";
@@ -55078,7 +54548,7 @@
 /obj/structure/rack,
 /obj/item/watertank,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "qap" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -55118,6 +54588,12 @@
 	dir = 4
 	},
 /area/science/research)
+"qca" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/slot_machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "qcp" = (
 /obj/structure/table,
 /obj/item/tcgcard_deck,
@@ -55148,10 +54624,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"qcH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/commons/storage/mining)
 "qcR" = (
 /turf/open/floor/iron{
 	dir = 4;
@@ -55333,13 +54805,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
 "qhw" = (
-/obj/effect/turf_decal/tile/purple/half{
+/obj/effect/turf_decal/tile/purple/anticorner{
 	color = "#4D0067";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
 /turf/open/floor/iron/white/side{
-	dir = 4
+	dir = 5
 	},
 /area/science/research)
 "qhA" = (
@@ -55640,12 +55114,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"qlC" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/under/suit/burgundy,
-/obj/item/cane,
-/turf/open/floor/carpet/orange,
-/area/commons/dorms)
 "qlG" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -55662,45 +55130,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"qlP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/orange,
-/area/commons/dorms)
 "qmj" = (
 /turf/closed/wall/r_wall,
 /area/security/processing)
-"qmv" = (
-/obj/machinery/door/airlock{
-	id_tag = "Orange Dorm";
-	name = "Orange Dorm"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/orange,
-/area/commons/dorms)
-"qmy" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
-"qmB" = (
-/obj/structure/toilet,
-/obj/machinery/light/small/directional/north,
-/obj/item/toy/sword,
-/obj/machinery/button/door/directional/south{
-	id = "ToiletA";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_y = 24;
-	specialfunctions = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "qmE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55736,16 +55168,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"qoB" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/commons/dorms";
-	name = "Dorms APC"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "qoJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56089,11 +55511,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "quH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/fitness)
+/turf/closed/wall/r_wall,
+/area/hallway/primary/port)
 "quM" = (
 /obj/structure/table/glass,
 /obj/item/folder/blue,
@@ -56131,6 +55550,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"quX" = (
+/obj/effect/spawner/random/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "quY" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -56162,40 +55585,10 @@
 	dir = 4
 	},
 /area/hallway/secondary/exit)
-"qvC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "qvR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"qvT" = (
-/obj/structure/noticeboard{
-	dir = 4;
-	pixel_x = -32
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"qvY" = (
-/obj/item/beacon,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"qwa" = (
-/obj/structure/table,
-/obj/item/paicard,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/open/floor/iron,
-/area/commons/lounge)
 "qwf" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/turf_decal/tile/bar,
@@ -56204,15 +55597,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
-"qwo" = (
-/obj/machinery/duct,
-/obj/machinery/door/airlock/public{
-	name = "Showers"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "qwq" = (
 /turf/closed/wall,
 /area/maintenance/department/medical/central)
@@ -56234,6 +55618,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"qxp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/science/research)
 "qxH" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/iron/white,
@@ -56346,6 +55743,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"qAj" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/service/abandoned_gambling_den)
 "qAy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -56373,6 +55779,8 @@
 "qAZ" = (
 /obj/structure/table,
 /obj/machinery/microwave,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "qBA" = (
@@ -56454,6 +55862,24 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"qCy" = (
+/obj/machinery/door/window/eastleft,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "qCA" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -56528,25 +55954,24 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
-"qDp" = (
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
+"qDk" = (
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067"
 	},
-/obj/effect/turf_decal/tile/random{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/white/side,
+/area/science/research)
 "qDr" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
 	req_access_txt = "2"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "qDM" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/duct,
@@ -56569,19 +55994,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison)
-"qEL" = (
-/obj/machinery/door/airlock{
-	id_tag = "Red Dorm";
-	name = "Red Dorm"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/red,
-/area/commons/dorms)
-"qFc" = (
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "qFd" = (
 /obj/machinery/space_heater,
 /turf/open/floor/iron,
@@ -56590,11 +56002,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
-"qFh" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "qFL" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 4
@@ -56604,19 +56011,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"qFN" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Public - Restroom"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "qFQ" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "qFS" = (
 /turf/open/floor/glass/reinforced,
 /area/security)
@@ -56626,22 +56027,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
-"qGb" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "qGf" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/item/food/grown/banana,
 /turf/open/floor/grass,
 /area/science/genetics)
 "qGo" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/security/checkpoint)
 "qGz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56681,26 +56073,17 @@
 /obj/item/clothing/gloves/color/latex,
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
-"qHl" = (
-/obj/machinery/light/directional/south,
-/obj/structure/sign/directions/vault{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/dark/side,
-/area/hallway/primary/port)
 "qHw" = (
-/obj/structure/toilet,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/button/door/directional/south{
-	id = "ToiletC";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_y = 24;
-	specialfunctions = 4
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/area/maintenance/port/fore)
+"qHD" = (
+/obj/structure/rack,
+/obj/item/wirecutters,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "qHK" = (
 /obj/structure/sink{
 	dir = 8;
@@ -56814,17 +56197,6 @@
 	},
 /turf/closed/wall,
 /area/service/kitchen)
-"qJX" = (
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/science/research)
 "qKb" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -56848,7 +56220,7 @@
 /area/maintenance/department/medical/morgue)
 "qKm" = (
 /turf/closed/wall,
-/area/commons/storage/mining)
+/area/ai_monitored/command/nuke_storage)
 "qKo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green/anticorner{
@@ -56866,16 +56238,6 @@
 "qKw" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"qKM" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/science/research)
 "qLd" = (
 /obj/structure/rack,
 /obj/item/flashlight/seclite,
@@ -57069,17 +56431,19 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/science/research)
+"qOc" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "qOf" = (
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"qOo" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/hangover,
-/obj/item/radio/intercom/directional/west,
-/obj/item/bedsheet/random,
-/turf/open/floor/carpet/red,
-/area/commons/dorms)
 "qOv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -57091,22 +56455,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
-"qOT" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"qOW" = (
-/obj/machinery/duct,
-/obj/machinery/door/airlock/public{
-	name = "Restroom & Laundry"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/toilet)
 "qPa" = (
 /obj/structure/chair/comfy/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -57121,23 +56469,13 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
-"qPe" = (
-/obj/machinery/door/airlock{
-	id_tag = "ToiletD";
-	name = "Toilet D"
+"qPw" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
-"qPz" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/commons/toilet";
-	name = "Dorms Restroom APC"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/service/abandoned_gambling_den)
 "qPM" = (
 /obj/structure/chair/pew,
 /obj/effect/landmark/start/hangover,
@@ -57385,7 +56723,6 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "qVH" = (
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -57449,40 +56786,39 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"qXi" = (
+/obj/structure/table,
+/obj/item/food/grown/cannabis{
+	pixel_y = 20
+	},
+/obj/item/food/grown/cannabis{
+	pixel_x = -6
+	},
+/obj/item/food/grown/cannabis{
+	pixel_y = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qXj" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/science/test_area)
+"qXY" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qXZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/range)
-"qYd" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "qYh" = (
 /obj/structure/chair/stool/directional/west,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
-"qYt" = (
-/obj/structure/chair/stool/directional/west{
-	pixel_y = 8
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Rec-room Rage Cage E";
-	name = "Recreation Camera - East"
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/assistant,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 30
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "qYx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -57679,73 +57015,26 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"rbG" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"rcc" = (
-/obj/machinery/vending/games,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"rcg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+"rca" = (
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/commons/lounge)
-"rck" = (
-/obj/item/cardpack/series_one,
-/obj/item/storage/crayons,
-/obj/structure/table,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"rcp" = (
-/obj/structure/sink{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = -8
-	},
-/obj/structure/mirror/directional/south,
-/obj/machinery/light/small/directional/west,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "rcq" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/grass/jungle,
 /area/service/hydroponics/garden/abandoned)
-"rcx" = (
-/obj/structure/mirror/directional/south,
-/obj/structure/sink{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = -8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "rcC" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "rcI" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/button/door/directional/south{
-	id = "ToiletD";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rcX" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -57755,31 +57044,20 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "rdp" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door_timer{
+	id = "CellArr";
+	name = "Arrivals Cell";
+	pixel_y = 32
 	},
+/obj/structure/table,
+/obj/machinery/recharger,
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
-	dir = 9;
+	dir = 1;
 	name = "security red"
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "CellArr";
-	name = "Arrivals Cell Locker"
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/security/checkpoint)
-"rdu" = (
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 15
-	},
-/obj/item/razor{
-	pixel_y = 12
-	},
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
-/area/commons/dorms)
 "rdB" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -57815,12 +57093,9 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "reV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/space_heater,
+/obj/item/trash/candy,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/port/fore)
 "reW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -57864,6 +57139,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
+"rgb" = (
+/turf/open/floor/wood,
+/area/commons/dorms)
 "rgj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -58109,16 +57387,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"rmz" = (
-/obj/machinery/computer/security/mining{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "rmD" = (
 /obj/item/bedsheet/qm,
 /obj/structure/bed,
@@ -58184,11 +57452,14 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "rnr" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/anticorner{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
 	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
+/obj/machinery/computer/bank_machine,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "rnv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -58225,7 +57496,7 @@
 	name = "Bar Access"
 	},
 /turf/open/floor/carpet/black,
-/area/maintenance/port/aft)
+/area/service/abandoned_gambling_den)
 "roi" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -58289,6 +57560,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
+"roV" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/service/abandoned_gambling_den)
 "rpf" = (
 /obj/item/food/grown/banana,
 /turf/open/floor/grass,
@@ -58317,12 +57595,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/surgery)
-"rpQ" = (
-/obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "rpV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -58619,6 +57891,14 @@
 /obj/effect/spawner/random/techstorage/rnd_all,
 /turf/open/floor/iron/dark/side,
 /area/engineering/storage/tech)
+"ruZ" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "rvh" = (
 /obj/effect/turf_decal/tile/yellow/full,
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -58692,6 +57972,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/explab)
+"rvQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "rwe" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
@@ -58772,10 +58066,22 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "rwS" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "rwU" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -58993,20 +58299,6 @@
 /obj/item/storage/bag/plants,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"rAg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/maintenance{
-	name = "Ordnance Lab Maintenance";
-	req_access_txt = "8"
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
-	id = "toxinsrd";
-	name = "Toxins Shield RD Office"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "rAj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59014,11 +58306,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"rAp" = (
-/obj/structure/closet/wardrobe/mixed,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "rAA" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
@@ -59029,11 +58316,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"rAI" = (
-/obj/structure/closet/wardrobe/white,
-/obj/item/clothing/head/taqiyahwhite,
-/turf/open/floor/iron,
-/area/commons/dorms)
+"rAB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067";
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "rAW" = (
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
@@ -59050,20 +58342,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"rBc" = (
-/obj/structure/closet/wardrobe/black,
-/obj/machinery/camera/directional/north{
-	c_tag = "Dorms - Lockers";
-	name = "Dorms Camera"
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
-"rBg" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light/small/directional/north,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white,
-/area/commons/toilet)
 "rBm" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 8;
@@ -59079,14 +58357,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"rBo" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Post - Medbay";
-	req_access_txt = "63"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "rBt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59121,16 +58391,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"rBY" = (
-/obj/structure/weightmachine/stacklifter,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "rCf" = (
 /obj/effect/turf_decal/siding/purple/corner{
 	color = "#990099"
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"rCl" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "rCC" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/tile/brown/anticorner{
@@ -59138,12 +58408,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
-"rCN" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
+"rCO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rCR" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -59482,12 +58752,9 @@
 /turf/closed/wall,
 /area/security/prison/mess)
 "rIS" = (
-/obj/machinery/door/airlock{
-	id_tag = "ToiletC";
-	name = "Toilet C"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/item/trash/chips,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rIZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59505,22 +58772,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"rJg" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"rJh" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "rJm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -59537,32 +58788,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
-"rJp" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"rJt" = (
-/obj/machinery/door/airlock/public{
-	name = "Restroom & Laundry"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/toilet)
-"rJE" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/commons/toilet)
 "rJG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red{
@@ -59577,16 +58802,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
-"rJJ" = (
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "security red"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint)
 "rJK" = (
 /obj/structure/table,
 /obj/item/pinpointer/wayfinding,
@@ -59597,16 +58812,12 @@
 "rJM" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
-	dir = 5;
+	dir = 1;
 	name = "security red"
 	},
-/obj/machinery/door_timer{
-	id = "CellArr";
-	name = "Arrivals Cell";
-	pixel_y = 32
-	},
-/obj/structure/table,
-/obj/machinery/recharger,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "rJQ" = (
@@ -59619,34 +58830,19 @@
 /turf/open/floor/plating/grass/jungle,
 /area/service/hydroponics/garden/abandoned)
 "rKh" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "CellArr";
-	name = "Arrivals Cell Locker"
-	},
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
-	dir = 1;
+	dir = 5;
 	name = "security red"
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/turf/open/floor/iron,
 /area/security/checkpoint)
 "rKn" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"rKp" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "CellArr";
-	name = "Arrivals Cell Locker"
-	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 5;
-	name = "security red"
-	},
-/turf/open/floor/iron/dark,
-/area/security/checkpoint)
 "rKq" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -59680,15 +58876,6 @@
 	},
 /turf/open/floor/grass,
 /area/science/genetics)
-"rKT" = (
-/obj/machinery/light/directional/north,
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/hallway/primary/port)
 "rLr" = (
 /obj/structure/closet/secure_closet/brig/genpop,
 /obj/effect/turf_decal/bot,
@@ -59734,6 +58921,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"rLX" = (
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "rMi" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Prison Medbay";
@@ -59760,6 +58951,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"rMw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/service/abandoned_gambling_den)
 "rMB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -59777,17 +58974,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"rNs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/science/storage)
 "rNH" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
 /obj/item/food/mint,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"rNI" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/service/abandoned_gambling_den)
 "rNY" = (
 /obj/structure/flora/junglebush,
 /turf/closed/wall,
@@ -60048,6 +59246,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"rSX" = (
+/obj/item/shard/plasma,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/item/stack/cable_coil/five,
+/obj/item/clothing/neck/tie/black,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"rSY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/service/abandoned_gambling_den)
 "rTb" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
@@ -60086,13 +59299,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"rTL" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Locker Room"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "rTX" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating{
@@ -60126,27 +59332,14 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"rUu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"rUx" = (
-/obj/machinery/door/airlock/public{
-	name = "Restroom & Laundry"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/commons/toilet)
 "rUB" = (
-/turf/open/floor/iron/white,
-/area/commons/toilet)
-"rUD" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white,
-/area/commons/toilet)
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
+	},
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/commons/fitness/recreation)
 "rUI" = (
 /turf/open/floor/iron,
 /area/security/checkpoint)
@@ -60159,9 +59352,9 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
 "rVb" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "rVd" = (
@@ -60172,48 +59365,22 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
-"rVq" = (
+"rVr" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
 	dir = 4;
 	name = "security red"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
-"rVr" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/checkpoint)
-"rVQ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "security red"
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/flasher/directional/east{
-	id = "CellArr"
-	},
-/turf/open/floor/iron/dark,
-/area/security/checkpoint)
 "rWh" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 8;
-	output_dir = 4
-	},
-/obj/structure/railing{
-	dir = 4;
-	layer = 3.1;
-	pixel_x = 3
-	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/commons/storage/mining)
+/area/ai_monitored/command/nuke_storage)
 "rWk" = (
 /mob/living/carbon/human/species/monkey,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -60417,7 +59584,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "rYv" = (
 /obj/item/trash/sosjerky,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -60506,14 +59673,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"rZD" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/science/storage)
 "rZH" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/half,
@@ -60555,6 +59714,12 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"say" = (
+/obj/effect/mob_spawn/corpse/human/assistant,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
+/area/maintenance/port/fore)
 "saH" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
@@ -60603,11 +59768,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "scZ" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/port/fore)
 "sdg" = (
 /obj/machinery/door/airlock/security{
 	name = "Secure E.V.A. Room";
@@ -60802,10 +59972,22 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "shE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "shG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -60893,14 +60075,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
-"sjM" = (
-/obj/structure/closet/wardrobe/yellow,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"sjU" = (
-/obj/structure/closet/wardrobe/pink,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "sjX" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -60914,11 +60088,6 @@
 	dir = 4
 	},
 /area/hallway/primary/central/fore)
-"sjY" = (
-/obj/structure/closet/wardrobe/green,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "skh" = (
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 1
@@ -60952,42 +60121,16 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"skP" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/vending/clothing,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "skX" = (
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/security/prison)
-"slb" = (
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron/white,
-/area/commons/toilet)
-"slg" = (
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/table,
-/turf/open/floor/iron/white,
-/area/commons/toilet)
 "sll" = (
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"slp" = (
-/obj/structure/window{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/obj/structure/urinal/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "slr" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -61013,44 +60156,29 @@
 /area/medical/storage)
 "slw" = (
 /obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/red/corner{
+	color = "#FF0000";
+	dir = 8;
+	name = "security red"
+	},
+/obj/structure/chair,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "slz" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 10;
-	name = "security red"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/red/corner,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron,
 /area/security/checkpoint)
 "slA" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	name = "security red"
-	},
-/turf/open/floor/iron/dark,
-/area/security/checkpoint)
-"slB" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
 	dir = 6;
 	name = "security red"
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/security/checkpoint)
 "slG" = (
 /obj/effect/turf_decal/tile/purple/half{
@@ -61082,6 +60210,13 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/grass,
 /area/science/genetics)
+"slR" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -30
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "slT" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -61291,14 +60426,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"spn" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/rag,
-/obj/item/reagent_containers/glass/rag,
-/obj/item/reagent_containers/glass/rag,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "sps" = (
 /turf/open/floor/carpet/black,
 /area/service/bar)
@@ -61341,6 +60468,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"sqZ" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "srj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -61349,6 +60481,15 @@
 	dir = 4
 	},
 /area/security/range)
+"srk" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms)
 "srr" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Chemistry S";
@@ -61574,6 +60715,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"suM" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/bar/atrium)
 "suX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -61589,42 +60735,25 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"suZ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Locker Room"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "svh" = (
-/obj/machinery/door/airlock/public{
-	name = "Restroom & Laundry"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
-"svy" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	name = "security red"
-	},
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint)
-"svF" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 6;
-	name = "security red"
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
+"svy" = (
+/obj/item/radio/off,
+/obj/item/screwdriver,
+/obj/structure/table,
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 10;
+	name = "security red"
+	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "svI" = (
@@ -61635,7 +60764,7 @@
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/port/fore)
 "svM" = (
 /obj/structure/closet{
 	anchored = 1;
@@ -62078,40 +61207,21 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"sCN" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Port South Hallway - Arrivals";
-	name = "South Port Hallway Camera"
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/hallway/primary/port)
 "sCW" = (
 /obj/structure/cable,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"sCX" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/hallway/primary/port)
 "sDa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
 	dir = 4
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Research - Annex Inner Entryway";
-	name = "Research Camera";
-	network = list("ss13","rd")
-	},
 /turf/open/floor/iron/white/side{
-	dir = 4
+	dir = 5
 	},
 /area/science/research)
 "sDb" = (
@@ -62124,6 +61234,11 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/plating/grass/jungle,
 /area/service/hydroponics/garden/abandoned)
+"sDK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "sDO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -62140,14 +61255,6 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/wood,
 /area/service/lawoffice/upper)
-"sEv" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "sEH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -62173,6 +61280,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"sFv" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "sFG" = (
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/wood,
@@ -62208,6 +61322,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"sGv" = (
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/random/maintenance/two,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "sGw" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -62494,6 +61616,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"sNl" = (
+/obj/structure/rack,
+/obj/item/screwdriver,
+/obj/item/screwdriver,
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "sNu" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#73c2fb";
@@ -62554,12 +61683,6 @@
 /obj/structure/chair/pew/left,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"sOk" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/commons/fitness)
 "sOl" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#73c2fb";
@@ -62785,6 +61908,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "sRZ" = (
@@ -62934,6 +62058,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"sUq" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "sUv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
@@ -63012,11 +62140,16 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "sWw" = (
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/siding/red/corner{
+/obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
-	dir = 8;
+	dir = 10;
 	name = "security red"
+	},
+/obj/structure/filingcabinet,
+/obj/machinery/requests_console/directional/south{
+	department = "Security";
+	departmentType = 5;
+	name = "Sec Outpost - Arrivals"
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
@@ -63053,28 +62186,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"sXx" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 4
-	},
-/area/hallway/primary/port)
-"sXy" = (
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "sXC" = (
 /obj/structure/sign/poster/random{
 	pixel_y = -32
@@ -63097,17 +62208,6 @@
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron,
 /area/security/prison)
-"sYa" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "sYj" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -63139,10 +62239,6 @@
 /obj/item/mop,
 /turf/open/floor/iron,
 /area/security/prison)
-"sYC" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/commons/fitness)
 "sYH" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -63258,6 +62354,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
+"tal" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "taB" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -63290,6 +62394,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "tbs" = (
@@ -63616,17 +62723,31 @@
 	dir = 4
 	},
 /area/hallway/primary/starboard)
+"tgX" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Holodeck - Control";
+	name = "holodeck camera"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "thg" = (
 /obj/structure/closet/crate/engineering/electrical,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"thh" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "thk" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/item/radio/intercom/directional/north,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "thn" = (
@@ -63645,12 +62766,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"thK" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/maintenance/port/aft)
 "tih" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
@@ -63664,6 +62779,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
+"tiz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "tiE" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L14"
@@ -63683,16 +62804,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"tiI" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Arrivals SE";
-	name = "Hallway Camera"
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "tiY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window,
@@ -63708,7 +62819,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "tji" = (
 /obj/machinery/computer/rdconsole,
 /obj/machinery/light/directional/north,
@@ -63721,14 +62832,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"tjm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "tjs" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -63782,15 +62885,6 @@
 /obj/structure/reagent_dispensers/wall/peppertank/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
-"tjU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "tjW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
@@ -63863,19 +62957,20 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
+"tmg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "tmh" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "South Port Hallway"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
 "tmG" = (
 /obj/machinery/light/directional/east,
 /obj/structure/closet/toolcloset,
@@ -63886,6 +62981,11 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
+"tmH" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "tmP" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/full{
@@ -63940,6 +63040,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"tnp" = (
+/obj/machinery/door/airlock{
+	name = "Unit B"
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "tnu" = (
 /obj/structure/table,
 /obj/item/instrument/accordion,
@@ -63963,6 +63069,15 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"tnV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "tog" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/stripes/line,
@@ -63981,40 +63096,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"tpj" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=rec1";
-	location = "dorms1";
-	name = "Patrol Beacon"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"tpv" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=swcross2";
-	location = "rec2";
-	name = "Patrol Beacon"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "tpw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64074,16 +63155,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "trq" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067";
+	dir = 1
 	},
-/obj/structure/disposalpipe/junction/flip{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/side,
 /area/hallway/primary/port)
 "trs" = (
 /obj/structure/cable,
@@ -64101,7 +63183,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/side,
@@ -64276,10 +63358,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/smooth,
 /area/security/warden)
-"ttJ" = (
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "ttT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -64596,10 +63674,6 @@
 /obj/structure/flora/ausbushes,
 /turf/open/floor/plating/grass/jungle,
 /area/service/hydroponics/garden/abandoned)
-"tyr" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/science/research)
 "tyu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -64620,20 +63694,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/side,
 /area/engineering/storage/tech)
-"tzr" = (
-/obj/structure/table,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/rglass{
-	amount = 50;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/stack/cable_coil/five,
-/obj/item/stack/cable_coil/five,
-/obj/item/stack/cable_coil/five,
-/obj/item/stack/cable_coil/five,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "tzB" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/two,
@@ -64716,6 +63776,22 @@
 "tAx" = (
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"tAA" = (
+/obj/item/storage/toolbox/emergency,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "tAG" = (
 /obj/item/radio/intercom/chapel{
 	pixel_y = 25
@@ -64724,6 +63800,14 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet/green,
 /area/service/chapel)
+"tAR" = (
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	name = "security red"
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron,
+/area/security/checkpoint)
 "tBk" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
@@ -64741,13 +63825,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"tBE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/commons/fitness)
 "tBF" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -64758,7 +63835,12 @@
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
+"tBJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "tBU" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Electrical Maintenance";
@@ -64927,14 +64009,6 @@
 /obj/item/clothing/under/suit/checkered,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"tEE" = (
-/turf/open/floor/iron/white/corner{
-	dir = 8
-	},
-/area/hallway/primary/port)
-"tER" = (
-/turf/open/floor/iron/white/corner,
-/area/hallway/primary/port)
 "tET" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/side,
@@ -65066,6 +64140,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"tIq" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "tIy" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
 /obj/machinery/disposal/bin,
@@ -65240,12 +64318,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "tMt" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Activity Rooms"
-	},
-/obj/machinery/door/firedoor,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/hallway/primary/port)
 "tMF" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/blue{
@@ -65270,73 +64346,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/security/processing)
-"tMN" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Activity Rooms"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"tNc" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Port South Hallway - Vacant Space";
-	name = "South Port Hallway Camera"
-	},
-/obj/structure/closet/firecloset,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white/side{
-	dir = 10
-	},
-/area/hallway/primary/port)
-"tNh" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/side,
-/area/hallway/primary/port)
-"tNl" = (
-/obj/structure/table,
-/obj/item/food/cheesiehonkers,
-/turf/open/floor/iron/white/side,
-/area/hallway/primary/port)
-"tNm" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/dry_ramen,
-/turf/open/floor/iron/white/side,
-/area/hallway/primary/port)
 "tNK" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"tNP" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white/side{
-	dir = 6
-	},
-/area/hallway/primary/port)
-"tOb" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "tOd" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "South Port Hallway"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/hallway/primary/port)
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "tOH" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -65354,7 +64374,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "tOR" = (
 /obj/structure/closet,
 /obj/item/wirecutters,
@@ -65437,16 +64457,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"tQQ" = (
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "tQT" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -65487,6 +64497,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"tRQ" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "tSa" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -65633,9 +64648,10 @@
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "tUH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "tUM" = (
 /obj/structure/grille/broken,
 /turf/closed/wall/r_wall,
@@ -65750,14 +64766,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
-"tXM" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	alpha = 255;
-	dir = 1
-	},
-/obj/structure/punching_bag,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "tYc" = (
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
@@ -65768,21 +64776,16 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"tYm" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	alpha = 255;
-	dir = 4
-	},
-/obj/structure/punching_bag,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "tYF" = (
 /turf/closed/wall/r_wall,
 /area/security/lockers)
 "tYV" = (
-/obj/machinery/light/directional/north,
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/commons/fitness/recreation)
+/area/hallway/primary/port)
 "tZc" = (
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
@@ -65801,23 +64804,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"tZv" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
-/obj/structure/table,
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/machinery/camera/directional/north{
-	c_tag = "Rec-room N";
-	name = "Recreation Camera - East"
-	},
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
-"tZy" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "tZL" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
@@ -65829,10 +64815,6 @@
 	},
 /turf/open/floor/carpet/lone,
 /area/medical/psychology)
-"tZU" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "tZZ" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
@@ -65854,10 +64836,9 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "uau" = (
-/obj/item/toy/balloon/arrest,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/punching_bag,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "uax" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/smooth_large,
@@ -65868,14 +64849,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
-"uaC" = (
-/obj/structure/cable,
-/obj/machinery/navbeacon/wayfinding,
-/obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
 "uaD" = (
 /obj/item/crowbar,
 /obj/item/crowbar,
@@ -65934,13 +64907,6 @@
 "ubs" = (
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"ubu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/commons/fitness)
 "ubw" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -66019,6 +64985,13 @@
 /obj/item/radio,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
+"ucv" = (
+/obj/machinery/space_heater,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 30
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ucF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -66086,8 +65059,8 @@
 /area/security/range)
 "udp" = (
 /obj/structure/cable,
-/obj/machinery/newscaster/security_unit/directional/south,
 /obj/machinery/light/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "udq" = (
@@ -66151,13 +65124,15 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "udS" = (
-/obj/structure/window{
-	dir = 1
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
 	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/urinal/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "udU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -66222,6 +65197,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"ueW" = (
+/obj/structure/chair/stool/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/service/abandoned_gambling_den)
 "ufs" = (
 /turf/open/floor/iron/white/side{
 	dir = 1
@@ -66467,22 +65447,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"ujG" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "ujJ" = (
 /obj/structure/chair/pew,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/security/courtroom)
-"ujP" = (
-/obj/machinery/firealarm/directional/west,
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "ujT" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -66510,10 +65479,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/security/processing)
-"ukg" = (
-/obj/machinery/light/floor,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "ukk" = (
 /turf/open/floor/iron,
 /area/maintenance/department/crew_quarters/bar)
@@ -66526,21 +65491,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"uku" = (
-/obj/structure/sign/warning/explosives/alt{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "ukx" = (
 /obj/vehicle/ridden/wheelchair,
 /obj/machinery/status_display/evac/directional/north,
@@ -66556,24 +65506,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"ukF" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Come here to practice punching"
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
-"ukQ" = (
-/turf/open/floor/iron/white/side{
-	dir = 6
-	},
-/area/commons/fitness)
-"ukZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "ulD" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
@@ -66588,15 +65520,15 @@
 /obj/item/integrated_circuit/loaded/speech_relay,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"ulL" = (
-/obj/structure/table,
-/turf/open/floor/iron/white/corner{
-	dir = 8
-	},
-/area/commons/fitness/recreation)
 "ulW" = (
-/turf/open/floor/iron,
-/area/commons/storage/mining)
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue half"
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "umc" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/east,
@@ -66909,11 +65841,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"uqr" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/tile/brown/half,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "uqs" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -66977,20 +65904,23 @@
 	},
 /turf/open/floor/plating/grass/jungle,
 /area/maintenance/starboard/fore)
-"urn" = (
-/obj/machinery/light/directional/west,
-/obj/structure/chair{
-	dir = 4
+"urx" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"urP" = (
+/obj/item/trash/boritos{
+	pixel_y = 14
 	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"urN" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Port South Hallway - Dorm Lockers Entrance";
-	name = "South Port Hallway Camera"
+/obj/item/trash/boritos,
+/obj/item/trash/candy{
+	pixel_x = -12
 	},
-/turf/open/floor/iron/white/side,
-/area/hallway/primary/port)
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
+/area/maintenance/port/fore)
 "urU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -67027,13 +65957,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
-"usA" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "usD" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/central)
@@ -67048,13 +65971,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"usY" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	alpha = 255
-	},
-/obj/structure/punching_bag,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "usZ" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -67062,19 +65978,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "utd" = (
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=rec2";
-	location = "rec1";
-	name = "Patrol Beacon"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/hallway/primary/port)
 "uth" = (
 /obj/machinery/computer/shuttle/labor{
 	dir = 1
@@ -67118,23 +66027,18 @@
 	},
 /turf/open/floor/plating/grass/jungle,
 /area/service/hydroponics/garden/abandoned)
-"uto" = (
+"utt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/commons/fitness/recreation)
-"utt" = (
-/turf/open/floor/iron/white/corner,
-/area/commons/fitness/recreation)
+/area/hallway/primary/port)
 "utz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side,
-/area/commons/fitness/recreation)
-"utG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/side,
-/area/commons/fitness/recreation)
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "utK" = (
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 4
@@ -67146,11 +66050,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"uuc" = (
-/turf/open/floor/iron/white/corner{
-	dir = 8
-	},
-/area/commons/fitness/recreation)
 "uuf" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 4
@@ -67171,14 +66070,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"uuH" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "uuN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall,
-/area/commons/fitness/recreation)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "uuR" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron,
@@ -67196,24 +66094,15 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "uvd" = (
-/obj/structure/safe,
-/obj/item/clothing/head/bearpelt,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/obj/item/stack/spacecash/c500,
-/obj/item/stack/spacecash/c500,
-/obj/item/stack/spacecash/c500,
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c1000,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/commons/dorms)
+"uvt" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "uvw" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -67221,6 +66110,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "uvx" = (
@@ -67442,6 +66332,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
+"uyA" = (
+/obj/machinery/light/directional/south,
+/obj/structure/sign/poster/official/no_erp{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "uyF" = (
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase,
@@ -67570,6 +66470,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"uBt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/service/abandoned_gambling_den)
 "uBA" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -67684,6 +66591,12 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"uDH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "uDV" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
@@ -67695,15 +66608,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
-"uEz" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"uEA" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/side,
-/area/hallway/primary/port)
 "uEK" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -67728,16 +66632,6 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/primary/central/fore)
-"uFe" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"uFf" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "uFn" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/ai/directional/north,
@@ -67767,6 +66661,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"uFM" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"uGg" = (
+/turf/closed/wall,
+/area/maintenance/port/fore)
 "uGh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67834,11 +66738,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
-"uHi" = (
-/turf/open/floor/iron/white/side{
-	dir = 5
-	},
-/area/commons/fitness)
 "uHk" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/clothing/head/rice_hat,
@@ -67852,6 +66751,21 @@
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall/r_wall,
 /area/medical/pharmacy)
+"uHw" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "uHz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -67860,14 +66774,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"uHS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/side{
-	dir = 9
+"uHL" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
 	},
-/area/commons/fitness)
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
+"uHS" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "uHU" = (
 /obj/machinery/computer/slot_machine,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
@@ -67911,41 +66828,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
-"uIw" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	alpha = 255
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
-"uIy" = (
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/commons/fitness/recreation)
 "uIE" = (
-/obj/structure/closet/athletic_mixed,
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	color = "#f2c2e3";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/commons/fitness/recreation)
-"uIK" = (
-/obj/structure/closet/athletic_mixed,
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	color = "#f2c2e3";
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover/closet,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/commons/fitness/recreation)
-"uIL" = (
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/commons/fitness/recreation)
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "uIW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -67961,10 +66847,6 @@
 "uJl" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science)
-"uJF" = (
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "uJU" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -67982,16 +66864,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"uKg" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/camera/autoname/directional/north{
-	c_tag = "Holodeck - Fore";
-	name = "Holodeck Camera"
-	},
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/holodeck/rec_center)
 "uKi" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
@@ -68206,6 +67078,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"uOq" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "uOs" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/camera/directional/north{
@@ -68308,6 +67189,10 @@
 /obj/structure/closet/secure_closet/brig/genpop,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"uQg" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/closed/wall,
+/area/maintenance/port/aft)
 "uQk" = (
 /obj/machinery/power/solar{
 	id = "aftport";
@@ -68412,10 +67297,6 @@
 "uRX" = (
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"uRZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/commons/fitness)
 "uSr" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/machinery/camera/directional/north{
@@ -68516,6 +67397,14 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
+"uTW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "uUc" = (
 /obj/machinery/computer/security/mining,
 /obj/effect/turf_decal/tile/brown{
@@ -68619,14 +67508,13 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "uVI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "uVS" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /turf/closed/wall/r_wall,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "uVX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -68719,13 +67607,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
-"uYU" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	alpha = 255;
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "uZe" = (
 /obj/item/fakeartefact,
 /turf/open/floor/plating,
@@ -68755,19 +67636,24 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"vak" = (
-/obj/structure/closet/emcloset,
+"vag" = (
+/obj/structure/weightmachine/stacklifter,
 /turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"vaq" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/dorms)
 "vau" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /turf/open/floor/engine,
 /area/science/explab)
+"vax" = (
+/obj/structure/chair/comfy{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "vaz" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -68788,19 +67674,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"vaI" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/disposal/bin,
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "vaJ" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 4
@@ -68831,14 +67704,6 @@
 	dir = 1
 	},
 /area/hallway/primary/starboard)
-"vbu" = (
-/obj/structure/closet/masks,
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	color = "#f2c2e3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/commons/fitness/recreation)
 "vbx" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
@@ -68924,18 +67789,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"vcU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+"vcR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/light/small/directional/east,
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/blue/full{
-	color = "#4169E1";
-	name = "Command blue full"
+/obj/machinery/meter,
+/obj/machinery/button/door/incinerator_vent_ordmix{
+	pixel_x = -25;
+	pixel_y = 5
 	},
+/obj/machinery/button/ignition/incinerator/ordmix{
+	pixel_x = -25;
+	pixel_y = -5
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/area/science/mixing)
 "vcX" = (
 /obj/effect/turf_decal/tile/red/full{
 	color = "#FF0000"
@@ -68971,7 +67841,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "vdx" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -69109,10 +67979,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"vfK" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron/white,
-/area/science/storage)
 "vfL" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/firealarm/directional/west,
@@ -69178,6 +68044,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/purple,
 /area/command/heads_quarters/rd)
+"vhw" = (
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/light/small/directional/east,
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "vhY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69391,7 +68268,7 @@
 	name = "South Port Hallway"
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/central/aft)
 "vly" = (
 /obj/structure/chair,
 /obj/machinery/light/small/directional/north,
@@ -69421,6 +68298,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
+"vlT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/commons/dorms)
+"vmr" = (
+/obj/effect/wisp,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
+/area/maintenance/port/fore)
 "vmy" = (
 /obj/effect/turf_decal/tile/red/anticorner{
 	color = "#FF0000";
@@ -69429,11 +68319,6 @@
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/white,
 /area/security)
-"vmJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "vmV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -69460,6 +68345,10 @@
 	icon_state = "chapel"
 	},
 /area/service/chapel)
+"vnV" = (
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "vom" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	color = "#FF6700";
@@ -69480,6 +68369,16 @@
 /obj/structure/closet/secure_closet/evidence,
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
+"voF" = (
+/obj/machinery/navbeacon/wayfinding/dorms,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "voG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69502,13 +68401,6 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/service/bar)
-"voQ" = (
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/science/storage)
 "voZ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/insectguts,
@@ -69532,23 +68424,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "vpB" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
-"vpP" = (
-/obj/effect/turf_decal/bot_white{
-	color = "#0000ff";
-	name = "bot blue"
-	},
-/obj/structure/closet/lasertag/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/commons/fitness/recreation)
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "vpZ" = (
 /turf/closed/wall,
 /area/security/prison/safe)
@@ -69557,23 +68434,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
-"vqd" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/bot_white{
-	color = "#0000ff";
-	name = "bot blue"
-	},
-/obj/structure/closet/lasertag/blue,
-/obj/effect/landmark/start/hangover/closet,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/commons/fitness/recreation)
 "vqu" = (
 /obj/effect/turf_decal/tile/bar/half{
 	dir = 1
@@ -69582,10 +68442,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"vqv" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "vqF" = (
 /turf/open/floor/iron/stairs{
 	dir = 8
@@ -69683,14 +68539,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/command/nuke_storage)
-"vrV" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue half"
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
 "vsu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/southright{
@@ -69724,6 +68572,8 @@
 	dir = 8
 	},
 /obj/machinery/vending/tool,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "vsV" = (
@@ -69746,6 +68596,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/kitchen)
+"vtf" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vtq" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -69759,6 +68613,21 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"vtC" = (
+/obj/structure/sign/warning/explosives/alt{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "vtO" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
@@ -69820,6 +68689,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"vuI" = (
+/obj/structure/chair/wood,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "vuY" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -69880,6 +68753,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"vvV" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/service/abandoned_gambling_den)
 "vwg" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
@@ -70087,6 +68967,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"vBp" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 3;
+	height = 5;
+	id = "commonmining_home";
+	name = "SS13: Common Mining Dock";
+	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "vBG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -70100,12 +68992,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"vBQ" = (
-/obj/structure/closet/wardrobe/grey,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "vBV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -70147,11 +69033,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
-"vCD" = (
-/obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "vCF" = (
 /obj/effect/turf_decal/weather,
 /obj/item/kirbyplants{
@@ -70175,13 +69056,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"vCT" = (
-/obj/machinery/light/directional/north,
-/obj/structure/bed/roller,
-/obj/machinery/status_display/evac/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "vDb" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -70198,14 +69072,16 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"vDw" = (
-/obj/structure/sign/poster/contraband/masked_men{
-	pixel_y = 32
+"vDD" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
 	},
-/obj/structure/bed/roller,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/fitness)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "vEb" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/freezer,
@@ -70222,18 +69098,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/service/bar/atrium)
-"vEh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"vEk" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "vEm" = (
 /obj/structure/chair{
 	dir = 4
@@ -70253,12 +69117,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"vFl" = (
-/obj/structure/cable,
-/obj/structure/closet/athletic_mixed,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "vFp" = (
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
@@ -70268,10 +69126,6 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/hallway/primary/central/fore)
-"vFB" = (
-/obj/item/trash/syndi_cakes,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "vFO" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
@@ -70299,17 +69153,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"vGi" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/lasertag/red,
-/obj/effect/landmark/start/hangover/closet,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/commons/fitness/recreation)
 "vGv" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -70320,6 +69163,14 @@
 	dir = 4
 	},
 /area/science/research)
+"vGB" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/commons/dorms)
 "vGD" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Auxiliary Public Tool Storage"
@@ -70329,16 +69180,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"vGE" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
-"vHk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/commons/fitness/recreation)
 "vHz" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -70346,19 +69187,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"vHG" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Dock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "publicmining";
-	name = "Public Mining Lockdown"
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "vHJ" = (
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -70371,17 +69199,6 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "vHL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
-"vIk" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
@@ -70405,44 +69222,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"vIv" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
-"vIy" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/commons/fitness/recreation)
-"vIC" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/holodeck/rec_center)
-"vIW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/lasertag/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/commons/fitness/recreation)
-"vIX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "vJe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -70461,15 +69240,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"vJx" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
-"vJC" = (
-/obj/structure/training_machine,
-/obj/item/target,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "vJD" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/glass/reinforced,
@@ -70532,16 +69302,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"vKr" = (
-/obj/machinery/computer/bank_machine{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/anticorner{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
 "vKu" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -70619,44 +69379,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/cargo/qm)
-"vLM" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue half"
-	},
-/obj/effect/turf_decal/tile/random{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "vLQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/maintenance/two,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"vLU" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 4
-	},
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/science/research)
 "vMa" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red{
@@ -70707,6 +69437,20 @@
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
+"vMQ" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "rdxeno";
+	name = "Xenobiology Containment Door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Lab";
+	req_access_txt = "47"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "vMY" = (
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/turf_decal/tile/blue/half{
@@ -70873,17 +69617,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/bar/atrium)
-"vQl" = (
-/obj/structure/closet/wardrobe/miner,
-/obj/item/storage/backpack/satchel/explorer,
-/obj/machinery/camera/directional/south{
-	c_tag = "Cargo - Public Mining";
-	name = "cargo camera"
-	},
-/obj/effect/landmark/start/hangover/closet,
-/obj/effect/turf_decal/tile/brown/half,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "vQn" = (
 /obj/machinery/photocopier,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -71022,12 +69755,6 @@
 "vRt" = (
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
-"vRw" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "vRy" = (
 /obj/machinery/iv_drip,
 /obj/machinery/airalarm/directional/north,
@@ -71094,10 +69821,6 @@
 /obj/machinery/research/explosive_compressor,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"vSK" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "vSQ" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -71195,26 +69918,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/central)
-"vVl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/side{
-	dir = 10
-	},
-/area/commons/fitness)
 "vVo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
-"vVr" = (
-/obj/structure/cable,
-/obj/structure/closet/boxinggloves,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"vVC" = (
-/turf/open/floor/iron/white/corner{
-	dir = 4
-	},
-/area/commons/fitness/recreation)
 "vVD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south{
@@ -71242,12 +69949,6 @@
 	dir = 1
 	},
 /area/security/range)
-"vVX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/commons/fitness/recreation)
 "vVZ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rdgene";
@@ -71257,12 +69958,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/genetics)
-"vWc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/side{
-	dir = 1
+"vWd" = (
+/obj/structure/sign/directions/vault{
+	dir = 8;
+	pixel_x = -32;
+	pixel_y = 37
 	},
-/area/commons/fitness/recreation)
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "vWm" = (
 /turf/closed/wall,
 /area/medical/morgue)
@@ -71289,26 +69992,14 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "vWL" = (
-/obj/effect/turf_decal/tile/random{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Central Hallway E - Medbay Entrance";
 	name = "East Central Hallway Camera"
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
-"vWM" = (
-/turf/open/floor/iron/white/corner{
-	dir = 1
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
-/area/commons/fitness/recreation)
+/area/hallway/primary/central/aft)
 "vWO" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/structure/disposalpipe/segment{
@@ -71350,16 +70041,22 @@
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
 "vXN" = (
-/obj/machinery/computer/holodeck{
-	dir = 4
+/obj/structure/sink{
+	pixel_y = 14
 	},
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
+/obj/structure/mirror/directional/north,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "vXP" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
+/obj/structure/sink{
+	pixel_y = 14
+	},
+/obj/structure/mirror/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "vXU" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -71367,14 +70064,6 @@
 "vYa" = (
 /turf/open/floor/wood,
 /area/service/library)
-"vYe" = (
-/obj/machinery/status_display/evac/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Holodeck - Control";
-	name = "holodeck camera"
-	},
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "vYt" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -71384,7 +70073,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "vYG" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -71395,7 +70084,7 @@
 "vYO" = (
 /obj/structure/sign/poster/official/love_ian,
 /turf/closed/wall,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "vZc" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -71542,6 +70231,10 @@
 /obj/item/paper,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"waf" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "wan" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/blue{
@@ -71600,6 +70293,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"wbQ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Arrival Airlock"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "wcd" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
@@ -71729,6 +70431,14 @@
 "wdf" = (
 /turf/closed/wall,
 /area/science/server)
+"wdg" = (
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/commons/dorms)
+"wdl" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "wdr" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -71758,6 +70468,12 @@
 /obj/effect/spawner/random/trash/bin,
 /turf/open/floor/iron,
 /area/security/prison)
+"weh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "wet" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -71782,6 +70498,9 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wfk" = (
+/turf/open/floor/plating,
+/area/service/abandoned_gambling_den)
 "wfs" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 4
@@ -71805,6 +70524,10 @@
 /obj/effect/turf_decal/trimline/red/line,
 /turf/open/floor/iron/smooth,
 /area/security/warden)
+"wgE" = (
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "wgH" = (
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -71863,26 +70586,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"wid" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/hollow/reinforced,
-/turf/open/floor/plating,
-/area/commons/fitness)
-"wii" = (
-/obj/machinery/door/window/northright,
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
-"wiu" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Ordnance Maintenance";
-	req_access_txt = "8"
+"wib" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/service/abandoned_gambling_den)
 "wiB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/engine{
@@ -71897,35 +70607,25 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"wiN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/commons/fitness/recreation)
 "wjw" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "wjL" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
+"wjP" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Showers"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"wjP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/commons/fitness/recreation)
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "wjS" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -71936,13 +70636,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"wjT" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "wjZ" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxToilet2";
@@ -71953,7 +70646,7 @@
 "wka" = (
 /obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "wkv" = (
 /obj/item/circuitboard/machine/exoscanner{
 	pixel_y = -3
@@ -72005,6 +70698,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"wlW" = (
+/obj/structure/chair/comfy,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "wlZ" = (
 /obj/structure/rack,
 /obj/item/clothing/head/welding{
@@ -72022,14 +70725,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"wmb" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	alpha = 255;
-	dir = 8
-	},
-/obj/structure/punching_bag,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "wmd" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/half{
@@ -72041,14 +70736,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"wme" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "wml" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -72144,6 +70831,15 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"wnC" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "wnK" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/brown/half{
@@ -72272,6 +70968,16 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/iron,
 /area/security/prison)
+"wqD" = (
+/obj/structure/dresser,
+/obj/structure/sign/picture_frame/portrait/bar{
+	pixel_x = -28
+	},
+/turf/open/floor/carpet,
+/area/commons/dorms)
+"wqG" = (
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "wqN" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -72364,6 +71070,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"wtv" = (
+/obj/item/trash/candy,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
+/area/maintenance/port/fore)
 "wtA" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -72394,36 +71106,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"wui" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "wuq" = (
 /obj/machinery/light_switch/directional/south,
 /obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/service/library)
-"wus" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "wuu" = (
 /obj/machinery/computer/exodrone_control_console,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
-"wuv" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Rec-room S";
-	name = "Recreation Camera - East"
-	},
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "wuA" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Security Maintenance";
@@ -72451,27 +71143,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
-"wvd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "wvh" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/fore)
-"wvk" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
-"wvl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "wvr" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#73c2fb";
@@ -72530,14 +71206,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse/upper)
-"wws" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "wwy" = (
 /obj/machinery/computer/upload/ai{
 	dir = 8
@@ -72548,13 +71216,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
-"wwD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "wwG" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/carpet/purple,
@@ -72578,7 +71239,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "wxi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -72782,12 +71443,11 @@
 /turf/closed/wall,
 /area/security/detectives_office)
 "wAj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "wAm" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
@@ -72795,6 +71455,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"wAr" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms)
 "wAu" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half{
@@ -72912,11 +71581,10 @@
 	},
 /area/science/research)
 "wCu" = (
-/obj/structure/reagent_dispensers/plumbed{
-	dir = 1
-	},
+/obj/item/trash/boritos,
+/obj/effect/mob_spawn/corpse/human/assistant,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/port/fore)
 "wCz" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -72983,6 +71651,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"wDk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "wDo" = (
 /turf/closed/wall,
 /area/service/janitor)
@@ -73013,20 +71690,21 @@
 	},
 /turf/open/floor/plating,
 /area/security/lockers)
-"wDH" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	alpha = 255;
+"wDE" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
-"wDP" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	dir = 1
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/commons/fitness)
+/area/service/abandoned_gambling_den)
 "wDW" = (
 /turf/closed/wall,
 /area/hallway/primary/central/fore)
@@ -73069,9 +71747,11 @@
 /obj/item/food/grown/poppy,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"wEA" = (
-/turf/closed/wall,
-/area/service/library/abandoned)
+"wER" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "wEX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -73108,14 +71788,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/carpet/purple,
 /area/command/heads_quarters/rd)
-"wFD" = (
-/obj/machinery/door/airlock{
-	name = "art storage room"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "wFQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -73124,14 +71796,6 @@
 /obj/machinery/vending/snack/green,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"wGl" = (
-/obj/machinery/door/airlock{
-	name = "art storage room"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "wGm" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73141,21 +71805,9 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "wGz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/commons/fitness/recreation)
-"wGJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/commons/fitness/recreation)
-"wGK" = (
-/obj/structure/cable,
-/obj/item/assembly/mousetrap/armed,
-/obj/item/stack/sheet/cardboard,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/rack,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/analyzer,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "wGO" = (
@@ -73170,16 +71822,10 @@
 /obj/item/trash/raisins,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"wGU" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "wGV" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "wGY" = (
 /obj/effect/landmark/start/warden,
 /obj/effect/turf_decal/trimline/red/line{
@@ -73194,7 +71840,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "wHo" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -73253,10 +71899,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"wIf" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/maintenance/department/crew_quarters/dorms)
 "wIg" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
@@ -73310,6 +71952,14 @@
 "wJc" = (
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
+"wJh" = (
+/obj/structure/chair/comfy,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "wJp" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -73534,6 +72184,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/purple,
 /area/command/heads_quarters/rd)
+"wNc" = (
+/obj/item/trash/cheesie,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "wNo" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -73587,16 +72242,6 @@
 /obj/structure/bed/dogbed,
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"wOk" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"wOp" = (
-/obj/machinery/light/floor,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "wOI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -73631,19 +72276,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"wPk" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
-"wPJ" = (
-/obj/structure/chair/stool/directional/west{
-	pixel_y = 8
-	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/cable,
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "wPW" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -73657,6 +72289,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
+"wQi" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/full{
+	alpha = 255
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=rec1";
+	location = "dorms1";
+	name = "Patrol Beacon"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "wQk" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /obj/effect/turf_decal/tile/brown/anticorner,
@@ -73671,42 +72320,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/service/bar/atrium)
-"wQu" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	color = "#f2c2e3";
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/item/storage/toolbox/artistic,
-/obj/item/chisel,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
-"wQH" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3";
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/north,
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/stack/sheet/iron/ten,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
-"wQP" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "wQX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half{
@@ -73720,30 +72333,11 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/primary/central/fore)
-"wRa" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "wRc" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
 /turf/open/space/basic,
 /area/maintenance/solars/port/aft)
-"wRj" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3";
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "wRm" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -73752,19 +72346,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
-"wRs" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	color = "#f2c2e3";
-	dir = 4
-	},
-/obj/structure/closet,
-/obj/item/food/grown/sunflower,
-/obj/item/clothing/gloves/color/green,
-/obj/item/clothing/under/dress/sundress,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/shoes/sandal,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "wRt" = (
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
@@ -73808,7 +72389,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "wSv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
@@ -73820,9 +72401,12 @@
 /obj/item/grenade/chem_grenade/glitter,
 /obj/item/bikehorn/airhorn,
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "wSO" = (
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "wSP" = (
@@ -73834,10 +72418,10 @@
 	name = "Dear Ian 2"
 	},
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "wSR" = (
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "wST" = (
 /obj/structure/closet/crate/grave,
 /obj/structure/sign/poster/official/ian{
@@ -73845,7 +72429,7 @@
 	},
 /obj/item/clothing/under/costume/skeleton,
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "wSY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/blue/corner{
@@ -73875,7 +72459,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "wTD" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -73942,12 +72526,6 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"wUv" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/commons/fitness)
 "wUw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -74000,10 +72578,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/science/lab)
-"wWb" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/maintenance/department/crew_quarters/dorms)
 "wWc" = (
 /turf/open/floor/iron/white/side,
 /area/hallway/primary/port)
@@ -74030,16 +72604,6 @@
 "wWJ" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"wWQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Rage Cage"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "wWY" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -74130,22 +72694,16 @@
 /turf/open/floor/plating/grass/jungle,
 /area/maintenance/starboard/fore)
 "wZb" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/meter,
-/obj/machinery/button/door/incinerator_vent_ordmix{
-	pixel_x = -25;
-	pixel_y = 5
-	},
-/obj/machinery/button/ignition/incinerator/ordmix{
-	pixel_x = -25;
-	pixel_y = -5
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "wZe" = (
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -74200,62 +72758,15 @@
 	dir = 1
 	},
 /area/hallway/primary/central/aft)
-"xbf" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"xbh" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	alpha = 255;
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
-"xbj" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "xbl" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"xbx" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3";
-	dir = 8
-	},
-/obj/structure/easel,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
-"xbC" = (
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
-"xbO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
-"xbQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "xcp" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/jukebox,
 /turf/open/floor/wood,
 /area/service/bar/atrium)
-"xct" = (
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "xcu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/blue/half{
@@ -74278,28 +72789,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/grass/jungle,
 /area/engineering/engine_smes)
-"xcJ" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3";
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/camera_film,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
-"xcS" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/camera/autoname/directional/north{
-	c_tag = "Holodeck - Fore";
-	dir = 2;
-	name = "Holodeck Camera"
-	},
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/holodeck/rec_center)
 "xda" = (
 /obj/item/clothing/suit/hooded/ian_costume,
 /obj/item/stack/sheet/animalhide/corgi,
@@ -74307,7 +72796,7 @@
 /obj/effect/spawner/random/maintenance/four,
 /obj/structure/closet,
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "xdl" = (
 /obj/effect/turf_decal/tile/bar/half{
 	dir = 8
@@ -74321,7 +72810,7 @@
 "xdH" = (
 /obj/item/toy/balloon/corgi,
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "xdL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -74332,8 +72821,11 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "xdX" = (
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
+/obj/machinery/light/directional/south,
+/obj/structure/training_machine,
+/obj/item/target,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "xet" = (
 /obj/effect/turf_decal/tile/brown/half,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -74342,6 +72834,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
+"xev" = (
+/obj/structure/sign/map{
+	icon_state = "map-pubby";
+	pixel_y = 32
+	},
+/obj/machinery/vending/clothing,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "xeA" = (
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -74448,9 +72948,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"xgF" = (
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "xgR" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
@@ -74591,8 +73088,17 @@
 "xjq" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"xjN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "xkj" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -74621,14 +73127,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
-"xkD" = (
-/obj/machinery/light/directional/west,
-/obj/structure/sign/poster/contraband/the_griffin{
-	pixel_x = -32
-	},
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "xkF" = (
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 4
@@ -74646,13 +73144,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
-"xkN" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "xkT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74692,11 +73183,6 @@
 "xlq" = (
 /turf/closed/wall,
 /area/medical/chemistry)
-"xlC" = (
-/obj/machinery/door/window/eastleft,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "xlQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -74726,22 +73212,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
-"xml" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/side{
-	dir = 4
+"xmj" = (
+/obj/structure/table,
+/obj/item/training_toolbox,
+/obj/item/training_toolbox{
+	pixel_y = 5
 	},
-/area/commons/fitness)
-"xmz" = (
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3";
-	dir = 8
-	},
-/obj/structure/easel,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
+/turf/open/floor/iron,
+/area/commons/dorms)
 "xmC" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
@@ -74768,14 +73246,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"xmT" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3";
-	dir = 4
-	},
-/obj/structure/easel,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "xng" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -74803,7 +73273,7 @@
 	name = "Dear Ian"
 	},
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "xnJ" = (
 /obj/structure/table,
 /obj/effect/landmark/start/hangover,
@@ -74820,7 +73290,11 @@
 	dir = 8
 	},
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
+"xog" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "xoE" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -74828,7 +73302,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "xoX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating,
@@ -74949,7 +73423,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/cargo/qm)
+/area/maintenance/department/cargo)
 "xsD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -75000,6 +73474,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"xtM" = (
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067";
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/science/research)
 "xtS" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -75284,18 +73768,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"xDp" = (
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
-"xDA" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/commons/fitness)
 "xDG" = (
 /turf/closed/wall,
 /area/maintenance/fore)
@@ -75315,12 +73787,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
-"xDU" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/hollow/reinforced,
-/turf/open/floor/plating,
-/area/commons/fitness)
 "xDW" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Cargo - Quartermaster Chambers";
@@ -75340,29 +73806,24 @@
 	},
 /turf/open/floor/wood,
 /area/cargo/qm)
-"xEt" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	color = "#f2c2e3";
-	dir = 8
+"xEx" = (
+/obj/structure/table,
+/obj/item/food/grown/cannabis{
+	pixel_x = -7;
+	pixel_y = 16
 	},
-/obj/structure/table/wood,
-/obj/item/canvas/twentyfour_twentyfour,
-/obj/item/canvas/twentyfour_twentyfour,
-/obj/item/canvas/twentyfour_twentyfour,
-/obj/item/canvas/twentyfour_twentyfour,
-/obj/item/canvas/twentyfour_twentyfour,
-/obj/item/canvas/twentyfour_twentyfour,
-/obj/item/canvas/twentyfour_twentyfour,
-/obj/item/canvas/twentyfour_twentyfour,
-/obj/item/canvas/twentyfour_twentyfour,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
+/obj/item/food/grown/cannabis,
+/obj/item/food/grown/cannabis{
+	pixel_x = 9;
+	pixel_y = 12
+	},
+/obj/item/seeds/cannabis{
+	pixel_x = -6
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
+/area/maintenance/port/fore)
 "xEH" = (
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/grass/jungle,
@@ -75370,42 +73831,6 @@
 "xEJ" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"xEM" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3"
-	},
-/obj/structure/table/wood,
-/obj/item/storage/fancy/candle_box,
-/obj/item/stack/pipe_cleaner_coil/random/five,
-/obj/item/stack/pipe_cleaner_coil/random/five,
-/obj/item/stack/pipe_cleaner_coil/random/five,
-/obj/item/stack/pipe_cleaner_coil/random/five,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
-"xER" = (
-/obj/structure/table/wood,
-/obj/item/canvas/twentythree_nineteen,
-/obj/item/canvas/twentythree_nineteen,
-/obj/machinery/camera/directional/south{
-	c_tag = "Public - Abandoned Art Room"
-	},
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3"
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south{
-	name = "Art Room"
-	},
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "xFb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75424,18 +73849,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
-"xFg" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3"
-	},
-/obj/structure/sign/poster/official/fruit_bowl{
-	pixel_y = -32
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/carving_block,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "xFv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -75445,22 +73858,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xFM" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/half{
-	color = "#f2c2e3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
-"xFR" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	color = "#f2c2e3"
-	},
-/obj/structure/easel,
-/turf/open/floor/iron/dark,
-/area/service/library/abandoned)
 "xGd" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 5
@@ -75586,12 +73983,6 @@
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/iron/white,
 /area/science/research)
-"xIw" = (
-/obj/effect/wisp,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/maintenance/port/aft)
 "xIJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75601,9 +73992,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"xIM" = (
-/turf/open/floor/iron,
-/area/commons/fitness)
 "xIR" = (
 /turf/closed/wall,
 /area/medical/surgery)
@@ -75626,6 +74014,18 @@
 "xJj" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
+"xJn" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Arrival Airlock"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/port)
+"xJy" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "xJQ" = (
 /turf/closed/wall,
 /area/security/prison)
@@ -75635,6 +74035,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"xKo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/spawner/random/trash/mess,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "xKy" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Core";
@@ -75682,9 +74097,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
-"xLA" = (
-/turf/closed/wall,
-/area/commons/fitness)
 "xLP" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
@@ -75834,14 +74246,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"xPP" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/service/hydroponics/garden";
-	name = "Garden APC"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "xQa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75890,10 +74294,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
-"xQB" = (
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron/white/side,
-/area/commons/fitness)
 "xQD" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
@@ -75903,19 +74303,6 @@
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"xQI" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron/white/side,
-/area/commons/fitness)
-"xQN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/side{
-	dir = 9
-	},
-/area/commons/fitness)
 "xQQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75928,15 +74315,6 @@
 "xQY" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/security)
-"xRb" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "xRc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -75993,8 +74371,11 @@
 /area/service/abandoned_gambling_den)
 "xRE" = (
 /obj/item/trash/popcorn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "xRH" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -76010,14 +74391,9 @@
 "xSe" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "xSi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "publicmining";
-	name = "Public Mining Lockdown"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/cargo/miningoffice)
 "xSk" = (
 /obj/machinery/button/door/directional/west{
@@ -76125,16 +74501,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"xTu" = (
-/obj/structure/closet/boxinggloves,
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	color = "#f2c2e3";
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover/closet,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/commons/fitness/recreation)
 "xTy" = (
 /turf/closed/wall,
 /area/service/hydroponics)
@@ -76169,14 +74535,6 @@
 /obj/effect/landmark/start/captain,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
-"xTY" = (
-/obj/structure/window{
-	dir = 1
-	},
-/obj/item/food/urinalcake,
-/obj/structure/urinal/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/commons/toilet)
 "xUk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76246,17 +74604,18 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "xVt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half{
+/obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
-	dir = 8
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/iron/white/side{
+/turf/open/floor/iron/white/corner{
 	dir = 8
 	},
 /area/science/research)
@@ -76312,52 +74671,28 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"xWr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/aft)
+"xWu" = (
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "xWF" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark/side,
 /area/command/gateway)
-"xXh" = (
-/obj/item/storage/toolbox/emergency,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/structure/rack,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "xXn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"xXB" = (
-/obj/structure/rack,
-/obj/item/clothing/under/color/red,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/neck/tie/red,
-/obj/item/clothing/head/soft/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
-"xXG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance";
-	req_one_access_txt = "47"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "xXI" = (
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 8
@@ -76378,6 +74713,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "xXS" = (
@@ -76389,24 +74725,6 @@
 /obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron/white,
 /area/security/prison)
-"xXT" = (
-/obj/structure/rack,
-/obj/item/clothing/under/color/blue,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/neck/tie/blue,
-/obj/item/clothing/head/soft/blue,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "xXV" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#4169E1";
@@ -76430,6 +74748,10 @@
 "xYf" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
+"xYh" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/ai_monitored/command/nuke_storage)
 "xYm" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -76444,40 +74766,9 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
-"xYD" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
-	},
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"xYF" = (
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"xYO" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
-"xYT" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Rec-room Rage Cage S";
-	name = "Recreation Camera - South"
-	},
-/obj/machinery/status_display/evac/directional/south,
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "xYW" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"xYX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "xZg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -76489,6 +74780,9 @@
 "xZk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "xZm" = (
@@ -76612,6 +74906,13 @@
 /obj/item/kirbyplants/dead,
 /turf/open/floor/carpet/purple,
 /area/command/heads_quarters/rd)
+"ycH" = (
+/obj/effect/turf_decal/tile/purple/half{
+	color = "#4D0067"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "ycI" = (
 /turf/closed/wall/r_wall,
 /area/command/teleporter)
@@ -76751,24 +75052,9 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "yfx" = (
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
+/turf/open/floor/iron/dark/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/random{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	color = "#000000";
-	name = "dark corner"
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "yfC" = (
 /obj/machinery/holopad,
@@ -76781,8 +75067,9 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
 "yfE" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/tile/blue/full{
@@ -76886,6 +75173,11 @@
 "yhb" = (
 /turf/closed/wall,
 /area/commons/toilet/auxiliary)
+"yhf" = (
+/obj/structure/chair/comfy,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "yhj" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -77101,6 +75393,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"ykY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "yle" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half{
@@ -77132,6 +75430,7 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "yly" = (
@@ -77159,15 +75458,26 @@
 /obj/item/storage/fancy/cigarettes/dromedaryco,
 /turf/open/floor/carpet/black,
 /area/service/abandoned_gambling_den)
-"ylL" = (
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ylN" = (
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/crew_quarters/dorms)
+"ylO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/service/abandoned_gambling_den)
 "ylX" = (
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/neck/stethoscope,
@@ -77177,6 +75487,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/cmo)
+"ymh" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms)
 
 (1,1,1) = {"
 meC
@@ -83237,9 +81557,6 @@ meC
 meC
 meC
 meC
-uhg
-uhg
-uhg
 meC
 meC
 meC
@@ -83248,7 +81565,10 @@ meC
 meC
 meC
 meC
-gHm
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -83492,11 +81812,1553 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+"}
+(26,1,1) = {"
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+"}
+(27,1,1) = {"
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+"}
+(28,1,1) = {"
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+pfu
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+"}
+(29,1,1) = {"
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+bZt
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+qII
+trU
+qII
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+"}
+(30,1,1) = {"
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+qII
+kNl
+qII
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+"}
+(31,1,1) = {"
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 uhg
 uhg
-uhg
-uhg
-uhg
+qII
+pfy
+qII
 uhg
 uhg
 meC
@@ -83603,7 +83465,7 @@ meC
 meC
 meC
 "}
-(26,1,1) = {"
+(32,1,1) = {"
 meC
 meC
 meC
@@ -83860,7 +83722,7 @@ meC
 meC
 meC
 "}
-(27,1,1) = {"
+(33,1,1) = {"
 meC
 meC
 meC
@@ -84012,7 +83874,7 @@ kNl
 kNl
 kNl
 tCT
-qII
+uhg
 meC
 meC
 meC
@@ -84117,7 +83979,7 @@ meC
 meC
 meC
 "}
-(28,1,1) = {"
+(34,1,1) = {"
 meC
 meC
 meC
@@ -84269,9 +84131,9 @@ kNl
 kNl
 kNl
 jII
-qII
-qII
-qII
+uhg
+meC
+meC
 meC
 meC
 meC
@@ -84374,7 +84236,7 @@ meC
 meC
 meC
 "}
-(29,1,1) = {"
+(35,1,1) = {"
 meC
 meC
 meC
@@ -84468,7 +84330,7 @@ meC
 meC
 meC
 meC
-bZt
+meC
 meC
 meC
 meC
@@ -84526,9 +84388,9 @@ sTs
 thn
 kNl
 bwY
-vpw
-mwM
-vUI
+uhg
+meC
+meC
 meC
 meC
 meC
@@ -84631,7 +84493,7 @@ meC
 meC
 meC
 "}
-(30,1,1) = {"
+(36,1,1) = {"
 meC
 meC
 meC
@@ -84783,9 +84645,9 @@ sTR
 lUf
 kNl
 jII
-qII
-qII
-qII
+uhg
+meC
+meC
 meC
 meC
 meC
@@ -84888,7 +84750,7 @@ meC
 meC
 meC
 "}
-(31,1,1) = {"
+(37,1,1) = {"
 meC
 meC
 meC
@@ -84964,7 +84826,7 @@ meC
 meC
 meC
 meC
-meC
+bZt
 meC
 meC
 meC
@@ -85040,7 +84902,7 @@ sUn
 thz
 kNl
 tDK
-qII
+uhg
 meC
 meC
 meC
@@ -85145,7 +85007,7 @@ meC
 meC
 meC
 "}
-(32,1,1) = {"
+(38,1,1) = {"
 meC
 meC
 meC
@@ -85356,7 +85218,7 @@ meC
 meC
 meC
 meC
-meC
+bZt
 meC
 meC
 meC
@@ -85402,7 +85264,7 @@ meC
 meC
 meC
 "}
-(33,1,1) = {"
+(39,1,1) = {"
 meC
 meC
 meC
@@ -85659,7 +85521,7 @@ meC
 meC
 meC
 "}
-(34,1,1) = {"
+(40,1,1) = {"
 meC
 meC
 meC
@@ -85811,1550 +85673,8 @@ sVY
 mbp
 kNl
 tDK
-qII
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-"}
-(35,1,1) = {"
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-qII
-qII
-qII
-nwr
-sWf
-tih
-kNl
-jII
-qII
-qII
-qII
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-"}
-(36,1,1) = {"
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lEM
-meC
-meC
-meC
-gzV
-aJJ
-mwM
-wxn
-kNl
-sWM
-tiE
-kNl
-bwY
-vpw
-mwM
-vUI
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-"}
-(37,1,1) = {"
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-bZt
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-qII
-qII
-qII
-nwr
-sWW
-kxB
-kNl
-jII
-qII
-qII
-qII
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-"}
-(38,1,1) = {"
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-pfu
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-qII
-xaa
-kNl
-tjm
-tyj
-tDR
-qII
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-bZt
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-"}
-(39,1,1) = {"
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-qII
-trU
-qII
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-uhg
-sCH
-kNl
-aJW
-kNl
-tEp
 uhg
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-"}
-(40,1,1) = {"
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-gCP
-gCP
-gCP
-jUt
-meC
-meC
-qII
-kNl
-qII
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-uhg
-uhg
-sCK
-xuJ
-tjU
-xuJ
-uje
-uhg
-uhg
 meC
 meC
 meC
@@ -87583,40 +85903,40 @@ meC
 meC
 meC
 meC
-gCP
-gFR
-ofU
-jUt
-jUt
-jUt
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 qII
-pfy
-qII
-uhg
-uhg
 qII
 qII
-qII
-qII
-qII
-qII
-qII
-qII
-uhg
-uhg
-jVk
+nwr
+sWf
+tih
 kNl
-kNl
-aJW
-kNl
-kNl
-iGd
+jII
 uhg
-uhg
-uhg
-uhg
-uhg
-uhg
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -87840,40 +86160,40 @@ meC
 meC
 meC
 meC
-gCP
-nop
-ofY
-nop
-hib
-jUt
-gxL
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+lEM
+meC
+meC
+meC
+gzV
+aJJ
+mwM
+wxn
 kNl
+sWM
+tiE
 kNl
-iuU
-pUZ
-jsw
-jsw
-jsw
-jsw
-jIY
-itR
-jsw
-jsw
-gna
-tSj
-kNl
-kNl
-kNl
-aJW
-kNl
-kNl
-kNl
-qII
-ujP
-urn
-jsw
-vak
+bwY
 uhg
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -88097,42 +86417,42 @@ meC
 meC
 meC
 meC
-jUt
-nXl
-oge
-nop
-iiL
-jUt
-oQE
-kNl
-kNl
-kNl
-pVd
-kNl
-jgU
-kNl
-kNl
-kNl
-kNl
-kNl
-kNl
-kNl
-hvY
-kNl
-kNl
-kNl
-aJW
-tyu
-kNl
-kNl
-uFf
-kNl
-kNl
-kNl
-kNl
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 qII
 qII
 qII
+nwr
+sWW
+cmt
+waf
+lAm
+uhg
+meC
+meC
+meC
+meC
+meC
+meC
+gHm
+meC
 meC
 meC
 meC
@@ -88353,44 +86673,44 @@ rCR
 rCR
 rCR
 rCR
-wWb
-jUt
-hbd
-hbd
-ook
-hbd
-jUt
-oRi
+rCR
+rCR
+rCR
+rCR
+rCR
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+qII
+xaa
 kNl
-kNl
-kNl
-pWj
-vFU
-vFU
-vFU
-vFU
-vFU
-vFU
-vFU
-vFU
-vFU
-siK
-vFU
-vFU
-lIM
-tjW
-kNl
-kNl
-kNl
-uFf
-kNl
-kNl
-kNl
-kNl
-vpw
-mwM
-vUI
-whN
+wDk
+tyj
+tDR
+uhg
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -88610,43 +86930,43 @@ xOw
 xOw
 xOw
 xOw
-jUt
-jUt
-fdX
-fdX
-fdX
-fdX
-oFf
-vmJ
-cmt
-cmt
-cmt
-cmt
+xOw
+xOw
+xOw
+xOw
+rCR
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+uhg
+sCH
 kNl
-qvC
+tnV
 kNl
-kNl
-kNl
-kNl
-kNl
-cmt
-kNl
-hvY
-kNl
-kNl
-kNl
-tjx
-tjG
-kNl
-kNl
-uFf
-kNl
-kNl
-kNl
-kNl
-qII
-qII
-qII
+tEp
+uhg
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -88863,45 +87183,45 @@ xOw
 xOw
 xOw
 xOw
-xOw
-xOw
-xOw
 meC
-jUt
-naf
-fdX
-nop
-nop
-ezZ
-jUt
-oRE
-uFe
-pvS
-pGw
-usA
-ljp
-ljp
-ljp
-kFJ
-ljp
-rpQ
-mjR
-cmt
-kNl
-lIO
-fcP
-kNl
-kNl
-tjx
-kNl
-kNl
-tiI
-qII
-moa
-usA
-ljp
-ttJ
+meC
+meC
+meC
+meC
+meC
+meC
+xOw
+rCR
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 uhg
+sCK
+xuJ
+apJ
+xuJ
+uje
+qII
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -89109,57 +87429,57 @@ xOw
 xOw
 xOw
 xOw
+xOw
+xOw
+xOw
+xOw
 xYW
 xYW
 xYW
 xYW
 xYW
 xYW
-meC
+urx
+xOw
+xOw
+xOw
 meC
 meC
 meC
 meC
 xOw
-xOw
-xOw
+rCR
+pYp
+pYp
+pYp
+hXq
 meC
-jUt
-naf
-fdX
-haK
-hfx
-gCS
-gCS
-gCS
-gCS
-gCS
-gCS
-gCS
-gCS
-gCS
-gCS
-gCS
-gCS
-gCS
-gCS
-kzg
-rTL
-gCS
-gCS
-slT
-vlr
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+uhg
+uhg
+kNl
+kNl
 tmh
-vlr
-slT
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
+kNl
+kNl
+qII
+qII
+qII
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -89366,6 +87686,10 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
+meC
 kYj
 wLI
 wLI
@@ -89375,65 +87699,61 @@ xYW
 xYW
 xYW
 xYW
+xOw
+meC
+meC
 meC
 meC
 xOw
 xOw
-xOw
-xOw
-wIf
-uVI
-fdX
-hbd
-hbd
-gCS
+pYp
 oFh
 hPo
-hUk
-gCS
-ixO
-pWL
-qlC
-gCS
-jvm
-qOo
-jRu
-gCS
-kud
-kAo
-pwb
-kud
-gCS
-sCN
-sjf
-qPN
-sjf
-wWc
-loc
-rkv
-etE
-rkv
-rkv
-yls
-eed
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
+hXq
+hXq
+hXq
+uhg
+uhg
+uhg
+uhg
+uhg
+qII
+qII
+qII
+qII
+uhg
+uhg
+jVk
+kNl
+kNl
+tnV
+kNl
+kNl
+vpw
+mwM
+vUI
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -89623,6 +87943,10 @@ xOw
 xOw
 xOw
 xOw
+xOw
+xOw
+xOw
+xOw
 evD
 ldy
 ldy
@@ -89632,65 +87956,61 @@ xYW
 rFW
 lZh
 xYW
+xOw
+xOw
+xOw
 meC
 meC
 meC
-meC
-meC
-meC
-jUt
-nOD
-fdX
-hbd
-mqE
-gCS
-oFn
+xOw
+pYp
+wqG
 hPs
-pgy
-gCS
-ixS
+wqG
+rSX
+hXq
 iHA
-qlP
-gCS
-jvq
+iuU
+hXc
+kNl
 jDf
-jRz
-gCS
-kpu
-kAo
-pwb
-sjM
-kfz
-wNs
-sjf
-qPN
-sjf
-wWc
-pCI
-eed
-sBx
-sBx
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-pCI
-dQx
-wAB
-dQx
-pCI
+kNl
+iuU
+jsw
+jsw
+ruZ
+tSj
+kNl
+kNl
+kNl
+tnV
+kNl
+kNl
+qII
+qII
+qII
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -89880,6 +88200,10 @@ xOw
 xOw
 xOw
 xOw
+xOw
+xOw
+xOw
+xOw
 evD
 ldQ
 lnf
@@ -89894,61 +88218,57 @@ gyn
 xOw
 xOw
 xOw
-gyn
-jUt
-jUt
-qoB
-gCS
-gCS
-gCS
-gCS
-gCS
-hUo
-gCS
-gCS
-gCS
-qmv
-gCS
-qEL
-gCS
-gCS
-gCS
-kpA
-rJg
-pwb
-sjU
-kfz
-wNs
-sjf
-sQW
-sjf
-wWc
-pCI
-pCI
-pCI
-pCI
-pCI
-rkv
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-loc
-pCI
-pCI
-unL
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
+xOw
+xOw
+hXq
+jSm
+ucv
+wqG
+quX
+hXq
+pGw
+kNl
+kNl
+kNl
+kNl
+kNl
+kNl
+kNl
+kNl
+pVd
+hvY
+kNl
+kNl
+kNl
+tnV
+tyu
+kNl
+qII
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -90137,6 +88457,10 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
+meC
 evD
 yjS
 qiG
@@ -90153,59 +88477,55 @@ gnk
 gnk
 gyn
 xOw
-jUt
-fdX
-gCS
-oon
-hsU
-gCS
-oSm
+hXq
+uGg
+uGg
+qXY
+uGg
+hXq
+oRi
 jwH
-pwa
-pGB
-iJm
-jwH
-qvT
-jwH
-jVB
-pwa
-kfz
-rAp
-kAo
-pwb
-sjY
-kfz
-wNs
-sjf
-qPN
-sjf
-fNZ
-uRZ
-tXM
-cAK
-wmb
-pCI
-rkv
-pCI
-vCD
-mGv
-myM
-lDv
-fDg
-wOk
-xbf
-xkD
-myM
-xIM
-xXB
-pCI
-rkv
-rkv
-lkM
-fQZ
-oHd
-kqD
-pCI
+cmt
+cmt
+cmt
+cmt
+cmt
+cmt
+cmt
+pWj
+siK
+vFU
+vFU
+lIM
+tjW
+kNl
+kNl
+qII
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -90370,6 +88690,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 rCR
 rCR
 xOw
@@ -90378,6 +88701,7 @@ rCR
 rCR
 rCR
 rCR
+xOw
 xOw
 xOw
 xOw
@@ -90402,67 +88726,63 @@ vSo
 xYW
 xTS
 fmX
-nkZ
-tQQ
+gJK
+kcZ
 fLO
 mSH
 gfL
 goP
 gyn
 xOw
-jUt
-fdX
-gCS
-oot
-htT
-gCS
-oSn
-jwH
-pwH
+hXq
+pxJ
+pxJ
+pxJ
+pxJ
+mMW
 jVB
-jVB
-jwH
-jVB
-jwH
-jVB
-rbG
-kfz
-rAI
-kAo
-pwb
-rAI
-kfz
-wNs
-sjf
-qPN
-sjf
-fNZ
-uRZ
-wDP
-ukg
-xbj
-pCI
-rkv
-pCI
-spn
-lxO
-bQW
-xDA
-xDA
-bQW
-xDA
-xDA
-xDA
-uHi
-xXT
-pCI
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-pCI
+cmt
+kNl
+kNl
+kNl
+kNl
+kNl
+kNl
+kNl
+kNl
+hvY
+kNl
+kNl
+kNl
+tjx
+tjG
+kNl
+qII
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -90626,6 +88946,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 xOw
 xOw
@@ -90656,70 +88979,67 @@ pMY
 pMY
 pMY
 jPx
+jPx
 xYW
 iGS
 erd
-kHI
-voQ
+vBa
+ycH
 fLO
 mST
 ggf
 nlm
 gyn
 xOw
-jUt
-fdX
-gCS
-hgF
-hpK
-hGE
-jwH
-hYP
-jwH
-jwH
-jwH
-jwH
-jwH
-jwH
-jwH
-rcc
-kfz
-krm
-kAo
-pwb
-vBQ
-gCS
-nTE
-sjf
-qPN
-sjf
-fNZ
-uRZ
-tYm
-mEv
-usY
-pCI
-rkv
-pCI
-tzr
-fUV
-wid
-sOk
-sOk
-sOk
-sOk
-sOk
-wid
-xQB
-xYD
-pCI
-rkv
-upX
-lwM
-lQK
-tSa
-rkv
-pCI
+hXq
+pxJ
+wqG
+wqG
+tIq
+uGg
+oRE
+kNl
+kNl
+kNl
+kNl
+kNl
+kNl
+kNl
+kNl
+kdX
+lIO
+fcP
+kNl
+kNl
+tjx
+kNl
+kNl
+qII
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -90883,6 +89203,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 xOw
 xOw
@@ -90913,70 +89236,67 @@ jbq
 jBR
 sVf
 jBR
+jBR
 xYW
 uhG
 erd
-jej
-rZD
+erd
+tal
 gyn
 vrg
 ggE
 gmA
 gyn
 xOw
-jUt
-fdX
-gCS
-gCS
-gCS
-gCS
+hXq
+pxJ
 oSC
-jwH
-isK
-iJM
-pXo
-iSO
-jVB
-jVB
-jwH
-jSj
-kfz
-rBc
-kAo
-pwb
-pJh
-kfz
-wNs
-sXp
-qPN
-xHr
-wWc
-xLA
-uRZ
-ukF
-uRZ
-pCI
-loc
-pCI
-mGi
-tBE
-wii
-wui
-xgF
-xYO
-xgF
-xgF
-sYC
-xQB
-xYF
-pCI
-rkv
-pCI
-pCI
-pCI
-pCI
-rkv
-pCI
+iat
+uGg
+uGg
+uGg
+vXk
+vXk
+rUB
+vXk
+vXk
+vXk
+rUB
+vXk
+vXk
+eXJ
+eXJ
+pmQ
+fbV
+pRF
+fbV
+pmQ
+vlD
+vlD
+vlD
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -91140,6 +89460,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 xOw
 xOw
@@ -91170,70 +89493,67 @@ jbq
 jBR
 sXd
 jBR
+jBR
 xYW
 eRd
 lPu
-rNs
-uku
+aVz
+vtC
 fMj
 mSW
 ghg
 nlK
 gwW
 xOw
-jUt
-fdX
-gCS
-ooy
-hvy
-hGg
-jwH
-jwH
-pwV
+hXq
+pxJ
+uGg
+uGg
+uGg
 iJM
 pYp
-iSI
-qvY
-jVB
-jwH
-rcg
-kfg
-kru
-rJh
-rUr
-kud
-kfz
-wNs
+oGf
+oGf
+oGf
+oGf
+wiB
+oGf
+oGf
+oGf
+oGf
+oGf
+vXk
+joT
 sjf
 qPN
 sjf
-ncd
-xLA
-xIM
-xIM
-xIM
-xIM
-xIM
-uRZ
-mMZ
-lyE
-wUv
-xgF
-wDH
-lQB
-xbh
-xYO
-sYC
-xQB
-xYF
-pCI
-rkv
-pCI
+wWc
+xJn
+vpB
+wbQ
 meC
 meC
-pCI
-rkv
-pCI
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -91397,6 +89717,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 xOw
 xOw
@@ -91427,71 +89750,68 @@ jbq
 kkl
 hxx
 jBR
+jBR
 xYW
 oFy
 fdq
-jej
-aWr
+erd
+omJ
 gyn
 vrg
 gih
 gmA
 gwW
-nFL
-jUt
-fdX
-gCS
 ooz
 oxe
-gCS
-jVB
-jwH
+pxJ
+uGg
+tIq
 isK
 iym
-iJM
-iSO
-jVB
-jVB
-jwH
-jwH
-kfi
-eYb
-kAs
-rUu
-kud
-kfz
+pYp
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+vXk
 wNs
 sjf
-qPN
+sQW
 sjf
-urN
-xLA
-ujG
-ukQ
-xDp
-uHi
-xIM
-xLA
-vCT
-lyE
-wUv
-xgF
-wDP
-wOp
-xbj
-xgF
-sYC
-xQB
-xYT
-pCI
-rkv
-pCI
+wWc
+vlD
+vlD
+vlD
 meC
 meC
-pCI
-rkv
-pCI
 meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+pCI
+pCI
+pCI
+pCI
+pCI
 meC
 meC
 meC
@@ -91655,13 +89975,16 @@ meC
 meC
 meC
 meC
-xOw
-xOw
+meC
+meC
 meC
 meC
 xOw
 xOw
 meC
+meC
+xOw
+xOw
 ebr
 ebr
 ebr
@@ -91684,71 +90007,68 @@ ihA
 dti
 lyH
 ihA
+ihA
 xYW
 eRd
 fdq
-jej
-gBK
-mLf
-ncK
-aCi
+erd
 wZb
 aus
 fVR
-nop
-fdX
-gCS
-ooE
+rAB
+vcR
+akg
+hXq
 oxo
-gCS
-oSL
-jwH
-jVB
-jVB
-jVB
-jVB
-jVB
-jVB
-jwH
-jUS
-kfz
-kud
-kCK
-pwb
-kud
-kfz
+pxJ
+uGg
+vtf
+wqG
+wqG
+pYp
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+vXk
 wNs
 sjf
 qPN
 sjf
-meZ
-xLA
-pDt
-vSK
-xDp
-rBY
-vaq
-xLA
-vDw
-lyE
-wUv
-xYO
-uYU
-mEv
-uIw
-xgF
-sYC
-xQB
-xYF
-pCI
-rkv
-pFH
+wWc
+vlD
 meC
 meC
-pCI
-rkv
-pCI
 meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+pCI
+dQx
+wAB
+dQx
+pCI
 meC
 meC
 meC
@@ -91912,13 +90232,16 @@ meC
 meC
 meC
 meC
-xOw
-xOw
+meC
+meC
 meC
 meC
 xOw
 xOw
 meC
+meC
+xOw
+xOw
 ebr
 bvq
 jOc
@@ -91940,73 +90263,70 @@ jOc
 led
 jOc
 jyX
+ceq
 dZk
 xYW
 hTL
 fdq
-jej
-jwn
-jej
+erd
 aeC
-jej
-aeC
-pOd
-bgm
-nop
-fdX
-gCS
-gCS
-gCS
-gCS
-oTd
-qOT
-pwZ
-jyx
-jyx
-jyx
-jyx
-jyx
-qOT
-jVB
-kfz
-kud
-kCK
-pwb
-pwb
-rTL
+erd
+eLw
+erd
+eLw
+mCO
+hXq
+wqG
+pxJ
+uGg
+uGg
+wqG
+wqG
+pYp
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+kNg
+vXk
 wNs
 sjf
 qPN
 sjf
 wWc
-xLA
-xIM
-vSK
-xDp
-rBY
-xIM
-eso
-mVZ
-lyE
-wUv
-vGE
-xgF
-wPk
-xgF
-xkN
-sYC
-xQB
-xYF
-pCI
-rkv
-pFH
+quH
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 pCI
-rkv
 pCI
-meC
-meC
+pCI
+pCI
+pCI
+pCI
+pCI
 meC
 meC
 xOw
@@ -92169,6 +90489,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 ebr
 ebr
@@ -92197,75 +90520,72 @@ jZK
 jZK
 jZK
 ttV
+jZK
 lGN
 xYW
 rvq
 nfc
-vfK
-vRw
-jej
+fmX
 wAj
-eER
-wAj
-aSB
-rAg
+erd
+pbC
 uVI
-fdX
-gCS
+pbC
+boW
 ooI
 oxz
 hHl
-jwH
+pxf
 icv
 pxf
-iyr
-iJR
+wqG
+pYp
 iZt
-qwa
-jyy
-qOT
-rck
-kfz
-kud
-rJp
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
 fIV
-fIV
-suZ
-sCX
-eUW
-tmP
+vXk
+nTE
 sjf
-gyR
-xLA
-lui
-vSK
-xDp
-rBY
+qPN
+sjf
+wWc
 quH
-wWQ
-vEh
-lyE
-xDU
-ubu
-ubu
-ubu
-ubu
-xlC
-xDU
-xQI
-xYD
+quH
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 pCI
 rkv
-pFH
-meC
-meC
-pFH
-rkv
+lkM
+fQZ
+oHd
+kqD
 pCI
 meC
-meC
-meC
-meC
+xOw
 xOw
 xOw
 xOw
@@ -92425,6 +90745,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 xOw
 ebr
@@ -92454,75 +90777,72 @@ cBX
 len
 dvv
 ttV
+jZK
 dZs
 xYW
 hsJ
 fdq
 fmX
 fsQ
-jej
-jej
-jej
-jej
-bDO
-jUt
-nop
-fdX
-gCS
-epA
-oxK
-gCS
-oTg
-qOT
-hQM
-hQM
-hQM
-hQM
-hQM
-hQM
-qOW
-hQM
-hQM
-kug
-kAo
-pwb
-skP
-gCS
-nTE
-jDI
-tmY
-sjf
+erd
+erd
+erd
+erd
+lKo
+hXq
+wqG
+hHl
+uGg
+uGg
+pxf
+wqG
+pYp
+mne
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+vXk
+wNs
+sXp
+qPN
+xHr
 wWc
 tMt
-xIM
-vSK
-xDp
-rBY
 quH
-xLA
-vEk
-vVl
-lXZ
-lXZ
-lXZ
-lXZ
-lXZ
-xml
-lXZ
-xQN
-xYX
+quH
+quH
+quH
+quH
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+pCI
+pCI
 pCI
 rkv
-pFH
-pFH
-pFH
-pFH
-etE
+rkv
+rkv
+rkv
+rkv
 pCI
 xOw
 xOw
-lfA
-lfA
 lfA
 lfA
 heI
@@ -92682,6 +91002,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 ebr
 ebr
@@ -92711,6 +91034,7 @@ kYo
 lfz
 dvK
 ttV
+jZK
 ebX
 xYW
 aBi
@@ -92722,58 +91046,56 @@ erd
 erd
 erd
 nzp
-jUt
-jUt
-gUa
-gCS
-rdu
-oyd
-gCS
-oVd
+hXq
+wqG
+hHl
+uGg
 pgU
-hQM
-iJV
-iJV
-jes
-hQM
-qFc
-jFO
-rcp
-hQM
-hQM
-rJt
-rUx
-hQM
-hQM
+oXk
+wqG
+pYp
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+vXk
 wNs
-jDI
-tni
-kXU
-aXC
-tMN
-quH
+sjf
+qPN
+sjf
+wWc
+fEr
+vlD
 lkZ
 utd
 uHS
 quH
-uRZ
-vFl
-vVr
-lZF
-lDA
-qYt
-wPJ
-lZF
-mzs
-lZF
-mVZ
-mVZ
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 pCI
 rkv
-hAa
 rkv
 rkv
-hAa
+lwM
+lQK
+tSa
 rkv
 pCI
 xOw
@@ -92782,8 +91104,6 @@ jik
 oQQ
 xOw
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -92939,6 +91259,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 ebr
 jBR
@@ -92968,6 +91291,7 @@ kYu
 lfE
 dwd
 ttV
+jZK
 efc
 xYW
 eRd
@@ -92979,58 +91303,56 @@ lmG
 lmG
 lmG
 kIj
-jUt
-nop
-fdX
-hbd
-hbd
-hbd
-hbd
-hbd
-idw
-hbd
+hXq
+wqG
+hHl
+uGg
+pgU
+pxf
 pGC
-pYs
-qmy
-qwo
-jFO
-jFO
-jYI
-hQM
-kuw
-kET
-rUB
-slb
-hQM
-lIk
-jDI
-tpj
-tyy
-uEA
-lgE
+pYp
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+oGf
+vXk
+wNs
+sjf
+qPN
+sjf
+wWc
+sjf
 etF
-llq
+sjf
+xHr
 fEr
-fEr
-vaI
-xLA
-xLA
-uRZ
-uRZ
-uRZ
-xLA
-xLA
-uRZ
-xLA
-uRZ
-pCI
-lEV
+vlD
+vlD
+vlD
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 pCI
 rkv
-pFH
-pFH
-pFH
-pFH
+rkv
+pCI
+pCI
+pCI
+pCI
 rkv
 pCI
 xOw
@@ -93039,8 +91361,6 @@ vKu
 oQQ
 xOw
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -93196,6 +91516,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 ebr
 hDf
@@ -93225,6 +91548,7 @@ cPQ
 kaN
 kgQ
 ttV
+jZK
 efC
 xYW
 lVQ
@@ -93236,58 +91560,56 @@ erd
 erd
 fmX
 nzx
-nFL
-nop
-scZ
-hbd
 ooM
-iUK
-ezZ
-nop
-ikJ
-hbd
+wqG
+mhq
+uGg
+uGg
+uGg
 iJY
-iJY
-iJY
-hQM
-jAz
-jFO
-jYI
-hQM
-rBg
-rJE
-rUD
-hwa
-hQM
-jey
-jDI
-tpv
+pYp
+oGf
+oGf
+oGf
+oGf
+jil
+oGf
+oGf
+oGf
+oGf
+oGf
+vXk
+wNs
 sjf
+qPN
+opd
 gyR
-eXJ
+opd
 tYV
-nWu
-uto
-ubs
-ubs
+opd
+sjf
+sjf
+xJn
 vpB
-ubs
-ubs
-ubs
-wus
-mtB
-wQu
-xbx
-xmz
-xEt
+wbQ
+whN
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 pCI
-jvJ
-fiZ
+pCI
 rkv
-pFH
-meC
-meC
-pFH
+rkv
+hAa
+rkv
+eed
+hAa
 rkv
 pCI
 xOw
@@ -93296,8 +91618,6 @@ vKu
 oQQ
 xOw
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -93453,6 +91773,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 ebr
 hnf
@@ -93482,6 +91805,7 @@ kYu
 lfE
 dwd
 ttV
+jZK
 lGO
 xYW
 lVQ
@@ -93493,58 +91817,56 @@ nXK
 nXK
 qYx
 nzL
-nFL
-aOU
+ooM
+lBJ
+mhq
 scZ
-eXT
-scZ
-scZ
-scZ
-scZ
-ikJ
-hbd
-hbd
-hbd
-hQM
-hQM
-qFh
-jFO
-rcx
-hQM
-kuM
-kET
+uFM
+uGg
+uGg
+uGg
+vXk
+vXk
+vXk
+eXJ
+vXk
 rUB
-slg
-hQM
-kcJ
-jDI
-qPN
+vXk
+vXk
+rUB
+vXk
+eXJ
+sDb
+sjf
+gOm
 sjf
 wWc
-eXJ
-vJx
-nWu
+sjf
+etF
+sjf
 utt
-uIy
-uIy
-uIy
-uIy
-vVC
-ubs
-wuv
-wEA
-wQH
-xbC
-xbC
-xEM
-pCI
-jvJ
-rkv
-upX
-pCI
+fEr
+vlD
+vlD
+vlD
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 pCI
-pCI
+rkv
+rkv
+upX
+pFH
+pFH
+pFH
+pFH
 rkv
 pCI
 ccz
@@ -93553,8 +91875,6 @@ dNl
 oQQ
 xvt
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -93710,6 +92030,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 ebr
 ebr
@@ -93739,6 +92062,7 @@ kYC
 crm
 lph
 ttV
+heZ
 aJV
 xYW
 xYW
@@ -93750,52 +92074,50 @@ rZt
 rZt
 rZt
 lPI
-jUt
-nop
-nop
-hbd
-nop
-nop
-nop
-nop
-ikJ
-nYR
-wCu
-hbd
-qmB
-gqR
-xdX
-jHZ
+hXq
+wqG
+wqG
+uGg
+uFM
+uGg
+meC
+meC
+meC
+meC
+meC
+eXJ
 rcC
-hQM
+fMI
+vHL
+ubs
+ubs
 xdX
-oHf
-xdX
-xdX
-hQM
-rKT
-jDI
-qPN
+eXJ
+wNs
+sjf
+tmP
 sjf
 wWc
-eXJ
-tZv
-nWu
+fEr
+vlD
+eOj
 utz
 uIE
-xTu
-vpP
-vGi
-vVX
-wvl
-wvd
-wFD
-wQP
-xbO
-xbC
-xER
-pCI
-jvJ
+quH
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+ndh
+rkv
 tSa
 nqg
 pCI
@@ -93810,8 +92132,6 @@ oGA
 jeX
 xvt
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -93967,6 +92287,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 xOw
 xOw
 ebr
@@ -93996,8 +92319,9 @@ kNw
 dmk
 dvv
 ttV
-lHc
-mPU
+heZ
+ilN
+vMQ
 pwt
 miF
 lYA
@@ -94007,52 +92331,50 @@ erd
 erd
 erd
 nNE
-jUt
-nop
-nop
-hbd
-xUT
-nop
-nop
-nop
-fdX
-nYR
-wCu
-hbd
-hQM
-hQM
-qFN
-jHZ
-xdX
-hQM
+hXq
+tIq
+sGv
+uGg
+uFM
+uGg
+uGg
+uGg
+uGg
+uGg
+uGg
+uGg
+iJp
+thh
 tUH
 oHf
-kMk
-xdX
+dyk
+dyk
 svh
-wNs
-jDI
-qPN
+hSa
+ohb
+tmY
 sjf
 wWc
-eXJ
-jrl
-ukZ
-utG
-uIK
-vbu
-vqd
-vIW
-vWc
-vHL
-nWu
-wGl
-wRa
-xbQ
-xbC
-xFg
+nai
+mgu
+mgu
+mgu
+mgu
+mgu
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 pCI
-sEv
+unL
 pCI
 pCI
 pCI
@@ -94067,8 +92389,6 @@ wCe
 tXJ
 xvt
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -94226,6 +92546,9 @@ asz
 asz
 asz
 meC
+meC
+meC
+meC
 ebr
 ebr
 ebr
@@ -94253,9 +92576,10 @@ kfI
 kfI
 kfI
 kfI
+heZ
 lHn
-lhe
-arK
+dbp
+aiT
 uaj
 woX
 xYW
@@ -94264,52 +92588,50 @@ jbx
 lNp
 oQv
 oSR
-jUt
-nop
-nop
-jUt
-jUt
-jUt
-jUt
-jUt
-fdX
-nYR
+hXq
+hXq
+hXq
+hXq
+uFM
+uGg
 wCu
-hbd
+jfO
 hCz
 jmX
-oHf
-oHf
-oHf
+ntb
+uGg
+hQJ
 kkG
-oHf
-oHf
-xdX
-xdX
-hQM
-sDb
-jDI
-qPN
-sjf
-wWc
+vnV
+tgX
+uDH
+viw
 eXJ
-tZy
-ubs
-uuc
-uIL
-uIL
-uIL
-vHk
-vWM
-ubs
-wvk
-wEA
-wRj
-xct
-nDj
-xFM
-xRb
-kTv
+lIk
+sjf
+tni
+sjf
+meZ
+mgu
+mgu
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+pCI
+rkv
 kTv
 kTv
 kTv
@@ -94325,8 +92647,6 @@ vRs
 xvt
 xOw
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -94489,6 +92809,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 ebr
 iAF
 jhO
@@ -94510,8 +92833,9 @@ hZk
 lfM
 hZk
 kGt
+hZk
 efY
-jMd
+cXG
 sPr
 uaj
 nQd
@@ -94521,53 +92845,51 @@ xYW
 xYW
 xYW
 xYW
-jUt
-jUt
-jUt
-jUt
-bQh
+xYW
 ciD
 azc
-xXG
-fdX
-fdX
+hXq
+uFM
+uGg
 reV
-hbd
-hQM
-hQM
-oHf
-hQM
-hQM
-hQM
-kuU
-xTY
+cRk
+qXi
+xEx
+urP
+uGg
+uGg
+uGg
+uGg
+uGg
 udS
-slp
-hQM
+uGg
+uGg
 wNs
-jDI
-qPN
+sjf
+wQi
 sjf
 wWc
-eXJ
-tZU
-ulL
-uuH
-uJF
-ubs
-vqv
-vHL
-ubs
-ubs
-wvl
-mtB
-wRs
-xcJ
-xmT
-xFR
+mgu
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 pCI
 weI
-jvJ
+lpN
 rkv
 rkv
 pCI
@@ -94582,8 +92904,6 @@ ccz
 ccz
 pCI
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -94746,6 +93066,9 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 bsj
 bsj
 iLP
@@ -94768,13 +93091,10 @@ ihA
 lpH
 lyK
 ihA
-ols
-sPr
+ebr
+ebr
+lZC
 miQ
-mol
-kCo
-qKM
-yfd
 xVt
 tPh
 oWS
@@ -94783,48 +93103,50 @@ xrS
 lxI
 qkg
 aLF
-iiu
+nXy
 woX
-jUt
-nop
-nop
-fdX
-hbd
+hXq
+uFM
+uGg
+wtv
+vmr
 qHw
 rIS
-oHf
-qPe
+say
+uGg
 rcI
-hQM
-qGo
-qGo
-qGo
-qGo
-qGo
-ufQ
-sXx
+kji
+kji
+kji
+kji
+wqG
+nrd
+wNs
+sjf
 trq
 sjf
-gyR
-eXJ
-eXJ
-eXJ
-eXJ
-eXJ
-eXJ
-eXJ
-vIk
-vXk
-vXk
-wws
-mtB
-mtB
-mtB
-mtB
-mtB
+wWc
+vlD
+vlD
+vlD
+vlD
+bCL
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 pCI
 pCI
-jvJ
+lpN
 yls
 lDM
 pCI
@@ -94839,8 +93161,6 @@ rkv
 fnG
 pCI
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -95003,6 +93323,9 @@ asz
 asz
 meC
 meC
+meC
+meC
+meC
 bsj
 bxh
 jjp
@@ -95025,12 +93348,9 @@ jbq
 jIf
 hxx
 jBR
-ols
-lZC
-agu
-agu
+ebr
 nTD
-agu
+qxp
 agu
 oxg
 agu
@@ -95042,46 +93362,48 @@ swM
 swM
 agu
 mMU
-jUt
-imw
-nop
-fdX
-hbd
-hbd
-hbd
-qGb
-hbd
-hbd
-hbd
-jUt
-kFg
-lNG
-kOk
-qGo
-qGo
-exB
-tmh
-vlr
-slT
-mgu
-mgu
+hXq
+uFM
+uGg
+uGg
+uGg
+uGg
+uGg
+uGg
+uGg
+dmF
+kji
+uGg
+uGg
+uGg
+uGg
+uGg
+ufQ
+tyy
+iKQ
+sjf
+wWc
+cMd
+sjf
+sjf
+hhT
+vBp
 meC
 meC
 meC
 meC
-eXJ
-vIv
-ubs
-ubs
-wvk
-eXJ
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
 meC
 meC
 pCI
-jvJ
+lpN
 pCI
 pCI
 pCI
@@ -95096,8 +93418,6 @@ pCI
 pCI
 pCI
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -95260,6 +93580,9 @@ iXh
 asz
 asz
 meC
+meC
+meC
+meC
 bsj
 iAM
 jjp
@@ -95282,63 +93605,62 @@ jbq
 jBR
 sXd
 jBR
-tyr
-ixg
-qJX
-nNn
+fdz
 qhw
 sDa
-rug
+xtM
 eOp
 rug
 nAK
 nGw
 jMd
-vLU
+rug
 qaM
 hNL
 agu
-mnZ
-jUt
-imw
-evn
-fdX
-fdX
-fdX
-fdX
-fdX
-qPz
-fdX
-fdX
-jUt
+qDk
+evt
+uFM
+rCO
+rCO
+rCO
+rCO
+rCO
+rCO
+rCO
+rCO
+rCO
+uGg
 fhd
-rUI
+kHx
 sWw
-kOq
 qGo
-ipg
+qGo
+sjf
 pkw
 sjf
-tEE
-tNc
+wWc
+vlD
+bZI
+uHS
 vlD
 meC
-uuN
-mZH
-mZH
-mZH
-vIy
-vXk
-vXk
-wjP
-wGz
-wGz
-wGz
-wGJ
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 pCI
-jvJ
+lpN
 udl
 pCI
 tSa
@@ -95353,8 +93675,6 @@ moE
 mAq
 pCI
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -95517,6 +93837,9 @@ asz
 asz
 asz
 meC
+meC
+meC
+meC
 bsj
 hyi
 jjp
@@ -95539,12 +93862,9 @@ jbq
 jBR
 lyU
 jBR
-uJl
-mji
-uJl
-uJl
+ebr
 xHU
-xHU
+cje
 xHU
 oDK
 ejO
@@ -95556,46 +93876,48 @@ xHU
 opB
 wqN
 oFN
-jUt
-jUt
-jUt
-jUt
-jUt
-jUt
-jUt
-jUt
-jUt
-jUt
-fdX
-jUt
-rJG
+hXq
+hXq
+hXq
+hXq
+hXq
+hXq
+hXq
+hXq
+hXq
+hXq
+pxJ
+uGg
+nyp
 rVb
 slw
 svy
 sEH
-ipg
+sjf
 uqs
 sjf
-sjf
-tNh
+wWc
 vlD
+vlD
+vlD
+vlD
+bCL
 meC
-mZH
-oGf
-oGf
-oGf
-oGf
-oGf
-wiB
-oGf
-oGf
-oGf
-oGf
-wGz
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 pCI
-jvJ
+lpN
 ush
 pCI
 tSa
@@ -95610,8 +93932,6 @@ rkv
 cSs
 pCI
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -95774,7 +94094,10 @@ bBo
 jyw
 asz
 asz
-bsj
+asz
+asz
+asz
+asz
 lFa
 jjp
 bsj
@@ -95796,10 +94119,7 @@ pMY
 pMY
 pMY
 pMY
-uJl
-qvR
-dEz
-uJl
+ebr
 gPb
 coO
 eNP
@@ -95822,37 +94142,39 @@ vex
 nat
 mSZ
 mSZ
-jUt
-fdX
-rBo
-rJJ
+hXq
+pxJ
+uGg
+rJG
 cwa
-lxA
-rIe
+rUI
+tAR
 eWf
-sXy
+sjf
 uqs
 sjf
-sjf
-tNh
-vlD
+wWc
+mgu
 meC
-mZH
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-wGz
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 pCI
-rwS
+pCI
+pCI
+iPX
 rkv
 pCI
 pCI
@@ -95867,8 +94189,6 @@ rkv
 cSs
 pCI
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -96031,13 +94351,13 @@ glC
 glC
 glC
 glC
+eir
+eir
+eir
 glC
 iLW
 jjp
 bsj
-xOw
-xOw
-xOw
 xOw
 xOw
 xOw
@@ -96053,12 +94373,12 @@ xOw
 xOw
 xOw
 xOw
-uJl
-qvR
-fnV
+xOw
+xOw
+xOw
 uJl
 oDR
-cEu
+ehD
 cEu
 oJx
 aun
@@ -96079,55 +94399,55 @@ lra
 hYq
 mSZ
 mSZ
-jUt
-fdX
-jUt
+hXq
+pxJ
+gDF
 rJM
-rVq
 poA
-svF
-sEH
+poA
+rIe
+iSb
 ipg
 uqs
 sjf
-sjf
-fNZ
-vlD
+wWc
+pCI
+pCI
+pCI
+pCI
+pCI
+pCI
+pCI
+pCI
 meC
-mZH
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-vIC
-oGf
-oGf
-oGf
-wGz
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 pCI
-jvJ
-jvJ
-jvJ
-jvJ
-jvJ
-jvJ
-jvJ
-lDo
+lpN
+oUA
+lpN
+lpN
+lpN
+lpN
+lpN
+lpN
+lpN
+euv
 lpN
 pCI
 pCI
-pCI
-pCI
+rkv
+rkv
 pCI
 xOw
 xOw
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -96289,8 +94609,12 @@ bBo
 iiX
 bBo
 bBo
+bBo
+bBo
+bBo
 iMj
 bBo
+bsj
 bsj
 aBs
 aBs
@@ -96305,17 +94629,13 @@ aBs
 aBs
 aBs
 aBs
-aBs
-aBs
-aBs
-asz
-hSl
-hSl
 qvR
-mFo
-wiu
+qvR
+qvR
+hSl
+hSl
 fAT
-nTp
+oJx
 ooG
 dwe
 bSk
@@ -96336,37 +94656,39 @@ sxz
 eMb
 lGU
 mSZ
-jUt
-fdX
-jUt
+hXq
+pxJ
+uGg
 rdp
 fnw
 slz
-qGo
-qGo
-ipg
+ezJ
+eWf
+sjf
 aSQ
-sjf
-sjf
-tNl
-vlD
+kXU
+aXC
+oUA
+lpN
+lpN
+lpN
+lpN
+lpN
+tRQ
+pCI
+pCI
 meC
-mZH
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-wGz
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 pCI
-jvJ
+lpN
+pCI
+rkv
 rkv
 pCI
 pCI
@@ -96376,7 +94698,7 @@ pCI
 pCI
 ipd
 wGP
-ylL
+pCI
 pCI
 pCI
 pCI
@@ -96384,8 +94706,6 @@ pCI
 jyU
 xOw
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -96546,8 +94866,12 @@ ibY
 glE
 bBo
 bBo
+bBo
+bBo
+bBo
 iMC
 eir
+glC
 lQm
 glC
 glC
@@ -96563,16 +94887,12 @@ eir
 eir
 eir
 eir
-eir
-eir
-eir
-lQm
 lZO
-mjs
-mIe
-uJl
+lZO
+lZO
+fko
 thk
-wSO
+buG
 wSO
 wIk
 jdG
@@ -96593,46 +94913,48 @@ mSZ
 mSZ
 dLo
 oRU
-jUt
-fdX
-jUt
+hXq
+pxJ
+uGg
 rKh
 rVr
 slA
 qGo
-fcH
-sYa
+qGo
+sjf
 uqs
 sjf
-sjf
-tNh
-vlD
+wWc
+pCI
+pCI
+pCI
+pCI
+pCI
+lpN
+lpN
+lpN
+pCI
+pCI
+pCI
+pCI
+pCI
+pCI
 meC
-mZH
-uKg
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-xcS
-wGz
 meC
 meC
 pCI
-jvJ
-rkv
-mms
-rkv
-rkv
-rkv
-rkv
-unL
 lpN
-xXY
+pCI
+unL
+pCI
+uQg
+xtS
+rkv
+mdz
+pCI
+rkv
+lpN
+rkv
 rkv
 iJE
 rkv
@@ -96641,8 +94963,6 @@ xFv
 jyU
 jyU
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -96803,6 +95123,10 @@ aBs
 aBs
 aBs
 aBs
+aBs
+aBs
+aBs
+asz
 asz
 asz
 asz
@@ -96819,13 +95143,9 @@ bBo
 asz
 bBo
 bBo
-bBo
-bBo
-lFa
-bBo
-hSl
-ldZ
-nBG
+fnV
+fnV
+vdi
 atP
 uJl
 sTk
@@ -96850,47 +95170,49 @@ mSZ
 mSZ
 mSZ
 mSZ
-jUt
-fdX
-jUt
-rKp
-rVQ
-slB
-qGo
-vDb
-jDI
+hXq
+pxJ
+uGg
+uGg
+uGg
+uGg
+uGg
+fcH
+sjf
 uqs
 sjf
-sjf
-tNm
-vlD
-meC
-mZH
-oGf
-oGf
-oGf
-vIC
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-wGz
-meC
-meC
+wWc
+gCS
+lVh
+lWI
+ial
 pCI
-sEv
+uOq
 pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-lXV
 lpN
+lpN
+lpN
+lpN
+lpN
+lpN
+pCI
+pCI
+pCI
+pCI
+pCI
+lpN
+pCI
+rkv
+mdq
+pCI
+vgD
+aPw
+eed
+pCI
+pCI
 nnV
+lpN
+ldx
 pCI
 pCI
 pCI
@@ -96898,8 +95220,6 @@ pCI
 jyU
 xOw
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -97062,16 +95382,16 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
+meC
 asz
 asz
 asz
 asz
 aBs
 aBs
-asz
-asz
-asz
-asz
 asz
 asz
 asz
@@ -97081,8 +95401,8 @@ asz
 asz
 asz
 hSl
-ldZ
-xYm
+hSl
+hSl
 atP
 uJl
 foE
@@ -97107,45 +95427,47 @@ sMR
 tFb
 mSZ
 dkk
-jUt
-fdX
-jUt
-jUt
-jUt
-jUt
-jUt
-qeT
-jDI
+hXq
+pxJ
+wqG
+gol
+wNc
+vtf
+uGg
+vDb
+sjf
 uqs
 sjf
-sjf
-tNh
-vlD
-meC
-mZH
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-wGz
-meC
-meC
+wWc
+gCS
+wAr
+esd
+srk
+xmj
+tiz
 pCI
-jvJ
-mdq
+pCI
+pCI
+pCI
+pCI
+pCI
+lpN
+lpN
+lpN
+lpN
+lpN
+lpN
+lpN
+pCI
+rkv
+mfn
 pCI
 xtS
-xtS
-vgD
-aPw
-ylL
-mdz
+rkv
+rkv
+rkv
+rkv
+rkv
 lpN
 rkv
 weI
@@ -97155,8 +95477,6 @@ xOw
 xOw
 xOw
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -97337,9 +95657,9 @@ meC
 meC
 meC
 meC
+meC
+meC
 hSl
-ldZ
-xYm
 atP
 uJl
 pPR
@@ -97364,42 +95684,42 @@ mSZ
 mSZ
 mSZ
 mSZ
-jUt
-fdX
-fdX
-fdX
-fdX
-fdX
+hXq
+pxJ
+pxJ
+pxJ
+pxJ
+pxJ
 svI
 iaM
-oPx
+kXU
 fsW
 sjf
-sjf
-fNZ
-vlD
-meC
-mZH
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-oGf
-wGz
-meC
-meC
+wWc
+gCS
+wAr
+ymh
+pwb
+pwb
+tiz
+hQM
+jvh
+jvh
+jvh
+uyA
 pCI
-jvJ
-mfn
+bAZ
+rkv
+weI
+sBx
 pCI
-rkv
-rkv
-etE
+pCI
+pCI
+pCI
+pCI
+pCI
+pCI
+pCI
 rkv
 rkv
 rkv
@@ -97621,52 +95941,52 @@ bNj
 bNj
 bNj
 lra
-jUt
-jUt
-jUt
-jUt
-jUt
-jUt
-jUt
+hXq
+hXq
+hXq
+hXq
+hXq
+hXq
+hXq
 sEL
-jDI
+sjf
 pkw
 sjf
-sjf
-fNZ
-vlD
-meC
-mZH
-oGf
-oGf
-oGf
-oGf
-jil
-oGf
-oGf
-oGf
-oGf
-oGf
-wGz
-meC
-meC
+wWc
+gCS
+fiw
+ngB
+awn
+iEp
+tiz
+hQM
+caN
+eSk
+eFQ
+jHk
 pCI
-jvJ
-jJq
+sNl
+rkv
 pCI
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-lpN
+pCI
+pCI
+rca
+rca
+rWs
+rWs
+rWs
+onO
+ndh
+pCI
+rGG
 lpN
 lpN
 lpN
 lpN
 pCI
-xOw
+mgP
+fWk
+bqT
 xOw
 meC
 meC
@@ -97886,44 +96206,44 @@ rWk
 slI
 svO
 qeT
-nJY
+sXp
 pkw
 xHr
-tER
-tNP
-vlD
-meC
+wWc
+gCS
+gCS
+gCS
 uuN
 mZH
-mZH
-uuN
-vIy
-mZH
-wiN
+tiz
+hQM
+hQM
+hQM
+hQM
 wjP
-wGJ
-wGz
-wGz
-wGJ
-meC
-meC
 pCI
-jvJ
-rkv
-unL
-rkv
-nWT
-nWT
-upX
-upX
-rkv
-shE
+wGz
+etE
+pCI
+xWu
+eBK
+rSY
+xWu
+rMw
+rSY
+wfk
+onO
+xWu
+pCI
+rGG
 pCI
 pCI
 mBd
 mCM
 pCI
 pCI
+fWk
+fWk
 xOw
 meC
 meC
@@ -98143,44 +96463,44 @@ xta
 uKi
 svO
 qeT
-jDI
+sjf
 qiA
 sjf
-kYR
-mgu
-mgu
-meC
-meC
-meC
-meC
-eXJ
-vIX
+wWc
+gCS
+vag
+pwb
+vlT
+tiz
+pwb
+iVE
+hQM
 vXN
 wjw
-wwD
-eXJ
-meC
-meC
-meC
-meC
-meC
-pCI
-jvJ
-rkv
+jHk
 pCI
 pCI
 pCI
 pCI
+ueW
+wib
+vvV
+vvV
+vvV
+vvV
+vvV
+hFU
+xWu
 pCI
-pCI
-pCI
-shE
+rGG
 pCI
 mkB
 mBe
 mCV
 mMO
 pCI
+fWk
+fWk
 xOw
 meC
 meC
@@ -98400,44 +96720,44 @@ tLM
 tLM
 svO
 qeT
-jDI
+sjf
 qiA
 sjf
-kYR
-mgu
+wWc
+gCS
 uau
-meC
-meC
-meC
-meC
-eXJ
-vJx
+pwb
+mfZ
+oqC
+pwb
+niH
+hQM
 vXP
-nWu
-ubs
-eXJ
-meC
-meC
-meC
-meC
-meC
-pCI
-jvJ
-rkv
-pCI
-met
+jHk
+jHk
+tnp
+nve
+tQJ
+vuI
+onO
+fHr
+kOB
+kOB
+wDE
+wDE
+wfk
 ldu
-lkS
-vFB
-lEC
+onO
 pCI
-shE
+rGG
 epP
 mnA
 mBr
 mDu
 mNp
 pCI
+fWk
+fWk
 xOw
 meC
 meC
@@ -98607,7 +96927,6 @@ meC
 meC
 meC
 meC
-dqB
 meC
 meC
 meC
@@ -98615,7 +96934,8 @@ meC
 meC
 meC
 meC
-bCZ
+meC
+meC
 meC
 meC
 meC
@@ -98657,44 +96977,44 @@ vko
 slL
 svO
 qeT
-jDI
+sjf
 qiA
 sjf
 tET
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-vJC
-vYe
+gCS
+fHZ
+pwb
+mfZ
+tiz
+pwb
+mNA
+hQM
+vXP
 nWu
-viw
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
+mdY
+hQM
+hQM
+tQJ
+vuI
+onO
+dpf
+cXB
 rwS
-rKn
-pCI
+wfk
+gCH
 kOB
-niP
-ooa
-edl
-myB
+ldu
+onO
 pCI
-shE
+rGG
 pCI
 mnO
 mBB
 mIT
 mQQ
 pCI
+fWk
+fWk
 xOw
 meC
 meC
@@ -98862,18 +97182,18 @@ meC
 meC
 meC
 meC
-sLn
-sLn
-cet
-sLn
+meC
+meC
+dqB
 meC
 meC
 meC
 meC
-qcH
-qcH
-bkA
-qcH
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -98914,44 +97234,44 @@ rWz
 wDi
 svO
 qeT
-jDI
+sjf
 trt
-uEz
-kWA
-tOb
-mzF
-npK
+sjf
+kYR
+gCS
+gCS
+gCS
+lBP
 nHz
-nHz
-nNe
+gCS
+gCS
+hQM
+sqZ
+jHk
+iQp
+dfw
+vhw
+tQJ
+vuI
+uBt
+roV
+ezF
+ylO
+xKo
+uHw
+rSY
+ldu
+onO
 pCI
-pCI
-pCI
-pKj
-pCI
-pCI
-kTv
-kTv
-kTv
-kTv
-kTv
-mXZ
-kTv
-pCI
-pCI
-nxF
-xIw
-thK
-nnV
-flc
-pCI
-shE
+rGG
 pCI
 mqj
 mBr
 mJH
 mYj
 pCI
+fWk
+fWk
 xOw
 meC
 meC
@@ -99120,17 +97440,17 @@ meC
 meC
 meC
 sLn
-umI
-tTg
-gON
+sLn
+cet
+sLn
 meC
 meC
 meC
 meC
-qcH
-kFI
-ulW
-jNQ
+meC
+meC
+meC
+meC
 meC
 meC
 hSl
@@ -99171,44 +97491,44 @@ qPP
 qyE
 hZS
 qeT
-jDI
+sjf
 qiA
 sjf
 kYR
-pCI
-weI
-rkv
-rkv
-rkv
+gCS
+gdn
+gvq
+mfZ
+tiz
 nOP
+mOr
+wnC
 mzF
-mzF
-mzF
+jHk
 wjL
-wjL
-wGK
-mpM
-rkv
-rkv
+hQM
+hQM
+tQJ
+vuI
+rSY
+roV
+ezF
+rSY
+tAA
+pfG
+ylO
+ldu
+onO
 pCI
-pCI
-pCI
-shE
-lDM
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-shE
+rGG
 pCI
 mkB
 mCb
 mJZ
 nbd
 pCI
+fWk
+fWk
 xOw
 meC
 meC
@@ -99377,17 +97697,17 @@ meC
 meC
 meC
 sLn
-nGt
+umI
 tTg
-sLn
+gON
 meC
 meC
 meC
 meC
-qcH
-qYd
-ulW
-qcH
+meC
+meC
+meC
+meC
 meC
 meC
 hSl
@@ -99428,44 +97748,44 @@ qPP
 mTl
 xHk
 qeT
-jDI
+sjf
 qiA
 sjf
 tEW
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-rkv
+gCS
+xev
+ykY
+weh
+tiz
+iEp
+pwb
+iBJ
+dNX
+eec
+bmb
+mUT
 mwp
-pCI
-pCI
-pCI
-rkv
-pCI
-oEo
+tQJ
+xog
+xWu
+roV
+rSY
+wfk
+wfk
+rvQ
 shE
-shE
-shE
-leC
-shE
-shE
-shE
-shE
-shE
+ldu
+onO
+pCI
+rGG
 pCI
 pCI
 pCI
 pCI
 pCI
 pCI
+fWk
+fWk
 xOw
 meC
 meC
@@ -99641,10 +97961,10 @@ meC
 meC
 meC
 meC
-qKm
-kFU
-ulW
-qKm
+meC
+meC
+meC
+meC
 meC
 hSl
 hSl
@@ -99685,38 +98005,38 @@ qPP
 tld
 sww
 qeT
-jDI
+sjf
 qiA
 sjf
 kYR
-mgu
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
-pCI
-rkv
-mwp
-pCI
+mgo
+cpo
+mcQ
+gaG
+xjN
+ibr
+pwb
+gCS
+gCS
+gCS
+gCS
+tQJ
+tQJ
+tQJ
 mFk
-rkv
-rkv
-pCI
-nGr
+xWu
+gPj
 nHl
+nHl
+nHl
+pgb
+qCy
+qPw
+rSY
+pCI
+rGG
 rkv
-rkv
-rkv
-rkv
-tSa
 kqD
-rkv
-rkv
 nWT
 pCI
 xOw
@@ -99898,11 +98218,11 @@ sLn
 sLn
 sLn
 xMq
-qKm
-qKm
-vHG
-qKm
-qcH
+meC
+meC
+meC
+meC
+meC
 hSl
 hSl
 lzo
@@ -99942,36 +98262,36 @@ qPP
 djc
 xHk
 sFk
-jDI
+sjf
 qiA
 sjf
 tEY
-mgu
-xOw
-xmC
-xmC
-xmC
-xmC
-xmC
-xmC
-xmC
-xOw
+mgo
+wdg
+mcQ
+lNj
+iii
+gjN
+kew
+gCS
+jUo
+exc
+ltU
+tQJ
+xog
+hoN
+xWu
+gTZ
+rSY
+qAj
+rNI
+meQ
+rMw
+hwf
+rLX
+xWu
 pCI
-rkv
-mwp
-pCI
-pCI
-ndh
-pCI
-pCI
-pCI
-pCI
-pCI
-ndh
-ndh
-pCI
-pCI
-unL
+vDD
 pCI
 pCI
 pCI
@@ -100155,11 +98475,11 @@ tZZ
 xVZ
 rCC
 xMq
-rmz
-kFV
-rCN
-kTJ
-cSf
+xOw
+xOw
+xOw
+xOw
+xOw
 hSl
 hSl
 lzF
@@ -100199,26 +98519,26 @@ mmC
 ayH
 vVZ
 qeT
-jDI
+sjf
 qiA
 sjf
-qHl
-mgu
-xOw
-xmC
+tET
+gCk
+pwb
+wJh
 uvd
-uKj
-vbz
-vrf
-vJQ
-xmC
-xOw
-pCI
-wGP
+uvt
+oJE
+pwb
+nBJ
+rgb
+jhj
+oWb
+tQJ
 mpM
-pCI
-mbP
 xRc
+onO
+xWu
 nuz
 nMr
 nXL
@@ -100227,8 +98547,8 @@ oli
 oZa
 onO
 tQJ
-mFk
-rkv
+pCI
+rGG
 evJ
 evJ
 pCI
@@ -100412,12 +98732,12 @@ piX
 kgp
 rsw
 xSi
-rnr
-bMx
-ulW
-ulW
-kZu
-hSl
+xmC
+xmC
+xmC
+xmC
+xmC
+uJl
 hSl
 hSl
 hSl
@@ -100456,26 +98776,26 @@ bcK
 jAh
 vVZ
 sFM
-jDI
-qiA
 sjf
-kYR
-vlD
-noj
-xmC
-uvx
-uKT
-vcb
-vrI
-vJV
-xmC
-xOw
-pCI
-eed
-mwp
-pCI
-kcF
+trt
+kXU
+tFy
+voF
+nfU
+wlW
+owT
+uvt
+oJE
+nGb
+gCS
+gCS
+gCS
+gCS
+tQJ
+sDK
 xRm
+onO
+xWu
 nvj
 vLQ
 nYo
@@ -100485,7 +98805,7 @@ pha
 okq
 tQJ
 weI
-fnG
+kKg
 rkv
 loW
 pCI
@@ -100670,11 +98990,11 @@ tTg
 rsw
 xSi
 rnr
-egz
-hZP
-ulW
-uqr
-hSl
+uKj
+vbz
+vrf
+vJQ
+uJl
 waN
 waN
 wCN
@@ -100713,26 +99033,26 @@ tOH
 fze
 vVZ
 qeT
-jDI
-qiA
-kXU
-tFy
+gQf
+ilk
+tyy
+pTQ
 tOd
-uaC
-umo
-uvC
-uLi
-vcj
-vrL
-vKc
-xmC
-xOw
-pCI
-rkv
-mwp
-pCI
-awb
+kru
+yhf
+uvd
+uvt
+oJE
+slR
+gCS
+sUq
+hdk
+wqD
+tQJ
+qca
 new
+onO
+onO
 xZg
 nTi
 cHG
@@ -100742,7 +99062,7 @@ oZa
 onO
 tQJ
 tFG
-rkv
+rGG
 rkv
 upX
 pCI
@@ -100926,12 +99246,12 @@ skh
 tTg
 rsw
 xSi
-rnr
-egz
-aEc
-xXh
-cTn
-hSl
+uvx
+uKT
+vcb
+vrI
+vJV
+uJl
 rDl
 rDl
 hSl
@@ -100974,32 +99294,32 @@ sYX
 qiA
 sjf
 kYR
-vlD
-noj
-xmC
-uvO
-kua
-vcl
-vrO
-itK
-xmC
-xOw
-pCI
-wGU
-mwp
-pCI
-awb
+mgo
+dxy
+wgE
+mpN
+vax
+gjN
+pwb
+aXJ
+gjN
+bZQ
+wER
+tQJ
+qca
 njs
+xWu
+xWu
 nvj
 nTk
 oaN
 okq
 onO
-onO
+hwf
 onO
 tQJ
 tSa
-tSa
+sFv
 rkv
 klm
 pCI
@@ -101183,12 +99503,12 @@ tFT
 usx
 jji
 xSi
-rnr
-hIq
-aEc
-xXh
-vQl
-hSl
+uvC
+uLi
+vcj
+vrL
+vKc
+uJl
 lVr
 fnV
 sUb
@@ -101230,33 +99550,33 @@ lIj
 jDI
 hfk
 sjf
-qHl
-mgu
-xOw
-xmC
-jUe
-uMh
-vcU
-vrV
-vKr
-xmC
-xOw
-pCI
-rkv
-mwp
-pCI
+tET
+mgo
+dxy
+wgE
+gqo
+tmg
+gjN
+pwb
+gCS
+gCS
+gCS
+gCS
+hbd
+hbd
+hbd
 edX
 nuz
 nuz
 ylv
 eGP
 gSZ
-onO
-rWs
+hwf
+ggv
 rWs
 tQJ
 tFG
-kfb
+xWr
 rkv
 xtS
 pCI
@@ -101440,12 +99760,12 @@ jWu
 kgx
 dDe
 kth
-epv
-cuQ
-kOt
-kTT
-cTR
-hSl
+uvO
+kua
+vcl
+vrO
+itK
+uJl
 dDP
 fnV
 fnV
@@ -101488,18 +99808,18 @@ jDI
 qiA
 sjf
 lcl
-mgu
-xOw
-xmC
-xmC
-xmC
-xmC
-xmC
-xmC
-xmC
-xOw
-pCI
-owc
+gCS
+dxy
+rCl
+rCl
+kAo
+rUr
+pwb
+gCS
+dcu
+vGB
+gks
+hbd
 wRU
 tja
 aPy
@@ -101507,13 +99827,13 @@ taZ
 xZk
 xjq
 hPT
-onO
-nvj
+hwf
+uTW
 huv
 xfz
 tQJ
 rTX
-tFG
+can
 rkv
 rkv
 pCI
@@ -101696,13 +100016,13 @@ xaf
 cfr
 kgD
 mrV
-xSi
-rnr
-iHc
+nsm
+jUe
+uMh
 cuQ
 ulW
 cWV
-hSl
+uJl
 dEz
 kMi
 lrv
@@ -101745,20 +100065,20 @@ jDI
 qiA
 sjf
 kYR
-mgu
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
-pCI
-fzl
-lpN
-pCI
+gCS
+dxy
+dFf
+oJq
+kfS
+tiz
+pwb
+pat
+evb
+axW
+kFG
+hbd
+fdX
+hbd
 jNI
 xRy
 xZm
@@ -101770,7 +100090,7 @@ mtf
 mtf
 tQJ
 kfb
-kfb
+xWr
 rkv
 rkv
 pCI
@@ -101953,13 +100273,13 @@ xaf
 ygp
 kgD
 sJy
-xMq
-wme
-ulW
-cwE
-kUd
-cYo
-hSl
+nsm
+xmC
+xmC
+umo
+xmC
+xmC
+uJl
 hSl
 mUa
 hSl
@@ -102002,20 +100322,20 @@ jDI
 qiA
 sjf
 kYR
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-rkv
-lpN
-pCI
+hbd
+hbd
+hbd
+hbd
+hbd
+qOc
+hbd
+hbd
+hbd
+hbd
+hbd
+hbd
+fdX
+hbd
 rnV
 xRA
 xZv
@@ -102027,7 +100347,7 @@ wSv
 wSv
 tQJ
 kfb
-kfb
+xWr
 rkv
 pCI
 pCI
@@ -102211,12 +100531,12 @@ ygp
 kgD
 sJy
 iyS
-kxT
-kGV
+xOw
+noj
 kOx
-cFb
-jOD
-qKm
+noj
+xOw
+wDW
 bIz
 lzW
 wwR
@@ -102260,20 +100580,20 @@ qiA
 hra
 hNi
 tON
-xXY
-xXY
-xXY
-xXY
-xXY
-lpN
-lpN
-lpN
-lpN
-lpN
-lpN
-lpN
-pCI
-mwK
+fVn
+fVn
+fVn
+fVn
+eJi
+fdX
+fdX
+fdX
+fdX
+fdX
+fdX
+fdX
+hbd
+xHq
 lzN
 xHq
 ylD
@@ -102284,7 +100604,7 @@ oLC
 cmd
 tQJ
 fnG
-kfb
+xWr
 pCI
 pCI
 pAG
@@ -102467,13 +100787,13 @@ lhW
 mJb
 kgD
 ykh
-xMq
-qKm
+jBU
+xYh
 rWh
 cwG
+noj
 qKm
-qKm
-qKm
+wDW
 lpI
 xlb
 cdd
@@ -102516,20 +100836,20 @@ iyN
 tsi
 tac
 slT
-pCI
-yls
+hbd
+dto
 jJq
 kgf
-rkv
-jvJ
-kRL
-rkv
-rkv
+nop
+nnR
+nop
+tmH
+nop
 kYm
-pCI
-weI
-lpN
-pCI
+hbd
+ezZ
+fdX
+hbd
 nEc
 xRB
 xZR
@@ -102541,7 +100861,7 @@ bba
 doq
 tQJ
 yls
-rkv
+rGG
 pCI
 xOw
 xOw
@@ -102773,32 +101093,32 @@ nJY
 orr
 xHr
 tFU
-pCI
-pCI
-pCI
-pCI
-pCI
+hbd
+hbd
+hbd
+hbd
+hbd
 vdo
-pCI
-pCI
-rkv
-pCI
-pCI
-pCI
+hbd
+hbd
+nop
+hbd
+hbd
+hbd
 lrG
-pCI
-pCI
-pCI
-pCI
-pCI
+hbd
+hbd
+hbd
+hbd
+hbd
 pCI
 pCI
 pCI
 pCI
 epP
 epP
-rkv
-rkv
+rGG
+rGG
 pCI
 xOw
 meC
@@ -103037,24 +101357,24 @@ kjp
 kBB
 vdz
 vsP
-pCI
-nWT
-pCI
-rGG
-rGG
-lpN
-rkv
-rkv
-rkv
+hbd
+wdl
+hbd
+eJi
+eJi
+fdX
+eJi
+eJi
+eJi
 xRE
-unL
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
-rkv
+jCG
+rGG
+rGG
+rGG
+rGG
+rGG
+rGG
+rGG
 lxj
 pCI
 xOw
@@ -103294,18 +101614,18 @@ uwg
 kEY
 vdG
 vtq
-pCI
-pCI
-pCI
-rGG
+hbd
+hbd
+hbd
+eJi
 wGV
-pCI
-rkv
-rkv
-rkv
-rkv
-pCI
-rkv
+hbd
+nop
+nop
+nop
+nop
+hbd
+lpN
 upX
 rkv
 rkv
@@ -103551,19 +101871,19 @@ kmf
 kEo
 vdL
 vtT
-pCI
-oHd
-rkv
-rGG
+hbd
+noF
+nop
+eJi
 wHa
-pCI
-yls
-udl
-rKn
-pCI
-pCI
-unL
-ccz
+hbd
+dto
+bQx
+xJy
+hbd
+hbd
+oUM
+jUt
 ccz
 ccz
 ccz
@@ -103808,19 +102128,19 @@ kmh
 kEY
 kKu
 kSq
-pCI
-rkv
-rkv
-rGG
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-nWT
-rkv
-ccz
+hbd
+nop
+nop
+eJi
+hbd
+hbd
+hbd
+hbd
+hbd
+hbd
+wdl
+fdX
+jUt
 bPs
 iAJ
 srj
@@ -104065,19 +102385,19 @@ knO
 uMm
 kLY
 vul
-pCI
+hbd
 kUe
-rkv
-rGG
+nop
+eJi
 vYO
 wSK
 xda
 xnq
-pCI
-rkv
-rkv
-rkv
-ccz
+hbd
+nop
+nop
+fdX
+jUt
 ocN
 szf
 bPR
@@ -104253,7 +102573,7 @@ hRZ
 hRZ
 hRZ
 hRZ
-hRZ
+yfo
 yfo
 pMK
 yfo
@@ -104261,7 +102581,7 @@ yfo
 yfo
 lrO
 yfo
-ayB
+yfo
 jOC
 jWD
 khx
@@ -104322,19 +102642,19 @@ uws
 hpn
 hpn
 hpn
-pCI
-pCI
-rkv
-rGG
-pCI
+hbd
+hbd
+nop
+eJi
+hbd
 wSP
 xdH
 xoa
-pCI
+hbd
 xSe
-pCI
-rkv
-ccz
+hbd
+fdX
+jUt
 hPm
 cLv
 bPR
@@ -104580,18 +102900,18 @@ uMB
 vdT
 vuy
 vuy
-pCI
-pCI
-rGG
+hbd
+hbd
+eJi
 vYO
 wSR
 hxT
 wSR
-pCI
+hbd
 xSe
-pCI
-rkv
-ccz
+hbd
+fdX
+jUt
 ocN
 aPb
 bPR
@@ -104775,7 +103095,7 @@ yfo
 yfo
 yfo
 yfo
-ayB
+yfo
 pPX
 hoK
 khS
@@ -104836,19 +103156,19 @@ knZ
 kGh
 pYM
 pYM
-jRA
-pCI
-xPP
-rGG
-pCI
+anB
+hbd
+nop
+eJi
+hbd
 wST
 wSR
 hHg
-pCI
-rkv
-pCI
-rkv
-ccz
+hbd
+nop
+hbd
+fdX
+jUt
 ocN
 jcq
 bPR
@@ -105019,7 +103339,7 @@ yfo
 yfo
 yfo
 xsB
-hRZ
+yfo
 hKd
 vLD
 wQk
@@ -105093,19 +103413,19 @@ koV
 kJL
 kMb
 vva
-vva
-pCI
-yls
-rGG
-pCI
-pCI
-pCI
+hJT
+hbd
+dto
+eJi
+hbd
+hbd
+hbd
 xoE
-pCI
-rkv
-pCI
-rkv
-ccz
+hbd
+nop
+hbd
+fdX
+jUt
 iqa
 xip
 leW
@@ -105352,17 +103672,17 @@ vev
 vvi
 vKH
 vYt
-wjT
+ikJ
 wwX
-nWT
-pCI
-lwM
-rkv
-pCI
+wdl
+hbd
+qHD
+nop
+hbd
 ylN
-pCI
-rkv
-ccz
+hbd
+fdX
+jUt
 bqu
 jcq
 vVL
@@ -105608,18 +103928,18 @@ kKs
 veF
 veF
 vKV
-pCI
+hbd
 wka
 qFQ
-loW
-pCI
-rKn
-rkv
-rkv
-rkv
-pCI
-unL
-ccz
+ldO
+hbd
+xJy
+nop
+nop
+nop
+hbd
+oUM
+jUt
 loj
 qXZ
 kPb
@@ -105797,7 +104117,7 @@ yfo
 yfo
 yfo
 yfo
-pSQ
+yfo
 iPu
 jaT
 whT
@@ -105852,11 +104172,11 @@ smT
 iSx
 smT
 jkT
-slT
+uTO
 exB
 kPV
 vlr
-slT
+uTO
 rSC
 uaY
 umV
@@ -105865,18 +104185,18 @@ uML
 kMb
 vvw
 vvw
-pCI
+hbd
 wka
 qFQ
 lpK
-pCI
-pCI
-pCI
-pCI
-pCI
-pCI
-rkv
-ccz
+hbd
+hbd
+hbd
+hbd
+hbd
+hbd
+fdX
+jUt
 mGO
 rre
 cOo
@@ -106073,7 +104393,7 @@ shZ
 shZ
 icX
 lqR
-nYv
+vWd
 omy
 xlb
 fjW
@@ -106122,8 +104442,8 @@ pYM
 pYM
 pYM
 jRA
-pCI
-rkv
+hbd
+nop
 eqU
 eqU
 eqU
@@ -106133,8 +104453,8 @@ eqU
 eqU
 eqU
 eqU
-ccz
-ccz
+jUt
+jUt
 qzb
 lBE
 aJn
@@ -106379,19 +104699,19 @@ uNv
 oFV
 lIn
 lIn
-pCI
-pCI
-pCI
-unL
-pCI
-ccz
-ccz
-ccz
-ccz
-ccz
+hbd
+hbd
+hbd
+uHL
+hbd
+jUt
+jUt
+jUt
+jUt
+jUt
 eqU
-oHd
-ccz
+noF
+jUt
 jZz
 aDh
 kuT
@@ -106636,18 +104956,18 @@ uNU
 veQ
 sHl
 vLl
-pCI
-rKn
+hbd
+xJy
 mnh
-rkv
-mFk
-ccz
+nop
+ofY
+jUt
 wTe
 dMd
 dMd
-ccz
+jUt
 eqU
-jvJ
+tBJ
 eof
 fxr
 udn
@@ -106893,19 +105213,19 @@ uOn
 eze
 csH
 csH
-pCI
+hbd
 qam
-rkv
+nop
 ndG
 jZc
-ccz
+jUt
 cZb
 hny
 esD
-ccz
+jUt
 gjA
-weI
-ccz
+ezZ
+jUt
 usm
 qMe
 udn
@@ -107150,19 +105470,19 @@ csH
 bzc
 vvO
 csH
-pCI
-lDM
-rkv
-rkv
-weI
-ccz
+hbd
+oEJ
+nop
+nop
+ezZ
+jUt
 nSP
-rkv
+nop
 rYp
 qDr
 gjA
-kqD
-ccz
+xUT
+jUt
 dir
 jFX
 lHs
@@ -107407,19 +105727,19 @@ hFP
 hFP
 hFP
 hFP
-ccz
-ccz
-ccz
-ccz
-ccz
-ccz
+jUt
+jUt
+jUt
+jUt
+jUt
+jUt
 ofS
-ccz
+jUt
 lqp
 uVS
 gjA
-ccz
-ccz
+jUt
+jUt
 nGU
 sZu
 sZu
@@ -107673,9 +105993,9 @@ jPU
 hPV
 kIR
 vzS
-ccz
+jUt
 tBF
-ccz
+jUt
 mfB
 xKM
 ldP
@@ -112981,7 +111301,7 @@ fZK
 gvl
 gFm
 gPK
-gFb
+arS
 hgK
 hjd
 huh
@@ -115090,10 +113410,10 @@ yly
 oKt
 oYo
 lbB
-nVU
-bBZ
+ltk
+jea
 xXP
-upE
+npW
 gxa
 imP
 uGV
@@ -115347,7 +113667,7 @@ wTR
 wTR
 wTR
 lbB
-lbB
+suM
 xnQ
 cJP
 lbB
@@ -115592,15 +113912,15 @@ gVL
 gug
 gug
 bVO
-qDp
-qDp
-nbk
-qDp
-qDp
-qDp
-qDp
-nbk
-qDp
+gug
+gug
+gug
+gug
+gug
+gug
+gug
+gug
+gug
 yfx
 xnQ
 xnQ
@@ -116106,15 +114426,15 @@ rPK
 rPK
 rPK
 rPK
-vLM
-vLM
-vLM
-vLM
-vLM
-vLM
-vLM
-vLM
-vLM
+rPK
+rPK
+rPK
+rPK
+rPK
+rPK
+rPK
+rPK
+rPK
 oLO
 oYt
 wDy
@@ -117615,7 +115935,7 @@ sQJ
 sQJ
 hLd
 hTF
-aZc
+pWg
 iax
 imF
 vdE
@@ -118868,9 +117188,9 @@ bRY
 cbB
 cbB
 cbB
-cbB
+arg
 cCj
-bSQ
+kYk
 bTr
 bTr
 bTr
@@ -123815,9 +122135,9 @@ xQQ
 qwq
 yfE
 vCk
-otI
+gUP
 eQG
-mmN
+hog
 nEv
 yfE
 yiT
@@ -124893,7 +123213,7 @@ yjB
 yjB
 iBB
 yiL
-uZn
+nAM
 kuq
 kLZ
 gZG
@@ -132320,9 +130640,9 @@ qKw
 qKw
 fjc
 iur
-ktz
+oVY
 uvw
-ktz
+oVY
 ikQ
 qKw
 qKw
@@ -132580,7 +130900,7 @@ fjc
 sgA
 iur
 qKw
-ktz
+oVY
 qKw
 qKw
 kBM
@@ -133094,12 +131414,12 @@ rTb
 qKw
 iur
 nri
-ktz
-qKw
-qKw
-qKw
-qKw
-qKw
+oVY
+oVY
+oVY
+oVY
+oVY
+oVY
 qQq
 qKw
 iur
@@ -133356,9 +131676,9 @@ iur
 iur
 vXU
 qKw
-qKw
-qKw
-qKw
+oVY
+oVY
+oVY
 iur
 uZg
 iur
@@ -133615,7 +131935,7 @@ iur
 iur
 iur
 iur
-qKw
+oVY
 iur
 iur
 iur
@@ -133872,7 +132192,7 @@ tCr
 qKw
 qKw
 iur
-qKw
+oVY
 iur
 qKw
 tIl
@@ -134129,8 +132449,8 @@ qKw
 qKw
 qKw
 tIl
-qKw
-qKw
+oVY
+oVY
 qKw
 iur
 tWA


### PR DESCRIPTION
## About The Pull Request

- Addresses some problems brought up in https://github.com/fulpstation/fulpstation/pull/488
- Remakes most of arrivals, including holodeck/dorms/maints around it
- Moves science down
- Fixes random problems I found while working on this
- Cuts back on more maints

![image](https://user-images.githubusercontent.com/53777086/154688284-d25cdce7-a199-4823-96cf-ad38726abe7b.png)


## Why It's Good For The Game

Solitaire needs a complete disposal overhaul, but first we need to overhaul all the individual departments.
Service, Medical, Engineering and Supply, and Departures is what's left to be done after this PR, as well as maints but I'd worry about that last.
We can make Solitaire an actual unique map since it does have a lot of promise to it. I've also sunk to much time into this map to just let it die.
