### PR TITLE
Swags Heliostation

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -35689,7 +35689,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bJj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -36182,6 +36181,7 @@
 	color = "#FFD700";
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bKw" = (
@@ -36901,7 +36901,6 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen)
 "bMq" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -63824,12 +63823,6 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen)
-"dpW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "dqW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -65235,6 +65228,23 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"gck" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "gcL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -65258,12 +65268,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"gfm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "ggI" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -67272,12 +67276,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"jHZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "jIj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -67818,14 +67816,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
-"kMY" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Minisat Exterior NNE";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
 "kNo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -69451,6 +69441,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
+"nsZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "ntV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -69493,14 +69496,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"nzg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/solars)
 "nzi" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -70699,16 +70694,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"pBU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "pCn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -71082,6 +71067,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"qld" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "qlV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/beer,
@@ -71168,6 +71159,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"qxr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/solars)
 "qyu" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -71199,6 +71198,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"qCn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -72273,6 +72278,14 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"stF" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Minisat Exterior NNE";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "stL" = (
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 1
@@ -72733,25 +72746,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"tcZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/service/kitchen";
-	dir = 1;
-	name = "Kitchen APC";
-	pixel_y = 25
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "tdb" = (
 /obj/machinery/power/emitter,
 /obj/effect/decal/cleanable/dirt,
@@ -73361,6 +73355,12 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"urX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "uvU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -73804,23 +73804,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
-"vgX" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "vhW" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/beer,
@@ -73997,6 +73980,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"vwK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "vwM" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/blue/end{
@@ -75187,19 +75180,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"xGV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "xHv" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/bot_red,
@@ -75233,6 +75213,25 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/upper)
+"xMa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/service/kitchen";
+	dir = 1;
+	name = "Kitchen APC";
+	pixel_y = 25
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "xMT" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -94612,8 +94611,8 @@ bOV
 bQz
 bRZ
 bxJ
-gfm
-xGV
+qld
+nsZ
 bOQ
 bYl
 bZH
@@ -94870,7 +94869,7 @@ bNr
 bSa
 bxJ
 bxJ
-vgX
+gck
 bOQ
 bYm
 bZH
@@ -95126,7 +95125,7 @@ bOX
 bQA
 bSb
 bxJ
-jHZ
+urX
 glC
 bOQ
 bYn
@@ -96665,9 +96664,9 @@ iCN
 iCN
 iCN
 uYO
-dpW
+qCn
 iYl
-dpW
+qCn
 wBp
 lkO
 bOQ
@@ -104636,7 +104635,7 @@ bQW
 bNP
 bMj
 bxJ
-tcZ
+xMa
 bOQ
 aak
 bZZ
@@ -105224,7 +105223,7 @@ kJX
 ngx
 cUu
 cUQ
-nzg
+qxr
 cUH
 cTZ
 cTZ
@@ -110609,7 +110608,7 @@ aaa
 aaa
 aaa
 aaa
-kMY
+stF
 cSt
 cSt
 idi
@@ -118787,7 +118786,7 @@ cmv
 cnB
 cov
 vUt
-pBU
+vwK
 csb
 ctf
 cut

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -55,11 +55,6 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
-"aan" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/maintenance/solars/starboard/fore)
 "aao" = (
 /obj/machinery/power/solar{
 	id = "forestarboard";
@@ -67,20 +62,11 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/starboard/fore)
-"aap" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/maintenance/solars/starboard/fore)
+/area/solars/port/fore)
 "aaq" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
