### PR TITLE
More Selene issues

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -10435,7 +10435,7 @@
 	},
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue Maintenance";
-	req_one_access_txt = "5;6;12;22"
+	req_access_txt = "6"
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/medical)
@@ -31236,7 +31236,7 @@
 	},
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue Maintenance";
-	req_one_access_txt = "5;6;12;22"
+	req_access_txt = "6"
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/medical)

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1055,7 +1055,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "aoF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -1235,6 +1235,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "art" = (
@@ -1778,7 +1781,7 @@
 "axo" = (
 /obj/structure/window,
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "axv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2211,9 +2214,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "aFK" = (
 /obj/item/food/egg/green,
 /turf/open/floor/plating,
@@ -2758,7 +2760,7 @@
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/light/directional/south,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/hallway/secondary/entry)
 "aMW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -3703,7 +3705,7 @@
 	},
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "aXr" = (
 /obj/effect/turf_decal/tile/blue{
@@ -3821,9 +3823,7 @@
 /area/command/heads_quarters/ce)
 "baq" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/iron,
 /area/maintenance/department/medical)
 "bar" = (
@@ -4175,7 +4175,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "bfK" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -4227,7 +4227,7 @@
 /obj/structure/cable,
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/starboard/fore)
 "bgv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -4809,7 +4809,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/science/genetics)
 "bmQ" = (
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -5424,6 +5424,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bvY" = (
 /obj/structure/table,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/prison/rec)
 "bwb" = (
@@ -5693,7 +5694,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/department/medical)
+/area/maintenance/starboard/fore)
 "bza" = (
 /obj/structure/cable,
 /obj/machinery/navbeacon{
@@ -6830,6 +6831,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"bLY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "bMh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/crate,
@@ -7157,6 +7164,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "bRe" = (
@@ -7186,7 +7194,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "bRi" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -8134,7 +8142,7 @@
 /area/security/prison/visit)
 "cdh" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "cdk" = (
 /obj/machinery/firealarm/directional/west,
@@ -10742,7 +10750,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "cLZ" = (
 /obj/effect/turf_decal/siding{
 	color = "#4C3117";
@@ -10907,6 +10915,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/department/medical)
 "cPo" = (
@@ -11227,7 +11236,7 @@
 	},
 /obj/structure/flora/ausbushes/fernybush,
 /obj/item/food/grown/banana,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/science/genetics)
 "cTz" = (
 /obj/machinery/vending/coffee,
@@ -12184,7 +12193,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "deL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -12685,7 +12694,7 @@
 	},
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/machinery/light/directional/west,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/hallway/secondary/entry)
 "dnK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -12960,7 +12969,7 @@
 /obj/structure/window,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "dso" = (
 /obj/structure/table/wood/fancy/royalblack,
@@ -13686,7 +13695,7 @@
 /area/medical/medbay)
 "dDs" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "dDt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -13806,7 +13815,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/hallway/secondary/entry)
 "dFA" = (
 /obj/effect/turf_decal/tile/purple,
@@ -14725,7 +14734,7 @@
 /obj/machinery/holopad,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "dSe" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -15155,7 +15164,7 @@
 	network = list("ss13", "medbay")
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "dWR" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -15812,6 +15821,7 @@
 	name = "Security red corner"
 	},
 /obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "egm" = (
@@ -15821,7 +15831,7 @@
 	name = "surgery shutters"
 	},
 /turf/open/floor/plating,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "egD" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -15997,7 +16007,7 @@
 /area/science/xenobiology)
 "eip" = (
 /obj/structure/flora/tree/jungle,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "eiz" = (
 /obj/effect/turf_decal/tile/purple{
@@ -16763,7 +16773,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "esO" = (
 /obj/structure/chair/stool/directional/west{
@@ -17089,7 +17099,7 @@
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/hallway/secondary/entry)
 "ewB" = (
 /obj/structure/rack,
@@ -17929,6 +17939,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "eJo" = (
@@ -20216,7 +20227,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "fnM" = (
 /obj/machinery/door/airlock/command/glass{
@@ -20366,7 +20377,7 @@
 	resize = 1.1
 	},
 /obj/effect/turf_decal/siding/wideplating/dark/end,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/theater)
 "fpn" = (
 /obj/structure/chair/comfy/brown{
@@ -20467,6 +20478,9 @@
 "fqq" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	name = "Output Release"
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -20595,7 +20609,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "frE" = (
 /obj/item/toy/cattoy,
 /obj/machinery/power/apc{
@@ -20763,7 +20777,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/starboard/fore)
 "ftL" = (
 /obj/machinery/door/airlock{
 	id_tag = "Purple Dorm";
@@ -21348,6 +21362,7 @@
 	},
 /obj/item/screwdriver,
 /obj/item/pen,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "fBM" = (
@@ -21379,11 +21394,6 @@
 /turf/open/floor/iron/dark,
 /area/science)
 "fBW" = (
-/obj/machinery/power/apc{
-	areastring = "/area/tcommsat/computer";
-	name = "Telecomms Monitoring APC";
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -22308,6 +22318,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "fNi" = (
@@ -24978,6 +24989,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "gzd" = (
@@ -27111,6 +27123,7 @@
 /area/security/prison/rec)
 "haq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/prison/rec)
 "haw" = (
@@ -30433,10 +30446,9 @@
 	dir = 10
 	},
 /obj/machinery/holopad,
-/obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "hTZ" = (
 /turf/closed/wall,
 /area/medical/break_room)
@@ -31550,7 +31562,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "iiO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -31648,6 +31660,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
+"ijV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "ijW" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/grimy,
@@ -32159,7 +32178,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - West Hall";
-	dir = 10;
+	dir = 5;
 	network = list("ss13","security")
 	},
 /turf/open/floor/iron,
@@ -32619,7 +32638,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "ixD" = (
 /obj/structure/closet/firecloset,
@@ -35011,11 +35030,9 @@
 /turf/open/floor/iron,
 /area/security/office)
 "jge" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/engineering/main)
 "jgr" = (
@@ -35523,22 +35540,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"joh" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/machinery/light/directional/north,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery/aft)
 "joj" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/grimy,
@@ -36156,7 +36157,7 @@
 /obj/machinery/door/window{
 	name = "Garden Door"
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "jvU" = (
 /obj/machinery/camera/directional/south{
@@ -36311,7 +36312,7 @@
 "jyg" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "jyh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -37626,6 +37627,7 @@
 	network = list("engineering","atmos");
 	pixel_y = -30
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "jPB" = (
@@ -39086,7 +39088,7 @@
 "kiq" = (
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "kiB" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/tile/yellow{
@@ -40749,7 +40751,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/starboard/fore)
 "kEs" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
@@ -41232,10 +41234,10 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "kKm" = (
@@ -42455,7 +42457,7 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/north,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "lcD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -43311,6 +43313,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "lnT" = (
@@ -44221,7 +44224,10 @@
 /area/command/heads_quarters/hos)
 "lAb" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "lAc" = (
@@ -44386,10 +44392,9 @@
 /turf/open/floor/iron,
 /area/maintenance/fore)
 "lCx" = (
-/obj/structure/cable,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/hydroponics/constructable,
+/turf/open/misc/grass,
+/area/security/prison/garden)
 "lCz" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -45123,7 +45128,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/dark,
 /area/science)
 "lJV" = (
@@ -45462,7 +45466,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "lOK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -45559,7 +45563,7 @@
 "lPs" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/turf_decal/siding/wood/end,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "lPz" = (
 /obj/effect/turf_decal/stripes/line{
@@ -45988,7 +45992,7 @@
 /area/maintenance/starboard/fore)
 "lUK" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "lUO" = (
 /obj/structure/window/reinforced,
@@ -46052,6 +46056,7 @@
 "lVf" = (
 /obj/effect/landmark/start/prisoner,
 /obj/structure/chair/stool/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/prison/rec)
 "lVj" = (
@@ -48319,7 +48324,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/starboard/fore)
 "mwX" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -48854,6 +48859,7 @@
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "mEF" = (
@@ -48960,6 +48966,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "mFY" = (
@@ -50778,8 +50788,10 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "nch" = (
@@ -51011,10 +51023,10 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "nex" = (
@@ -51094,7 +51106,6 @@
 "nfH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 8;
@@ -51105,7 +51116,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "nfS" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
@@ -51379,7 +51390,7 @@
 /obj/item/clothing/head/powdered_wig,
 /obj/item/clothing/shoes/laceup,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/starboard/fore)
 "nkd" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2"
@@ -52000,7 +52011,7 @@
 "nrA" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/hallway/secondary/entry)
 "nsn" = (
 /obj/structure/cable,
@@ -52814,6 +52825,11 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"nCW" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "nDe" = (
 /obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
@@ -53150,7 +53166,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/lavendergrass,
 /mob/living/simple_animal/chick,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "nIp" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -53510,7 +53526,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "nNJ" = (
 /obj/machinery/light/directional/east,
@@ -54014,7 +54030,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/hallway/secondary/entry)
 "nVU" = (
 /obj/structure/window/reinforced{
@@ -55139,7 +55155,7 @@
 /area/engineering/main)
 "omE" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "omM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -55202,7 +55218,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/science/genetics)
 "onm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -55510,6 +55526,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/depsec/medical,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "opJ" = (
@@ -56215,6 +56232,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/depsec/supply,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "oCp" = (
@@ -56449,7 +56467,6 @@
 "oFh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 4;
@@ -56469,7 +56486,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "oFH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
@@ -57147,7 +57164,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "oPu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
@@ -57302,6 +57319,12 @@
 	},
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/aisat/atmos)
+"oRj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "oRm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 10
@@ -57710,7 +57733,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "oWX" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Access";
@@ -58181,7 +58204,7 @@
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "pdK" = (
 /obj/machinery/door_timer{
 	id = "Cell 5";
@@ -58937,7 +58960,7 @@
 	name = "surgery shutters"
 	},
 /turf/open/floor/plating,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "ppj" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -61614,7 +61637,7 @@
 "pZd" = (
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/hallway/secondary/entry)
 "pZf" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
@@ -62031,6 +62054,7 @@
 	dir = 4;
 	name = "Security red corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "qeA" = (
@@ -62439,7 +62463,7 @@
 	req_access_txt = "31"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "qiD" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -63312,7 +63336,7 @@
 	req_one_access_txt = "12;22"
 	},
 /turf/open/floor/plating,
-/area/service/chapel/office)
+/area/maintenance/starboard/fore)
 "quH" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -63871,7 +63895,7 @@
 /obj/structure/window,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "qCw" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -65664,14 +65688,14 @@
 "rbX" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/closed/wall,
-/area/service/chapel/office)
+/area/maintenance/starboard/fore)
 "rcc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/starboard/fore)
 "rcm" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -65723,7 +65747,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "rcT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -66325,24 +66349,11 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "rkj" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/service";
-	dir = 1;
-	name = "AI Satellite Service APC";
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue corner"
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
+/turf/open/floor/iron,
+/area/maintenance/starboard/fore)
 "rkt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -66448,6 +66459,13 @@
 "rma" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/status_display/ai/directional/east,
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat/service";
+	dir = 1;
+	name = "AI Satellite Service APC";
+	pixel_y = 25
+	},
+/obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat/service)
 "rmc" = (
@@ -66631,7 +66649,7 @@
 /area/service/bar/atrium)
 "rnT" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "rnY" = (
 /obj/structure/reagent_dispensers/watertank/high,
@@ -68349,7 +68367,7 @@
 "rLI" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light/directional/east,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "rLR" = (
 /obj/machinery/holopad,
@@ -68641,7 +68659,7 @@
 	},
 /obj/item/book/manual/wiki/surgery,
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "rQu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -69477,7 +69495,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/hallway/secondary/entry)
 "scz" = (
 /turf/closed/wall,
@@ -69724,7 +69742,7 @@
 /obj/structure/window,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "sfv" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -69917,7 +69935,7 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/security/prison/garden)
 "siL" = (
 /obj/machinery/telecomms/message_server/preset,
@@ -70388,12 +70406,11 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "soh" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/starboard/fore)
 "soi" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -70529,7 +70546,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/hallway/secondary/entry)
 "sqm" = (
 /obj/machinery/computer/chef_order,
@@ -70833,7 +70850,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark/end{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/theater)
 "stL" = (
 /obj/structure/table,
@@ -71416,7 +71433,7 @@
 "sAE" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/security/prison/garden)
 "sAQ" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -72257,7 +72274,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "sLL" = (
 /obj/structure/disposalpipe/segment{
@@ -72442,7 +72459,7 @@
 	},
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "sPf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -73856,7 +73873,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 1;
@@ -73867,7 +73883,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "tkS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -75105,16 +75121,18 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "tzQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/firecloset/full,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -75790,7 +75808,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "tLE" = (
 /obj/structure/table/wood,
@@ -76125,6 +76143,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "tRo" = (
@@ -76147,6 +76166,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"tRz" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "tRA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -76527,6 +76550,7 @@
 	pixel_y = 10
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "tWX" = (
@@ -76786,7 +76810,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "uad" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -77049,7 +77073,7 @@
 "udf" = (
 /mob/living/carbon/human/species/monkey,
 /obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/science/genetics)
 "udo" = (
 /obj/machinery/power/apc{
@@ -77863,7 +77887,8 @@
 /area/maintenance/fore)
 "upi" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/grass,
+/obj/structure/cable,
+/turf/open/misc/grass,
 /area/security/prison/garden)
 "upk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -78557,6 +78582,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "uuZ" = (
@@ -79164,8 +79192,10 @@
 /area/service/library/abandoned)
 "uFq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Maintenance";
+	req_one_access_txt = "12;22"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -79859,7 +79889,7 @@
 	name = "surgery shutters"
 	},
 /turf/open/floor/plating,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "uPn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -79972,6 +80002,7 @@
 /area/medical/medbay)
 "uRk" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "uRv" = (
@@ -80782,9 +80813,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/warden)
-"vbc" = (
-/turf/closed/wall,
-/area/medical/surgery/theatre)
 "vbh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -81249,7 +81277,7 @@
 "vgM" = (
 /obj/machinery/vending/wallmed/directional/south,
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/security/prison/garden)
 "vgP" = (
 /obj/structure/table/wood,
@@ -82105,7 +82133,7 @@
 "vtt" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom/prison/directional/west,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/security/prison/garden)
 "vtx" = (
 /obj/item/storage/cans/sixsoda,
@@ -82426,6 +82454,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"vyE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
 "vyK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -82919,7 +82952,7 @@
 	layer = 2.9
 	},
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/hallway/secondary/entry)
 "vFt" = (
 /obj/structure/table/reinforced,
@@ -82987,7 +83020,7 @@
 "vFV" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/security/prison/garden)
 "vFW" = (
 /obj/structure/window/reinforced,
@@ -83427,7 +83460,7 @@
 /area/ai_monitored/command/storage/eva)
 "vMB" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "vMH" = (
 /obj/effect/turf_decal/tile/red{
@@ -83497,7 +83530,7 @@
 /area/hallway/primary/fore)
 "vOK" = (
 /turf/closed/wall,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "vOQ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -84077,13 +84110,6 @@
 "vXl" = (
 /obj/structure/table/glass,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/surgery/aft";
-	dir = 4;
-	name = "Surgery B APC";
-	pixel_x = 25
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 4;
@@ -84094,7 +84120,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "vXr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -84423,6 +84449,18 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"wbK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/tcommsat/computer";
+	name = "Telecomms Monitoring APC";
+	pixel_y = -25
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "wce" = (
 /turf/closed/wall/r_wall,
 /area/command/teleporter)
@@ -84659,7 +84697,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/science)
 "wgH" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -85517,7 +85555,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/science)
 "wtT" = (
 /obj/structure/closet,
@@ -86008,7 +86046,7 @@
 	c_tag = "Public - Picnic";
 	dir = 9
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "wzS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -86241,7 +86279,7 @@
 	dir = 8;
 	name = "Garden Door"
 	},
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "wCv" = (
 /obj/machinery/door/airlock/maintenance{
@@ -87023,7 +87061,7 @@
 	req_access_txt = "31"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/theatre)
+/area/medical/surgery)
 "wMl" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -87286,6 +87324,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"wPJ" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/engineering/atmospherics_engine)
 "wPO" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -87789,7 +87832,7 @@
 "wVR" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /mob/living/basic/cow,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "wWk" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -88575,7 +88618,7 @@
 	},
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "xek" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
@@ -88670,6 +88713,7 @@
 /area/ai_monitored/turret_protected/aisat/atmos)
 "xgd" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "xgk" = (
@@ -89687,7 +89731,7 @@
 "xpi" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/chick,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "xpq" = (
 /obj/item/storage/bag/plants/portaseeder,
@@ -90588,7 +90632,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "xDs" = (
 /obj/effect/turf_decal/tile/purple,
@@ -90713,11 +90757,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xEJ" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/engineering/main)
 "xEK" = (
@@ -91509,7 +91550,7 @@
 /obj/structure/window,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "xPA" = (
 /obj/machinery/door/airlock/maintenance{
@@ -92204,7 +92245,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/aft)
+/area/medical/surgery)
 "xYe" = (
 /obj/structure/closet/secure_closet/hos,
 /obj/item/storage/box/seccarts{
@@ -92346,6 +92387,7 @@
 /obj/item/paper_bin,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "xZD" = (
@@ -92471,6 +92513,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "yaV" = (
@@ -92891,6 +92934,7 @@
 	c_tag = "Engineering - SM Room SW";
 	network = list("ss13", "engineering")
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
 "yfx" = (
@@ -93055,6 +93099,7 @@
 	dir = 1;
 	name = "Command blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "ygZ" = (
@@ -93253,7 +93298,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/lavendergrass,
 /mob/living/simple_animal/chicken,
-/turf/open/floor/grass,
+/turf/open/misc/grass,
 /area/service/hydroponics/garden)
 "yjZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -109397,7 +109442,7 @@ ugF
 euk
 rXB
 upi
-upi
+lCx
 siK
 vtt
 sAE
@@ -117759,7 +117804,7 @@ fHR
 tse
 dCs
 rgs
-dCs
+oRj
 vWn
 ouh
 xdv
@@ -118273,7 +118318,7 @@ vlZ
 uqr
 vlZ
 ogN
-dCs
+oRj
 xEJ
 ouh
 xdv
@@ -118530,7 +118575,7 @@ qWw
 qiQ
 aQq
 wuD
-dCs
+bLY
 tzQ
 kOC
 iQW
@@ -118788,7 +118833,7 @@ nZr
 nZr
 wuD
 chJ
-tja
+ijV
 kOC
 iQW
 vmD
@@ -124417,12 +124462,12 @@ cOW
 iTT
 suI
 kJI
-joo
+vyE
 mHH
 fgq
 vSJ
 kvU
-kCb
+wPJ
 sDN
 rgH
 aPN
@@ -124931,7 +124976,7 @@ qDb
 wqx
 wqx
 biS
-joo
+vyE
 gzb
 uVe
 suB
@@ -125446,10 +125491,10 @@ xCX
 xCX
 xCX
 leB
-joo
+vyE
 joo
 nVF
-koK
+nCW
 nVF
 nVF
 hdc
@@ -126971,7 +127016,7 @@ iKp
 iKp
 rRQ
 ndt
-wOO
+wbK
 uIm
 ihO
 vsb
@@ -128942,10 +128987,10 @@ rvY
 rvY
 rvY
 rvY
-ycg
-ycg
+rvY
+rvY
 byX
-xsA
+rvY
 wtJ
 wtJ
 iIC
@@ -128959,7 +129004,7 @@ wtJ
 dWU
 wtJ
 wtJ
-xsA
+ycg
 ycg
 wCv
 ycg
@@ -129199,10 +129244,10 @@ fjX
 jDG
 wWY
 iKo
-vja
+wWY
 mwV
-kqZ
-xsA
+lyv
+rvY
 dRV
 xfn
 hsa
@@ -129216,7 +129261,7 @@ rqH
 alb
 xfn
 thH
-xsA
+ycg
 ygs
 ivk
 ygs
@@ -129456,10 +129501,10 @@ vzb
 sPX
 rvY
 rvY
-ycg
-rXm
-kqZ
-xsA
+rvY
+unK
+lyv
+rvY
 vMN
 uHE
 tQB
@@ -129473,7 +129518,7 @@ uHE
 hri
 nPD
 cYJ
-xsA
+ycg
 ygs
 ivk
 qFe
@@ -129713,10 +129758,10 @@ eft
 sPX
 rvY
 yju
-ycg
-oLT
+rvY
+rkj
 bgu
-xsA
+rvY
 ljP
 xJe
 ehF
@@ -129730,7 +129775,7 @@ qyN
 iaE
 xJe
 cWJ
-xsA
+ycg
 ygs
 uwq
 weh
@@ -129970,10 +130015,10 @@ vzb
 sPX
 rvY
 yju
-ycg
+rvY
 ftK
-ttg
-xsA
+pXQ
+rvY
 eMm
 xJe
 eWx
@@ -129987,7 +130032,7 @@ xJe
 iaE
 xJe
 uOM
-xsA
+ycg
 ygs
 skR
 jdw
@@ -130227,10 +130272,10 @@ vzb
 sPX
 rvY
 yju
-ycg
-rXm
-ttg
-xsA
+rvY
+unK
+pXQ
+rvY
 aIE
 uHE
 uHE
@@ -130244,7 +130289,7 @@ uHE
 euw
 uHE
 rUf
-xsA
+ycg
 ygs
 ygs
 wmk
@@ -130484,10 +130529,10 @@ nVB
 sPX
 rvY
 yju
-ycg
-oLT
-kqZ
-xsA
+rvY
+rkj
+lyv
+rvY
 mPf
 xfn
 meI
@@ -130501,7 +130546,7 @@ gqA
 gPN
 xIL
 uSs
-xsA
+ycg
 ycg
 ygs
 wmk
@@ -130512,11 +130557,11 @@ ycg
 ycg
 ycg
 ycg
-vbc
-vbc
-vbc
-vbc
-vbc
+vOK
+vOK
+vOK
+vOK
+vOK
 wpP
 oKi
 wJu
@@ -130741,13 +130786,13 @@ vzb
 sPX
 rvY
 yju
-ycg
+rvY
 rcc
-ttg
-ycg
-xsA
-xsA
-xsA
+pXQ
+rvY
+rvY
+rvY
+rvY
 dqz
 xCM
 sXL
@@ -130756,14 +130801,14 @@ xsA
 emN
 xsA
 kfg
-xsA
-xsA
-xsA
+ycg
+ycg
+ycg
 cww
 kqZ
 wmk
-lCx
-ttg
+ycg
+ygs
 oLT
 ycg
 weh
@@ -130998,22 +131043,22 @@ wWY
 ssZ
 rvY
 yju
-ycg
-isa
-vja
-vja
-uZc
-uFq
-xsA
-xsA
-xsA
-xsA
+rvY
+soh
+wWY
+wWY
+sOc
+jTX
+rvY
+rvY
+rvY
+rvY
 gBk
 xsA
 xhL
 qSv
 hDD
-xsA
+ycg
 kqZ
 xff
 ttg
@@ -131259,18 +131304,18 @@ rvY
 rvY
 rvY
 rvY
-weh
+vkm
 kEk
-uZc
-uFq
-ygs
-wQj
+sOc
+jTX
+vzb
+rvY
 vVs
-wQj
-xsA
-xsA
-xsA
-xsA
+ycg
+ycg
+ycg
+ycg
+ycg
 ttg
 ycg
 ycg
@@ -131279,7 +131324,7 @@ ycg
 ycg
 nXz
 ohS
-ycg
+tRz
 qFe
 rBa
 ycg
@@ -131517,13 +131562,13 @@ bTA
 jrL
 rvY
 njU
-ygs
-tTG
-soh
-oGB
+vzb
+wid
+pvt
+kvR
 quz
 kNd
-quz
+uFq
 oGB
 oGB
 mgy
@@ -131544,7 +131589,7 @@ uPm
 uPm
 kiq
 uPm
-vbc
+vOK
 mXV
 nxF
 rfN
@@ -131775,12 +131820,12 @@ eto
 rvY
 rvY
 mBh
-wQj
-wQj
-wQj
+rvY
+rvY
+rvY
 rbX
 cUN
-wQj
+ycg
 hTl
 ttg
 ndM
@@ -132032,12 +132077,12 @@ fYq
 rvY
 vzb
 vzb
-wQj
+rvY
 iXW
 hCh
 wQj
 tjD
-wQj
+ycg
 ycg
 ygs
 yfs
@@ -132054,7 +132099,7 @@ xnz
 ycg
 gBC
 ycg
-joh
+pdG
 hTQ
 aFg
 nfH
@@ -132289,14 +132334,14 @@ pKQ
 rvY
 vzb
 vzb
-wQj
+rvY
 xQv
 mdk
 caz
 uMe
-wQj
-wQj
-wQj
+ycg
+ycg
+ycg
 yfs
 ygs
 ycg
@@ -132546,14 +132591,14 @@ bjI
 rvY
 vzb
 tgA
-wQj
+rvY
 slw
 mdk
 dIF
 qub
 dbm
 ndK
-wQj
+ycg
 eXy
 weh
 ycg
@@ -132803,14 +132848,14 @@ vzb
 rvY
 vzb
 riO
-wQj
+rvY
 jnA
 qAY
 duo
 qEC
 dbm
 muq
-wQj
+ycg
 yfs
 ygs
 ycg
@@ -133060,14 +133105,14 @@ rvY
 rvY
 vzb
 pzp
-wQj
+rvY
 jXc
 ryf
 dIF
 gee
 dbm
 cne
-wQj
+ycg
 yfs
 rmL
 ycg
@@ -133317,14 +133362,14 @@ wEX
 vzb
 vzb
 vzX
-wQj
+rvY
 jYl
 mjP
 fqT
-wQj
-wQj
-wQj
-wQj
+ycg
+ycg
+ycg
+ycg
 fmU
 ycg
 ycg
@@ -133574,11 +133619,11 @@ vzb
 vzb
 rvY
 rvY
-wQj
-wQj
-wQj
-wQj
-wQj
+rvY
+ycg
+ycg
+ycg
+ycg
 lNg
 ygs
 ygs
@@ -142289,7 +142334,7 @@ pwe
 ijf
 pdP
 eaR
-rkj
+fKO
 rXl
 lSD
 tCr

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -7446,13 +7446,20 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bUH" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/space/basic,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
+	name = "AI Hallway APC";
+	pixel_y = -25
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "bVc" = (
 /obj/structure/table,
 /obj/item/storage/dice,
@@ -19391,8 +19398,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/south,
 /obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "fcR" = (
@@ -92934,21 +92941,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
-"yfr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
-	name = "AI Hallway APC";
-	pixel_y = -25
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
 "yfs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -112841,7 +112833,7 @@ iQW
 iQW
 iQW
 iQW
-bUH
+rbz
 ily
 xSD
 csr
@@ -140822,7 +140814,7 @@ gRV
 gRV
 uiB
 xOL
-xJb
+bUH
 ijf
 isJ
 hiN
@@ -141079,7 +141071,7 @@ aUC
 gRV
 rqx
 wMr
-yfr
+xJb
 ijf
 jom
 caV
@@ -142621,7 +142613,7 @@ eKQ
 gRV
 rqx
 uNz
-fcG
+xJb
 ijf
 jom
 caV
@@ -142878,7 +142870,7 @@ gRV
 gRV
 uiB
 xOL
-xJb
+fcG
 ijf
 jrO
 hvQ

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1250,20 +1250,19 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "arG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/holodeck/rec_center)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "arK" = (
 /mob/living/simple_animal/hostile/retaliate/clown,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"asb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "asd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -2581,7 +2580,7 @@
 /obj/machinery/component_printer,
 /obj/machinery/camera{
 	c_tag = "Research - Circuits Lab W";
-	dir = 5;
+	dir = 8;
 	network = list("ss13", "rd")
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -4110,7 +4109,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/camera{
 	c_tag = "Public - Arrivals N";
-	dir = 9
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -5531,13 +5530,8 @@
 	},
 /area/maintenance/starboard)
 "bwJ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/commons/dorms";
-	dir = 4;
-	name = "Dormitory Maintenance APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "bwP" = (
@@ -5938,10 +5932,10 @@
 	name = "Holodeck Door"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
@@ -6831,12 +6825,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"bLY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "bMh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/crate,
@@ -7350,6 +7338,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"bTo" = (
+/obj/structure/chair/stool/directional/east,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood,
+/area/service/library/printer)
 "bTu" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
@@ -8192,6 +8185,7 @@
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "cdD" = (
@@ -10652,6 +10646,21 @@
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"cJq" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 4;
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/security/lockers)
 "cJD" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -11371,6 +11380,7 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "cUt" = (
@@ -12733,9 +12743,11 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "doc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/commons/fitness)
 "doe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -13838,7 +13850,6 @@
 "dFF" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #5";
-	dir = 5;
 	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
@@ -15107,6 +15118,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/bar/atrium)
+"dWv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/tcommsat/computer";
+	name = "Telecomms Monitoring APC";
+	pixel_y = -25
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "dWx" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 13
@@ -17926,7 +17949,6 @@
 	name = "Server Room";
 	req_access_txt = "61"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	name = "Command blue corner"
@@ -20116,6 +20138,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "fmm" = (
@@ -22567,7 +22590,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Upper W";
-	dir = 5;
 	network = list("ss13","rd","xeno")
 	},
 /obj/machinery/newscaster/directional/south,
@@ -23883,6 +23905,12 @@
 	},
 /turf/open/misc/asteroid/basalt,
 /area/maintenance/fore)
+"gjH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gkj" = (
 /obj/structure/closet/secure_closet/courtroom,
 /obj/item/megaphone{
@@ -23914,9 +23942,10 @@
 /obj/structure/ore_box,
 /obj/machinery/camera{
 	c_tag = "Cargo - Mining Bay";
-	dir = 10;
 	network = list("ss13", "cargo")
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "glc" = (
@@ -24956,13 +24985,8 @@
 /turf/open/floor/iron/grimy,
 /area/hallway/primary/port)
 "gyV" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/aft";
-	dir = 1;
-	name = "Port Quarter Maintenance APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "gyX" = (
@@ -26250,7 +26274,7 @@
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Public - Botany Hall";
-	dir = 9
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -26756,7 +26780,7 @@
 /obj/item/book/random,
 /obj/machinery/camera{
 	c_tag = "Service - Library Desk";
-	dir = 9;
+	dir = 4;
 	network = list("ss13", "service")
 	},
 /obj/machinery/requests_console/directional/east{
@@ -27370,6 +27394,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"hdQ" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/engineering/atmospherics_engine)
 "heF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -27464,6 +27493,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"hfG" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "hfN" = (
 /obj/effect/turf_decal/tile/random{
 	dir = 4
@@ -27503,7 +27539,6 @@
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Middle N";
-	dir = 5;
 	network = list("ss13","rd","xeno")
 	},
 /obj/structure/cable,
@@ -28733,7 +28768,7 @@
 /obj/structure/displaycase/captain,
 /obj/machinery/camera{
 	c_tag = "Command - Captain Office E";
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
@@ -30261,7 +30296,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "hRm" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 1;
@@ -30278,6 +30312,11 @@
 	name = "Security red corner"
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/button/door/directional/north{
+	id = "justiceblast";
+	name = "Justice Blast Doors";
+	req_access_txt = "1"
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "hRH" = (
@@ -30537,6 +30576,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "hXa" = (
@@ -31660,13 +31700,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
-"ijV" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "ijW" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/grimy,
@@ -32178,7 +32211,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - West Hall";
-	dir = 5;
 	network = list("ss13","security")
 	},
 /turf/open/floor/iron,
@@ -33588,7 +33620,6 @@
 	},
 /obj/machinery/camera/motion{
 	c_tag = "AI - Chamber N";
-	dir = 10;
 	network = list("aicore")
 	},
 /obj/machinery/turretid{
@@ -37026,6 +37057,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "jHY" = (
@@ -38728,9 +38760,13 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "kdV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/commons/fitness)
 "kdY" = (
@@ -39146,15 +39182,13 @@
 /area/cargo/office)
 "kiT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 5
 	},
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/holodeck/rec_center)
+/turf/closed/wall/r_wall,
+/area/commons/locker)
 "kiX" = (
 /obj/item/paperplane{
 	pixel_x = 4;
@@ -39714,7 +39748,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/directional/east{
-	c_tag = "Service - Stage";
+	c_tag = "Service - Botany E";
 	network = list("ss13", "service")
 	},
 /turf/open/floor/iron/white,
@@ -39722,6 +39756,10 @@
 "kpU" = (
 /turf/open/floor/iron,
 /area/maintenance/fore)
+"kqb" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood,
+/area/service/bar/atrium)
 "kql" = (
 /obj/item/trash/raisins,
 /obj/machinery/light/small/directional/west,
@@ -41911,7 +41949,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Detective";
-	dir = 9;
+	dir = 4;
 	network = list("ss13","security")
 	},
 /turf/open/floor/iron/grimy,
@@ -44392,9 +44430,14 @@
 /turf/open/floor/iron,
 /area/maintenance/fore)
 "lCx" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/misc/grass,
-/area/security/prison/garden)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/commons/locker)
 "lCz" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -46765,6 +46808,15 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"mdZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Maintenance";
+	req_one_access_txt = "12;22"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "meb" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -47925,6 +47977,7 @@
 /obj/structure/ore_box,
 /obj/machinery/light/directional/south,
 /obj/machinery/status_display/evac/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "mrA" = (
@@ -48231,6 +48284,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/library/abandoned)
+"mvU" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "mwf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -48536,6 +48593,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"mAA" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "mAH" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Coldroom";
@@ -52649,6 +52711,7 @@
 /area/hallway/primary/central)
 "nBb" = (
 /obj/effect/spawner/random/entertainment/gambling,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/grimy,
 /area/service/bar/atrium)
 "nBf" = (
@@ -52825,11 +52888,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"nCW" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
 "nDe" = (
 /obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
@@ -52986,6 +53044,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "nGa" = (
@@ -55291,7 +55350,7 @@
 /obj/structure/lattice,
 /obj/machinery/camera{
 	c_tag = "AI - Outer Sat SW";
-	dir = 9;
+	dir = 4;
 	network = list("ss13", "minisat")
 	},
 /turf/open/space/basic,
@@ -56145,8 +56204,8 @@
 /obj/structure/table,
 /obj/machinery/firealarm/directional/west,
 /obj/item/storage/medkit/toxin,
-/obj/item/storage/medkit/advanced{
-	pixel_x = -3;
+/obj/item/storage/medkit/regular{
+	pixel_x = 3;
 	pixel_y = 3
 	},
 /turf/open/floor/vault,
@@ -57319,12 +57378,6 @@
 	},
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/aisat/atmos)
-"oRj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "oRm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 10
@@ -58700,6 +58753,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "plo" = (
@@ -61272,7 +61326,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Brig Medical";
-	dir = 9;
+	dir = 4;
 	network = list("ss13","security")
 	},
 /turf/open/floor/iron/white,
@@ -61954,7 +62008,7 @@
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Engineering - SM Chamber";
-	dir = 9;
+	dir = 4;
 	network = list("ss13", "engineering")
 	},
 /turf/open/floor/engine,
@@ -62745,7 +62799,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
-	c_tag = "Engineering - Power Storage";
+	c_tag = "Engineering - Secure Storage";
 	network = list("ss13", "engineering")
 	},
 /turf/open/floor/iron/dark,
@@ -63403,7 +63457,7 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Engineering - SM Entrance";
-	dir = 9;
+	dir = 4;
 	network = list("ss13", "engineering")
 	},
 /obj/machinery/status_display/evac/directional/east,
@@ -65436,7 +65490,7 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Public - Boxing Ring";
-	dir = 9
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -66349,11 +66403,14 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "rkj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/fore)
+/turf/closed/wall/r_wall,
+/area/commons/fitness)
 "rkt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -66874,6 +66931,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "rqH" = (
@@ -68499,6 +68557,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "rOf" = (
@@ -69456,12 +69515,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "sby" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/area/holodeck/rec_center)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/commons/fitness)
 "sbQ" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -69603,6 +69664,7 @@
 	dir = 8;
 	name = "pink corner"
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/service/library/abandoned)
 "sel" = (
@@ -69778,7 +69840,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Morgue";
-	dir = 9;
+	dir = 4;
 	network = list("ss13", "medbay")
 	},
 /turf/open/floor/iron/dark,
@@ -70056,6 +70118,7 @@
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "skq" = (
@@ -70406,11 +70469,15 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "soh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/commons/fitness)
 "soi" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -71163,17 +71230,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "sxb" = (
-/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/holodeck/rec_center)
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "sxu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -71198,6 +71265,7 @@
 /obj/item/toy/crayon/blue,
 /obj/item/toy/crayon/orange,
 /obj/item/toy/crayon/yellow,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/commons/dorms/laundry)
 "sxz" = (
@@ -72784,6 +72852,12 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"sUv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "sUE" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/firealarm/directional/east,
@@ -73452,16 +73526,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tfA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/holodeck/rec_center)
+/obj/machinery/hydroponics/constructable,
+/turf/open/misc/grass,
+/area/security/prison/garden)
 "tfD" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -76166,10 +76233,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"tRz" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "tRA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -78700,8 +78763,7 @@
 	name = "Command blue corner"
 	},
 /obj/machinery/camera{
-	c_tag = "Command - Bridge E";
-	dir = 10
+	c_tag = "Command - Bridge E"
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/vault,
@@ -79016,7 +79078,6 @@
 "uCN" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Test Chamber";
-	dir = 5;
 	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
@@ -79191,14 +79252,11 @@
 /turf/open/floor/iron,
 /area/service/library/abandoned)
 "uFq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Maintenance";
-	req_one_access_txt = "12;22"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/maintenance/starboard/fore)
 "uFr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -82454,11 +82512,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"vyE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/engineering)
 "vyK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -84449,18 +84502,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"wbK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/tcommsat/computer";
-	name = "Telecomms Monitoring APC";
-	pixel_y = -25
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
 "wce" = (
 /turf/closed/wall/r_wall,
 /area/command/teleporter)
@@ -85874,6 +85915,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"wyn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
 "wyr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 6
@@ -86044,7 +86090,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/camera{
 	c_tag = "Public - Picnic";
-	dir = 9
+	dir = 4
 	},
 /turf/open/misc/grass,
 /area/service/hydroponics/garden)
@@ -87324,11 +87370,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"wPJ" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/engineering/atmospherics_engine)
 "wPO" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -90349,7 +90390,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "xzG" = (
 /obj/structure/bed,
@@ -90487,7 +90528,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Entrance";
-	dir = 10;
 	network = list("ss13","security")
 	},
 /turf/open/floor/iron,
@@ -90563,7 +90603,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "xBU" = (
 /turf/closed/wall,
@@ -91578,6 +91618,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "xPK" = (
@@ -93032,6 +93073,7 @@
 	name = "Medical blue corner"
 	},
 /obj/item/toy/figure/paramedic,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "ygp" = (
@@ -109442,7 +109484,7 @@ ugF
 euk
 rXB
 upi
-lCx
+tfA
 siK
 vtt
 sAE
@@ -113639,7 +113681,7 @@ mJt
 sTt
 hYk
 tcL
-doc
+tcL
 hWZ
 plj
 rqD
@@ -114121,7 +114163,7 @@ qgN
 gNY
 aRM
 cst
-aRM
+kqb
 azk
 tdo
 ojJ
@@ -117804,7 +117846,7 @@ fHR
 tse
 dCs
 rgs
-oRj
+sUv
 vWn
 ouh
 xdv
@@ -118318,7 +118360,7 @@ vlZ
 uqr
 vlZ
 ogN
-oRj
+sUv
 xEJ
 ouh
 xdv
@@ -118575,7 +118617,7 @@ qWw
 qiQ
 aQq
 wuD
-bLY
+asb
 tzQ
 kOC
 iQW
@@ -118833,7 +118875,7 @@ nZr
 nZr
 wuD
 chJ
-ijV
+hfG
 kOC
 iQW
 vmD
@@ -123855,7 +123897,7 @@ seo
 oLB
 fYN
 rVg
-rVg
+bTo
 sBh
 yho
 joy
@@ -124462,12 +124504,12 @@ cOW
 iTT
 suI
 kJI
-vyE
+wyn
 mHH
 fgq
 vSJ
 kvU
-wPJ
+hdQ
 sDN
 rgH
 aPN
@@ -124976,7 +125018,7 @@ qDb
 wqx
 wqx
 biS
-vyE
+wyn
 gzb
 uVe
 suB
@@ -125362,10 +125404,10 @@ cUw
 eKB
 eKB
 bAW
-eKB
-eKB
-eKB
-rVl
+doc
+doc
+doc
+kiT
 kKo
 lFr
 cPA
@@ -125491,10 +125533,10 @@ xCX
 xCX
 xCX
 leB
-vyE
+wyn
 joo
 nVF
-nCW
+mAA
 nVF
 nVF
 hdc
@@ -125618,11 +125660,11 @@ wLQ
 wLQ
 wLQ
 wLQ
-kiT
 wLQ
 wLQ
 wLQ
-rVl
+wLQ
+lCx
 kSB
 lHe
 izi
@@ -125875,11 +125917,11 @@ dkP
 wLQ
 wLQ
 wLQ
-tfA
 wLQ
 wLQ
 wLQ
-rVl
+wLQ
+lCx
 pwc
 lJX
 mfh
@@ -126132,11 +126174,11 @@ wLQ
 wLQ
 wLQ
 wLQ
-sxb
+dkP
 wLQ
 wLQ
 wLQ
-jMI
+rkj
 cZA
 cZA
 cZA
@@ -126389,11 +126431,11 @@ wLQ
 wLQ
 wLQ
 wLQ
-tfA
 wLQ
 wLQ
 wLQ
-cZA
+wLQ
+sby
 kVl
 lNA
 vpI
@@ -126646,11 +126688,11 @@ wLQ
 wLQ
 wLQ
 wLQ
-tfA
+wLQ
 wLQ
 wLQ
 hFE
-eKB
+soh
 kYK
 pHB
 mjd
@@ -126903,11 +126945,11 @@ wLQ
 wLQ
 dkP
 wLQ
-tfA
+wLQ
 dkP
 wLQ
 wLQ
-eKB
+soh
 kYK
 pHB
 mPq
@@ -127016,7 +127058,7 @@ iKp
 iKp
 rRQ
 ndt
-wbK
+dWv
 uIm
 ihO
 vsb
@@ -127160,11 +127202,11 @@ wLQ
 wLQ
 wLQ
 wLQ
-tfA
 wLQ
 wLQ
 wLQ
-eKB
+wLQ
+soh
 kYK
 pHB
 mjd
@@ -127235,7 +127277,7 @@ xdW
 xdW
 xdW
 fTM
-uQL
+wai
 skm
 xPB
 cdu
@@ -127417,10 +127459,10 @@ wLQ
 wLQ
 wLQ
 wLQ
-arG
-sby
-sby
-sby
+wLQ
+wLQ
+wLQ
+wLQ
 kdV
 keN
 hbm
@@ -128782,7 +128824,7 @@ eTy
 cmy
 yju
 szE
-tUi
+cJq
 puI
 aba
 uhW
@@ -129759,7 +129801,7 @@ sPX
 rvY
 yju
 rvY
-rkj
+uFq
 bgu
 rvY
 ljP
@@ -130530,7 +130572,7 @@ sPX
 rvY
 yju
 rvY
-rkj
+uFq
 lyv
 rvY
 mPf
@@ -131044,7 +131086,7 @@ ssZ
 rvY
 yju
 rvY
-soh
+gjH
 wWY
 wWY
 sOc
@@ -131324,7 +131366,7 @@ ycg
 ycg
 nXz
 ohS
-tRz
+mvU
 qFe
 rBa
 ycg
@@ -131568,7 +131610,7 @@ pvt
 kvR
 quz
 kNd
-uFq
+mdZ
 oGB
 oGB
 mgy
@@ -142846,7 +142888,7 @@ ijf
 msk
 jrO
 ijf
-gAM
+sxb
 eaR
 eaR
 eaR
@@ -143091,7 +143133,7 @@ gRV
 gRV
 gRV
 gRV
-rqx
+arG
 wMr
 xJb
 ijf

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -66654,8 +66654,9 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "rnq" = (
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/security/brig)
+/area/solars/starboard/fore)
 "rnv" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -92939,10 +92940,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
-"yfr" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/solars/starboard/fore)
 "yfs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -122926,7 +122923,7 @@ dcu
 kdR
 tGh
 qCw
-rnq
+iQW
 giF
 vgz
 chR
@@ -123183,7 +123180,7 @@ xvU
 wxT
 eLe
 qCw
-rnq
+iQW
 giF
 cOv
 aXd
@@ -123440,7 +123437,7 @@ xvU
 wqL
 avV
 qCw
-rnq
+iQW
 giF
 vYn
 fBm
@@ -123697,7 +123694,7 @@ xvU
 msB
 sla
 qCw
-rnq
+iQW
 giF
 pmh
 aXd
@@ -123954,7 +123951,7 @@ bEv
 mic
 tRo
 qCw
-rnq
+iQW
 giF
 ycs
 lIa
@@ -141368,7 +141365,7 @@ fUN
 fUN
 fUN
 iQW
-yfr
+rnq
 iQW
 fUN
 fUN
@@ -141624,9 +141621,9 @@ xbp
 xbp
 xbp
 xbp
-yfr
-yfr
-yfr
+rnq
+rnq
+rnq
 xbp
 xbp
 xbp
@@ -141882,7 +141879,7 @@ fUN
 fUN
 fUN
 iQW
-yfr
+rnq
 iQW
 fUN
 fUN
@@ -142139,7 +142136,7 @@ iQW
 iQW
 iQW
 iQW
-yfr
+rnq
 iQW
 iQW
 iQW
@@ -142396,7 +142393,7 @@ fUN
 fUN
 fUN
 iQW
-yfr
+rnq
 iQW
 fUN
 fUN
@@ -142653,7 +142650,7 @@ xbp
 xbp
 xbp
 vBx
-yfr
+rnq
 vBx
 xbp
 xbp
@@ -142910,7 +142907,7 @@ fUN
 fUN
 fUN
 iQW
-yfr
+rnq
 iQW
 fUN
 fUN
@@ -143167,7 +143164,7 @@ iQW
 iQW
 iQW
 iQW
-yfr
+rnq
 iQW
 iQW
 iQW
@@ -143424,7 +143421,7 @@ fUN
 fUN
 fUN
 iQW
-yfr
+rnq
 iQW
 fUN
 fUN
@@ -143681,7 +143678,7 @@ xbp
 xbp
 xbp
 vBx
-yfr
+rnq
 vBx
 xbp
 xbp

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -8808,7 +8808,7 @@
 	maxcharge = 15000
 	},
 /obj/machinery/button/door/directional/south{
-	id = "bridge blast2";
+	id = "bridgeentrance blast";
 	name = "Bridge Blast Door Control";
 	pixel_x = 7;
 	req_access_txt = "19"
@@ -54468,7 +54468,7 @@
 	},
 /obj/machinery/button/door/directional/east{
 	id = "armory";
-	name = "Armory Shutters";
+	name = "Armory Shutter";
 	pixel_y = 26;
 	req_access_txt = "3"
 	},

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -4537,12 +4537,11 @@
 	name = "Arrivals Dock"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/hallway/primary/port)
 "bkw" = (
 /obj/effect/turf_decal/tile/brown{
@@ -19279,8 +19278,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/navbeacon/wayfinding/dockarrival,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/hallway/primary/port)
 "fbo" = (
 /obj/structure/cable,
@@ -21022,9 +21020,9 @@
 /turf/open/floor/iron/white,
 /area/science)
 "fwv" = (
-/obj/item/radio/intercom/directional/south,
-/turf/closed/wall/r_wall,
-/area/security/checkpoint/customs)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/solars/starboard/fore)
 "fwx" = (
 /obj/machinery/power/shieldwallgen,
 /obj/effect/turf_decal/tile/blue{
@@ -27711,18 +27709,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/space/basic,
 /area/science/test_area)
-"hjc" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "arrivalslock";
-	name = "Arrivals Lockdown"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/entry)
 "hji" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/security_all,
@@ -66653,10 +66639,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"rnq" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/solars/starboard/fore)
 "rnv" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -68162,19 +68144,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "rIz" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "arrivalslock";
-	name = "Arrivals Lockdown"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "rIB" = (
 /obj/effect/turf_decal/tile/random,
@@ -72918,14 +72893,18 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron,
 /area/hallway/primary/port)
 "sVW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -81243,20 +81222,13 @@
 "vfV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/poddoor/preopen{
-	id = "arrivalslock";
-	name = "Arrivals Lockdown"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "vgd" = (
 /obj/effect/turf_decal/tile/brown{
@@ -105169,7 +105141,7 @@ xlr
 mFK
 wOb
 dbQ
-fwv
+oeA
 iMB
 rML
 tSk
@@ -106705,7 +106677,7 @@ xmk
 kFq
 fgp
 mog
-hjc
+mog
 fbn
 adW
 wOM
@@ -141365,7 +141337,7 @@ fUN
 fUN
 fUN
 iQW
-rnq
+fwv
 iQW
 fUN
 fUN
@@ -141621,9 +141593,9 @@ xbp
 xbp
 xbp
 xbp
-rnq
-rnq
-rnq
+fwv
+fwv
+fwv
 xbp
 xbp
 xbp
@@ -141879,7 +141851,7 @@ fUN
 fUN
 fUN
 iQW
-rnq
+fwv
 iQW
 fUN
 fUN
@@ -142136,7 +142108,7 @@ iQW
 iQW
 iQW
 iQW
-rnq
+fwv
 iQW
 iQW
 iQW
@@ -142393,7 +142365,7 @@ fUN
 fUN
 fUN
 iQW
-rnq
+fwv
 iQW
 fUN
 fUN
@@ -142650,7 +142622,7 @@ xbp
 xbp
 xbp
 vBx
-rnq
+fwv
 vBx
 xbp
 xbp
@@ -142907,7 +142879,7 @@ fUN
 fUN
 fUN
 iQW
-rnq
+fwv
 iQW
 fUN
 fUN
@@ -143164,7 +143136,7 @@ iQW
 iQW
 iQW
 iQW
-rnq
+fwv
 iQW
 iQW
 iQW
@@ -143421,7 +143393,7 @@ fUN
 fUN
 fUN
 iQW
-rnq
+fwv
 iQW
 fUN
 fUN
@@ -143678,7 +143650,7 @@ xbp
 xbp
 xbp
 vBx
-rnq
+fwv
 vBx
 xbp
 xbp

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1179,7 +1179,7 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aqm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/ordnance_mixing_input{
 	dir = 1
@@ -6416,7 +6416,7 @@
 "bGJ" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "bGV" = (
 /obj/structure/closet/crate/medical,
 /obj/item/stack/medical/suture,
@@ -7536,7 +7536,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bWh" = (
 /obj/machinery/power/solar_control{
-	id = "auxsolareast";
+	id = "foreport";
 	name = "Port Bow Solar Control"
 	},
 /obj/structure/cable,
@@ -14417,7 +14417,7 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/starboard/fore)
+/area/solars/starboard/fore)
 "dLY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -22831,13 +22831,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "fUN" = (
-/obj/machinery/power/solar{
-	id = "auxsolareast";
-	name = "Port Auxiliary Solar Array"
-	},
 /obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "forestarboard";
+	name = "Fore-Starboard Solar Array"
+	},
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/starboard/fore)
+/area/solars/starboard/fore)
 "fUR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -29939,7 +29939,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars)
+/area/solars/aux/port)
 "hLO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -32273,12 +32273,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "iqN" = (
-/obj/machinery/power/tracker{
-	id = "perma"
-	},
 /obj/structure/cable,
+/obj/machinery/power/tracker,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars)
+/area/solars/aux/port)
 "iqQ" = (
 /obj/structure/closet/crate/secure/loot,
 /turf/open/floor/plating,
@@ -33420,13 +33418,13 @@
 /turf/open/floor/plating/rust,
 /area/maintenance/starboard)
 "iJf" = (
-/obj/machinery/power/solar{
-	id = "auxsolareast";
-	name = "Port Auxiliary Solar Array"
-	},
 /obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "foreport";
+	name = "Fore-Port Solar Array"
+	},
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "iJh" = (
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -36653,7 +36651,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "jDs" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/blue,
@@ -39077,7 +39075,7 @@
 /obj/structure/cable,
 /obj/machinery/power/tracker,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "khU" = (
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom/directional/west{
@@ -43619,7 +43617,7 @@
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
 	dir = 4;
-	id = "perma";
+	id = "permar";
 	name = "Perma Solar Control"
 	},
 /turf/open/floor/plating,
@@ -49877,7 +49875,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars)
+/area/solars/aux/port)
 "mQd" = (
 /turf/closed/wall,
 /area/security/prison/work)
@@ -70489,7 +70487,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "soj" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/spawner/random/trash/mess,
@@ -71863,7 +71861,7 @@
 "sGf" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "sGh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -83982,7 +83980,7 @@
 	name = "Port Solar Array"
 	},
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "vTI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -88436,7 +88434,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/fore)
+/area/solars/starboard/fore)
 "xbE" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -91429,7 +91427,7 @@
 "xNu" = (
 /obj/machinery/power/solar_control{
 	dir = 8;
-	id = "auxsolareast";
+	id = "forestarboard";
 	name = "Starboard Bow Solar Control"
 	},
 /obj/structure/cable,
@@ -92941,6 +92939,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
+"yfr" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/solars/starboard/fore)
 "yfs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -141366,7 +141368,7 @@ fUN
 fUN
 fUN
 iQW
-vBx
+yfr
 iQW
 fUN
 fUN
@@ -141622,9 +141624,9 @@ xbp
 xbp
 xbp
 xbp
-vBx
-vBx
-vBx
+yfr
+yfr
+yfr
 xbp
 xbp
 xbp
@@ -141880,7 +141882,7 @@ fUN
 fUN
 fUN
 iQW
-vBx
+yfr
 iQW
 fUN
 fUN
@@ -142137,7 +142139,7 @@ iQW
 iQW
 iQW
 iQW
-vBx
+yfr
 iQW
 iQW
 iQW
@@ -142394,7 +142396,7 @@ fUN
 fUN
 fUN
 iQW
-vBx
+yfr
 iQW
 fUN
 fUN
@@ -142651,7 +142653,7 @@ xbp
 xbp
 xbp
 vBx
-vBx
+yfr
 vBx
 xbp
 xbp
@@ -142908,7 +142910,7 @@ fUN
 fUN
 fUN
 iQW
-vBx
+yfr
 iQW
 fUN
 fUN
@@ -143165,7 +143167,7 @@ iQW
 iQW
 iQW
 iQW
-vBx
+yfr
 iQW
 iQW
 iQW
@@ -143422,7 +143424,7 @@ fUN
 fUN
 fUN
 iQW
-vBx
+yfr
 iQW
 fUN
 fUN
@@ -143679,7 +143681,7 @@ xbp
 xbp
 xbp
 vBx
-vBx
+yfr
 vBx
 xbp
 xbp

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -17,9 +17,20 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "aab" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
+	name = "AI Hallway APC";
+	pixel_y = -25
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "aap" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -7452,11 +7463,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
-	name = "AI Hallway APC";
-	pixel_y = -25
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "bVc" = (
@@ -19305,7 +19312,9 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "fbt" = (
@@ -19394,16 +19403,11 @@
 /turf/open/floor/sepia,
 /area/maintenance/starboard/fore)
 "fcG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/effect/spawner/random/entertainment/arcade{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
+/turf/open/floor/iron/grimy,
+/area/maintenance/starboard/fore)
 "fcR" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -21819,7 +21823,9 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "fHO" = (
-/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/grimy,
 /area/hallway/primary/port)
@@ -26362,7 +26368,9 @@
 /area/maintenance/starboard/fore)
 "gQq" = (
 /obj/machinery/firealarm/directional/south,
-/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
 /turf/open/floor/iron/grimy,
 /area/hallway/primary/port)
 "gQA" = (
@@ -28922,6 +28930,7 @@
 /obj/item/clothing/shoes/sandal,
 /obj/item/clothing/under/dress/sundress,
 /obj/item/food/grown/sunflower,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/service/library/abandoned)
 "hAu" = (
@@ -31379,7 +31388,7 @@
 	},
 /obj/machinery/camera/motion{
 	c_tag = "Engineering - Secure Tech Storage";
-	dir = 9;
+	dir = 4;
 	network = list("ss13", "engineering")
 	},
 /turf/open/floor/iron,
@@ -128205,7 +128214,7 @@ iQW
 iQW
 iQW
 iQW
-aab
+puQ
 iQW
 iQW
 iQW
@@ -128462,7 +128471,7 @@ iQW
 iQW
 iQW
 iQW
-aab
+puQ
 iQW
 iQW
 iQW
@@ -128719,9 +128728,9 @@ yju
 yju
 yju
 yju
-aab
-aab
-aab
+puQ
+puQ
+puQ
 yju
 jMI
 jMI
@@ -131310,8 +131319,8 @@ rvY
 rvY
 vUQ
 rvY
-oDF
-oDF
+fcG
+fcG
 rvY
 vzb
 pXQ
@@ -140806,7 +140815,7 @@ gRV
 gRV
 uiB
 xOL
-bUH
+aab
 ijf
 isJ
 hiN
@@ -142862,7 +142871,7 @@ gRV
 gRV
 uiB
 xOL
-fcG
+bUH
 ijf
 jrO
 hvQ

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -2858,7 +2858,7 @@
 "aOQ" = (
 /obj/machinery/door/airlock{
 	name = "Service Techfab";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	req_access_txt = "73"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -3822,7 +3822,7 @@
 "baq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "5;12"
+	req_access_txt = "12"
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/medical)
@@ -9179,7 +9179,7 @@
 "csg" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	req_access_txt = "12;73"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -10435,7 +10435,7 @@
 	},
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue Maintenance";
-	req_access_txt = "5;6;12;22"
+	req_one_access_txt = "5;6;12;22"
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/medical)
@@ -31236,7 +31236,7 @@
 	},
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue Maintenance";
-	req_access_txt = "5;6;12;22"
+	req_one_access_txt = "5;6;12;22"
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/medical)
@@ -46427,7 +46427,7 @@
 "lZM" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	req_access_txt = "73"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -55835,14 +55835,14 @@
 "ovF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_access_txt = "12;73"
+	},
 /turf/open/floor/iron,
 /area/maintenance/fore)
 "ovM" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -11880,6 +11880,7 @@
 /obj/machinery/requests_console/directional/west{
 	department = "Chemistry";
 	departmentType = 2;
+	name = "Pharmacy Requests Console";
 	receive_ore_updates = 1
 	},
 /turf/open/floor/iron/white,
