### PR TITLE
Fixes solar areas in Helio.

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -59,7 +59,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/fore)
+/area/solars/starboard/fore)
 "aao" = (
 /obj/machinery/power/solar{
 	id = "forestarboard";
@@ -67,11 +67,11 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/starboard/fore)
+/area/solars/starboard/fore)
 "aap" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/fore)
+/area/solars/starboard/fore)
 "aaq" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -80,7 +80,7 @@
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/fore)
+/area/solars/starboard/fore)
 "aas" = (
 /obj/docking_port/stationary/random{
 	id = "pod_lavaland2";
@@ -157,7 +157,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/starboard/fore)
+/area/solars/starboard/fore)
 "aaF" = (
 /obj/machinery/power/solar_control{
 	id = "forestarboard";
@@ -13873,7 +13873,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aFk" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -13998,7 +13998,7 @@
 /obj/machinery/power/solar,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aFx" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -14350,7 +14350,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aGi" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -15724,7 +15724,7 @@
 "aJV" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aJW" = (
 /obj/structure/frame/computer{
 	dir = 4
@@ -16043,12 +16043,12 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aKN" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "aKO" = (
 /obj/structure/frame/computer{
 	dir = 4
@@ -44719,7 +44719,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "ceW" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/siding/yellow{
@@ -45204,7 +45204,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "cgk" = (
 /obj/structure/rack,
 /obj/item/stock_parts/micro_laser/high,
@@ -48207,7 +48207,7 @@
 "cmO" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "cmQ" = (
 /turf/open/floor/plating,
 /area/engineering/lobby)
@@ -48587,7 +48587,7 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "cnO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -49073,7 +49073,7 @@
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
 /turf/open/space/basic,
-/area/maintenance/solars/port/aft)
+/area/solars/port/aft)
 "coH" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Access";
@@ -53740,7 +53740,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "czJ" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -54258,7 +54258,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "cAS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -56648,7 +56648,7 @@
 "cGU" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "cGV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57470,7 +57470,7 @@
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "cIg" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -58157,7 +58157,7 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "cJQ" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/engine,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ever wondered why all the Helio solars are dark as shit? Well that's because they used area/maintenance/solars instead of area/solars.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Solars are now bright like nearstation areas and not dark and ugly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed Heliostation solar areas not being the right ones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