-"aar" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/cable_coil,
-/turf/open/space/basic,
-/area/maintenance/solars/starboard/fore)
 "aas" = (
 /obj/docking_port/stationary/random{
 	id = "pod_lavaland2";
@@ -157,7 +143,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/starboard/fore)
+/area/solars/port/fore)
 "aaF" = (
 /obj/machinery/power/solar_control{
 	id = "forestarboard";
@@ -448,6 +434,7 @@
 "abr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/office)
 "abs" = (
@@ -687,15 +674,13 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "abX" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 6;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/smes,
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/fore)
 "abZ" = (
@@ -1454,23 +1439,20 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/security/detectives_office)
 "aef" = (
 /obj/structure/chair{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -1602,6 +1584,9 @@
 	color = "#FF0000";
 	name = "security red"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "aeA" = (
@@ -1611,6 +1596,9 @@
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
 	name = "security red"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
@@ -1666,10 +1654,10 @@
 "aeF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/detectives_office)
 "aeG" = (
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/detectives_office)
 "aeH" = (
@@ -1691,7 +1679,6 @@
 /area/maintenance/department/security/upper)
 "aeQ" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red{
@@ -1702,6 +1689,9 @@
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/newscaster/directional/east,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "aeS" = (
@@ -1780,6 +1770,7 @@
 	name = "Security red corner"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "afd" = (
@@ -1826,15 +1817,15 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/det,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/detectives_office)
 "afh" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kanyewest";
 	name = "privacy shutters"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "afi" = (
@@ -1877,8 +1868,15 @@
 /turf/open/space/basic,
 /area/space)
 "afm" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	name = "security red"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "afn" = (
 /obj/structure/sign/poster/official/random{
@@ -1888,7 +1886,7 @@
 /area/maintenance/department/security/upper)
 "afp" = (
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "afr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -1905,7 +1903,7 @@
 /area/hallway/primary/fore)
 "afv" = (
 /obj/effect/spawner/random/clothing/costume,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "afA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -1998,6 +1996,7 @@
 	dir = 1;
 	name = "security red"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/office)
 "afM" = (
@@ -2091,7 +2090,7 @@
 /area/security/prison)
 "agd" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "age" = (
 /obj/effect/turf_decal/siding/brown{
@@ -2328,7 +2327,6 @@
 /turf/open/floor/iron,
 /area/security/office)
 "agH" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
@@ -2618,12 +2616,11 @@
 /area/security/office)
 "ahv" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 30
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/office)
 "ahw" = (
@@ -7776,6 +7773,7 @@
 /obj/item/multitool,
 /obj/machinery/camera/directional/north{
 	c_tag = "EVA Storage W";
+	dir = 8;
 	name = "EVA Camera";
 	network = list("ss13","command")
 	},
@@ -10669,8 +10667,8 @@
 	dir = 1;
 	name = "command blue"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
@@ -10683,8 +10681,8 @@
 	dir = 1;
 	name = "command blue"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
@@ -12334,18 +12332,16 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
 "aBO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "security red"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/command)
+/turf/open/floor/iron,
+/area/security/office)
 "aBP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12409,9 +12405,6 @@
 /area/command/teleporter)
 "aBV" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
@@ -13873,7 +13866,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aFk" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -13998,7 +13991,7 @@
 /obj/machinery/power/solar,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aFx" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -14350,7 +14343,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aGi" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -15392,28 +15385,26 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aIR" = (
-/obj/machinery/power/smes{
-	charge = 500000
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 30
+	},
+/turf/open/floor/iron,
+/area/security/office)
 "aIS" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/department/bridge)
 "aIT" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/sign/map/fulp/helio/left,
+/turf/closed/wall,
+/area/maintenance/port/fore)
 "aIU" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
 	},
-/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aIV" = (
@@ -15531,11 +15522,20 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aJy" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/maintenance/department/medical)
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "aJz" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Backup Power Supply"
 	},
@@ -15724,7 +15724,7 @@
 "aJV" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aJW" = (
 /obj/structure/frame/computer{
 	dir = 4
@@ -16043,12 +16043,12 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aKN" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aKO" = (
 /obj/structure/frame/computer{
 	dir = 4
@@ -19727,15 +19727,13 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aTy" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 6;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/smes,
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
 "aTz" = (
@@ -19854,13 +19852,9 @@
 /area/maintenance/fore/lesser)
 "aTN" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/maintenance/department/medical"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "aTO" = (
 /obj/structure/sink{
 	dir = 4;
@@ -19892,7 +19886,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/medical/surgery"
+	areastring = "/area/medical/surgery/theatre"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -28466,13 +28460,15 @@
 /area/medical/pharmacy)
 "bqr" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 10;
 	name = "engineering yellow"
 	},
 /obj/machinery/light_switch/directional/west,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "bqs" = (
@@ -28507,6 +28503,9 @@
 	name = "Auxiliary Construction Shutters";
 	req_access_txt = "72"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "bqu" = (
@@ -28515,6 +28514,9 @@
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	name = "engineering yellow"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
@@ -29155,7 +29157,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "brT" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/sign/map/fulp/helio/right,
 /turf/closed/wall,
 /area/construction/mining/aux_base)
 "brU" = (
@@ -29229,6 +29231,7 @@
 	name = "Auxiliary Construction Zone";
 	req_one_access_txt = "72"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "bsb" = (
@@ -29451,7 +29454,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bsE" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
@@ -29463,7 +29465,6 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bsF" = (
@@ -29483,6 +29484,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bsH" = (
@@ -29811,7 +29813,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "btO" = (
-/obj/structure/disposalpipe/junction/flip,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "btP" = (
@@ -29821,11 +29825,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "btQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "btR" = (
@@ -29969,6 +29973,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bus" = (
@@ -29979,6 +29984,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "but" = (
@@ -29989,6 +29995,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "buu" = (
@@ -29999,6 +30006,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "buy" = (
@@ -30112,6 +30120,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/navigate_destination/dockarrival,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "buV" = (
@@ -30249,6 +30258,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bvp" = (
@@ -32580,6 +32590,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "bBl" = (
@@ -32897,7 +32908,9 @@
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 6
 	},
-/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bBV" = (
@@ -33564,7 +33577,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/directional/west{
-	c_tag = "Mech Bay";
+	c_tag = "Science - Mech Bay";
 	name = "Mech Bay Camera";
 	network = list("ss13","rd")
 	},
@@ -33802,7 +33815,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bEo" = (
-/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -35121,14 +35136,14 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bHN" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 1;
 	name = "engineering yellow"
+	},
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
@@ -36544,10 +36559,11 @@
 /area/science/research)
 "bLr" = (
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "bLs" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -36755,9 +36771,6 @@
 /area/service/hydroponics)
 "bLV" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -37170,6 +37183,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bNe" = (
@@ -37374,6 +37390,9 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bNI" = (
@@ -37402,6 +37421,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -37848,17 +37870,26 @@
 "bOU" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "bOV" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/ale,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "bOW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/bar/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
 	},
@@ -37869,11 +37900,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "bOY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -37885,6 +37922,9 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -37999,6 +38039,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "bPq" = (
@@ -38027,6 +38070,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -38675,7 +38721,9 @@
 /area/service/kitchen)
 "bQX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -39093,7 +39141,9 @@
 "bRY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "bRZ" = (
@@ -39293,7 +39343,9 @@
 /area/hallway/secondary/entry)
 "bSA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
@@ -39579,9 +39631,15 @@
 /turf/open/floor/iron,
 /area/science/research)
 "bTj" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "bTk" = (
 /obj/structure/cable,
 /obj/effect/landmark/blobstart,
@@ -40284,11 +40342,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bUF" = (
-/obj/structure/disposalpipe/junction/flip{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "bUG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41014,15 +41076,14 @@
 /area/maintenance/department/electrical)
 "bWz" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/electrical)
-"bWA" = (
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/electrical";
 	name = "Electrical Maintenance APC";
 	pixel_y = -25
 	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/electrical)
+"bWA" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/electrical)
@@ -43917,10 +43978,10 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "cdr" = (
+/obj/structure/cable,
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cds" = (
@@ -44719,7 +44780,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "ceW" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/siding/yellow{
@@ -45204,7 +45265,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "cgk" = (
 /obj/structure/rack,
 /obj/item/stock_parts/micro_laser/high,
@@ -46341,7 +46402,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/preset/ordnance{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
@@ -47649,7 +47710,7 @@
 "clI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/camera/directional/north{
-	c_tag = "Engineering Hall - Escape Pod";
+	c_tag = "Engineering Hall - Atmospherics Port Side";
 	name = "Engineering Camera";
 	network = list("ss13","engineering")
 	},
@@ -47765,7 +47826,7 @@
 /area/engineering/lobby)
 "clV" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "Engineering Hall - Telecomms";
+	c_tag = "Engineering Hall - Entrance";
 	name = "Engineering Camera";
 	network = list("ss13","engineering")
 	},
@@ -48207,7 +48268,7 @@
 "cmO" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "cmQ" = (
 /turf/open/floor/plating,
 /area/engineering/lobby)
@@ -48587,7 +48648,7 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "cnO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -48634,7 +48695,7 @@
 /area/engineering/lobby)
 "cnT" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "Engineering Hall - CE Office";
+	c_tag = "Engineering Hall - Shared Engineering Storage";
 	name = "Engineering Camera";
 	network = list("ss13","engineering")
 	},
@@ -48683,7 +48744,7 @@
 /area/engineering/lobby)
 "cnZ" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "Engineering Hall - Tech Storage";
+	c_tag = "Engineering Hall - CE Office";
 	name = "Engineering Camera";
 	network = list("ss13","engineering")
 	},
@@ -49073,7 +49134,7 @@
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
 /turf/open/space/basic,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "coH" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Access";
@@ -50529,6 +50590,7 @@
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "csc" = (
@@ -50693,10 +50755,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cst" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/space_heater,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "csv" = (
@@ -51015,6 +51077,9 @@
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
 	name = "research purple"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -52603,7 +52668,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cxh" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/space/nearstation)
@@ -52702,10 +52767,7 @@
 /area/engineering/engine_smes)
 "cxr" = (
 /obj/item/storage/toolbox/electrical,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01";
-	luminosity = 2
-	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cxs" = (
 /obj/structure/table,
@@ -53130,15 +53192,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cyl" = (
-/obj/machinery/power/smes{
-	charge = 500000
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 9;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/smes,
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/aft)
 "cym" = (
@@ -53558,13 +53618,13 @@
 "czn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 1;
 	name = "engineering yellow"
+	},
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -53740,7 +53800,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "czJ" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -54258,7 +54318,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "cAS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -56648,7 +56708,7 @@
 "cGU" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "cGV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57470,7 +57530,7 @@
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "cIg" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -58157,7 +58217,7 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "cJQ" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/engine,
@@ -59901,13 +59961,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"cOr" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/engineering/main)
 "cOs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -60977,6 +61030,8 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cRf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cRh" = (
@@ -61009,24 +61064,18 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cRm" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Satellite Interior APC";
-	pixel_y = -25
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cRn" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cRo" = (
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/south{
 	broadcasting = 1;
 	frequency = 1447;
@@ -61036,7 +61085,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cRp" = (
-/obj/structure/cable,
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -61444,7 +61492,9 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cSE" = (
-/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cSF" = (
@@ -61963,8 +62013,10 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars)
 "cUa" = (
-/obj/machinery/power/smes,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north{
+	name = "AI satellite"
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/solars)
 "cUc" = (
@@ -62033,10 +62085,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cUp" = (
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/solars)
 "cUq" = (
@@ -62119,10 +62170,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cUE" = (
-/obj/machinery/power/solar_control{
-	id = "aisolar";
-	name = "AI Solar Control"
-	},
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
@@ -62132,8 +62179,8 @@
 	uses = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/solars)
@@ -62263,6 +62310,9 @@
 /area/maintenance/solars)
 "cUY" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/solars)
 "cUZ" = (
@@ -62428,20 +62478,19 @@
 /turf/open/floor/circuit,
 /area/maintenance/solars)
 "cVq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/north,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/solars)
 "cVs" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/aisat/atmos)
+/area/space/nearstation)
 "cVt" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -62467,13 +62516,15 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/solars)
 "cVw" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cVx" = (