@@ -12160,7 +12161,8 @@
 	},
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/requests_console/directional/north{
-	department = "medbay lobby"
+	department = "medbay lobby";
+	name = "Medbay Lobby Requests Console"
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -15535,7 +15537,8 @@
 	},
 /obj/machinery/requests_console/directional/east{
 	department = "Security office";
-	departmentType = 5
+	departmentType = 5;
+	name = "Security Office Requests Console"
 	},
 /turf/open/floor/iron,
 /area/security/office)
@@ -16660,7 +16663,8 @@
 	name = "Medical blue corner"
 	},
 /obj/machinery/requests_console/directional/east{
-	department = "Plasma Medbay"
+	department = "Plasma Medbay";
+	name = "Plasma Medbay Requests Console"
 	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Medical - Plasma Medbay N";
@@ -22035,7 +22039,8 @@
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/requests_console/directional/south{
 	department = "Engineering security post";
-	departmentType = 5
+	departmentType = 5;
+	name = "Engineering Post Requests Console"
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
@@ -25627,8 +25632,9 @@
 	dir = 8
 	},
 /obj/machinery/requests_console/directional/south{
-	department = "Janitorial";
-	departmentType = 1
+	department = "Custodial Closet";
+	departmentType = 1;
+	name = "Custodial Closet Requests Console"
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -26789,7 +26795,8 @@
 	network = list("ss13", "service")
 	},
 /obj/machinery/requests_console/directional/east{
-	department = "Library"
+	department = "Library";
+	name = "Library Requests Console"
 	},
 /turf/open/floor/wood,
 /area/service/library)
