### PR TITLE
Fixes trash spawning in structures on prison shuttle

### DIFF
--- a/fulp_modules/features/prison/prison_shuttle/prison_shuttle_template.dm
+++ b/fulp_modules/features/prison/prison_shuttle/prison_shuttle_template.dm
@@ -124,7 +124,7 @@
 	var/list/area/shuttle/shuttle_areas = SSshuttle.prison_shuttle.shuttle_areas
 	for(var/area/shuttle/shuttle_area in shuttle_areas)
 		for(var/turf/shuttle_turf in shuttle_area)
-			if(iswallturf(shuttle_turf))
+			if(iswallturf(shuttle_turf) || isstructure(shuttle_turf))
 				continue
 			if(!pod_loc && prob(5))
 				pod_loc = shuttle_turf


### PR DESCRIPTION
fixes trash spawns spawning in weird places that it shouldn't (i.e. in TURBINES)

:cl:
fix: Trash will no longer spawn in odd places on the prison shuttles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
