### PR TITLE
Predatory lunge rework

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/lunge.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/lunge.dm
@@ -3,28 +3,31 @@
 	desc = "Spring at your target to grapple them without warning, or tear the dead's heart out. Attacks from concealment or the rear may even knock them down if strong enough."
 	button_icon_state = "power_lunge"
 	power_explanation = "<b>Predatory Lunge</b>:\n\
-		Click any player to instantly dash at them, aggressively grabbing them.\n\
-		You cannot use the Power if you are aggressively grabbed.\n\
-		Higher levels will increase the knockdown dealt to enemies.\n\
+		Click any player to, after a short delay, dash at them.\n\
+		When lunging at someone, you will grab them, immediately starting off at aggressive.\n\
+		There is an exception to this, those wearing Riot gear, and Monster Hunters, will be passively grabbed instead.\n\
+		You cannot use the Power if you are already grabbing someone, or are being grabbed.\n\
 		If used on a dead body, will tear their heart out.\n\
-		Once this power reaches level 4, you unlock two new abilities;\n\
-		1 - If the target is wearing riot gear or is a Monster Hunter, you will merely passively grab them.\n\
-		2 - If grabbed from behind or from the darkness (Cloak of Darkness counts), you will additionally knock the target down."
+		Higher levels increase the knockdown dealt to enemies.\n\
+		At level 4, if you grab from behind or from darkness (Cloak of Darkness works), you will knock the target down."
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_IN_FRENZY|BP_CANT_USE_WHILE_INCAPACITATED|BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY|VASSAL_CAN_BUY
 	bloodcost = 10
 	cooldown = 10 SECONDS
-	target_range = 3
-	power_activates_immediately = TRUE
+	target_range = 6
+	power_activates_immediately = FALSE
 
 /datum/action/bloodsucker/targeted/lunge/CheckCanUse(mob/living/carbon/user)
 	. = ..()
 	if(!.)
 		return FALSE
-	/// Are we being grabbed?
+	// Are we being grabbed?
 	if(user.pulledby && user.pulledby.grab_state >= GRAB_AGGRESSIVE)
-		to_chat(user, span_warning("You're being grabbed!"))
+		owner.balloon_alert(user, "grabbed!")
+		return FALSE
+	if(user.pulling)
+		owner.balloon_alert(user, "grabbing someone!")
 		return FALSE
 	return TRUE
 
@@ -56,81 +59,97 @@
 	var/mob/living/carbon/target = target_atom
 	var/turf/targeted_turf = get_turf(target)
 
-	/// Stop pulling anyone (If we are)
-	owner.pulling = null
-
 	owner.face_atom(target_atom)
-	/// Don't move as we perform this, please.
 	ADD_TRAIT(user, TRAIT_IMMOBILIZED, BLOODSUCKER_TRAIT)
-	/// Directly copied from haste.dm
+	if(level_current <= 3 && !prepare_target_lunge(target_atom))
+		PowerActivatedSuccessfully()
+		return
+
 	var/safety = get_dist(user, targeted_turf) * 3 + 1
 	var/consequetive_failures = 0
 	while(--safety && !target.Adjacent(user))
-		/// This does not try to go around obstacles.
-		var/success = step_towards(user, targeted_turf)
-		if(!success)
-			/// This does
-			success = step_to(user, targeted_turf)
-		if(!success)
+		if(!step_to(user, targeted_turf))
 			consequetive_failures++
-			/// If 3 steps don't work, just stop.
-			if(consequetive_failures >= 3)
-				break
-		/// we've succeeded at least once? Reset it.
-		else
-			consequetive_failures = 0
-	/// It ended? Let's get our target now.
+		if(consequetive_failures >= 3) // If 3 steps don't work, just stop.
+			break
 	lunge_end(target)
+	PowerActivatedSuccessfully()
+
+/datum/action/bloodsucker/targeted/lunge/proc/prepare_target_lunge(atom/target_atom)
+	START_PROCESSING(SSprocessing, src)
+	owner.balloon_alert(owner, "lunge started!")
+	//animate them shake
+	var/base_x = owner.base_pixel_x
+	var/base_y = owner.base_pixel_y
+	animate(owner, pixel_x = base_x, pixel_y = base_y, time = 1, loop = -1)
+	for(var/i in 1 to 25)
+		var/x_offset = base_x + rand(-3, 3)
+		var/y_offset = base_y + rand(-3, 3)
+		animate(pixel_x = x_offset, pixel_y = y_offset, time = 1)
+
+	if(!do_after(owner, 4 SECONDS, extra_checks = CheckCanTarget(target_atom)))
+		animate(owner, pixel_x = base_x, pixel_y = base_y, time = 1)
+		STOP_PROCESSING(SSprocessing, src)
+		return FALSE
+	animate(owner, pixel_x = base_x, pixel_y = base_y, time = 1)
+	STOP_PROCESSING(SSprocessing, src)
+	return TRUE
+
+/datum/action/bloodsucker/targeted/lunge/process()
+	if(prob(75))
+		owner.spin(8, 1)
+		owner.balloon_alert_to_viewers("spins wildly!", "you spin!")
+		return
+	do_smoke(0, owner.loc, smoke_type = /obj/effect/particle_effect/smoke/transparent)
 
 /datum/action/bloodsucker/targeted/lunge/proc/lunge_end(atom/hit_atom)
 	var/mob/living/user = owner
 	var/mob/living/carbon/target = hit_atom
 	var/turf/target_turf = get_turf(target)
 	// Check: Will our lunge knock them down? This is done if the target is looking away, the user is in Cloak of Darkness, or in a closet.