@@ -62484,10 +62535,10 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cVy" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars";
-	dir = 8;
-	pixel_x = -25
+/obj/machinery/power/solar_control{
+	dir = 4;
+	id = "aisolar";
+	name = "AI Solar Control"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -62806,9 +62857,18 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "cWn" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/ai_monitored/turret_protected/aisat/atmos)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cWo" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -63460,7 +63520,7 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cXT" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
 /area/space/nearstation)
@@ -63764,6 +63824,12 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen)
+"dpW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dqW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -64061,6 +64127,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "eaD" = (
@@ -65191,6 +65258,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"gfm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "ggI" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -65224,10 +65297,18 @@
 /turf/open/misc/grass,
 /area/security/prison)
 "glC" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/map/fulp/helio/right,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/department/engine)
 "gnv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
@@ -66846,6 +66927,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jaf" = (
@@ -67190,6 +67272,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"jHZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "jIj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -67389,10 +67477,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "jQU" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/map/fulp/helio/left,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/service/abandoned_gambling_den)
 "jRg" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	color = "#FF6700"
@@ -67483,10 +67573,10 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "kfu" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engineering/atmos)
 "kgY" = (
@@ -67584,11 +67674,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "kvA" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
 	dir = 1;
 	name = "security red"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/security/office)