@@ -33420,7 +33427,8 @@
 	dir = 8
 	},
 /obj/machinery/requests_console/directional/south{
-	department = "Virology"
+	department = "Virology";
+	name = "Virology Requests Console"
 	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Medical - Virology Break Room";
@@ -39087,6 +39095,7 @@
 /obj/machinery/requests_console/directional/east{
 	department = "AI";
 	departmentType = 5;
+	name = "AI Core Requests Console";
 	pixel_x = 28;
 	pixel_y = -28
 	},
@@ -40199,6 +40208,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kxO" = (
@@ -47299,7 +47309,8 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/requests_console/directional/west{
-	department = "Tool Storage"
+	department = "Tool Storage";
+	name = "Tool Storage Requests Console"
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
@@ -51376,7 +51387,8 @@
 	},
 /obj/machinery/requests_console/directional/north{
 	department = "Cargo Bay";
-	departmentType = 2
+	departmentType = 2;
+	name = "Cargo Bay Requests Console"
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
@@ -54739,7 +54751,8 @@
 	},
 /obj/machinery/requests_console/directional/west{
 	department = "Warden's office";
-	departmentType = 5
+	departmentType = 5;
+	name = "Warden's Office Requests Console"
 	},
 /turf/open/floor/iron/dark,
 /area/security/warden)
