### PR TITLE
moves bloodsucker powers to Process

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
@@ -163,14 +163,14 @@
 /datum/action/bloodsucker/proc/ActivatePower()
 	active = TRUE
 	if(power_flags & BP_AM_TOGGLE)
-		RegisterSignal(owner, COMSIG_LIVING_LIFE, .proc/UsePower)
+		START_PROCESSING(SSprocessing, src)
 
 	owner.log_message("used [src][bloodcost != 0 ? " at the cost of [bloodcost]" : ""].", LOG_ATTACK, color="red")
 	UpdateButtons()
 
 /datum/action/bloodsucker/proc/DeactivatePower()
 	if(power_flags & BP_AM_TOGGLE)
-		UnregisterSignal(owner, COMSIG_LIVING_LIFE)
+		STOP_PROCESSING(SSprocessing, src)
 	if(power_flags & BP_AM_SINGLEUSE)
 		RemoveAfterUse()
 		return
@@ -179,16 +179,12 @@
 	UpdateButtons()
 
 ///Used by powers that are continuously active (That have BP_AM_TOGGLE flag)
-/datum/action/bloodsucker/proc/UsePower(mob/living/user)
-	SIGNAL_HANDLER
-
-	if(!active) // Power isn't active? Then stop here, so we dont keep looping UsePower for a non existent Power.
-		return FALSE
-	if(!ContinueActive(user)) // We can't afford the Power? Deactivate it.
+/datum/action/bloodsucker/process(delta_time)
+	if(!ContinueActive(owner)) // We can't afford the Power? Deactivate it.
 		DeactivatePower()
 		return FALSE
 	// We can keep this up (For now), so Pay Cost!
-	if(!(power_flags & BP_AM_COSTLESS_UNCONSCIOUS) && user.stat != CONSCIOUS)
+	if(!(power_flags & BP_AM_COSTLESS_UNCONSCIOUS) && owner.stat != CONSCIOUS)
 		bloodsuckerdatum_power?.AddBloodVolume(-constant_bloodcost)
 	return TRUE
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
@@ -190,9 +190,6 @@
 
 /// Checks to make sure this power can stay active
 /datum/action/bloodsucker/proc/ContinueActive(mob/living/user, mob/living/target)
-	if(!active)
-		owner.balloon_alert(owner, "[src] cancelled...")
-		return FALSE
 	if(!user)
 		return FALSE
 	if(!constant_bloodcost > 0 || user.blood_volume > 0)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/cloak.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/cloak.dm
@@ -34,11 +34,12 @@
 	user.AddElement(/datum/element/digitalcamo)
 	user.balloon_alert(user, "cloak turned on.")
 
-/datum/action/bloodsucker/cloak/UsePower(mob/living/user)
+/datum/action/bloodsucker/cloak/process(delta_time)
 	// Checks that we can keep using this.
 	. = ..()
 	if(!.)
 		return
+	var/mob/living/user = owner
 	animate(user, alpha = max(25, owner.alpha - min(75, 10 + 5 * level_current)), time = 1.5 SECONDS)
 	// Prevents running while on Cloak of Darkness
 	if(user.m_intent != MOVE_INTENT_WALK)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
@@ -129,7 +129,8 @@
 	ADD_TRAIT(owner, TRAIT_IMMOBILIZED, FEED_TRAIT)
 	return ..()
 
-/datum/action/bloodsucker/feed/UsePower(mob/living/user)
+/datum/action/bloodsucker/feed/process(delta_time)
+	var/mob/living/user = owner
 	var/mob/living/feed_target = target_ref.resolve()
 	if(!ContinueActive(user, feed_target))
 		owner.balloon_alert(owner, "interrupted!")

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/fortitude.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/fortitude.dm
@@ -41,11 +41,12 @@
 	if(was_running)
 		bloodsucker_user.toggle_move_intent()
 
-/datum/action/bloodsucker/fortitude/UsePower(mob/living/carbon/user)
+/datum/action/bloodsucker/fortitude/process(delta_time)
 	// Checks that we can keep using this.
 	. = ..()
 	if(!.)
 		return
+	var/mob/living/carbon/user = owner
 	/// Prevents running while on Fortitude
 	if(user.m_intent != MOVE_INTENT_WALK)
 		user.toggle_move_intent()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
@@ -43,7 +43,7 @@
 	owner.balloon_alert(owner, "starting teleportation...")
 	to_chat(owner, span_notice("You focus on separating your consciousness from your physical form..."))
 
-/datum/action/bloodsucker/gohome/UsePower(mob/living/user)
+/datum/action/bloodsucker/gohome/process(delta_time)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -59,7 +59,7 @@
 		if(GOHOME_FLICKER_TWO)
 			INVOKE_ASYNC(src, .proc/flicker_lights, 4, 60)
 		if(GOHOME_TELEPORT)
-			INVOKE_ASYNC(src, .proc/teleport_to_coffin, user)
+			INVOKE_ASYNC(src, .proc/teleport_to_coffin, owner)
 	teleporting_stage++
 
 /datum/action/bloodsucker/gohome/ContinueActive(mob/living/user, mob/living/target)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/recuperate.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/recuperate.dm
@@ -28,11 +28,12 @@
 	to_chat(owner, span_notice("Your muscles clench as your master's immortal blood mixes with your own, knitting your wounds."))
 	owner.balloon_alert(owner, "recuperate turned on.")
 
-/datum/action/bloodsucker/recuperate/UsePower(mob/living/carbon/user)
+/datum/action/bloodsucker/recuperate/process(delta_time)
 	. = ..()
 	if(!.)
 		return
 
+	var/mob/living/carbon/user = owner
 	var/datum/antagonist/vassal/vassaldatum = IS_VASSAL(user)
 	vassaldatum.master.AddBloodVolume(-1)
 	user.Jitter(5)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/_powers_targeted.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/_powers_targeted.dm
@@ -37,7 +37,7 @@
 
 /datum/action/bloodsucker/targeted/DeactivatePower()
 	if(power_flags & BP_AM_TOGGLE)
-		UnregisterSignal(owner, COMSIG_LIVING_LIFE)
+		STOP_PROCESSING(SSprocessing, src)
 	active = FALSE
 	DeactivateRangedAbility()
 	UpdateButtons()


### PR DESCRIPTION
## About The Pull Request

Moves Bloodsucker stuff from the on_life signal to Process.

## Why It's Good For The Game

It's more consistent this way while not sacrificing lag or errors. This signal shouldnt be overused, and Bloodsuckers already use it lots for their own on_life.
It also isn't something that lasts a whole round, like Bloodsucker life, so its fine to process instead.