### PR TITLE
fixe s meatman icon bgu=

### DIFF
--- a/fulp_modules/features/species/beefmen/mob/beefman.dm
+++ b/fulp_modules/features/species/beefmen/mob/beefman.dm
@@ -386,6 +386,8 @@
 		span_notice("The meat sprouts digits and becomes [beefboy]'s new [new_bodypart.name]!"),
 		span_notice("The meat sprouts digits and becomes your new [new_bodypart.name]!"))
 	new_bodypart.attach_limb(beefboy)
+	new_bodypart.update_limb(is_creating = TRUE)
+	beefboy.update_body_parts()
 	new_bodypart.give_meat(beefboy, meat)
 	qdel(meat)
 	playsound(get_turf(beefboy), 'fulp_modules/features/species/sounds/beef_grab.ogg', 50, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> fixes this 
![awsad2](https://user-images.githubusercontent.com/95004236/164969773-6fa51012-8409-4131-a0b5-d021829ea2eb.png)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> fixes this
![awsad2](https://user-images.githubusercontent.com/95004236/164969809-5eb8635f-8367-4e55-b742-6bdec61016e9.png)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: es this 
![awsad2](https://user-images.githubusercontent.com/95004236/164969826-8e1f22aa-6640-468c-b87f-b4a6f79c3142.png)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