-	var/do_knockdown = !is_source_facing_target(target, owner) || owner.alpha <= 40
+	var/do_knockdown = level_current >= 4 && (!is_source_facing_target(target, owner) || owner.alpha <= 40)
 
-	/// We got a target?
-	/// Am I next to my target to start giving the effects?
-	if(user.Adjacent(target))
-		// Did I slip?
-		if(!user.body_position == STANDING_UP)
-			return
-		// Is my target a Monster hunter?
-		if(IS_MONSTERHUNTER(target))
-			owner.balloon_alert(owner, "you get pushed away!")
-			target.grabbedby(owner)
-			return
-
-		owner.balloon_alert(owner, "you lunge at [target]!")
-		/// Good to go!
-		target.Stun(10 + level_current * 5)
-		// Instantly aggro grab them if they don't have riot gear.
+	// We got a target?
+	// Am I next to my target to start giving the effects?
+	if(!user.Adjacent(target))
+		return
+	// Did I slip?
+	if(!user.body_position == STANDING_UP)
+		return
+	// Is my target a Monster hunter?
+	if(IS_MONSTERHUNTER(target) || target.is_shove_knockdown_blocked())
+		owner.balloon_alert(owner, "you get pushed away!")
 		target.grabbedby(owner)
-		if(!target.is_shove_knockdown_blocked() && level_current >= 4)
-			target.grippedby(owner, instant = TRUE)
-		// Did we knock them down?
-		if(do_knockdown && level_current >= 4)
-			target.Knockdown(10 + level_current * 5)
-			target.Paralyze(0.1)
-		/// Are they dead?
-		if(target.stat == DEAD)
-			var/obj/item/bodypart/chest = target.get_bodypart(BODY_ZONE_CHEST)
-			var/datum/wound/slash/moderate/crit_wound = new
-			crit_wound.apply_wound(chest)
-			owner.visible_message(
-				span_warning("[owner] tears into [target]'s chest!"),
-				span_warning("You tear into [target]'s chest!"),
-			)
-			var/obj/item/organ/heart/myheart_now = locate() in target.internal_organs
-			if(myheart_now)
-				myheart_now.Remove(target)
-				user.put_in_hands(myheart_now)
+		return
+
+	owner.balloon_alert(owner, "you lunge at [target]!")
+	if(target.stat == DEAD)
+		var/obj/item/bodypart/chest = target.get_bodypart(BODY_ZONE_CHEST)
+		var/datum/wound/slash/moderate/crit_wound = new
+		crit_wound.apply_wound(chest)
+		owner.visible_message(
+			span_warning("[owner] tears into [target]'s chest!"),
+			span_warning("You tear into [target]'s chest!"))
+		var/obj/item/organ/heart/myheart_now = locate() in target.internal_organs
+		if(myheart_now)
+			myheart_now.Remove(target)
+			user.put_in_hands(myheart_now)
+		return
+
+	//Grab now
+	target.grabbedby(owner)
+	target.grippedby(owner, instant = TRUE)
+	// Did we knock them down?
+	if(do_knockdown)
+		target.Knockdown(10 + level_current * 5)
+		target.Paralyze(0.1)
 	// Lastly, did we get knocked down by the time we did this?
-	if(user && user.incapacitated())
-		if(!(user.body_position == LYING_DOWN))
-			var/send_dir = get_dir(user, target_turf)
-			new /datum/forced_movement(user, get_ranged_target_turf(user, send_dir, 1), 1, FALSE)
-			user.spin(10)
+	if(user.incapacitated())
+		if(user.body_position == LYING_DOWN)
+			return
+		var/send_dir = get_dir(user, target_turf)
+		new /datum/forced_movement(user, get_ranged_target_turf(user, send_dir, 1), 1, FALSE)
+		user.spin(10)
 
 /datum/action/bloodsucker/targeted/lunge/DeactivatePower()
 	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, BLOODSUCKER_TRAIT)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/lunge.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/lunge.dm
@@ -106,15 +106,15 @@
 	var/mob/living/user = owner
 	var/mob/living/carbon/target = hit_atom
 	var/turf/target_turf = get_turf(target)
-	// Check: Will our lunge knock them down? This is done if the target is looking away, the user is in Cloak of Darkness, or in a closet.
-	var/do_knockdown = level_current >= 4 && (!is_source_facing_target(target, owner) || owner.alpha <= 40)
 
