### PR TITLE
Rearranges Helio & Selene Tcomms to make more sense for the 3 people that know how tcomms work

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -43170,7 +43170,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bZO" = (
-/obj/machinery/telecomms/receiver/preset_right,
+/obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bZP" = (
@@ -46555,7 +46555,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "chB" = (
-/obj/machinery/telecomms/receiver/preset_left,
+/obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "chC" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -2475,25 +2475,16 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aLr" = (
-/obj/machinery/telecomms/server/presets/security,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
+/obj/machinery/telecomms/server/presets/common,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "Security red corner"
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "Security red corner"
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
@@ -40044,16 +40035,25 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "kCA" = (
-/obj/machinery/telecomms/server/presets/common,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/machinery/telecomms/server/presets/medical,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue corner"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
@@ -42208,25 +42208,16 @@
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/restrooms)
 "ldJ" = (
-/obj/machinery/telecomms/server/presets/science,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
+/obj/machinery/telecomms/server/presets/supply,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 4;
-	name = "Science purple corner"
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
@@ -51710,25 +51701,25 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "nuL" = (
-/obj/machinery/telecomms/server/presets/medical,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
+/obj/machinery/telecomms/server/presets/service,
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
 	dir = 4;
-	name = "Medical blue corner"
+	name = "dark corner"
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
 	dir = 1;
-	name = "Medical blue corner"
+	name = "dark corner"
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 8;
+	name = "dark corner"
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
@@ -53973,16 +53964,25 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "obB" = (
-/obj/machinery/telecomms/server/presets/supply,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/machinery/telecomms/server/presets/command,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
@@ -59943,25 +59943,25 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "pJz" = (
-/obj/machinery/telecomms/server/presets/service,
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 4;
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
+/obj/machinery/telecomms/server/presets/security,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
 	dir = 1;
-	name = "dark corner"
+	name = "Security red corner"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 4;
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
 	dir = 8;
-	name = "dark corner"
+	name = "Security red corner"
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
@@ -63592,25 +63592,25 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "qIt" = (
-/obj/machinery/telecomms/server/presets/command,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
+/obj/machinery/telecomms/server/presets/engineering,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
 	dir = 1;
-	name = "Command blue corner"
+	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
 	dir = 8;
-	name = "Command blue corner"
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
@@ -80146,25 +80146,25 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "uUB" = (
-/obj/machinery/telecomms/server/presets/engineering,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
+/obj/machinery/telecomms/server/presets/science,
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
 	dir = 8;
-	name = "Engineering yellow corner"
+	name = "Science purple corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
 	dir = 4;
-	name = "Engineering yellow corner"
+	name = "Science purple corner"
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25415050/158050738-b5d64c10-b2b7-46c6-a312-9edb8e700a18.png)
Hard to explain without going in details of how tcomms in mapping works but the bs receiver's presets were meant for the servers opposite side of the room

## Why it's good for the game
More consistency, hard to notice unless you're familiar enough already with how Tcomms work

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: more consistency in how Tcomms operate on helio & selene
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
