### PR TITLE
makes body cams a component

### DIFF
--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -37,12 +37,14 @@
 	builtin_bodycamera.internal_light = FALSE
 	builtin_bodycamera.network = list("ss13")
 	builtin_bodycamera.c_tag = "-Body Camera: [(id_card.registered_name)] ([id_card.assignment])"
-	user.balloon_alert(user, "bodycamera activated.")
 	playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
+	if(user)
+		user.balloon_alert(user, "bodycamera activated.")
 
 /obj/item/bodycam_upgrade/proc/turn_off(mob/user)
+	if(user)
+		user.balloon_alert(user, "bodycamera deactivated.")
 	playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
-	user.balloon_alert(user, "bodycamera deactivated.")
 	QDEL_NULL(builtin_bodycamera)
 
 
@@ -82,7 +84,7 @@
 /// When the camera holder is unequipped
 /datum/component/bodycamera_holder/proc/on_unequip(mob/living/source, force, atom/newloc, no_move, invdrop, silent)
 	SIGNAL_HANDLER
-	turn_camera_off(source)
+	turn_camera_off()
 
 /// When examining
 /datum/component/bodycamera_holder/proc/on_examine_more(atom/source, mob/user, list/examine_list)

--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -1,7 +1,7 @@
 
 /obj/item/clothing/suit/armor/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/bodycamera_holder)
+	AddComponent(/datum/component/bodycamera_holder)
 
 /**
  * The bodycamera
@@ -37,54 +37,68 @@
 	builtin_bodycamera.internal_light = FALSE
 	builtin_bodycamera.network = list("ss13")
 	builtin_bodycamera.c_tag = "-Body Camera: [(id_card.registered_name)] ([id_card.assignment])"
-	user.balloon_alert(user, "bodycamera activated")
+	user.balloon_alert(user, "bodycamera activated.")
 	playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
 
 /obj/item/bodycam_upgrade/proc/turn_off(mob/user)
 	playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
-	user.balloon_alert(user, "bodycamera deactivated")
+	user.balloon_alert(user, "bodycamera deactivated.")
 	QDEL_NULL(builtin_bodycamera)
 
 
 /**
- * Bodycamera element
+ * Bodycamera component
  *
  * Allows anything to have a body camera inserted into it
  */
-/datum/element/bodycamera_holder
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
-	id_arg_index = 2
+/datum/component/bodycamera_holder
 	///The installed bodycamera
 	var/obj/item/bodycam_upgrade/bodycamera_installed
 	///The clothing part this needs to be on. This could possibly just be done by checking the clothing's slot
 	var/clothingtype_required = ITEM_SLOT_OCLOTHING
 
-/datum/element/bodycamera_holder/Attach(datum/target)
+/datum/component/bodycamera_holder/RegisterWithParent()
 	. = ..()
-	RegisterSignal(target, COMSIG_PARENT_ATTACKBY, .proc/on_attackby)
-	RegisterSignal(target, COMSIG_PARENT_EXAMINE_MORE, .proc/on_examine_more)
-	RegisterSignal(target, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER), .proc/on_screwdriver_act)
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/on_attackby)
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE_MORE, .proc/on_examine_more)
+	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER), .proc/on_screwdriver_act)
 
-/datum/element/bodycamera_holder/Detach(datum/source, ...)
-	UnregisterSignal(source, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER))
-	UnregisterSignal(source, COMSIG_PARENT_ATTACKBY)
-	UnregisterSignal(source, COMSIG_PARENT_EXAMINE)
+/datum/component/bodycamera_holder/UnregisterFromParent()
+	. = ..()
+	UnregisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER))
+	UnregisterSignal(parent, COMSIG_PARENT_ATTACKBY)
+	UnregisterSignal(parent, COMSIG_PARENT_EXAMINE)
 	QDEL_NULL(bodycamera_installed)
 	return ..()
 
