### PR TITLE
Standardize toxins + helio qol

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -43343,7 +43343,6 @@
 	dir = 9;
 	name = "research purple"
 	},
-/obj/machinery/light_switch/directional/north,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
@@ -43368,10 +43367,10 @@
 	dir = 1;
 	name = "research purple"
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "cbR" = (
@@ -45392,9 +45391,6 @@
 	color = "#990099";
 	name = "research purple"
 	},
-/obj/structure/chair/office{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "cgy" = (
@@ -46229,6 +46225,7 @@
 	name = "research purple"
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "ciB" = (
@@ -46239,6 +46236,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "ciC" = (
@@ -46525,10 +46523,7 @@
 /area/tcommsat/server)
 "cjp" = (
 /obj/effect/turf_decal/stripes/full,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -30
-	},
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/science/mixing)
 "cjq" = (
 /obj/structure/table,
@@ -64787,16 +64782,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "eXD" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/beer,
-/obj/item/reagent_containers/food/drinks/bottle/beer,
-/obj/item/reagent_containers/food/drinks/bottle/beer,
-/obj/item/reagent_containers/food/drinks/bottle/beer,
-/obj/item/reagent_containers/food/drinks/bottle/beer,
-/obj/item/reagent_containers/food/drinks/bottle/beer,
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
-	dir = 6;
 	name = "research purple"
 	},
 /turf/open/floor/iron/dark,
@@ -64879,6 +64866,15 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"fcF" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/purple{
+	color = "#990099";
+	dir = 4;
+	name = "research purple"
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "fdQ" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 8
@@ -65820,11 +65816,10 @@
 "gYz" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
-	dir = 5;
+	dir = 1;
 	name = "research purple"
 	},
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/doppler_array,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "haH" = (
@@ -66090,9 +66085,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "hrj" = (
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/full,
-/obj/machinery/door/poddoor/massdriver_ordnance,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -30
+	},
 /turf/open/floor/plating,
 /area/science/mixing)
 "hse" = (
@@ -66246,6 +66242,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"hCJ" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/poddoor/massdriver_ordnance,
+/turf/open/floor/plating,
+/area/science/mixing)
 "hDw" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
@@ -70843,11 +70845,8 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "pNq" = (
-/obj/structure/table,
-/obj/effect/turf_decal/siding/purple{
-	color = "#990099";
-	dir = 4;
-	name = "research purple"
+/obj/structure/chair/office{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
@@ -72088,15 +72087,13 @@
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "rTm" = (
-/obj/machinery/computer/security/telescreen/ordnance{
-	pixel_y = -29
-	},
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
-	dir = 4;
+	dir = 5;
 	name = "research purple"
 	},
-/obj/machinery/research/anomaly_refinery,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/doppler_array,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "rTq" = (
@@ -72456,6 +72453,18 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"sBR" = (
+/obj/machinery/computer/security/telescreen/ordnance{
+	pixel_y = -29
+	},
+/obj/effect/turf_decal/siding/purple{
+	color = "#990099";
+	dir = 4;
+	name = "research purple"
+	},
+/obj/machinery/research/anomaly_refinery,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "sEp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -73803,6 +73812,21 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"vhW" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/beer,
+/obj/item/reagent_containers/food/drinks/bottle/beer,
+/obj/item/reagent_containers/food/drinks/bottle/beer,
+/obj/item/reagent_containers/food/drinks/bottle/beer,
+/obj/item/reagent_containers/food/drinks/bottle/beer,
+/obj/item/reagent_containers/food/drinks/bottle/beer,
+/obj/effect/turf_decal/siding/purple{
+	color = "#990099";
+	dir = 6;
+	name = "research purple"
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "vjN" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 4
@@ -128482,7 +128506,7 @@ bBg
 eDV
 bxD
 gYz
-rTm
+cgc
 pNq
 eXD
 cbS
@@ -128738,10 +128762,10 @@ bJT
 bJT
 bJT
 bxD
-cbS
-cbS
-cbS
-cbS
+rTm
+sBR
+fcF
+vhW
 cbS
 hrj
 cbS
@@ -128994,14 +129018,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bZD
-aaa
-bZD
+bxD
+cbS
+cbS
+cbS
+cbS
+cbS
+hCJ
+cbS
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -23054,15 +23054,7 @@
 /area/hallway/primary/aft)
 "bDL" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
-/area/science/storage)
-"bDN" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/storage)
 "bDQ" = (
@@ -23381,19 +23373,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
-"bFa" = (
-/obj/effect/turf_decal/bot,
+"bFb" = (
+/obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine,
 /area/science/storage)
-"bFb" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
-/area/science/storage)
 "bFc" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -23614,24 +23601,17 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
-"bGf" = (
+"bGg" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/science/storage)
-"bGg" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/science/storage)
 "bGh" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/science/storage)
 "bGi" = (
@@ -35451,6 +35431,14 @@
 /obj/item/pen/red,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"eAa" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/engine,
+/area/science/storage)
 "eAF" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -46781,6 +46769,12 @@
 /obj/structure/musician/piano,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
+"pmq" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/engine,
+/area/science/storage)
 "pmv" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -47023,6 +47017,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"pDe" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/engine,
+/area/science/storage)
 "pDf" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -56246,6 +56248,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"wZx" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/engine,
+/area/science/storage)
 "wZB" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/cable,
@@ -95736,10 +95743,10 @@ bAA
 bBC
 bBC
 bDL
-bFa
-bGf
-bCR
-bCR
+bFb
+bGg
+wZx
+pmq
 aqm
 fBp
 eDR
@@ -95995,8 +96002,8 @@ bBC
 bDL
 bFb
 bGg
-bCR
-bCR
+wZx
+pmq
 bJO
 vMt
 iJc
@@ -96249,11 +96256,11 @@ byU
 bAA
 bBE
 bCQ
-bDN
+bFc
 bFc
 bGh
-bCR
-bCR
+pDe
+eAa
 aqO
 fBp
 auX

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -3030,6 +3030,9 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/large,
 /area/science/storage)
 "aQq" = (
@@ -21564,10 +21567,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "fEV" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/storage)
 "fEY" = (
@@ -26443,6 +26444,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"gSG" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
 "gSR" = (
 /obj/structure/table/reinforced,
 /obj/item/trash/chips,
@@ -32168,6 +32172,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/science/storage)
 "ipP" = (
@@ -38878,6 +38885,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/science/storage)
 "kfK" = (
@@ -45464,9 +45474,6 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/aft)
 "lOK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 10
@@ -45474,7 +45481,9 @@
 /obj/machinery/firealarm/directional/south{
 	pixel_x = -3
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron/dark/textured_large,
 /area/science/storage)
 "lOO" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -64368,12 +64377,11 @@
 /turf/open/floor/iron/white,
 /area/service/theater)
 "qKm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron/dark/textured_large,
 /area/science/storage)
 "qKK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
