### PR TITLE
Lowers pubby's prisoners to 2

### DIFF
--- a/_maps/pubbystation.json
+++ b/_maps/pubbystation.json
@@ -14,7 +14,7 @@
 			"additional_cqc_areas": ["/area/service/bar/atrium", "/area/security/prison/upper"]
 		},
 		"prisoner": {
-			"spawn_positions": 4
+			"spawn_positions": 2
 		}
 	}
 }


### PR DESCRIPTION
## About The Pull Request

Pubby is a smaller map with a smaller permabrig, so they should have half the prisoners to make up for it. They don't even HAVE 4 cells. kinda fucked up.