### PR TITLE
Bloodsucker expansion - Debraining

### DIFF
--- a/fulp_modules/_defines/signals.dm
+++ b/fulp_modules/_defines/signals.dm
@@ -1,6 +1,3 @@
-/// Deals with constant processes off of LifeTick()
-#define COMSIG_LIVING_BIOLOGICAL_LIFE "biological_life"
-
 ///Mentorsay's keybind being pressed.
 #define COMSIG_KB_ADMIN_MSAY_DOWN "keybinding_mentor_msay_down"
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/antagonists/vassal_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/antagonists/vassal_datum.dm
@@ -28,8 +28,13 @@
 /datum/antagonist/vassal/apply_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/current_mob = mob_override || owner.current
-	add_team_hud(current_mob)
+	current_mob.apply_status_effect(/datum/status_effect/agent_pinpointer/vassal_edition)
 	add_team_hud(current_mob, /datum/antagonist/bloodsucker)
+
+/datum/antagonist/vassal/remove_innate_effects(mob/living/mob_override)
+	. = ..()
+	var/mob/living/current_mob = mob_override || owner.current
+	current_mob.remove_status_effect(/datum/status_effect/agent_pinpointer/vassal_edition)
 
 /datum/antagonist/vassal/pre_mindshield(mob/implanter, mob/living/mob_override)
 	if(favorite_vassal)
@@ -50,8 +55,6 @@
 			bloodsuckerdatum.vassals |= src
 		owner.enslave_mind_to_creator(master.owner.current)
 	owner.current.log_message("has been vassalized by [master.owner.current]!", LOG_ATTACK, color="#960000")
-	/// Give Vassal Pinpointer
-	owner.current.apply_status_effect(/datum/status_effect/agent_pinpointer/vassal_edition)
 	/// Give Recuperate Power
 	BuyPower(new /datum/action/bloodsucker/recuperate)
 	/// Give Objectives
@@ -64,23 +67,27 @@
 	. = ..()
 
 /datum/antagonist/vassal/on_removal()
-	/// Free them from their Master
+	//Free them from their Master
 	if(master && master.owner)
 		master.vassals -= src
 		owner.enslaved_to = null
-	/// Remove Pinpointer
-	owner.current.remove_status_effect(/datum/status_effect/agent_pinpointer/vassal_edition)
-	/// Remove ALL Traits, as long as its from BLOODSUCKER_TRAIT's source.
+	//Remove ALL Traits, as long as its from BLOODSUCKER_TRAIT's source.
 	for(var/all_status_traits in owner.current.status_traits)
 		REMOVE_TRAIT(owner.current, all_status_traits, BLOODSUCKER_TRAIT)
-	/// Remove Recuperate Power
+	//Remove Recuperate Power
 	while(powers.len)
 		var/datum/action/bloodsucker/power = pick(powers)
 		powers -= power
 		power.Remove(owner.current)
-	/// Remove Language & Hud
+	//Remove Language & Hud
 	owner.current.remove_language(/datum/language/vampiric)
 	return ..()
+
+/datum/antagonist/vassal/on_body_transfer(mob/living/old_body, mob/living/new_body)
+	. = ..()
+	for(var/datum/action/bloodsucker/all_powers as anything in powers)
+		all_powers.Remove(old_body)
+		all_powers.Grant(new_body)
 
 /datum/antagonist/vassal/proc/add_objective(datum/objective/added_objective)
 	objectives += added_objective

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
@@ -38,11 +38,6 @@
 		return 0
 	. = ..()
 
-// Overwrites mob/living/life.dm instead of doing handle_changeling
-/mob/living/carbon/human/Life(delta_time = SSMOBS_DT, times_fired)
-	. = ..()
-	SEND_SIGNAL(src, COMSIG_LIVING_BIOLOGICAL_LIFE, delta_time, times_fired)
-
 // Used when analyzing a Bloodsucker, Masquerade will hide brain traumas (Unless you're a Beefman)
 /mob/living/carbon/get_traumas()
 	if(!mind)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -31,7 +31,7 @@
 		if(prob(85) || owner.current.stat != CONSCIOUS || HAS_TRAIT(owner.current, TRAIT_MASQUERADE))
 			return
 		var/message = pick(strings("malkavian_revelations.json", "revelations", "fulp_modules/strings/bloodsuckers"))
