### PR TITLE
Refactors bodycameras into an Element

### DIFF
--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -3,10 +3,6 @@
 	. = ..()
 	AddElement(/datum/element/bodycamera_holder)
 
-/obj/item/clothing/suit/armor/Destroy()
-	RemoveElement(/datum/element/bodycamera_holder)
-	return ..()
-
 /**
  * The bodycamera
  *

--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -1,124 +1,136 @@
-/obj/item/clothing/suit/armor
-	var/upgraded = FALSE
-	var/obj/machinery/camera/builtInCamera = null
-	var/registrant
 
-/obj/item/clothing/suit/armor/examine(mob/user)
+/obj/item/clothing/suit/armor/Initialize(mapload)
 	. = ..()
-	if(builtInCamera)
-		. += "It appears to have an <b>active</b> body camera attached."
+	AddElement(/datum/element/bodycamera_holder)
 
-/// Modifying the Jumpsuit
-/obj/item/clothing/suit/armor/attackby(obj/item/item, mob/user, params)
-	. = ..()
+/obj/item/clothing/suit/armor/Destroy()
+	RemoveElement(/datum/element/bodycamera_holder)
+	return ..()
 
-	// Using a bodycam on the jumpsuit, upgrading it
-	if(istype(item, /obj/item/bodycam_upgrade))
-		// Check if its already upgraded
-		if(upgraded)
-			to_chat(user, span_warning("We have already installed [item] into [src]!"))
-			playsound(loc, 'sound/machines/buzz-two.ogg', get_clamped_volume(), TRUE, -1)
-			return
-		upgraded = TRUE
-		to_chat(user, span_warning("You install [item] into [src]."))
-		playsound(loc, 'sound/items/drill_use.ogg', get_clamped_volume(), TRUE, -1)
-		qdel(item)
-		return
-
-	// Check: Is the Jumpsuit upgraded?
-	if(!upgraded)
-		return
-	// Upgraded, but removing it.
-	if(item.tool_behaviour == TOOL_SCREWDRIVER)
-		// If it isnt upgraded, it will go onto the next check, and just return.
-		if(upgraded)
-			to_chat(user, span_warning("You remove the upgrade from [src]."))
-			playsound(loc, 'sound/items/drill_use.ogg', get_clamped_volume(), TRUE, -1)
-			upgraded = FALSE
-			unregister_body_camera()
-			var/obj/item/bodycam_upgrade/bodycam = new /obj/item/bodycam_upgrade
-			user.put_in_hands(bodycam)
-			return
-
-	// Registering our ID
-	var/obj/item/card/id/id_card
-	if(isidcard(item))
-		id_card = item
-	else if(istype(item, /obj/item/pda))
-		var/obj/item/pda/worn_pda = item
-		id_card = worn_pda.id
-	if(!id_card)
-		to_chat(user, span_warning("No ID detected for body camera registration."))
-		return
-
-	register_body_camera(id_card, user)
-
-/// Manual Register via ID
-/obj/item/clothing/suit/armor/proc/register_body_camera(obj/item/card/id/id_card, mob/living/carbon/human/user)
-	if(!id_card)
-		return
-	var/obj/item/clothing/suit/armor/worn_suit = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-	if(!istype(worn_suit))
-		to_chat(user, span_warning("You have to be wearing [src] to turn the body camera on!"))
-		return
-	var/id_name = id_card.registered_name
-	if(id_name == registrant) //If already registered to the same person swiping the ID, we will 'toggle off' registration and unregister the body camera.
-		unregister_body_camera(user)
-		return
-
-	registrant = id_name
-
-	/**
-	 *	# Body Camera
-	 *
-	 *	Due to how TG deals with moving cameras, they have to be set to a PERSON, rather than an ITEM, otherwise its a black screen.
-	 *	We're tying the body camera to the body via the Jumpsuit, unregistering the Body camera if unequipped,
-	 *	Otherwise we'll have jumpsuit-less officers running about with body cameras permanently on them.
-	 */
-	/// Signal to remove the camera when the jumpsuit is removed
-	RegisterSignal(src, COMSIG_ITEM_POST_UNEQUIP, .proc/unregister_body_camera)
-	builtInCamera = new(usr)
-	builtInCamera.internal_light = FALSE
-	builtInCamera.network = list("ss13")
-
-	var/cam_name = "-Body Camera: [id_name] ([id_card.assignment])"
-	for(var/obj/machinery/camera/matching_camera in GLOB.cameranet.cameras)
-		if(cam_name == matching_camera.c_tag)
-			to_chat(user, span_notice("Matching registration found. Unregistering previously registered body camera."))
-			if(worn_suit)
-				worn_suit.unregister_body_camera(user)
-			break
-
-	builtInCamera.c_tag = "[cam_name]"
-
-	playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
-	if(user)
-		user.balloon_alert(user, "bodycamera activated")
-		to_chat(user, span_notice("[src] body camera successfully registered to [id_name]."))
-
-/// Unregistering the ID - Called when using your ID on an already claimed jumpsuit, or removing it.
-/obj/item/clothing/suit/armor/proc/unregister_body_camera(mob/user)
-	if(!builtInCamera)
-		return
-	QDEL_NULL(builtInCamera)
-	UnregisterSignal(src, COMSIG_ITEM_POST_UNEQUIP)
-	registrant = null
-	if(user)
-		playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
-		user.balloon_alert(user, "bodycamera deactivated")
-
-/// Bodycamera upgrade
+/**
+ * The bodycamera
+ *
+ * This is the item that gets installed into items that have the bodycamera_holder element
+ */
 /obj/item/bodycam_upgrade
 	name = "body camera upgrade"
 	icon = 'fulp_modules/features/clothing/body_cameras/bodycamera.dmi'
 	icon_state = "bodycamera"
