### PR TITLE
Makes cloak not care for people who can't see you

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/cloak.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/cloak.dm
@@ -20,7 +20,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	for(var/mob/living/watchers in viewers(9, owner) - owner)
+	for(var/mob/living/watchers in view(9, owner) - owner)
 		owner.balloon_alert(owner, "you can only vanish unseen.")
 		return FALSE
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Cloak of darkness now only takes into account people who can visibly see you, rather than people near you.

## Why It's Good For The Game

People can't see through walls, unless they can, in which case they can, but generally can't.