-/datum/element/bodycamera_holder/proc/on_examine_more(atom/source, mob/user, list/examine_list)
+/datum/component/bodycamera_holder/proc/turn_camera_on(mob/living/user, obj/item/card)
+	RegisterSignal(parent, COMSIG_ITEM_POST_UNEQUIP, .proc/on_unequip)
+	bodycamera_installed.turn_on(user, card)
+
+/datum/component/bodycamera_holder/proc/turn_camera_off(mob/living/user)
+	UnregisterSignal(parent, COMSIG_ITEM_POST_UNEQUIP)
+	bodycamera_installed.turn_off(user)
+
+/// When the camera holder is unequipped
+/datum/component/bodycamera_holder/proc/on_unequip(mob/living/source, force, atom/newloc, no_move, invdrop, silent)
+	SIGNAL_HANDLER
+	turn_camera_off(source)
+
+/// When examining
+/datum/component/bodycamera_holder/proc/on_examine_more(atom/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	if(!isnull(bodycamera_installed))
+	if(bodycamera_installed)
 		examine_list += span_notice("It has [bodycamera_installed] installed.")
 	else
 		examine_list += span_notice("It has a spot to hook up a body camera onto.")
 
-/datum/element/bodycamera_holder/proc/on_attackby(datum/source, obj/item/item, mob/living/user)
+/// When items are used on it. Bodycamera/ID card
+/datum/component/bodycamera_holder/proc/on_attackby(datum/source, obj/item/item, mob/living/user)
 	SIGNAL_HANDLER
 
 	if(istype(item, /obj/item/bodycam_upgrade))
-		if(!isnull(bodycamera_installed))
+		if(bodycamera_installed)
 			to_chat(user, span_warning("We have already installed [bodycamera_installed] installed!"))
 			playsound(source, 'sound/machines/buzz-two.ogg', item.get_clamped_volume(), TRUE, -1)
 		else
@@ -94,8 +108,9 @@
 			playsound(source, 'sound/items/drill_use.ogg', item.get_clamped_volume(), TRUE, -1)
 		return
 
-	if(isnull(bodycamera_installed))
+	if(!bodycamera_installed)
 		return
+
 	var/obj/item/card/id/card = item.GetID()
 	if(!card)
 		return
@@ -106,27 +121,20 @@
 
 	//Do we have a camera on or off?
 	if(bodycamera_installed.is_on())
-		UnregisterSignal(source, COMSIG_ITEM_POST_UNEQUIP)
-		bodycamera_installed.turn_off(user)
+		turn_camera_off(user)
 	else
-		RegisterSignal(source, COMSIG_ITEM_POST_UNEQUIP, .proc/on_unequip)
-		bodycamera_installed.turn_on(user, card)
+		turn_camera_on(user, card)
 
-/datum/element/bodycamera_holder/proc/on_screwdriver_act(atom/source, mob/user, obj/item/tool)
+/// When a screwdriver is used on it
+/datum/component/bodycamera_holder/proc/on_screwdriver_act(atom/source, mob/user, obj/item/tool)
 	SIGNAL_HANDLER
 
-	if(isnull(bodycamera_installed))
+	if(!bodycamera_installed)
 		return
 	if(bodycamera_installed.is_on())
-		UnregisterSignal(source, COMSIG_ITEM_POST_UNEQUIP)
-		bodycamera_installed.turn_off(user)
+		turn_camera_off(user)
 	to_chat(user, span_warning("You remove the [bodycamera_installed] from [source]."))
 	playsound(source, 'sound/items/drill_use.ogg', tool.get_clamped_volume(), TRUE, -1)
 	bodycamera_installed.forceMove(user.loc)
 	INVOKE_ASYNC(user, /mob.proc/put_in_hands, bodycamera_installed)
 	bodycamera_installed = null
-
-/datum/element/bodycamera_holder/proc/on_unequip(obj/item/source, force, atom/newloc, no_move, invdrop, silent)
-	SIGNAL_HANDLER
-	UnregisterSignal(source, COMSIG_ITEM_POST_UNEQUIP)
-	bodycamera_installed.turn_off(source)


### PR DESCRIPTION
## About The Pull Request

Body cameras try to do things elements aren't supposed to do, so I swapped them out for Component instead.

## Why It's Good For The Game

If 2 officers got a body camera, what the first officer did with it would affect all others, because all elements were DUPLICATES AND AFFECTS EACHOTHER because THAT'S how elements work YEA