-	desc = "An armor vest upgrade, it says to examine closer to understand how it works."
+	desc = "An armor vest upgrade, there's an instructions tag if you look a little closer..."
+	///The camera itself.
+	var/obj/machinery/camera/builtin_bodycamera
 
 /obj/item/bodycam_upgrade/examine_more(mob/user)
-	. = list(span_notice("<i>You examine [src]'s instruction tag...</i>"))
-	. += list(span_warning("How to use Body Cameras v3.5: EMP-proof Edition!"))
-	. += list(span_notice("Use [src] on an armor vest to install it."))
-	. += list(span_notice("Use a Screwdriver to remove it when needed."))
-	. += list(span_notice("While equipped, use your ID card on the vest to activate the camera."))
-	. += list(span_notice("Unequipping the vest or using your ID again will deactivate the camera."))
-	. += list(span_notice("While the camera is active, the wearer will be visible to camera consoles."))
+	. += list(span_notice("Use [src] on any valid vest to quickly install."))
+	. += list(span_notice("Use a [span_bold("screwdriver")] to remove it."))
+	. += list(span_notice("While equipped, use your ID card on the vest to activate/deactivate the camera."))
+	. += list(span_notice("Unequipping the vest will immediately deactivate the camera."))
+
+/obj/item/bodycam_upgrade/Destroy()
+	if(builtin_bodycamera)
+		turn_off()
+	return ..()
+
+/obj/item/bodycam_upgrade/proc/is_on()
+	if(isnull(builtin_bodycamera))
+		return FALSE
+	return TRUE
+
+/obj/item/bodycam_upgrade/proc/turn_on(mob/user, obj/item/card/id/id_card)
+	builtin_bodycamera = new(user)
+	builtin_bodycamera.internal_light = FALSE
+	builtin_bodycamera.network = list("ss13")
+	builtin_bodycamera.c_tag = "-Body Camera: [(id_card.registered_name)] ([id_card.assignment])"
+	user.balloon_alert(user, "bodycamera activated")
+	playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
+
+/obj/item/bodycam_upgrade/proc/turn_off(mob/user)
+	playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
+	user.balloon_alert(user, "bodycamera deactivated")
+	QDEL_NULL(builtin_bodycamera)
+
+
+/**
+ * Bodycamera element
+ *
+ * Allows anything to have a body camera inserted into it
+ */
+/datum/element/bodycamera_holder
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	id_arg_index = 2
+	///The installed bodycamera
+	var/obj/item/bodycam_upgrade/bodycamera_installed
+	///The clothing part this needs to be on. This could possibly just be done by checking the clothing's slot
+	var/clothingtype_required = ITEM_SLOT_OCLOTHING
+
+/datum/element/bodycamera_holder/Attach(datum/target)
+	. = ..()
+	RegisterSignal(target, COMSIG_PARENT_ATTACKBY, .proc/on_attackby)
+	RegisterSignal(target, COMSIG_PARENT_EXAMINE_MORE, .proc/on_examine_more)
+	RegisterSignal(target, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER), .proc/on_screwdriver_act)
+
+/datum/element/bodycamera_holder/Detach(datum/source, ...)
+	UnregisterSignal(source, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER))
+	UnregisterSignal(source, COMSIG_PARENT_ATTACKBY)
+	UnregisterSignal(source, COMSIG_PARENT_EXAMINE)
+	QDEL_NULL(bodycamera_installed)
+	return ..()
+
+/datum/element/bodycamera_holder/proc/on_examine_more(atom/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	if(!isnull(bodycamera_installed))
+		examine_list += span_notice("It has [bodycamera_installed] installed.")
+	else
+		examine_list += span_notice("It has a spot to hook up a body camera onto.")
+
+/datum/element/bodycamera_holder/proc/on_attackby(datum/source, obj/item/item, mob/living/user)
+	SIGNAL_HANDLER
+
+	if(istype(item, /obj/item/bodycam_upgrade))
+		if(!isnull(bodycamera_installed))
+			to_chat(user, span_warning("We have already installed [bodycamera_installed] installed!"))
+			playsound(source, 'sound/machines/buzz-two.ogg', item.get_clamped_volume(), TRUE, -1)
+		else
+			item.forceMove(source)
+			bodycamera_installed = item
+			to_chat(user, span_warning("You install [item] into [source]."))
+			playsound(source, 'sound/items/drill_use.ogg', item.get_clamped_volume(), TRUE, -1)
+		return
+
+	if(isnull(bodycamera_installed))
+		return
+	var/obj/item/card/id/card = item.GetID()
+	if(!card)
+		return
+	var/obj/item/clothing/suit_slot = user.get_item_by_slot(clothingtype_required)
+	if(!istype(suit_slot))
+		to_chat(user, span_warning("You have to be wearing [source] to turn [bodycamera_installed] on!"))
+		return
+
+	//Do we have a camera on or off?
+	if(bodycamera_installed.is_on())
+		UnregisterSignal(source, COMSIG_ITEM_POST_UNEQUIP)
+		bodycamera_installed.turn_off(user)
+	else
+		RegisterSignal(source, COMSIG_ITEM_POST_UNEQUIP, .proc/on_unequip)
+		bodycamera_installed.turn_on(user, card)
+
+/datum/element/bodycamera_holder/proc/on_screwdriver_act(atom/source, mob/user, obj/item/tool)
+	SIGNAL_HANDLER
+
+	if(isnull(bodycamera_installed))
+		return
+	if(bodycamera_installed.is_on())
+		UnregisterSignal(source, COMSIG_ITEM_POST_UNEQUIP)
+		bodycamera_installed.turn_off(user)
+	to_chat(user, span_warning("You remove the [bodycamera_installed] from [source]."))
+	playsound(source, 'sound/items/drill_use.ogg', tool.get_clamped_volume(), TRUE, -1)
+	bodycamera_installed.forceMove(user.loc)
+	INVOKE_ASYNC(user, /mob.proc/put_in_hands, bodycamera_installed)
+	bodycamera_installed = null
+
+/datum/element/bodycamera_holder/proc/on_unequip(obj/item/source, force, atom/newloc, no_move, invdrop, silent)
+	SIGNAL_HANDLER
+	UnregisterSignal(source, COMSIG_ITEM_POST_UNEQUIP)
+	bodycamera_installed.turn_off(source)


### PR DESCRIPTION
## About The Pull Request

It's still currently only limited to vests, but in the future we can allow the element to maybe be admin-added onto anything, it sounds pretty cool on paper but I am just not motivated enough to go all the way, after being awake over 24 hours.
This change also makes it so bodycameras don't just fucking qdel itself when being inserted into a vest, and make a BRAND new one whenever you "take it out", and removes the dumb "upgraded" var.

Either way, this is still a major improvement, and allows us to add body cameras to different types of suits more easily (code-wise only atm)

I also don't like the copypaste in it but it is fine for now.
