### PR TITLE
Fixes Heliostation's SM thermomachines.

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -59110,6 +59110,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
 	dir = 10
 	},
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "cMp" = (
@@ -59314,12 +59317,10 @@
 	dir = 8;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
-	dir = 8
-	},
 /obj/machinery/meter/layer2{
 	name = "Gas Flow Meter"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
 "cMQ" = (
@@ -59503,10 +59504,10 @@
 	color = "#FFD700";
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital/on/layer2{
-	dir = 4
-	},
 /obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 5
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "cNl" = (
@@ -59621,8 +59622,8 @@
 /area/engineering/main)
 "cNA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
@@ -59734,7 +59735,7 @@
 /area/maintenance/department/engine/atmos)
 "cNL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -59821,7 +59822,7 @@
 /area/maintenance/department/engine/atmos)
 "cOa" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "cOb" = (
@@ -59840,7 +59841,6 @@
 	dir = 4;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -64030,6 +64030,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"dNK" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "dOB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -65335,7 +65342,7 @@
 /area/hallway/primary/fore)
 "gnS" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -66357,7 +66364,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "hVV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "hWb" = (
@@ -66829,6 +66836,12 @@
 	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"iJA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "iKK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
@@ -67975,6 +67988,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"kWo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
 "kXE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69997,6 +70016,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
+"obS" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "ocC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -70321,6 +70347,13 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"oMu" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "oNL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -73915,7 +73948,7 @@
 	dir = 6;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -74560,6 +74593,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"wEp" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
 "wEW" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -95162,7 +95201,7 @@ cAW
 pkx
 czR
 czV
-cAW
+iJA
 cNk
 cNe
 cWF
@@ -95933,10 +95972,10 @@ cHi
 cKg
 pMf
 cLF
-nCr
+obS
 cNL
 cOa
-cVs
+dNK
 aak
 aaa
 aaa
@@ -96189,8 +96228,8 @@ gTl
 cKD
 cKD
 cLz
-cAU
-cAT
+wEp
+oMu
 aak
 aak
 aak
@@ -96446,7 +96485,7 @@ cyt
 gnS
 cNL
 hVV
-iSu
+kWo
 aak
 aak
 aak


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The waste pipes on the exterior side of the machines were layer 2 pipes, now they're in layer 3.
![image](https://user-images.githubusercontent.com/42174630/167636236-9ae9213a-375d-4576-bf21-fe63c5b45db4.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The freezers just didn't work before, you couldn't even change the pipes easily since they're under reinforced walls and plasma windows, now they actually work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed thermomachines in the Heliostation SM chamber.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
