### PR TITLE
Makes Fulp maps' labour camp shuttles work again!

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -391,7 +391,7 @@
 /area/maintenance/solars/starboard/fore)
 "abi" = (
 /obj/docking_port/stationary{
-	dir = 4;
+	dir = 8;
 	dwidth = 2;
 	height = 5;
 	id = "laborcamp_home";
@@ -100494,7 +100494,7 @@ aaa
 aaa
 aaa
 aaP
-abi
+aaa
 aaP
 aaa
 aaP
@@ -101526,7 +101526,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abi
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6659,7 +6659,7 @@
 	height = 5;
 	id = "laborcamp_home";
 	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
+	roundstart_template = /datum/map_template/shuttle/labour/generic;
 	width = 9
 	},
 /turf/open/space/basic,

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -63325,7 +63325,7 @@
 /area/service/chapel/office)
 "quh" = (
 /obj/docking_port/stationary{
-	dir = 4;
+	dir = 8;
 	dwidth = 2;
 	height = 5;
 	id = "laborcamp_home";
@@ -113736,7 +113736,7 @@ iQW
 iQW
 iQW
 iQW
-quh
+iQW
 iQW
 iQW
 iQW
@@ -114768,7 +114768,7 @@ iQW
 iQW
 iQW
 iQW
-iQW
+quh
 iQW
 vmD
 vmD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Updates the Helio and Selene labour shuttle docking ports so they don't spawn facing the wrong way and changes Pubby's to use the new generic labour shuttle.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now you can enter the labour shuttle!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed the labour camp shuttles in Heliostation, Selenestation and Pubbystation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
