### PR TITLE
Adds body camera to sec vests

### DIFF
--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -7,6 +7,10 @@
 	. = ..()
 	AddComponent(/datum/component/bodycamera_holder)
 
+/obj/item/clothing/suit/security/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/bodycamera_holder)
+
 /**
  * The bodycamera
  *


### PR DESCRIPTION
## About The Pull Request

Lets sec vests hold body cameras.

## Why It's Good For The Game

security doesn't have to sacrifice better clothes for lack of a body camera (and it has lower armor already so :/ )
