### PR TITLE
halves the amount of paramedics

### DIFF
--- a/fulp_modules/Z_edits/job_edits.dm
+++ b/fulp_modules/Z_edits/job_edits.dm
@@ -56,8 +56,8 @@
 	exp_requirements = 180
 
 /datum/job/paramedic
-	total_positions = 4
-	spawn_positions = 8
+	total_positions = 2
+	spawn_positions = 4
 	exp_requirements = 180
 
 /datum/job/chemist


### PR DESCRIPTION
## About The Pull Request

Halves the Paramedic job slots (4 roundstart -> 2 roundstart, 8 total (roundstart+latejoin) -> 4 total)

## Why It's Good For The Game

Paramedics currently have very little to do, gathering bodies is hard to do when you have 7 other players doing so. This causes paramedics to completely lose interest in trying to be the first ones to find a body, and instead just loiters Medbay or starts doing the MD's jobs.
They also abuse their access to greytide and such, but all these cases relate to one thing:
Having less paramedics makes the lack of/greytiding by, Paramedics, more impactful (and noticable) on the round, and makes the individual paramedics be more invested in their own job as they have more to do, seeing it isn't split between so many people anymore.

Our current job position list (iirc) was made when we were hitting 150 pop, now our average is 80 i think, so we don't need all these slots laying around anymore.
