### PR TITLE
removes nearly all borg positions

### DIFF
--- a/fulp_modules/Z_edits/job_edits.dm
+++ b/fulp_modules/Z_edits/job_edits.dm
@@ -127,5 +127,5 @@
 /** Silicon */
 /datum/job/cyborg
 	total_positions = 0
-	spawn_positions = 4
+	spawn_positions = 1
 	exp_requirements = 300

--- a/fulp_modules/Z_edits/job_edits.dm
+++ b/fulp_modules/Z_edits/job_edits.dm
@@ -127,5 +127,5 @@
 /** Silicon */
 /datum/job/cyborg
 	total_positions = 0
-	spawn_positions = 1
+	spawn_positions = 2
 	exp_requirements = 300


### PR DESCRIPTION
## About The Pull Request

Brings Cyborg positions down to 1 (latejoin is still disabled).

## Why It's Good For The Game

Cyborgs spawning roundstart is something I've never been a fan of. Cyborg isn't a job, it's a role. You transition into one through borging.
I'd rather people who want to play Cyborg would go Assistant instead, and turn into one through Robotics. This gives Robotics a thing to do early in the shift, gives Miners a reason to get materials early on in the shift, and makes Cyborgs feel closer to the Robotics department as a whole, as they created your shell and did the surgery needed to get you in there.
I find Cyborgs with this, would be more likely to actually respect the Robotics department, and even return later for upgrades or model resets, something basically never see nowadays.

I also kept a single cyborg slot, because sometimes no one wants to be borged, and in a case of a malf AI or such, you need at least one borg to use something like the force borger.