@@ -67726,6 +67818,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"kMY" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Minisat Exterior NNE";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "kNo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -68682,7 +68782,7 @@
 /area/engineering/atmos)
 "mnG" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
 	},
 /turf/open/space/basic,
@@ -69393,6 +69493,14 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"nzg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/solars)
 "nzi" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -70591,6 +70699,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"pBU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "pCn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -71291,6 +71409,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "qUY" = (
@@ -71551,11 +71670,6 @@
 /obj/item/storage/crayons,
 /obj/item/stack/pipe_cleaner_coil/random,
 /obj/item/stack/pipe_cleaner_coil/random,
-/obj/machinery/camera/directional/west{
-	c_tag = "Prison Painting";
-	name = "Prison Camera";
-	network = list("ss13","prison")
-	},
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -71663,6 +71777,9 @@
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	name = "engineering yellow"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
@@ -72616,6 +72733,25 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"tcZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/service/kitchen";
+	dir = 1;
+	name = "Kitchen APC";
+	pixel_y = 25
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "tdb" = (
 /obj/machinery/power/emitter,
 /obj/effect/decal/cleanable/dirt,
@@ -72727,6 +72863,9 @@
 	color = "#FF0000";
 	dir = 1;
 	name = "security red"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/security/office)
@@ -73569,6 +73708,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vad" = (
@@ -73662,6 +73804,23 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"vgX" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "vhW" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/beer,
@@ -74367,7 +74526,6 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "wys" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -74393,11 +74551,11 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "wBp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wBA" = (
@@ -75029,6 +75187,19 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
+"xGV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "xHv" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/bot_red,
@@ -75133,6 +75304,7 @@
 "xTF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "xVb" = (
@@ -75263,8 +75435,8 @@
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/medical/virology)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "yll" = (
 /obj/machinery/computer/operating{
 	dir = 4
@@ -89037,7 +89209,7 @@ bvG
 bHj
 bHj
 bHj
-bLr
+bHj
 bNd
 bgD
 bgD
@@ -89547,11 +89719,11 @@ hoQ
 kuC
 bvG
 bxG
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 bKM
-bLu
+bxJ
 bNK
 bOQ
 bdQ
@@ -89803,13 +89975,13 @@ hoQ
 kuC
 bvG
 bxG
-bgD
-bgD
+bKG
+bKG
 bgD
 bgD
 bxJ
-bLu
-bWc
+bxJ
+cWn
 bOQ
 aaa
 aaa
@@ -90052,21 +90224,21 @@ omh
 bgD
 bib
 btM
-jQU
+bgD
 mcT
 bvD
 hoQ
 kuC
 bvG
 bxG
-bgD
+bKG
 qTU
 bju
 bif
 bxJ
 bxJ
 cst
-bWc
+glC
 bOQ
 aaa
 aaa
@@ -90309,13 +90481,13 @@ wpf
 omh
 bgD
 xDE
-glC
+bgD
 caW
 hoQ
 kuC
 bvG
 bxG
-bgD
+bKG
 qTU
 bEC
 bGs
@@ -90571,7 +90743,7 @@ quc
 kuC
 bvG
 bxG
-bgD
+bKG
 bBk
 mXV
 bEK
@@ -90827,7 +90999,7 @@ hLt
 bgD
 bvG
 bxG
-bgD
+bKG
 qTU
 mXV
 bDc
@@ -91080,10 +91252,10 @@ bvK
 bgD
 bgD
 bgD
-hLt
-bgD
-bvH
-bgD
+bTj
+bKG
+cRm
+bKG
 qTU
 bzX
 bBD
@@ -91337,7 +91509,7 @@ nis
 bgD
 bgD
 bgD
-hLt
+bTj
 bgD
 bvH
 bgD
@@ -91594,7 +91766,7 @@ bqz
 bgD
 bgD
 bgD
-hLt
+bTj
 bgD
 bvH
 bgD
@@ -91851,7 +92023,7 @@ azQ
 brZ
 bgD
 bgD
-hLt
+bTj
 bgD
 bwF
 bwZ
@@ -92619,10 +92791,10 @@ azQ
 azQ
 azQ
 azQ
-azQ
+aIT
 bsI
 bsI
-buB
+bUF
 bsI
 btP
 bwM
@@ -93136,7 +93308,7 @@ rxH
 brU
 pHZ
 btP
-buB
+bUF
 bsI
 bsI
 bwM
@@ -93648,7 +93820,7 @@ bnN
 bpl
 bqt
 aZp
-pHZ
+aJy
 btP
 dZh
 fiV
@@ -94180,10 +94352,10 @@ bwU
 bLI
 bNp
 bOU
-bNo
+jQU
 bRY
-bTj
-bUF
+bxJ
+bLv
 bWc
 bOQ
 bYk
@@ -94421,7 +94593,7 @@ bqw
 aZp
 bsH
 btP
-buB
+bUF
 bsI
 bsI
 bwM
@@ -94440,8 +94612,8 @@ bOV
 bQz
 bRZ
 bxJ
-bLv
-bWc
+gfm
+xGV
 bOQ
 bYl
 bZH
@@ -94676,9 +94848,9 @@ bnP
 bpk
 bqx
 aZp
-bsI
-btP
-buB
+aTN
+bLr
+bUF
 bsI
 bsI
 bwM
@@ -94697,8 +94869,8 @@ bOW
 bNr
 bSa
 bxJ
-bLu
-bWb
+bxJ
+vgX
 bOQ
 bYm
 bZH
@@ -94935,7 +95107,7 @@ bqA
 aZp
 bsJ
 btP
-buB
+bUF
 bsI
 bvN
 bwM
@@ -94954,8 +95126,8 @@ bOX
 bQA
 bSb
 bxJ
-bLv
-bWc
+jHZ
+glC
 bOQ
 bYn
 bZJ
@@ -95192,7 +95364,7 @@ azQ
 azQ
 bsS
 btP
-buB
+bUF
 bsI
 bvO
 bwM
@@ -95706,7 +95878,7 @@ aCp
 azQ
 bsM
 btP
-buB
+bUF
 bsI
 cXx
 bwO
@@ -95765,7 +95937,7 @@ cLF
 nCr
 cNL
 cOa
-cOr
+cVs
 aak
 aaa
 aaa
@@ -95963,7 +96135,7 @@ azQ
 azQ
 cXr
 btP
-buB
+bUF
 bsI
 lWR
 bwO
@@ -96220,7 +96392,7 @@ bfI
 aXj
 aHf
 btP
-buB
+bUF
 bsI
 lWR
 bwP
@@ -96477,7 +96649,7 @@ bfF
 brX
 bsI
 btP
-buB
+bUF
 bsI
 bvQ
 bwQ
@@ -96493,9 +96665,9 @@ iCN
 iCN
 iCN
 uYO
-iCN
+dpW
 iYl
-iCN
+dpW
 wBp
 lkO
 bOQ
@@ -96734,7 +96906,7 @@ bfK
 brX
 bsI
 btP
-buB
+bUF
 bsI
 lWR
 bwR
@@ -97248,7 +97420,7 @@ bfI
 brX
 bsN
 btP
-buB
+bUF
 bsI
 bvS
 bwO
@@ -97505,7 +97677,7 @@ bfJ
 brY
 cpG
 btP
-buB
+bUF
 bsI
 bsI
 bwO
@@ -97762,7 +97934,7 @@ big
 qFg
 cpG
 btP
-buB
+bUF
 bsI
 bsI
 bwS
@@ -98019,7 +98191,7 @@ bfE
 brY
 cpG
 btP
-buB
+bUF
 bsI
 bsI
 bwS
@@ -98276,7 +98448,7 @@ bfF
 brX
 bsN
 btP
-buB
+bUF
 bsI
 bvT
 bwS
@@ -98533,7 +98705,7 @@ bfK
 brX
 bsI
 btP
-buB
+bUF
 bsI
 wGo
 bwT
@@ -98790,7 +98962,7 @@ bfK
 brX
 bsI
 btP
-buB
+bUF
 bsI
 bvT
 bwS
@@ -99047,7 +99219,7 @@ bfI
 brX
 bsI
 btP
-buB
+bUF
 bsI
 bsI
 bwS
@@ -99304,7 +99476,7 @@ bfF
 aXj
 cXs
 aMc
-buB
+bUF
 bsI
 bsI
 bwS
@@ -99561,7 +99733,7 @@ aXj
 aXj
 bsI
 btP
-buB
+bUF
 bsI
 bsI
 bwU
@@ -99818,7 +99990,7 @@ bwL
 bzp
 bvm
 btV
-buB
+bUF
 bsI
 bvS
 bwU
@@ -103343,7 +103515,7 @@ adv
 abZ
 aeA
 iWf
-kVq
+aBO
 agz
 wJT
 dRQ
@@ -103598,9 +103770,9 @@ abZ
 acU
 abZ
 abZ
-lzK
+afm
 abk
-kVq
+aBO
 agz
 nQY
 wJT
@@ -103856,7 +104028,7 @@ faA
 hBm
 aex
 aeQ
-afm
+abj
 kvA
 agA
 aho
@@ -104464,7 +104636,7 @@ bQW
 bNP
 bMj
 bxJ
-bWj
+tcZ
 bOQ
 aak
 bZZ
@@ -105052,7 +105224,7 @@ kJX
 ngx
 cUu
 cUQ
-cUQ
+nzg
 cUH
 cTZ
 cTZ
@@ -105658,7 +105830,7 @@ aeF
 afg
 afL
 abr
-ahp
+aIR
 avn
 ady
 iXU
@@ -105913,7 +106085,7 @@ adC
 aef
 aeG
 afh
-kvA
+kVq
 agH
 ahv
 ajh
@@ -107175,13 +107347,13 @@ aaa
 aaf
 aak
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aak
 aaf
@@ -107352,7 +107524,7 @@ aaa
 cQZ
 cQZ
 cRh
-cRm
+cRu
 cRx
 cRx
 cRJ
@@ -107432,13 +107604,13 @@ aaa
 aae
 aak
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aak
 aae
@@ -107689,13 +107861,13 @@ aaa
 aae
 aak
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aak
 aae
@@ -107946,13 +108118,13 @@ aaa
 aae
 aak
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aak
 aae
@@ -108203,13 +108375,13 @@ aaa
 aak
 aak
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aak
 aaa
@@ -108460,13 +108632,13 @@ aak
 aak
 aak
 aaa
-aap
+aJV
 aaa
 aaa
-aap
+aJV
 aaa
 aaa
-aap
+aJV
 aaa
 aak
 aat
@@ -108714,18 +108886,18 @@ aaa
 aae
 aak
 aaE
-aan
-aan
-aan
-aap
-aap
-aap
-aap
-aap
-aap
-aap
-aap
-aan
+aGh
+aGh
+aGh
+aJV
+aJV
+aJV
+aJV
+aJV
+aJV
+aJV
+aJV
+aGh
 aaH
 aaV
 aaV
@@ -108974,13 +109146,13 @@ aak
 aak
 aak
 aaa
-aap
+aJV
 aaa
 aaa
-aap
+aJV
 aaa
 aaa
-aar
+aKN
 aaa
 aak
 aat
@@ -109231,13 +109403,13 @@ aaa
 aak
 aak
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aak
 aaa
@@ -109488,13 +109660,13 @@ aaa
 aae
 aak
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aak
 aaf
@@ -109745,13 +109917,13 @@ aaa
 aae
 aak
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aak
 aae
@@ -110002,13 +110174,13 @@ aaa
 aae
 aak
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aak
 aae
@@ -110259,13 +110431,13 @@ aaa
 aae
 aak
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aao
-aan
+aGh
 aao
 aak
 aae
@@ -110437,7 +110609,7 @@ aaa
 aaa
 aaa
 aaa
-cRw
+kMY
 cSt
 cSt
 idi
@@ -110707,7 +110879,7 @@ cRB
 cRB
 cRB
 cUz
-cWn
+aak
 aaa
 aaa
 aaa
@@ -115196,7 +115368,7 @@ aAM
 aBt
 aBX
 aCx
-auT
+aIS
 awY
 aAc
 aAc
@@ -117014,7 +117186,7 @@ aPW
 aQI
 bbl
 aSP
-aTN
+bbl
 bbl
 bvL
 bwJ
@@ -117245,7 +117417,7 @@ aro
 axk
 ajn
 ayy
-aBO
+azf
 azH
 aAd
 aAG
@@ -117773,8 +117945,8 @@ aFM
 aAd
 aak
 aEd
-aIR
-aJy
+xjL
+aEd
 aLm
 aLG
 aQK
@@ -118030,7 +118202,7 @@ aFN
 aAd
 aak
 aEd
-aIS
+aHx
 aEd
 aKD
 aQK
@@ -118287,7 +118459,7 @@ aFO
 aAd
 aak
 aEd
-aIT
+aHx
 aJz
 aKD
 aQK
@@ -118615,7 +118787,7 @@ cmv
 cnB
 cov
 vUt
-cIb
+pBU
 csb
 ctf
 cut

--- a/fulp_modules/mapping/ruins/space/beef_station.dmm
+++ b/fulp_modules/mapping/ruins/space/beef_station.dmm
@@ -1491,20 +1491,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/eighties,
 /area/ruin/space/has_grav/powered/beef)
-"wU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#414ad1";
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/powered/beef)
 "xi" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /obj/structure/table/wood,
@@ -3949,7 +3935,7 @@ iy
 Ui
 GR
 xv
-wU
+vr
 vr
 xv
 cN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this makes aspects of heliostation swagger

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/25415050/165560892-91d9d7b1-6985-4a0a-b599-01b3b678bd0a.png)
![image](https://user-images.githubusercontent.com/25415050/165563853-109a47bf-73d6-41d7-8815-fb5fc44a6bbd.png)

fixes these

![image](https://user-images.githubusercontent.com/25415050/165560985-b51d090a-d87f-4516-88af-7f294b370097.png)

updates arcades to use their dirs

![image](https://user-images.githubusercontent.com/25415050/165561059-ac72099e-ad02-4f1b-ad58-337815bbca3b.png)

this APC sucked & controlled an area that isnt even adjacent to it and it confused the shit out of me when i played AI today so I moved it inside of the area

![image](https://user-images.githubusercontent.com/25415050/165561173-fefcadb7-2238-41fc-99fb-c291c7f1d052.png)

fixes that

![image](https://user-images.githubusercontent.com/25415050/165561204-79dc664d-dd1f-43cf-ac33-f397c9703db8.png)

this was never connected to wastes so i connected it even if it wont be relevant next tgu

![image](https://user-images.githubusercontent.com/25415050/165561259-830e5b19-a53a-4e03-8d3c-590fe01af1ed.png)

y does linters allow this

![image](https://user-images.githubusercontent.com/25415050/165561295-8427fd8a-5569-472f-8534-d5ac70154750.png)

these are the subtypes meant for inside the gas 3x3 places in atmos not to dispose into space

![image](https://user-images.githubusercontent.com/25415050/165561420-116fb341-a870-4e9b-a664-da41a4303aea.png)

lots of c_tags had bad tags that didnt represent the current states of the places they were @ so i gave them better names

![image](https://user-images.githubusercontent.com/25415050/165561510-699b5238-8077-43b5-be7f-df4215d2963b.png)

this shit

![image](https://user-images.githubusercontent.com/25415050/165561536-eed2078e-c14b-4789-a7e6-a981ddc26a8c.png)

this

![image](https://user-images.githubusercontent.com/25415050/165561567-dafc218a-fd0c-458a-8656-050f0455ae27.png)

the arrow is meant to face east

![image](https://user-images.githubusercontent.com/25415050/165561614-ae3c0e42-1f17-4fb9-bc68-cf36ac1b329d.png)

updates the areas in solars to use /area/solars instead of /area/maintenance/solars

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
expansion: Expands content of an existing feature
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