-		INVOKE_ASYNC(owner.current, /atom/movable/proc/say, message, forced = CLAN_MALKAVIAN)
+		INVOKE_ASYNC(owner.current, /atom/movable/proc/say, message, , , , , , CLAN_MALKAVIAN)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //			BLOOD

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -1,7 +1,9 @@
-/// Runs from COMSIG_LIVING_BIOLOGICAL_LIFE, handles Bloodsucker constant proccesses.
+/// Runs from COMSIG_LIVING_LIFE, handles Bloodsucker constant proccesses.
 /datum/antagonist/bloodsucker/proc/LifeTick()
 	SIGNAL_HANDLER
 
+	if(isbrain(owner.current))
+		return
 	if(!owner)
 		INVOKE_ASYNC(src, .proc/HandleDeath)
 		return
@@ -29,7 +31,7 @@
 		if(prob(85) || owner.current.stat != CONSCIOUS || HAS_TRAIT(owner.current, TRAIT_MASQUERADE))
 			return
 		var/message = pick(strings("malkavian_revelations.json", "revelations", "fulp_modules/strings/bloodsuckers"))
-		INVOKE_ASYNC(owner.current, /atom/movable/proc/say, message, , , , , , CLAN_MALKAVIAN)
+		INVOKE_ASYNC(owner.current, /atom/movable/proc/say, message, forced = CLAN_MALKAVIAN)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //			BLOOD
@@ -208,7 +210,7 @@
 /// FINAL DEATH
 /datum/antagonist/bloodsucker/proc/HandleDeath()
 	// Not "Alive"?
-	if(!owner.current || !iscarbon(owner.current) || isbrain(owner.current) || !get_turf(owner.current))
+	if(!owner.current || !get_turf(owner.current))
 		FinalDeath()
 		return
 	// Fire Damage? (above double health)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
@@ -170,14 +170,14 @@
 /datum/action/bloodsucker/proc/ActivatePower()
 	active = TRUE
 	if(power_flags & BP_AM_TOGGLE)
-		RegisterSignal(owner, COMSIG_LIVING_BIOLOGICAL_LIFE, .proc/UsePower)
+		RegisterSignal(owner, COMSIG_LIVING_LIFE, .proc/UsePower)
 
 	owner.log_message("used [src][bloodcost != 0 ? " at the cost of [bloodcost]" : ""].", LOG_ATTACK, color="red")
 	UpdateButtonIcon()
 
 /datum/action/bloodsucker/proc/DeactivatePower()
 	if(power_flags & BP_AM_TOGGLE)
-		UnregisterSignal(owner, COMSIG_LIVING_BIOLOGICAL_LIFE)
+		UnregisterSignal(owner, COMSIG_LIVING_LIFE)
 	if(power_flags & BP_AM_SINGLEUSE)
 		RemoveAfterUse()
 		return

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/monstertrack.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/monstertrack.dm
@@ -22,7 +22,7 @@
 		return
 	if(give_pinpointer)
 		var/mob/living/user = owner
-		user.apply_status_effect(STATUS_EFFECT_HUNTERPINPOINTER)
+		user.apply_status_effect(/datum/status_effect/agent_pinpointer/hunter_edition)
 	display_proximity()
 
 /datum/action/bloodsucker/trackvamp/proc/display_proximity()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/_powers_targeted.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/_powers_targeted.dm
@@ -38,7 +38,7 @@
 
 /datum/action/bloodsucker/targeted/DeactivatePower()
 	if(power_flags & BP_AM_TOGGLE)
-		UnregisterSignal(owner, COMSIG_LIVING_BIOLOGICAL_LIFE)
+		UnregisterSignal(owner, COMSIG_LIVING_LIFE)
 	active = FALSE
 	DeactivateRangedAbility()
 	UpdateButtonIcon()


### PR DESCRIPTION
## About The Pull Request

Bloodsuckers, Monster Hunters, and Vassals, keep their stuff through debraining, such as their powers, martial arts, ect ect.

Bloodsuckers can also now be debrained, it won't final death them. They won't be able to do much, but in the case they are somehow revived, they will continue to be a Bloodsucker. I'm thinking maybe they would be able to rebuild their body by vanishing act like how they regrow limbs. Very stupid idea but sounds funny and forces security to properly final death a bloodsucker.
Also opens us later to maybe being more lax on Bloodsucker dismemberment? Lots of possibilities in the future so I think this is a neat step forward.
