### PR TITLE
fixes a runtime with beefmen spawners (fixes names)

### DIFF
--- a/fulp_modules/mapping/ruins/icemoon/beefman_cytology/beefcyto_spawner.dm
+++ b/fulp_modules/mapping/ruins/icemoon/beefman_cytology/beefcyto_spawner.dm
@@ -20,7 +20,7 @@
 
 /obj/effect/mob_spawn/ghost_role/human/beefman/special(mob/living/carbon/human/spawned_human)
 	. = ..()
-	spawned_human.fully_replace_character_name(null, random_unique_beefman_name(gender))
+	spawned_human.fully_replace_character_name(null, random_unique_beefman_name())
 
 /datum/job/fulp_cytology
 	title = ROLE_BEEFMAN_CYTOLOGY


### PR DESCRIPTION
## About The Pull Request

Fixes names on both beefmen spawners (Scientist Cytologist and the space one thing)

## Why It's Good For The Game

They actually get names now.
They were BOTH broken, not JUST the space ones. @SmoSmoSmoSmok F you
