### PR TITLE
removes prisoners

### DIFF
--- a/fulp_modules/Z_edits/job_edits.dm
+++ b/fulp_modules/Z_edits/job_edits.dm
@@ -19,7 +19,7 @@
 	spawn_positions = 8
 
 /datum/job/prisoner
-	total_positions = 2
+	total_positions = 0
 	spawn_positions = 0
 
 /** Engineering */


### PR DESCRIPTION
## About The Pull Request

Prisoners should still spawn on Helio/Selene/Pubby because of config, this removes them from all other maps.