-	// We got a target?
 	// Am I next to my target to start giving the effects?
 	if(!user.Adjacent(target))
 		return
-	// Did I slip?
-	if(!user.body_position == STANDING_UP)
+	// Did I slip or get knocked unconscious?
+	if(user.body_position != STANDING_UP || user.incapacitated())
+		var/send_dir = get_dir(user, target_turf)
+		new /datum/forced_movement(user, get_ranged_target_turf(user, send_dir, 1), 1, FALSE)
+		user.spin(10)
 		return
 	// Is my target a Monster hunter?
 	if(IS_MONSTERHUNTER(target) || target.is_shove_knockdown_blocked())
@@ -140,17 +140,10 @@
 	target.grabbedby(owner)
 	target.grippedby(owner, instant = TRUE)
 	// Did we knock them down?
-	if(do_knockdown)
+	if(level_current >= 4 && (!is_source_facing_target(target, owner) || owner.alpha <= 40))
 		target.Knockdown(10 + level_current * 5)
 		target.Paralyze(0.1)
-	// Lastly, did we get knocked down by the time we did this?
-	if(user.incapacitated())
-		if(user.body_position == LYING_DOWN)
-			return
-		var/send_dir = get_dir(user, target_turf)
-		new /datum/forced_movement(user, get_ranged_target_turf(user, send_dir, 1), 1, FALSE)
-		user.spin(10)
 
 /datum/action/bloodsucker/targeted/lunge/DeactivatePower()
 	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, BLOODSUCKER_TRAIT)
-	. = ..()
+	return ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/lunge.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/lunge.dm
@@ -60,11 +60,11 @@
 	var/turf/targeted_turf = get_turf(target)
 
 	owner.face_atom(target_atom)
-	ADD_TRAIT(user, TRAIT_IMMOBILIZED, BLOODSUCKER_TRAIT)
 	if(level_current <= 3 && !prepare_target_lunge(target_atom))
 		PowerActivatedSuccessfully()
 		return
 
+	ADD_TRAIT(user, TRAIT_IMMOBILIZED, BLOODSUCKER_TRAIT)
 	var/safety = get_dist(user, targeted_turf) * 3 + 1
 	var/consequetive_failures = 0
 	while(--safety && !target.Adjacent(user))

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/trespass.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/trespass.dm
@@ -72,8 +72,7 @@
 	// Effect Origin
 	var/sound_strength = max(60, 70 - level_current * 10)
 	playsound(get_turf(owner), 'sound/magic/summon_karp.ogg', sound_strength, 1)
-	var/datum/effect_system/steam_spread/puff = new /datum/effect_system/steam_spread/()
-	puff.effect_type = /obj/effect/particle_effect/smoke/vampsmoke
+	var/datum/effect_system/steam_spread/bloodsucker/puff = new /datum/effect_system/steam_spread()
 	puff.set_up(3, 0, my_turf)
 	puff.start()
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/veil.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/veil.dm
@@ -128,8 +128,7 @@
 /datum/action/bloodsucker/veil/proc/cast_effect()
 	// Effect
 	playsound(get_turf(owner), 'sound/magic/smoke.ogg', 20, 1)
-	var/datum/effect_system/steam_spread/puff = new /datum/effect_system/steam_spread/()
-	puff.effect_type = /obj/effect/particle_effect/smoke/vampsmoke
+	var/datum/effect_system/steam_spread/bloodsucker/puff = new /datum/effect_system/steam_spread/()
 	puff.set_up(3, 0, get_turf(owner))
 	puff.attach(owner) //OPTIONAL
 	puff.start()


### PR DESCRIPTION
## About The Pull Request

- Brings back immediate aggro grabs because just passive grabbing sucked
- Makes riot gear and monster hunters be protected from lunges the same way, as to cut down on needless copypaste.
- Removes instead, the Stun, from using the ability itself, which was detached from the grabbing itself. This still being in the game meant there was no different if lunge aggro grabbed since you can just aggro grab manually anyways.
- Adds a new limit, you can't lunge while you have someone grabbed already.
- Makes predatory lunging at low levels make you spin around and cause smoke, before you lunge at your target. this means that during low levels, predatory lunge is pretty weak. I'm considering bumping this bypass to level 6 or so, and make the timer needed to lunge lower as you level up.
- Because of the new changes making predatory lunge not, at least immediately, an insta-win ability, I buffed its target range to 6, it was at 3 before.

https://user-images.githubusercontent.com/53777086/158266629-bbe4f22b-35af-4a05-8e7a-cea295223678.mp4

## Why It's Good For The Game

Lunge sucks, it's basically become the must-have ability, overshadowing even Fortitude and Brawn. On top of this, recent nerfs have done nothing to actually change it, they were inneffective bandaids. This will hopefully bring them up to speed with the other powers, and makes predatory lunge look pretty sick to use.
