### PR TITLE
adds a mutadone medipen cargo crate + fixes exploits

### DIFF
--- a/fulp_modules/features/cargo/cargo.dm
+++ b/fulp_modules/features/cargo/cargo.dm
@@ -2,7 +2,7 @@
 
 // Medipens
 /datum/supply_pack/security/mutadone_medipen
-	name = "Emergency Mutadine Kit"
+	name = "Emergency Mutadone Kit"
 	desc = "Contains one Mutadone medipen for instant genetic removal. Best used for hulks."
 	cost = CARGO_CRATE_VALUE * 1.5
 	contains = list(/obj/item/reagent_containers/hypospray/medipen/mutadone)

--- a/fulp_modules/features/cargo/cargo.dm
+++ b/fulp_modules/features/cargo/cargo.dm
@@ -1,5 +1,12 @@
 //Put all modular Fulp cargo crates in this folder.
 
+// Medipens
+/datum/supply_pack/security/mutadone_medipen
+	name = "Emergency Mutadine Kit"
+	desc = "Contains one Mutadone medipen for instant genetic removal. Best used for hulks."
+	cost = CARGO_CRATE_VALUE * 1.5
+	contains = list(/obj/item/reagent_containers/hypospray/medipen/mutadone)
+
 //Halloween
 /datum/supply_pack/goody/halloween_beacon
 	name = "Halloween Beacon"
@@ -11,7 +18,7 @@
 /datum/supply_pack/goody/clown_costume
 	name = "Clown Costume"
 	desc = "Supply the station's wannabe clown with their equipment and costume! Contains a full clown outfit along with a bike horn."
-	cost = PAYCHECK_MEDIUM * 2
+	cost = CARGO_CRATE_VALUE
 	contains = list(
 		/obj/item/bikehorn,
 		/obj/item/clothing/mask/gas/clown_hat,
@@ -23,7 +30,7 @@
 /datum/supply_pack/goody/mime_costume
 	name = "Mime Costume"
 	desc = "Supply the station's wannabe mime with their equipment and costume! Contains a full mime outfit along with a bottle of nothing."
-	cost = PAYCHECK_MEDIUM * 2
+	cost = CARGO_CRATE_VALUE
 	contains = list(
 		/obj/item/clothing/gloves/color/white,
 		/obj/item/clothing/head/frenchberet,


### PR DESCRIPTION
## About The Pull Request

Adds a Mutadone Medipen cargo crate, under Security. This allows Security to easily de-hulk people assuming cargo delivers, and allows Science to replace used medipens.

Also fixes the price for the other crates, since they currently cost less than the price of the crate itself. You can buy these over and over, then resell the empty crate and turn a profit.

## Why It's Good For The Game

I added this item but we rarely see it used because it is limited to a single job that not many people play as. Hoping this would make dealing with hulks easier and less lethal.