@@ -141875,7 +141883,7 @@ bke
 oSC
 sDL
 wpj
-wpj
+gSG
 xBU
 mSd
 iMG

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -143681,7 +143681,7 @@ qmp
 qmp
 qmp
 qmp
-iQW
+yju
 yju
 yju
 yju
@@ -143937,8 +143937,8 @@ fIh
 iQW
 iQW
 yju
-iQW
-iQW
+yju
+yju
 vmD
 vmD
 vmD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR made some toxins changes: https://github.com/tgstation/tgstation/pull/65289.

This updates fulp maps to do it exept the removing co2 canisters part bc i like those and feel like it might get used in toxins later on. I also expanded helio launch chamber a bit since the connector would block machines if you put a canister on it. Puppy has a bit extra canisters since sci has to share with atmos (L)

Bit more lattice on Selene since i thought it looked weird.

## Helio:
![image](https://user-images.githubusercontent.com/95765134/161821771-fd6e7537-212f-471a-8ec7-493517c21f67.png)

![image](https://user-images.githubusercontent.com/95765134/161821816-658cf4c4-4e12-4288-bb81-94a8610f4d7f.png)


## Puppy
![image](https://user-images.githubusercontent.com/95765134/161822235-280b940f-c696-4bdb-b08c-e9b17c6d4c95.png)

## Selene
![image](https://user-images.githubusercontent.com/95765134/161822326-79f05171-2e2d-4a08-b99f-a379bdab285c.png)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
qol and updates fulp maps to TG canister ammounts.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Standardizes canister ammounts.
qol: Helio launch chamber is a bit bigger so that you don't block machines with your canisters on the tank compressor.
add: More lattice on Selene so it looks less weird hopefully.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