@@ -55933,7 +55946,8 @@
 /area/science)
 "ovN" = (
 /obj/machinery/requests_console/directional/south{
-	department = "Law office"
+	department = "Law office";
+	name = "Law Office Requests Console"
 	},
 /turf/open/floor/carpet/purple,
 /area/service/lawoffice)
@@ -56057,7 +56071,8 @@
 	},
 /obj/machinery/requests_console/directional/south{
 	department = "Hydroponics";
-	departmentType = 2
+	departmentType = 2;
+	name = "Hydroponics Requests Console"
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -65625,7 +65640,8 @@
 	name = "Security red corner"
 	},
 /obj/machinery/requests_console/directional/north{
-	department = "Prison"
+	department = "Prison";
+	name = "Prison Requests Console"
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
@@ -67338,7 +67354,8 @@
 	},
 /obj/machinery/requests_console/directional/south{
 	department = "Medbay Security Post";
-	departmentType = 5
+	departmentType = 5;
+	name = "Medical Post Requests Console"
 	},
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -70651,7 +70668,8 @@
 "sqQ" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Kitchen";
-	departmentType = 2
+	departmentType = 2;
+	name = "Kitchen Requests Console"
 	},
 /obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
@@ -70991,7 +71009,8 @@
 	},
 /obj/machinery/requests_console/directional/north{
 	department = "Cargo security post";
-	departmentType = 5
+	departmentType = 5;
+	name = "Cargo Post Request Console"
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -89141,7 +89160,8 @@
 	name = "Command blue corner"
 	},
 /obj/machinery/requests_console/directional/east{
-	department = "EVA"
+	department = "EVA";
+	name = "EVA Requests Console"
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
@@ -93155,7 +93175,8 @@
 	dir = 6
 	},
 /obj/machinery/requests_console/directional/west{
-	department = "Library Printer Room"
+	department = "Library Printer Room";
+	name = "Library Requests Console"
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -14353,7 +14353,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
 	},

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -35937,6 +35937,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "permainner"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "jsI" = (
@@ -82794,6 +82797,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "permalockdown"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "vDd" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -35599,10 +35599,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"joo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/checkpoint/engineering)
 "joq" = (
 /obj/structure/sign/departments/mait{
 	pixel_x = 32
@@ -125530,7 +125526,7 @@ xCX
 xCX
 leB
 wyn
-joo
+wyn
 nVF
 mAA
 nVF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request

![image](https://user-images.githubusercontent.com/25415050/162219671-21b5bc0a-3e91-4d74-b230-b8fafa321455.png)

Morgue's access from hallways needed medical, morgue, maints AND chapel access to enter so nobody on the station but the captain could actually go through, it now only requires morgue access.
Also changed the service hallway airlocks to use the new service access instead of what we had before

![image](https://user-images.githubusercontent.com/25415050/162221202-1e717ccf-655d-4580-8e57-87cdbfc52620.png)
this shit is confusing so both surgery rooms are now part of a single surgery area

![image](https://user-images.githubusercontent.com/25415050/162221417-c431bdf5-cd76-49ef-a503-021f00c607d4.png)
that chunk of med maints is now part of F/S maints for consistency, also adds maints to the walls where there should be maints

![image](https://user-images.githubusercontent.com/25415050/162221907-4e56b300-bc60-4438-bbe6-8b166ec97e92.png)
fixes some decal issues that were missed when the library was remade

![image](https://user-images.githubusercontent.com/25415050/162222290-64383d2c-666c-4054-a08e-666b41fc22e6.png)
fixes perma windows not actually being shocked

![image](https://user-images.githubusercontent.com/25415050/162222602-6a285058-b6da-4380-bf40-eb8b4c2ccae7.png)
shocks sec posts' windows

![image](https://user-images.githubusercontent.com/25415050/162224010-318ba120-2357-4c78-8757-595c83d2561b.png)
replaces these cycle links with multi ones

![image](https://user-images.githubusercontent.com/25415050/162224643-e640fde3-af0d-4f73-a17a-8b5fd2ac7a06.png)
Changes all grass tiles on the station from /turf/open/floor/grass to /turf/open/misc/grass

![image](https://user-images.githubusercontent.com/25415050/162225211-d05e7a23-933a-4684-8f86-595e4bd42c26.png)
fixes this stool in science

![image](https://user-images.githubusercontent.com/25415050/162225893-746f56cc-2e4a-4ba2-b708-2b10f11aefbd.png)
moves this hidden AI sat APC

![image](https://user-images.githubusercontent.com/25415050/162281435-59496360-db3b-46e1-8fe3-0c6d098ff794.png)
these wall mounts too

![image](https://user-images.githubusercontent.com/25415050/162226466-52f2f5be-138f-4af1-99de-9900604b6690.png)
makes it so you can use the SM's thermomachines even if you plan on sending the gases to the wasteline, they now use the wasteline to control temp instead of the SM's wastes

![image](https://user-images.githubusercontent.com/25415050/162229472-9c89a69f-6604-403a-aa87-7b9a2cedd252.png)
these blast doors do not have a button assigned to them

![image](https://user-images.githubusercontent.com/25415050/162231080-e290d425-c888-488b-be10-c591c2bb44de.png)
holodeck deletes these pipes when changing setting every other tgu so i made them go thru walls like tg maps do

![image](https://user-images.githubusercontent.com/25415050/162232519-459493b8-989a-4999-b3fd-8e19db782d2a.png)
replaces the free advanced medkit with a regular one, fuck you

![image](https://user-images.githubusercontent.com/25415050/162234353-5ddb8899-556d-4f09-bba5-230830ea0ea2.png)
connects gravity to the powernet idk y it wasnt

![image](https://user-images.githubusercontent.com/25415050/162235932-d0007416-f101-467b-86b2-061115cde5ad.png)
fixes that

![image](https://user-images.githubusercontent.com/25415050/162237260-8455cf07-f772-4c04-824f-1e407e9c2059.png)
all of that crap

![image](https://user-images.githubusercontent.com/25415050/162238223-730c77f7-0261-486e-81c3-ae30f02e11c1.png)
these too

![image](https://user-images.githubusercontent.com/25415050/162239647-872d19ac-7102-4275-92ba-41b9fb42ebda.png)
these

![image](https://user-images.githubusercontent.com/25415050/162281279-896af5c7-3f6d-4d70-a655-a98db340ae75.png)
lol

![image](https://user-images.githubusercontent.com/25415050/162282205-f6394b2a-fedf-4d3d-a155-b71ee4c5b399.png)
moves solars from /area/maintenance/ to /area/solars/

![image](https://user-images.githubusercontent.com/25415050/162282539-68260216-156a-4b3a-bb66-08218a220ca3.png)
starboard solars & fore central were called port solars

![image](https://user-images.githubusercontent.com/25415050/162284070-6ff32725-676d-4088-b93a-4fef955942da.png)
remove the brig area from that bit of space

![image](https://user-images.githubusercontent.com/25415050/162287287-a97d07bd-8126-4b3b-a5a3-b1a7e2e15d94.png)
hidden useless wall intercom

![image](https://user-images.githubusercontent.com/25415050/162287747-ace83273-9148-427f-a00e-4e524bfb5464.png)
removes these blast doors in arrivals because there is no point to them other than griefing & making it so people cant enter the station proper thx god nobody knows about them thats just my opinion though

![image](https://user-images.githubusercontent.com/25415050/162294409-cead538c-0d4e-4203-ba4b-2df84dff6649.png)
like 20 instances of request consoles not being properly named or being half assed

![image](https://user-images.githubusercontent.com/25415050/162308627-8f8521b0-fbeb-4ce1-a5cd-fe05e9e75291.png)
makes arcades face the correct way

![image](https://user-images.githubusercontent.com/25415050/162314026-cefddfd7-2d61-4e0f-886b-990cfa387427.png)
these windows didnt have anything supporting them

![image](https://user-images.githubusercontent.com/25415050/162318470-620b7f68-025b-4222-b6fb-9e17e7221c8a.png)
there is no blastdoor using that id and the blast doors at both sides of the bridge entrances dont have any button matching them so theyre now linked

renames armory shutters button to armory shutter because theres only 1

## Why It's Good For The Game

it is

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
expansion: Expands content of an existing feature
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
