### PR TITLE
Fulp Maps Access Overhaul (Mainly Solar/External Airlocks)

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -124,7 +124,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -178,7 +178,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/tile/yellow{
@@ -2543,8 +2543,7 @@
 /area/security/office)
 "ahn" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "24"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -15559,8 +15558,7 @@
 /area/maintenance/department/medical)
 "aJC" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "24"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -18280,7 +18278,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -24146,7 +24144,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/tile/yellow{
@@ -31861,7 +31859,7 @@
 "bzn" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
-	req_one_access_txt = "6;5;28"
+	req_access_txt = 6
 	},
 /obj/machinery/navbeacon/wayfinding,
 /obj/effect/turf_decal/tile/blue{
@@ -34960,8 +34958,7 @@
 /area/maintenance/department/science)
 "bHg" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -41241,7 +41238,7 @@
 "bWT" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Service Maintenance Access";
-	req_one_access_txt = "12;22;25;26;28;35;37;38;46;70"
+	req_one_access_txt = "12;73"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41383,8 +41380,7 @@
 /area/science/research)
 "bXk" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -54853,7 +54849,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/tile/yellow{
@@ -63381,7 +63377,7 @@
 "cXh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Morgue Maintenance";
-	req_one_access_txt = "6;5;12"
+	req_access_txt = 6
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -63728,7 +63724,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -71669,7 +71665,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/door/airlock{
 	name = "Service Techfab";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	req_one_access_txt = "73"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -72682,6 +72678,13 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"sQI" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Tech Storage Maintenance";
+	req_access_txt = "12;23"
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/engine)
 "sSa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 9
@@ -107201,7 +107204,7 @@ bMl
 bTv
 bSm
 bWq
-ckK
+sQI
 uys
 kSr
 kSr

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6966,6 +6966,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
 /obj/item/laser_pointer/blue,
+/obj/item/crowbar,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "awb" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6966,7 +6966,6 @@
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
 /obj/item/laser_pointer/blue,
-/obj/item/crowbar,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "awb" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -11083,7 +11083,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -11094,7 +11094,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -11417,18 +11417,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
+/obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aME" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
+/obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aMH" = (
@@ -32019,9 +32015,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
+/obj/machinery/door/airlock/external,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -32040,9 +32034,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
+/obj/machinery/door/airlock/external,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -38716,7 +38708,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -39098,9 +39090,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
+/obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "hTl" = (
@@ -49653,7 +49643,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -54181,9 +54171,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
+/obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "vtD" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -21647,7 +21647,7 @@
 	dir = 8;
 	name = "Security Delivery";
 	pixel_y = -7;
-	req_access_txt = "3"
+	req_access_txt = "1"
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -2108,7 +2108,7 @@
 "aCB" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
@@ -5164,7 +5164,7 @@
 "bst" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -8469,8 +8469,7 @@
 /area/hallway/primary/aft)
 "cit" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -9218,8 +9217,7 @@
 /area/security/prison/garden)
 "csr" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -9379,8 +9377,7 @@
 /area/science/mixing)
 "cuP" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -11125,8 +11122,7 @@
 /area/security/prison/visit)
 "cSn" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -12245,8 +12241,7 @@
 /area/command/heads_quarters/ce)
 "dfH" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -14646,7 +14641,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -17417,8 +17412,7 @@
 /area/maintenance/fore)
 "eAD" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -20618,7 +20612,7 @@
 "frz" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -24422,8 +24416,7 @@
 /area/maintenance/department/medical)
 "grF" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/machinery/navbeacon/wayfinding/dockaux,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -49224,8 +49217,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "mHO" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -53763,7 +53755,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -55893,8 +55885,7 @@
 /area/command/heads_quarters/cmo)
 "ouN" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -59118,7 +59109,7 @@
 "ppR" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -65760,8 +65751,7 @@
 /area/service/bar/atrium)
 "rbz" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -67922,8 +67912,7 @@
 /area/engineering/lobby)
 "rFr" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -79392,8 +79381,7 @@
 "uHL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -83854,7 +83842,7 @@
 "vSs" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
@@ -85281,8 +85269,7 @@
 /area/engineering/atmos)
 "wqo" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -87539,7 +87526,7 @@
 "wRs" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!--
IMPORTANT: For large prs, make sure include in your title [IDB IGNORE] and/or [MDB IGNORE] to keep their bots from crashing. 
MDB is especially important for large map changes
Failure to do so could result in repoban
If you need help please reach out on the discord!
-->

## About The Pull Request
List of change:

**HelioStation**

- Service Maint | ("12;22;25;26;28;35;37;38;46;70") to ("12;73") 
- Service Techfab | ("22;25;26;28;35;37;38;46;70") to ("73")
- "Engineering Maintenance" to "Tech Storage Maintenance"  | ("10; 24") to ("12;23) | 
 _why would you give atmo tech access to tech storage, and medic even used to be able to enter before the medic access  nerf_
- Solar External Airlocks - Port Bow, Starboard Bow, Starboard Quarter | ("10; 13") to ("10")
- External Airlocks - Med Maint | ("24") to (0)
- External Airlocks - Evac| ("13") to (0)
- Morgue Hallway - ("6;5;28") to ("6")  
 _Medical access(5) is supposed to use on medical morgue airlock to block off people from entering med with only morgue access, not using it on morgue hallway airlock. Also, cook comes with morgue access already, so they don't need kitchen access on morgue door._

- Morgue Maint - ("6;5;12") to ("6")

**SeleneStation**

- Solar External Airlocks - Security, Starboard Bow, Port Bow, Port Quarter  | ("10; 13") to ("10") 
- External Airlocks | ("13") to (0)
- Security Deliver Windoor | ("3") to ("1")

**PubbyStation**

- Solar External Airlocks | ("10; 13") to ("10") 
- External Airlocks | ("13") to (0)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Let me explain it.
I know having exclusive features are sometimes good, but access should be consistent.
In helio, the maint external airlocks access are extreme inconsistent, you have a pair with no access required(above dorm), another with atmo access required(the one above med...why?) then another pair with external access required. Furthermore, on Pubbystation and SeleneStation, all maint external airlocks require external access, which sounds reasonable at first. However, I checked TG maps and found out that normally maint external airlock do not need any access at all. (This can affect lone ops or nukie if they wish to go stealth, or maybe sec/medic too as they don't have external access)

As for solar, I change it from 10;13 to 10 because of following TG maps consistency too. This only affects engi sec I am pretty sure.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fulp doesn't have change log, and I already list the change up there. I wanna play game now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
