### PR TITLE
A few map fixes

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -12081,6 +12081,7 @@
 	dir = 4;
 	name = "command blue"
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "aBt" = (
@@ -14269,9 +14270,10 @@
 /turf/open/space/basic,
 /area/station/solars/port/fore)
 "aGi" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "aGj" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/stack/spacecash/c100,
@@ -15685,9 +15687,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "aKe" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/fore)
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/station/tcommsat/server)
 "aKf" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -18416,7 +18421,6 @@
 	},
 /area/station/maintenance/fore/lesser)
 "aQF" = (
-/obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
@@ -24473,9 +24477,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bgz" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "bgA" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/disposalpipe/segment,
@@ -24726,9 +24731,13 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bhp" = (
-/obj/effect/landmark/xeno_spawn,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/area/station/engineering/main)
 "bhq" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -34369,10 +34378,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bGe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/wood,
-/area/station/commons/vacant_room/office)
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "bGf" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -34669,10 +34681,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "bGW" = (
-/obj/machinery/modular_computer/console/preset/civilian{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/computer/rdconsole{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -34998,17 +35010,12 @@
 /area/station/engineering/gravity_generator)
 "bHO" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engineering/gravity_generator";
-	dir = 1;
-	name = "Gravity Generator APC";
-	pixel_y = 25
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 5;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "bHP" = (
@@ -37465,7 +37472,6 @@
 /area/station/service/bar)
 "bOl" = (
 /obj/effect/spawner/random/maintenance,
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bOm" = (
@@ -38635,7 +38641,6 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -39534,6 +39539,7 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "bTm" = (
@@ -40914,6 +40920,7 @@
 "bWz" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/electrical)
 "bWA" = (
@@ -41633,16 +41640,20 @@
 /turf/open/floor/engine,
 /area/station/science/mixing/chamber)
 "bYp" = (
-/obj/machinery/blackbox_recorder,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
 /obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "bYq" = (
 /obj/machinery/telecomms/bus/preset_one,
+/obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "bYr" = (
 /obj/machinery/telecomms/server/presets/medical,
+/obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "bYs" = (
@@ -41882,7 +41893,6 @@
 /area/station/engineering/storage/tech)
 "bYR" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/xeno_spawn,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 9;
@@ -43780,19 +43790,19 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "cdr" = (
-/obj/structure/cable,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/blackbox_recorder,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "cds" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 6
 	},
-/obj/structure/cable,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/station/tcommsat/server)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "cdt" = (
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -46073,10 +46083,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/mixing)
 "ciJ" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/science/storage)
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "ciK" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -59240,6 +59250,7 @@
 "cNt" = (
 /obj/effect/turf_decal/bot_red,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "cNu" = (
@@ -59417,14 +59428,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "cNP" = (
 /obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
+	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "cNQ" = (
@@ -59531,6 +59543,9 @@
 "cOe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/plush/goatplushie,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "cOf" = (
@@ -59625,6 +59640,8 @@
 	dir = 8;
 	name = "engineering yellow"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "cOs" = (
@@ -60355,10 +60372,13 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/science/xenobiology)
 "cQj" = (
-/obj/effect/landmark/xeno_spawn,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "cQk" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube,
@@ -61874,6 +61894,12 @@
 	name = "External Engine Room SMES";
 	req_one_access_txt = "10;24"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "cUN" = (
@@ -62603,8 +62629,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cWB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
@@ -63754,9 +63783,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "dWI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "dXf" = (
@@ -63774,9 +63801,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "eaD" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine,
-/area/station/medical/chemistry)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "eaT" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -67102,6 +67132,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
 /area/station/engineering/transit_tube)
 "jOz" = (
@@ -67269,6 +67300,20 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"khp" = (
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "khy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -67806,6 +67851,11 @@
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"lip" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/blacklight/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "liq" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -71253,6 +71303,10 @@
 /obj/item/folder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"rjJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "rjK" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
@@ -73175,6 +73229,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"uEb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/broken_flooring{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "uEF" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -89763,11 +89824,11 @@ cLs
 aak
 aOd
 cyo
-cNs
+bgz
 cNO
-cOc
+bhp
 cOp
-cNs
+uEb
 cyo
 aaa
 aaa
@@ -90022,8 +90083,8 @@ aOd
 cyo
 cNt
 cNP
-cOc
-cNs
+bGe
+ciJ
 cNs
 cyo
 aaa
@@ -90278,7 +90339,7 @@ cyt
 aOd
 cyo
 cNt
-cNP
+cOc
 cOe
 cNs
 cOB
@@ -90535,10 +90596,10 @@ cyt
 cyt
 cyo
 cNt
-cNP
 cOc
-cNs
-cNs
+bGe
+cQj
+lip
 cyo
 aaa
 aaa
@@ -90793,9 +90854,9 @@ cyo
 cyo
 cNu
 cNs
-cNs
-cNs
-cNs
+cds
+eaD
+rjJ
 cyo
 aaa
 aaa
@@ -91309,7 +91370,7 @@ ddh
 cNQ
 cWB
 cOq
-sHP
+khp
 cOG
 cOX
 cyo
@@ -91566,7 +91627,7 @@ cWD
 cNS
 cNS
 cNS
-cNS
+sgD
 cNS
 tVl
 cyt
@@ -91823,7 +91884,7 @@ cNx
 cNS
 cNR
 cNR
-cNR
+cNb
 cNR
 fcq
 cyt
@@ -92080,7 +92141,7 @@ cMN
 cNR
 cNS
 cNS
-cNS
+sgD
 cNR
 tVl
 cyt
@@ -92337,7 +92398,7 @@ cQn
 cNR
 cNR
 cNS
-cNS
+sgD
 cOH
 tVl
 cyo
@@ -95110,7 +95171,7 @@ bzK
 bBn
 bDl
 bEJ
-bGe
+bzJ
 bwU
 bGh
 bwU
@@ -96151,9 +96212,9 @@ bwU
 bLv
 bWc
 bOQ
-bYv
-bYv
-caH
+bZN
+bZN
+aGi
 bYp
 cdr
 cfb
@@ -96411,8 +96472,8 @@ bOQ
 bYq
 bZL
 caI
-cbV
-cds
+aKe
+caI
 caI
 caI
 chA
@@ -96923,8 +96984,8 @@ bLv
 bWc
 bOQ
 bYs
-bZN
-bZN
+bYv
+bYv
 bZN
 caI
 bYv
@@ -97887,7 +97948,7 @@ aaa
 aaa
 aak
 aak
-aDq
+aaa
 aaa
 aak
 aak
@@ -98152,7 +98213,7 @@ azQ
 aHL
 aIE
 aJj
-aKe
+aJj
 aJj
 aLM
 aMu
@@ -101488,7 +101549,7 @@ azQ
 azQ
 aEk
 aEk
-aGi
+aAi
 aAi
 azQ
 aAi
@@ -113337,7 +113398,7 @@ aYK
 bdh
 bdf
 aZO
-bhp
+aZO
 aZO
 bkj
 aYK
@@ -118258,7 +118319,7 @@ bSR
 cbq
 ccI
 cew
-ciJ
+cip
 cip
 orn
 ckf
@@ -123696,7 +123757,7 @@ cOU
 jtq
 cPF
 mES
-cQj
+rUk
 lNl
 lNl
 rUk
@@ -123873,7 +123934,7 @@ cjI
 bcw
 bdM
 aHx
-bgz
+aHx
 bhP
 aEd
 bla
@@ -128488,7 +128549,7 @@ aaa
 wVl
 aSm
 aSm
-eaD
+aSm
 aSm
 aSm
 wVl

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -4623,15 +4623,13 @@
 /area/station/security/brig)
 "alE" = (
 /obj/structure/cable,
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Officer Beepsky"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
 	},
+/mob/living/simple_animal/bot/secbot/beepsky/officer,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "alF" = (
@@ -67300,20 +67298,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"khp" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/station/engineering/main)
 "khy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -67851,11 +67835,6 @@
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"lip" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/blacklight/directional/south,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "liq" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -68605,6 +68584,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"msV" = (
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "mtB" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -70615,6 +70608,11 @@
 	},
 /turf/open/misc/grass,
 /area/station/security/prison)
+"pVf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/blacklight/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "pWh" = (
 /obj/structure/lattice,
 /obj/machinery/camera/directional/north{
@@ -71303,10 +71301,6 @@
 /obj/item/folder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"rjJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "rjK" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
@@ -73229,13 +73223,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"uEb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/broken_flooring{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "uEF" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -73507,6 +73494,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"uZM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/broken_flooring{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "vad" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -74396,6 +74390,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/lockers)
+"wLf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "wLA" = (
 /turf/closed/wall,
 /area/station/medical/surgery/aft)
@@ -89828,7 +89826,7 @@ bgz
 cNO
 bhp
 cOp
-uEb
+uZM
 cyo
 aaa
 aaa
@@ -90599,7 +90597,7 @@ cNt
 cOc
 bGe
 cQj
-lip
+pVf
 cyo
 aaa
 aaa
@@ -90856,7 +90854,7 @@ cNu
 cNs
 cds
 eaD
-rjJ
+wLf
 cyo
 aaa
 aaa
@@ -91370,7 +91368,7 @@ ddh
 cNQ
 cWB
 cOq
-khp
+msV
 cOG
 cOX
 cyo

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -302,12 +302,6 @@
 /area/station/maintenance/solars/starboard/fore)
 "aaW" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/starboard/fore";
-	dir = 8;
-	name = "Starboard Bow Solar APC";
-	pixel_x = -25
-	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -449,6 +443,7 @@
 	dir = 10;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/fore)
 "abt" = (
@@ -777,6 +772,7 @@
 /area/station/maintenance/department/security/upper)
 "acn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "aco" = (
@@ -833,18 +829,13 @@
 /area/station/maintenance/department/security/upper)
 "act" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/security/upper";
-	dir = 1;
-	name = "Security Maint APC";
-	pixel_y = 25
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "acu" = (
@@ -873,6 +864,8 @@
 /turf/open/floor/plating,
 /area/station/security/office)
 "acA" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "acB" = (
@@ -935,6 +928,7 @@
 	name = "Detective Maintenance";
 	req_access_txt = "4"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "acK" = (
@@ -1071,12 +1065,6 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/detectives_office";
-	dir = 8;
-	name = "Detective's Office APC";
-	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -1504,6 +1492,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "aer" = (
@@ -1537,11 +1526,6 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "aew" = (
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/hos";
-	name = "Head of Security's Office APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -1550,6 +1534,7 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light/directional/west,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "aex" = (
@@ -1617,12 +1602,7 @@
 	name = "security red"
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/security/office";
-	dir = 8;
-	name = "Security Office APC";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/security/office)
 "aeD" = (
@@ -1897,6 +1877,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "afv" = (
@@ -2777,8 +2758,8 @@
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/light/directional/north,
 /obj/effect/landmark/secequipment,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "ahQ" = (
@@ -3720,17 +3701,12 @@
 "ajU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/security/brig";
-	dir = 1;
-	name = "Brig APC";
-	pixel_y = 25
-	},
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
 	dir = 1;
 	name = "security red"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "ajV" = (
@@ -3743,6 +3719,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "ajX" = (
@@ -4179,6 +4156,7 @@
 	name = "Security red corner"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "akW" = (
@@ -4191,6 +4169,7 @@
 	dir = 10;
 	name = "security red"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "akX" = (
@@ -4604,6 +4583,7 @@
 	dir = 6;
 	name = "security red"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "alA" = (
@@ -4672,6 +4652,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "alJ" = (
@@ -4681,6 +4662,7 @@
 	name = "Patrol Beacon"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "alK" = (
@@ -4705,6 +4687,7 @@
 	name = "Security red corner"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "alL" = (
@@ -4893,18 +4876,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/brig/upper)
 "ami" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/brig/upper";
-	dir = 1;
-	name = "Brig Lockers APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
 	dir = 1;
 	name = "security red"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/brig/upper)
 "amj" = (
@@ -6581,18 +6559,13 @@
 	color = "#FF0000";
 	name = "security red"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/security/armory";
-	dir = 1;
-	name = "Armoury APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
 	dir = 1;
 	name = "security red"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "apy" = (
@@ -6661,12 +6634,6 @@
 /area/station/security/warden)
 "apE" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/security/warden";
-	dir = 1;
-	name = "Warden's Office APC";
-	pixel_y = 25
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -6678,6 +6645,7 @@
 	dir = 1;
 	name = "security red"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "apF" = (
@@ -6731,17 +6699,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "apN" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/fore";
-	dir = 8;
-	name = "Fore Primary Hallway APC";
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/upper)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "apO" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Warden's Office";
@@ -6835,6 +6797,8 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "apY" = (
@@ -6847,6 +6811,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "apZ" = (
@@ -6886,6 +6851,8 @@
 	department = "E.V.A. Storage";
 	name = "E.V.A. RC"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aqd" = (
@@ -6903,18 +6870,13 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/command/bridge";
-	dir = 8;
-	name = "Bridge APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
 	dir = 9;
 	name = "command blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/wood,
 /area/station/command/bridge)
 "aqg" = (
@@ -7342,6 +7304,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination/hop,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "arb" = (
@@ -7789,6 +7752,7 @@
 	dir = 4;
 	name = "command blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aso" = (
@@ -7827,17 +7791,10 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "ass" = (
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/hop";
-	dir = 8;
-	name = "HoP Office APC";
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/bridge)
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "ast" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced{
@@ -7876,15 +7833,14 @@
 /turf/open/floor/carpet,
 /area/station/command/bridge)
 "asy" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/command/storage/eva";
-	dir = 1;
-	name = "E.V.A. Storage APC";
-	pixel_y = 25
+/obj/effect/turf_decal/siding/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "command blue"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/bridge)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "asz" = (
 /obj/machinery/button/door/directional/west{
 	id = "panic";
@@ -7942,8 +7898,8 @@
 	name = "prison orange"
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "asL" = (
@@ -8189,6 +8145,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood/corner,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "atk" = (
@@ -8722,6 +8679,7 @@
 /area/station/hallway/primary/fore)
 "auy" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "auz" = (
@@ -9965,17 +9923,14 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "axi" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/command";
-	dir = 8;
-	name = "Command Hallway APC";
-	pixel_x = -25
+/obj/effect/turf_decal/siding/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "command blue"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/bridge)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "axj" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = -30
@@ -10365,6 +10320,7 @@
 	location = "command1";
 	name = "Patrol Beacon"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "ayb" = (
@@ -11781,12 +11737,8 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "aAO" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai_upload";
-	name = "Upload APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "aAP" = (
@@ -11857,12 +11809,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "aAV" = (
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/command/teleporter";
-	dir = 1;
-	name = "Teleporter APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -11874,6 +11820,7 @@
 /obj/item/beacon,
 /obj/item/beacon,
 /obj/item/beacon,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "aAW" = (
@@ -12403,16 +12350,12 @@
 	name = "command blue"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "aBX" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/command/gateway";
-	dir = 8;
-	name = "Gateway APC";
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
 	},
@@ -12623,6 +12566,7 @@
 	color = "#FF0000";
 	name = "security red"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "aCw" = (
@@ -12684,6 +12628,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "aCC" = (
@@ -12697,6 +12642,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/gateway)
 "aCD" = (
@@ -12839,6 +12785,7 @@
 	name = "Security red corner"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "aCV" = (
@@ -13086,6 +13033,8 @@
 	dir = 9;
 	name = "command blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "aDA" = (
@@ -13100,6 +13049,7 @@
 	dir = 1;
 	name = "command blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "aDB" = (
@@ -13199,13 +13149,8 @@
 	c_tag = "Vault";
 	network = list("vault")
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/command/nuke_storage";
-	dir = 1;
-	name = "Vault APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "aDM" = (
@@ -14152,16 +14097,12 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "aFN" = (
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/command/heads_quarters/captain";
-	name = "Captain's Office APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
 	name = "command blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "aFO" = (
@@ -14677,6 +14618,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "aHf" = (
@@ -14722,10 +14664,13 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "aHj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "aHk" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Courtroom Defence";
@@ -15063,11 +15008,6 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
 "aId" = (
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/command/heads_quarters/captain/private";
-	name = "Captain's Quarters APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/structure/rack,
 /obj/item/food/grown/tobacco,
@@ -15082,6 +15022,7 @@
 	color = "#4169E1";
 	name = "command blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
 "aIe" = (
@@ -15181,13 +15122,8 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 1
 	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/medical/virology";
-	dir = 1;
-	name = "Virology APC";
-	pixel_y = 25
-	},
 /obj/machinery/light/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aIs" = (
@@ -15451,15 +15387,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aJn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/security/courtroom";
-	dir = 4;
-	name = "Courtroom APC";
-	pixel_x = 25
-	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/area/station/maintenance/fore)
 "aJo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Emergency Oxygen Supply"
@@ -15908,26 +15840,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aKB" = (
+/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 30
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/exam_room";
-	name = "Medbay Exam Room APC";
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "aKD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -16424,6 +16340,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "aLV" = (
@@ -16537,6 +16454,7 @@
 	name = "medical blue"
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "aMk" = (
@@ -16687,6 +16605,8 @@
 	dir = 5;
 	name = "medical blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "aMA" = (
@@ -16738,17 +16658,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aMI" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/commons/fitness/recreation";
-	dir = 8;
-	name = "Recreation Area APC";
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/obj/effect/turf_decal/siding/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "medical blue"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "aMJ" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/window/reinforced{
@@ -16849,6 +16768,7 @@
 "aMW" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "aMX" = (
@@ -16886,18 +16806,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNc" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/cmo";
-	dir = 4;
-	name = "Chief Medical Officer's Office APC";
-	pixel_x = 25
+/obj/effect/turf_decal/siding/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "medical blue"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "aNd" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -17211,6 +17127,7 @@
 	color = "#73c2fb";
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "aNR" = (
@@ -17356,6 +17273,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "aOq" = (
@@ -17419,6 +17337,7 @@
 	color = "#73c2fb";
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aOx" = (
@@ -17429,6 +17348,7 @@
 	color = "#73c2fb";
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aOz" = (
@@ -17450,6 +17370,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "aOB" = (
@@ -17630,6 +17551,8 @@
 	dir = 6;
 	name = "medical blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aOV" = (
@@ -17652,6 +17575,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "aOY" = (
@@ -17677,6 +17602,8 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "aPd" = (
@@ -17789,6 +17716,8 @@
 	dir = 1;
 	name = "medical blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -17873,6 +17802,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aPv" = (
@@ -18057,6 +17987,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/landmark/navigate_destination/chemfactory,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "aPL" = (
@@ -18071,6 +18002,7 @@
 	dir = 9;
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "aPM" = (
@@ -18086,6 +18018,7 @@
 	name = "medical blue"
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "aPN" = (
@@ -18101,6 +18034,8 @@
 	name = "medical blue"
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "aPO" = (
@@ -18351,6 +18286,7 @@
 	dir = 4;
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aQo" = (
@@ -18369,6 +18305,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "aQq" = (
@@ -18380,6 +18317,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "aQs" = (
@@ -18472,6 +18410,7 @@
 	},
 /area/station/maintenance/fore/lesser)
 "aQE" = (
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -18481,6 +18420,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -18489,6 +18429,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -18533,6 +18474,7 @@
 	dir = 1;
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aQS" = (
@@ -18651,6 +18593,7 @@
 	dir = 4;
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -18678,12 +18621,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "aRh" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
-	},
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/medical/medbay/central"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
@@ -18801,6 +18740,7 @@
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "aRw" = (
@@ -18819,6 +18759,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "aRy" = (
@@ -18955,6 +18896,7 @@
 	name = "medical blue"
 	},
 /obj/machinery/light_switch/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -19110,17 +19052,12 @@
 /area/station/medical/medbay/central)
 "aSe" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/port/fore";
-	dir = 8;
-	name = "Port Bow Solar APC";
-	pixel_x = -25
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 8;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aSf" = (
@@ -19194,11 +19131,13 @@
 /obj/machinery/computer/warrant{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "aSr" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "aSs" = (
@@ -19223,6 +19162,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "aSv" = (
@@ -19292,17 +19232,18 @@
 	},
 /area/station/maintenance/fore/lesser)
 "aSF" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/service/lawoffice";
-	dir = 4;
-	name = "Law Office APC";
-	pixel_x = 25
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/blue{
+	color = "#73c2fb";
+	name = "medical blue"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "aSG" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Law Reception"
@@ -19313,6 +19254,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/navigate_destination/lawyer,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "aSI" = (
@@ -19338,6 +19280,7 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -19394,12 +19337,6 @@
 "aSN" = (
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/medical3,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/storage";
-	dir = 1;
-	name = "Medbay Storage APC";
-	pixel_y = 25
-	},
 /obj/item/clothing/neck/stethoscope,
 /obj/item/storage/belt/medical,
 /obj/effect/turf_decal/siding/blue{
@@ -19407,6 +19344,7 @@
 	dir = 1;
 	name = "medical blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aSO" = (
@@ -19427,14 +19365,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aSP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/maintenance/fore/lesser"
+/obj/effect/turf_decal/siding/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "medical blue"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "aSQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -19829,6 +19767,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -19866,13 +19805,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aTS" = (
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/medical/surgery/theatre"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/dark,
+/area/station/service/chapel/monastery)
 "aTU" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -20102,6 +20038,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "aUz" = (
@@ -20245,6 +20182,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -20385,16 +20323,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aVj" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/fore";
-	dir = 1;
-	name = "Port Bow Maintenance APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aVk" = (
@@ -20529,6 +20462,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "aVC" = (
@@ -20634,6 +20568,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -20834,18 +20769,9 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "aWk" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/chapel/monastery";
-	dir = 8;
-	name = "Space Burial APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/iron/dark,
+/area/station/service/chapel/monastery)
 "aWl" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -20890,31 +20816,25 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aWu" = (
-/obj/machinery/power/apc{
-	areastring = "/area/commons/dorms";
-	name = "Dormitories APC";
-	pixel_y = -25
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
-"aWw" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/treatment_center";
-	dir = 8;
-	name = "Medbay Treatment APC";
-	pixel_x = -25
+/turf/open/floor/iron/dark,
+/area/station/service/chapel/monastery)
+"aWw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/maintenance/port/fore)
 "aWx" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -20927,6 +20847,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "aWz" = (
@@ -21179,13 +21100,8 @@
 /turf/closed/wall,
 /area/station/commons/dorms)
 "aXn" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/crew_quarters/dorms";
-	dir = 8;
-	name = "Dorms Maint APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aXo" = (
@@ -21204,17 +21120,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aXs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/chemistry";
-	dir = 4;
-	name = "Chemistry APC";
-	pixel_x = 25
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "aXu" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -21226,6 +21136,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "aXw" = (
@@ -21280,15 +21191,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aXH" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/medical/psychology"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "aXJ" = (
 /obj/effect/turf_decal/siding/blue/end{
 	color = "#73c2fb";
@@ -21411,6 +21325,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aYa" = (
@@ -21436,15 +21351,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aYc" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/chapel/office";
-	dir = 8;
-	name = "Chapel Office APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/landmark/blobstart,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "aYd" = (
@@ -21657,14 +21567,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aYH" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/commons/lounge";
-	name = "Lounge APC";
-	pixel_y = -25
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "aYI" = (
 /obj/structure/cable,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -21725,6 +21635,7 @@
 	req_access_txt = "70"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
 "aYW" = (
@@ -22017,6 +21928,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "aZB" = (
@@ -22178,6 +22090,8 @@
 	name = "Psychology Camera";
 	network = list("ss13","medbay")
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/carpet/purple,
 /area/station/medical/psychology)
 "aZS" = (
@@ -22187,6 +22101,7 @@
 	dir = 8;
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "aZT" = (
@@ -22214,6 +22129,7 @@
 	dir = 4;
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bab" = (
@@ -22543,6 +22459,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "baV" = (
@@ -22682,6 +22599,7 @@
 	color = "#73c2fb";
 	name = "medical blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bbt" = (
@@ -22922,6 +22840,7 @@
 	dir = 1;
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bcc" = (
@@ -23142,11 +23061,11 @@
 /turf/open/floor/carpet/green,
 /area/station/service/chapel)
 "bcJ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "bcK" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Dormitories Maintenance";
@@ -23161,6 +23080,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "bcL" = (
@@ -23174,6 +23094,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "bcO" = (
@@ -23184,6 +23105,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "bcP" = (
@@ -23195,6 +23117,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "bcT" = (
@@ -23265,20 +23188,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bdd" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/service/hydroponics/garden";
-	name = "Garden APC";
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/turf/open/floor/carpet,
+/area/station/service/chapel)
 "bde" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -23302,15 +23216,10 @@
 /area/station/maintenance/starboard/fore)
 "bdg" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/starboard/fore";
-	dir = 1;
-	name = "Starboard Bow Maintenance APC";
-	pixel_y = 25
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bdh" = (
@@ -23727,6 +23636,7 @@
 	color = "#73c2fb";
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ben" = (
@@ -23837,6 +23747,7 @@
 "bey" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bez" = (
@@ -23862,12 +23773,6 @@
 /area/station/maintenance/starboard/fore)
 "beE" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/morgue";
-	name = "Morgue APC";
-	pixel_y = -25
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -24411,13 +24316,6 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "bge" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/chapel";
-	dir = 4;
-	name = "Chapel APC";
-	pixel_x = 25
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -24427,14 +24325,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bgg" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/commons/storage/tools";
-	name = "Auxiliary Tool Storage APC";
-	pixel_y = -25
+/obj/structure/chair/pew/left{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "bgh" = (
 /obj/structure/closet/emcloset,
 /obj/structure/disposalpipe/segment,
@@ -24733,6 +24629,7 @@
 	color = "#73c2fb";
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bhb" = (
@@ -24812,6 +24709,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "bho" = (
@@ -24848,6 +24746,8 @@
 	dir = 9;
 	name = "medical blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bhs" = (
@@ -24862,6 +24762,7 @@
 	name = "medical blue"
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bhu" = (
@@ -25489,12 +25390,6 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/medbay/lobby";
-	dir = 1;
-	name = "Medbay Lobby APC";
-	pixel_y = 25
-	},
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#73c2fb";
@@ -25505,6 +25400,7 @@
 	dir = 1;
 	name = "medical blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "biV" = (
@@ -25749,6 +25645,7 @@
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
@@ -25853,6 +25750,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bjR" = (
@@ -25897,6 +25795,8 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bjY" = (
@@ -26102,12 +26002,6 @@
 /area/station/medical/medbay/central)
 "bkH" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/pharmacy";
-	dir = 8;
-	name = "Pharmacy APC";
-	pixel_x = -25
-	},
 /obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
@@ -26185,6 +26079,8 @@
 	color = "#4169E1";
 	name = "command blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "bkP" = (
@@ -26197,15 +26093,14 @@
 /obj/item/stack/cable_coil,
 /obj/item/screwdriver,
 /obj/item/wirecutters,
-/obj/structure/sign/departments/chemistry/pharmacy{
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/siding/blue{
 	color = "#73c2fb";
 	dir = 4;
 	name = "medical blue"
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bkQ" = (
@@ -26272,16 +26167,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "blb" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/customs";
-	dir = 4;
-	name = "Customs Desk APC";
-	pixel_x = 25
+/obj/structure/chair/pew{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "blc" = (
 /obj/structure/closet/secure_closet/contraband/heads,
 /obj/item/storage/secure/briefcase,
@@ -26465,16 +26356,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "blA" = (
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/commons/toilet";
-	dir = 4;
-	name = "Dormitory Bathrooms APC";
-	pixel_x = 25
+/turf/open/floor/iron/chapel{
+	dir = 4
 	},
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/area/station/service/chapel)
 "blB" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -26490,6 +26377,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "blD" = (
@@ -26708,6 +26596,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "bmi" = (
@@ -26727,6 +26616,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "bmj" = (
@@ -26734,6 +26624,7 @@
 /area/station/security/checkpoint/customs)
 "bmk" = (
 /obj/structure/chair/comfy/brown,
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/station/security/checkpoint/customs)
 "bml" = (
@@ -26849,6 +26740,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bmz" = (
@@ -26948,6 +26840,8 @@
 	color = "#73c2fb";
 	name = "medical blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bmM" = (
@@ -26962,6 +26856,7 @@
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bmO" = (
@@ -26986,11 +26881,13 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "bmQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "bmR" = (
@@ -26998,18 +26895,22 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "bmS" = (
 /obj/effect/landmark/start/assistant,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "bmT" = (
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "bmU" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "bmV" = (
@@ -27127,6 +27028,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bnm" = (
@@ -27504,6 +27406,8 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bof" = (
@@ -27522,6 +27426,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "boi" = (
@@ -27559,6 +27464,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bon" = (
@@ -27608,6 +27514,8 @@
 	dir = 4;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "bou" = (
@@ -27930,12 +27838,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "bpn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "bpo" = (
@@ -27993,6 +27903,7 @@
 /area/station/commons/toilet)
 "bpw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bpx" = (
@@ -28037,18 +27948,11 @@
 /area/station/commons/toilet)
 "bpB" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/construction/mining/aux_base";
-	dir = 8;
-	name = "Auxiliary Construction APC";
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/carpet/royalblack,
+/area/station/security/checkpoint/customs)
 "bpC" = (
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bpD" = (
@@ -28060,6 +27964,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bpE" = (
@@ -28091,6 +27996,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "bpK" = (
@@ -28496,6 +28402,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "bqv" = (
@@ -28577,6 +28484,7 @@
 "bqB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/thinplating/light,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bqC" = (
@@ -28634,11 +28542,13 @@
 "bqL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "bqM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bqN" = (
@@ -28849,12 +28759,6 @@
 /area/station/medical/morgue)
 "brr" = (
 /obj/structure/filingcabinet,
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/medical";
-	dir = 8;
-	name = "Security Post - Medical APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -28862,6 +28766,7 @@
 	name = "security red"
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "brs" = (
@@ -29011,6 +28916,9 @@
 	dir = 6;
 	name = "medical blue"
 	},
+/obj/structure/sign/departments/chemistry/pharmacy{
+	pixel_x = 30
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "brH" = (
@@ -29120,11 +29028,6 @@
 /area/space)
 "brS" = (
 /obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/starboard";
-	name = "Starboard Primary Hallway APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -29210,6 +29113,7 @@
 	req_one_access_txt = "72"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "bsb" = (
@@ -29256,6 +29160,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bsg" = (
@@ -29267,6 +29172,7 @@
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bsh" = (
@@ -29463,6 +29369,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bsH" = (
@@ -29802,6 +29709,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "btR" = (
@@ -29817,6 +29725,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "btT" = (
@@ -29843,6 +29752,7 @@
 /area/station/hallway/primary/port)
 "btY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "btZ" = (
@@ -29988,14 +29898,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "buB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/service/hydroponics/garden)
 "buC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -30050,6 +29958,7 @@
 "buL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "buN" = (
@@ -30272,6 +30181,7 @@
 /obj/structure/plaque/static_plaque/golden/commission/helio{
 	pixel_y = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bvt" = (
@@ -30389,6 +30299,7 @@
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bvN" = (
@@ -30733,6 +30644,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bwH" = (
@@ -30782,6 +30694,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/office)
 "bwO" = (
@@ -30856,6 +30769,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bwZ" = (
@@ -31059,6 +30973,7 @@
 	req_one_access_txt = "35;28"
 	},
 /obj/effect/landmark/navigate_destination/hydro,
+/obj/structure/cable,
 /turf/open/floor/iron{
 	dir = 1
 	},
@@ -31143,6 +31058,8 @@
 "bxO" = (
 /obj/structure/chair/sofa/left,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "bxP" = (
@@ -31150,6 +31067,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "bxQ" = (
@@ -31160,6 +31078,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "bxR" = (
@@ -31349,6 +31268,8 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "byl" = (
@@ -31536,18 +31457,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "byI" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/central";
-	dir = 1;
-	name = "Central Primary Hallway APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating/corner,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "byJ" = (
@@ -32085,6 +32001,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "bAe" = (
@@ -32210,6 +32127,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "bAA" = (
@@ -32251,6 +32169,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "bAG" = (
@@ -32265,6 +32184,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "bAI" = (
@@ -32274,6 +32194,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "bAJ" = (
@@ -32321,6 +32242,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "bAM" = (
@@ -32335,6 +32257,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "bAN" = (
@@ -32348,6 +32271,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "bAO" = (
@@ -32421,6 +32345,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "bAW" = (
@@ -32488,6 +32413,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "bBc" = (
@@ -32790,6 +32716,8 @@
 	dir = 6;
 	name = "security red"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint)
 "bBK" = (
@@ -32835,13 +32763,6 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bBP" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/service/janitor";
-	dir = 8;
-	name = "Custodial Closet APC";
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -32911,6 +32832,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "bCb" = (
@@ -32982,6 +32904,7 @@
 	color = "#990099";
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "bCn" = (
@@ -33024,6 +32947,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "bCs" = (
@@ -33377,6 +33301,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "bDo" = (
@@ -33401,6 +33326,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bDt" = (
@@ -33574,6 +33500,7 @@
 	dir = 8;
 	name = "research purple"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "bDO" = (
@@ -33592,14 +33519,8 @@
 /area/station/service/library)
 "bDP" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/service/library";
-	dir = 8;
-	name = "Library APC";
-	pixel_x = -25
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "bDQ" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/welding,
@@ -33610,6 +33531,7 @@
 "bDR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "bDS" = (
@@ -33638,16 +33560,8 @@
 /area/station/science/robotics/lab)
 "bDW" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/science/robotics/mechbay";
-	dir = 4;
-	name = "Mech Bay APC";
-	pixel_x = 25
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "bDX" = (
 /obj/structure/sign/departments/science{
 	pixel_y = 30
@@ -33775,6 +33689,8 @@
 	c_tag = "EVAC S";
 	name = "Hallway Camera"
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bEn" = (
@@ -33799,18 +33715,13 @@
 /obj/item/stock_parts/scanning_module,
 /obj/item/stock_parts/capacitor,
 /obj/item/stock_parts/capacitor,
-/obj/machinery/power/apc{
-	areastring = "/area/science/lab";
-	dir = 4;
-	name = "Research Lab APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
 	dir = 4;
 	name = "research purple"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "bEq" = (
@@ -34001,6 +33912,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bEX" = (
@@ -34083,21 +33995,9 @@
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "bFi" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint";
-	dir = 4;
-	name = "Security Checkpoint APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/turf/open/floor/iron,
+/area/construction/mining/aux_base)
 "bFj" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -34148,7 +34048,8 @@
 	color = "#990099";
 	name = "research purple"
 	},
-/obj/machinery/light_switch/directional/south,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "bFo" = (
@@ -34170,6 +34071,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "bFs" = (
@@ -34473,12 +34375,7 @@
 /area/station/commons/vacant_room/office)
 "bGf" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/aft";
-	dir = 8;
-	name = "Port Quarter Maintenance APC";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bGh" = (
@@ -34511,15 +34408,8 @@
 /area/station/maintenance/port/aft)
 "bGn" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/science/genetics";
-	dir = 8;
-	name = "Genetics Lab APC";
-	pixel_x = -25
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/turf/open/floor/carpet,
+/area/station/service/chapel)
 "bGo" = (
 /obj/structure/table,
 /obj/item/toy/figure/botanist,
@@ -34535,6 +34425,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bGr" = (
@@ -34587,15 +34478,8 @@
 /area/station/service/kitchen)
 "bGx" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/service/hydroponics";
-	dir = 4;
-	name = "Hydroponics APC";
-	pixel_x = 25
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "bGz" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -34700,6 +34584,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "bGO" = (
@@ -34814,6 +34699,7 @@
 	name = "research purple"
 	},
 /obj/structure/chair/stool/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "bHa" = (
@@ -34864,21 +34750,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bHf" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/hallway/secondary/exit/departure_lounge";
-	dir = 1;
-	name = "Departure Lounge APC";
-	pixel_y = 25
-	},
+/obj/effect/landmark/start/hangover,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "bHg" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock"
@@ -35089,6 +34964,7 @@
 	color = "#990099";
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "bHL" = (
@@ -35096,6 +34972,7 @@
 	name = "Genetics Lab Maintenance";
 	req_access_txt = "9, 30"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/science)
 "bHM" = (
@@ -35170,6 +35047,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "bHX" = (
@@ -35268,6 +35146,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/chair/stool/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "bIj" = (
@@ -35287,6 +35166,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bIl" = (
@@ -35347,6 +35227,7 @@
 	dir = 4;
 	name = "research purple"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "bIw" = (
@@ -35390,6 +35271,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 30
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bIB" = (
@@ -35412,15 +35294,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bIF" = (
-/obj/machinery/power/apc{
-	areastring = "/area/commons/vacant_room/office";
-	dir = 1;
-	name = "Vacant Office APC";
-	pixel_y = 25
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "bIG" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -35430,14 +35310,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bIH" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/service/abandoned_gambling_den";
-	name = "Abandoned Gambling Den APC";
-	pixel_y = -25
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "bII" = (
 /obj/effect/decal/cleanable/food/flour,
 /obj/item/clothing/head/chefhat,
@@ -35626,6 +35509,7 @@
 	name = "research purple"
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "bJd" = (
@@ -35729,6 +35613,7 @@
 /obj/item/pen/red,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "bJt" = (
@@ -35777,6 +35662,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "bJB" = (
@@ -35795,6 +35681,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "bJF" = (
@@ -35818,13 +35705,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "bJI" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/science/robotics/lab";
-	dir = 4;
-	name = "Robotics Lab APC";
-	pixel_x = 25
-	},
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
@@ -35870,6 +35750,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "bJM" = (
@@ -35915,6 +35796,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "bJQ" = (
@@ -36012,18 +35894,13 @@
 /obj/structure/cable,
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/research,
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/science/research";
-	dir = 1;
-	name = "Security Post - Science APC";
-	pixel_y = 25
-	},
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
 	dir = 5;
 	name = "security red"
 	},
 /obj/machinery/newscaster/directional/east,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science/research)
 "bKe" = (
@@ -36124,6 +36001,8 @@
 	name = "research purple"
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "bKs" = (
@@ -36259,13 +36138,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bKM" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/entry";
-	dir = 4;
-	name = "Entry Hall APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bKN" = (
@@ -36475,6 +36349,7 @@
 	color = "#990099";
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "bLk" = (
@@ -36669,6 +36544,8 @@
 	dir = 1;
 	name = "Bar Camera"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "bLM" = (
@@ -36862,6 +36739,7 @@
 	req_access_txt = "28"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/maintenance/department/engine)
 "bMn" = (
@@ -37337,6 +37215,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bNG" = (
@@ -37499,6 +37378,8 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/siding/thinplating/light/corner,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "bNY" = (
@@ -37562,6 +37443,7 @@
 "bOh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bOi" = (
@@ -37801,6 +37683,7 @@
 	name = "Maintenance Access";
 	req_access_txt = "12"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bOP" = (
@@ -37874,6 +37757,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "bOY" = (
@@ -37884,6 +37768,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "bOZ" = (
@@ -37898,6 +37783,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "bPa" = (
@@ -38013,6 +37899,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "bPq" = (
@@ -38030,6 +37917,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen)
 "bPt" = (
@@ -38046,6 +37934,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bPu" = (
@@ -38094,6 +37983,7 @@
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "bPA" = (
@@ -38122,6 +38012,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bPC" = (
@@ -38145,12 +38036,8 @@
 "bPF" = (
 /obj/item/stack/sheet/pizza,
 /obj/machinery/space_heater,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/starboard";
-	name = "Starboard Maintenance APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bPG" = (
@@ -38345,6 +38232,7 @@
 	name = "research purple"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "bQg" = (
@@ -38760,6 +38648,7 @@
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "bRf" = (
@@ -38868,6 +38757,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library/private)
 "bRr" = (
@@ -39038,6 +38928,7 @@
 	name = "Science purple corner"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "bRO" = (
@@ -39178,6 +39069,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bSh" = (
@@ -39334,6 +39226,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bSD" = (
@@ -39425,11 +39318,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library/private)
 "bSN" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "bSO" = (
@@ -39469,6 +39366,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "bST" = (
@@ -39528,6 +39426,7 @@
 	name = "research purple"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "bTa" = (
@@ -39557,12 +39456,7 @@
 /area/station/security/prison/safe)
 "bTc" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/science";
-	dir = 8;
-	name = "Science Maint APC";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bTd" = (
@@ -39612,16 +39506,22 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bTk" = (
-/obj/structure/cable,
-/obj/effect/landmark/blobstart,
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 25
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Primary Tool Storage"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "bTl" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Gravity Generator Antechamber";
@@ -39666,6 +39566,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "bTs" = (
@@ -39706,6 +39607,7 @@
 	req_access_txt = "25"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
 "bTw" = (
@@ -39796,6 +39698,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bTG" = (
@@ -39831,6 +39734,8 @@
 	},
 /obj/item/stamp/clown,
 /obj/item/toy/mecha/honk,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bTM" = (
@@ -39849,6 +39754,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bTP" = (
@@ -39928,6 +39834,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "bTV" = (
@@ -40272,6 +40179,8 @@
 	dir = 5;
 	name = "research purple"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "bUB" = (
@@ -40424,6 +40333,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bUX" = (
@@ -40467,6 +40377,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
 "bVe" = (
@@ -40586,12 +40497,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/service/library/private";
-	dir = 1;
-	name = "Private Study APC";
-	pixel_y = 25
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bVs" = (
@@ -40619,15 +40524,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bVy" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/bar";
-	dir = 1;
-	name = "Bar APC";
-	pixel_y = 25
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "bVz" = (
 /obj/machinery/computer/rdservercontrol{
 	dir = 4
@@ -40728,18 +40635,15 @@
 /turf/closed/wall/r_wall,
 /area/station/science/mixing/chamber)
 "bVM" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/science/server";
-	dir = 4;
-	name = "Server Room APC";
-	pixel_x = 25
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "bVN" = (
 /turf/closed/wall/r_wall,
 /area/station/science/mixing)
@@ -40798,20 +40702,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bWa" = (
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/storage_shared";
-	name = "Engineering Shared Storage APC";
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "bWb" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -40876,24 +40779,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bWl" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/theater";
-	dir = 1;
-	name = "Theatre APC";
-	pixel_y = 25
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "bWm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -40919,22 +40809,8 @@
 /area/station/maintenance/department/engine)
 "bWo" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/storage/tech";
-	name = "Technology Storage APC";
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "bWp" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -41037,11 +40913,7 @@
 /area/station/maintenance/department/electrical)
 "bWz" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/electrical";
-	name = "Electrical Maintenance APC";
-	pixel_y = -25
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/electrical)
 "bWA" = (
@@ -41586,12 +41458,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/science/mixing/chamber";
-	dir = 1;
-	name = "Ordnance Chamber APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -41604,6 +41470,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/mixing/chamber)
 "bXV" = (
@@ -41628,15 +41495,13 @@
 /turf/open/floor/engine,
 /area/station/science/mixing/chamber)
 "bXY" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/science/mixing";
-	dir = 8;
-	name = "Ordnance Lab APC";
-	pixel_x = -25
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "bYb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -41781,13 +41646,8 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "bYs" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/tcommsat/server";
-	dir = 1;
-	name = "Telecomms Server APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "bYt" = (
@@ -41845,12 +41705,7 @@
 "bYB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/engine";
-	dir = 8;
-	name = "Engineering Maint APC";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bYC" = (
@@ -41940,12 +41795,6 @@
 /area/station/engineering/lobby)
 "bYJ" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/lobby";
-	dir = 1;
-	name = "Engineering Lobby APC";
-	pixel_y = 25
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	name = "engineering yellow"
@@ -41956,6 +41805,7 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/recharge_station,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bYK" = (
@@ -42139,7 +41989,8 @@
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bZb" = (
@@ -42305,14 +42156,9 @@
 	dir = 6;
 	name = "research purple"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/science/misc_lab/range";
-	dir = 4;
-	name = "Circuit Lab APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/machinery/vending/assist,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab/range)
 "bZy" = (
@@ -42334,7 +42180,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bZA" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -42573,12 +42418,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "cai" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "cak" = (
@@ -42791,15 +42638,10 @@
 /turf/closed/wall/r_wall,
 /area/station/science/mixing/chamber)
 "caP" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
 /obj/structure/cable,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/command/heads_quarters/ce";
-	name = "CE Office APC";
-	pixel_y = -25
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "caQ" = (
 /obj/structure/closet/crate{
 	name = "Spare Toner Cartridges"
@@ -42921,6 +42763,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/brown,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "cbh" = (
@@ -43050,12 +42893,6 @@
 "cbv" = (
 /obj/structure/cable,
 /obj/structure/filingcabinet/filingcabinet,
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/rd";
-	dir = 8;
-	name = "RD Office APC";
-	pixel_x = -25
-	},
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
 	dir = 9;
@@ -43066,6 +42903,7 @@
 /obj/machinery/light_switch/directional/north{
 	pixel_x = -26
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "cbw" = (
@@ -43186,6 +43024,8 @@
 	name = "research purple"
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/mixing)
 "cbH" = (
@@ -43541,6 +43381,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "ccs" = (
@@ -44580,6 +44421,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/mixing)
 "ceF" = (
@@ -44597,6 +44439,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/mixing)
 "ceH" = (
@@ -44609,6 +44452,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/mixing)
 "ceI" = (
@@ -44620,6 +44464,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/mixing)
 "ceJ" = (
@@ -44632,6 +44477,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/mixing)
 "ceL" = (
@@ -44756,6 +44602,7 @@
 /area/station/engineering/storage_shared)
 "ceY" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "ceZ" = (
@@ -44786,6 +44633,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "cfb" = (
@@ -44932,37 +44780,31 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "cfx" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/aft";
-	dir = 8;
-	name = "Aft Hall APC";
-	pixel_x = -25
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255
+	},
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "cfy" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/supply";
-	name = "Security Post - Cargo APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/carpet/green,
+/area/station/service/library)
 "cfz" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cfA" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/sorting";
-	name = "Delivery Office APC";
-	pixel_y = -25
+/obj/effect/turf_decal/siding/green{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "cfB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -45107,12 +44949,6 @@
 /area/station/science/research)
 "cfW" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/science/storage";
-	dir = 4;
-	name = "ORdnance Storage APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -45720,6 +45556,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "chz" = (
@@ -45896,7 +45733,7 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/status_display/ai/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "chV" = (
@@ -46093,6 +45930,8 @@
 /obj/effect/turf_decal/siding/brown{
 	dir = 5
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "ciu" = (
@@ -46418,6 +46257,7 @@
 "cjh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "cjj" = (
@@ -46467,16 +46307,12 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "cjr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/tcommsat/computer";
-	name = "Telecomms Monitoring APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "cjs" = (
@@ -46883,6 +46719,7 @@
 	color = "#990099";
 	name = "Science purple corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/storage)
 "cki" = (
@@ -46957,6 +46794,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "ckr" = (
@@ -47279,6 +47117,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ckX" = (
@@ -47286,9 +47125,6 @@
 	c_tag = "Research Hall - Xenobiology";
 	name = "Research Camera";
 	network = list("ss13","rd")
-	},
-/obj/structure/sign/warning/explosives/alt{
-	pixel_y = 30
 	},
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -47301,6 +47137,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ckY" = (
@@ -47318,6 +47155,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ckZ" = (
@@ -47333,6 +47171,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "cla" = (
@@ -47348,6 +47187,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "clb" = (
@@ -47363,6 +47203,7 @@
 	dir = 8
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "clc" = (
@@ -47376,6 +47217,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "cld" = (
@@ -47979,6 +47821,8 @@
 	name = "security red"
 	},
 /obj/effect/landmark/start/depsec/supply,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "cms" = (
@@ -48185,18 +48029,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "cmJ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/misc_lab";
-	dir = 4;
-	name = "Testing Lab APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
 	dir = 4;
 	name = "research purple"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "cmK" = (
@@ -48388,6 +48227,7 @@
 	name = "security red"
 	},
 /obj/effect/landmark/start/depsec/supply,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "cno" = (
@@ -48513,6 +48353,7 @@
 	color = "#990099";
 	name = "Science purple corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cnC" = (
@@ -48613,11 +48454,6 @@
 	color = "#FF0000";
 	dir = 6;
 	name = "security red"
-	},
-/obj/machinery/requests_console/directional/east{
-	department = "Security";
-	departmentType = 5;
-	name = "Security Post RD"
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
@@ -48790,6 +48626,7 @@
 	dir = 1;
 	name = "Security red corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "coi" = (
@@ -48801,6 +48638,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "coj" = (
@@ -48901,6 +48739,8 @@
 	dir = 9;
 	name = "research purple"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cos" = (
@@ -48946,6 +48786,7 @@
 	dir = 1;
 	name = "research purple"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cow" = (
@@ -49340,6 +49181,7 @@
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "cpl" = (
@@ -49458,6 +49300,7 @@
 	dir = 8;
 	name = "research purple"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cpA" = (
@@ -49800,12 +49643,7 @@
 	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engineering/atmos";
-	dir = 1;
-	name = "Atmospherics APC";
-	pixel_y = 25
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cqr" = (
@@ -50371,6 +50209,7 @@
 	name = "Library"
 	},
 /obj/effect/landmark/navigate_destination/library,
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "crG" = (
@@ -50678,17 +50517,11 @@
 /turf/open/floor/engine,
 /area/station/science/misc_lab)
 "csp" = (
+/obj/structure/table/wood,
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/science/xenobiology";
-	dir = 4;
-	name = "Xenobiology Lab APC";
-	pixel_x = 25
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/wood,
+/area/station/service/library)
 "csq" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/toggle/labcoat,
@@ -50876,7 +50709,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "csN" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/brown{
@@ -51126,12 +50958,6 @@
 /area/station/maintenance/solars/port/aft)
 "ctq" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/engine_smes";
-	dir = 1;
-	name = "SMES room APC";
-	pixel_y = 25
-	},
 /obj/structure/reagent_dispensers/fueltank/large,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -51139,6 +50965,7 @@
 	name = "engineering yellow"
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "ctr" = (
@@ -52066,18 +51893,13 @@
 /area/station/engineering/engine_smes)
 "cvK" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/transit_tube";
-	dir = 1;
-	name = "Transit Tubes APC";
-	pixel_y = 25
-	},
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
 	dir = 5;
 	name = "command blue"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/transit_tube)
 "cvL" = (
@@ -52130,6 +51952,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "cvS" = (
@@ -52361,11 +52184,6 @@
 "cwz" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
-	name = "Security Post - Engineering APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -52373,6 +52191,7 @@
 	name = "security red"
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "cwA" = (
@@ -52480,12 +52299,8 @@
 /area/station/maintenance/starboard/fore)
 "cwM" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/office";
-	name = "Cargo Office APC";
-	pixel_y = -25
-	},
 /obj/effect/turf_decal/siding/brown,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "cwN" = (
@@ -53020,13 +52835,6 @@
 /area/station/cargo/office)
 "cya" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/port/aft";
-	dir = 4;
-	name = "Port Quarter Solar APC";
-	pixel_x = 25;
-	pixel_y = 2
-	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Solar Control - Port Aft";
 	name = "Solars Camera";
@@ -53037,6 +52845,7 @@
 	dir = 6;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/aft)
 "cyb" = (
@@ -53700,13 +53509,8 @@
 /area/station/engineering/transit_tube)
 "czC" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/science/xenobiology";
-	dir = 8;
-	name = "Xenobiology Maint APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "czD" = (
@@ -53813,12 +53617,6 @@
 /area/station/engineering/main)
 "czT" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/qm";
-	dir = 1;
-	name = "Quartermaster's Office APC";
-	pixel_y = 25
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -53828,6 +53626,7 @@
 /obj/effect/turf_decal/siding/brown{
 	dir = 5
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "czU" = (
@@ -54169,14 +53968,10 @@
 /obj/machinery/modular_computer/console/preset/cargochat/cargo{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/storage";
-	name = "Cargo Bay APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/brown,
 /obj/machinery/light/directional/south,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "cAJ" = (
@@ -54229,12 +54024,6 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "cAO" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/starboard/aft";
-	dir = 8;
-	name = "Starboard Quarter Solar APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -30
@@ -54244,6 +54033,7 @@
 	dir = 10;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/aft)
 "cAQ" = (
@@ -55669,6 +55459,7 @@
 /obj/effect/turf_decal/siding/green/end{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "cED" = (
@@ -56392,18 +56183,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cGy" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal/incinerator";
-	dir = 8;
-	name = "Incinerator APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 8;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "cGz" = (
@@ -57982,16 +57768,11 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/atmos/upper";
-	dir = 4;
-	name = "Atmospherics Upper APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "cJC" = (
@@ -58073,12 +57854,8 @@
 /obj/item/stack/ore/glass,
 /obj/item/stack/ore/glass,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/miningoffice";
-	name = "Mining Office APC";
-	pixel_y = -25
-	},
 /obj/effect/turf_decal/siding/brown,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "cJL" = (
@@ -58162,14 +57939,9 @@
 /area/station/science/xenobiology)
 "cJT" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/storage";
-	dir = 4;
-	name = "External Engine APC";
-	pixel_x = 25
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "cJU" = (
@@ -59606,13 +59378,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cNH" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/engine/atmos";
-	dir = 8;
-	name = "Atmospherics Maint APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "cNI" = (
@@ -59741,7 +59508,6 @@
 	dir = 4;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -59990,14 +59756,8 @@
 /turf/closed/wall,
 /area/station/maintenance/department/science/xenobiology)
 "cOK" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal";
-	name = "Disposal APC";
-	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -60801,6 +60561,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination/disposals,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cQJ" = (
@@ -60897,6 +60658,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "cQZ" = (
@@ -60930,8 +60692,8 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cRf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cRh" = (
@@ -61030,6 +60792,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "cRw" = (
@@ -61070,13 +60834,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cRD" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
-	dir = 1;
-	name = "AI Satellite Foyer APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cRE" = (
@@ -61408,15 +61167,11 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cSG" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
-	name = "AI Hallway APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cSH" = (
@@ -61716,17 +61471,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cTv" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/atmos";
-	dir = 1;
-	name = "AI Satellite Service APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cTw" = (
@@ -61805,17 +61555,12 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cTI" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/service";
-	dir = 1;
-	name = "AI Satellite Service APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/item/storage/toolbox/electrical,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "cTJ" = (
@@ -61914,9 +61659,7 @@
 /area/station/maintenance/solars)
 "cUa" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north{
-	name = "AI satellite"
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/solars)
 "cUc" = (
@@ -61949,16 +61692,12 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai";
-	name = "AI Chamber APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/machinery/flasher/directional/south{
 	id = "AI";
 	pixel_x = -12
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cUi" = (
@@ -63722,6 +63461,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen)
 "dqW" = (
@@ -63998,6 +63738,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
 /turf/open/floor/plating,
 /area/station/medical/virology)
+"dVC" = (
+/obj/effect/turf_decal/siding/purple{
+	color = "#990099";
+	name = "research purple"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/storage)
 "dVU" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 6
@@ -64451,17 +64200,12 @@
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/surgery,
 /obj/item/reagent_containers/medigel/sterilizine,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/surgery/aft";
-	dir = 8;
-	name = "Surgery B APC";
-	pixel_x = -25
-	},
 /obj/effect/turf_decal/siding/blue{
 	color = "#73c2fb";
 	dir = 9;
 	name = "medical blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "eWM" = (
@@ -64544,6 +64288,7 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "fbw" = (
@@ -64697,6 +64442,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "fmY" = (
@@ -64779,6 +64525,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen)
 "fxI" = (
@@ -64794,6 +64541,7 @@
 "fxK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "fxO" = (
@@ -65210,6 +64958,7 @@
 /area/station/maintenance/department/engine)
 "gnv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "gnK" = (
@@ -65226,6 +64975,7 @@
 	dir = 8;
 	name = "Security red corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "gqT" = (
@@ -65309,6 +65059,17 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
+"gyr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	color = "#990099";
+	name = "research purple"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "gzW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65392,6 +65153,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/mixing)
 "gKm" = (
@@ -65758,16 +65520,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
+"hnV" = (
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen)
 "hoi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/warehouse";
-	name = "Cargo Warehouse APC";
-	pixel_y = -25
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "hoy" = (
@@ -65848,6 +65609,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"htV" = (
+/obj/effect/turf_decal/siding/purple{
+	color = "#990099";
+	name = "research purple"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "huq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -65860,6 +65631,8 @@
 	dir = 4;
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "hwE" = (
@@ -65952,6 +65725,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "hCA" = (
@@ -66562,7 +66336,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "ivt" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/green{
 	dir = 9
@@ -66570,6 +66343,7 @@
 /obj/structure/sink{
 	pixel_y = 20
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "izP" = (
@@ -66727,6 +66501,7 @@
 	dir = 8;
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "iNA" = (
@@ -66827,6 +66602,14 @@
 /obj/machinery/vending/hydroseeds/prison,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"jaL" = (
+/obj/effect/turf_decal/siding/purple{
+	color = "#990099";
+	name = "research purple"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/storage)
 "jbs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -66931,7 +66714,8 @@
 /area/space)
 "jkE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
-	dir = 1
+	dir = 1;
+	frequency = 1459
 	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
@@ -67067,6 +66851,7 @@
 	dir = 9
 	},
 /obj/effect/spawner/xmastree,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "jvF" = (
@@ -67098,6 +66883,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "jxx" = (
@@ -67136,6 +66922,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/supply,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "jFr" = (
@@ -67337,6 +67124,7 @@
 	color = "#4169E1";
 	name = "Command blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "jOS" = (
@@ -67626,6 +67414,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"kCL" = (
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/storage/tech)
 "kDe" = (
 /obj/machinery/door/poddoor{
 	id = "engstorage";
@@ -67741,6 +67543,7 @@
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "kQJ" = (
@@ -67864,6 +67667,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/mixing)
 "kXH" = (
@@ -68062,8 +67866,8 @@
 	dir = 4;
 	name = "research purple"
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "lmc" = (
@@ -68234,6 +68038,8 @@
 /obj/effect/turf_decal/siding/brown/end{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "lGZ" = (
@@ -68307,19 +68113,19 @@
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/machinery/light/directional/south,
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
 	name = "prison orange"
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/security/prison/work)
 "lMx" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/white,
 /area/station/security/prison/toilet)
 "lMU" = (
@@ -68728,6 +68534,11 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"mrU" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen)
 "msu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -69130,6 +68941,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen)
 "ngx" = (
@@ -69167,6 +68979,8 @@
 	dir = 4;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "nif" = (
@@ -69253,21 +69067,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "nnm" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/commons/vacant_room/commissary";
-	dir = 1;
-	name = "Vacant Commissary APC";
-	pixel_y = 25
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
 "nno" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -69313,6 +69122,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "nrA" = (
@@ -69517,8 +69327,18 @@
 	dir = 9;
 	name = "medical blue"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"nIV" = (
+/obj/effect/turf_decal/siding/purple{
+	color = "#990099";
+	name = "research purple"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "nJK" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -69616,6 +69436,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"nNX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/green,
+/area/station/service/library)
 "nOb" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/siding/brown{
@@ -69931,14 +69757,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "ofP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/service/hydroponics)
 "ogx" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/brown{
@@ -70013,12 +69834,7 @@
 /area/station/engineering/main)
 "opg" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/cargo";
-	dir = 8;
-	name = "Cargo Maint APC";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "opP" = (
@@ -70210,6 +70026,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "oNS" = (
@@ -70303,6 +70120,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "oZW" = (
@@ -70332,6 +70150,11 @@
 /obj/item/clothing/gloves/color/latex,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
+"pbD" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "pey" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -70603,6 +70426,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "pHZ" = (
@@ -70635,6 +70459,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/main)
+"pJD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "pKL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -70724,6 +70555,8 @@
 /area/station/engineering/lobby)
 "pUx" = (
 /obj/effect/turf_decal/siding/green,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "pUE" = (
@@ -71004,13 +70837,8 @@
 	dir = 9;
 	name = "security red"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/interrogation";
-	dir = 1;
-	name = "Interrogation Room APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "qva" = (
@@ -71125,6 +70953,7 @@
 	name = "Chapel"
 	},
 /obj/effect/landmark/navigate_destination/chapel,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "qFt" = (
@@ -71346,6 +71175,13 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"qXT" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "rbc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -71378,6 +71214,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "reN" = (
@@ -71433,6 +71270,7 @@
 	dir = 10
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "rla" = (
@@ -71497,6 +71335,7 @@
 	req_one_access_txt = "73"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "rqh" = (
@@ -72125,6 +71964,11 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen)
+"soR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "sqr" = (
 /obj/structure/table,
 /obj/item/coin/antagtoken{
@@ -72174,6 +72018,7 @@
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "suq" = (
@@ -72763,6 +72608,7 @@
 	dir = 1;
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "tpF" = (
@@ -72879,6 +72725,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "twB" = (
@@ -73021,6 +72868,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "tQr" = (
@@ -73258,6 +73106,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "uwK" = (
@@ -73365,6 +73214,7 @@
 "uJd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "uKj" = (
@@ -73580,6 +73430,7 @@
 	dir = 1;
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "uYO" = (
@@ -73592,6 +73443,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "vad" = (
@@ -73814,12 +73666,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "vqT" = (
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/engineering/main";
-	dir = 1;
-	name = "Engineering APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -73829,6 +73675,7 @@
 	dir = 5;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "vsM" = (
@@ -73920,6 +73767,7 @@
 /area/station/cargo/storage)
 "vCh" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vCx" = (
@@ -74015,6 +73863,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "vLD" = (
@@ -74113,6 +73962,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "vUG" = (
@@ -74149,6 +73999,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "vZX" = (
@@ -74287,6 +74138,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/main)
+"wmK" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "wmN" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -74590,6 +74446,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"wUp" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/storage_shared)
 "wVc" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -74622,6 +74482,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"wYn" = (
+/obj/effect/turf_decal/siding/purple{
+	color = "#990099";
+	dir = 1;
+	name = "research purple"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/sign/warning/explosives/alt{
+	pixel_y = 30
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "wYv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -74722,6 +74600,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "xgL" = (
@@ -74877,6 +74756,7 @@
 	color = "#FFD700";
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "xvt" = (
@@ -75004,6 +74884,7 @@
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "xFs" = (
@@ -75049,6 +74930,7 @@
 	dir = 8;
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "xHv" = (
@@ -75086,23 +74968,8 @@
 /area/station/security/prison/upper)
 "xMa" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/service/kitchen";
-	dir = 1;
-	name = "Kitchen APC";
-	pixel_y = 25
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "xMT" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -91617,9 +91484,9 @@ aak
 aaa
 aVf
 aWx
-aXd
-aXd
-caE
+aTS
+aWk
+aWu
 bay
 bbK
 bdm
@@ -92130,10 +91997,10 @@ aSe
 aTc
 bdS
 aVg
-aWk
-aAi
+aWl
+aCR
 aXY
-caF
+aWw
 baV
 aAi
 aAi
@@ -92932,7 +92799,7 @@ bCW
 bEE
 bCW
 bxJ
-bIF
+bNm
 bxJ
 ceP
 bNL
@@ -93969,7 +93836,7 @@ bNp
 bRX
 bxJ
 bLv
-bWa
+bWc
 bOQ
 dgG
 bZG
@@ -94458,7 +94325,7 @@ baq
 baq
 bmr
 bnO
-bpk
+bFi
 bqw
 aZp
 bsH
@@ -94715,7 +94582,7 @@ baq
 baq
 bmr
 bnP
-bpk
+bFi
 bqx
 aZp
 aTN
@@ -94747,7 +94614,7 @@ bZH
 tYm
 bXo
 cdo
-ceX
+wUp
 cgp
 ceX
 nmb
@@ -94988,10 +94855,10 @@ bzJ
 bzJ
 bzK
 bwU
-bIH
+bGh
 bwU
 bLL
-bNp
+soR
 bOX
 bQA
 bSb
@@ -95004,7 +94871,7 @@ bZJ
 fBx
 bXo
 cdp
-ceX
+wUp
 ceX
 ceX
 cjj
@@ -95486,7 +95353,7 @@ aCR
 aJt
 byn
 byn
-bpB
+byn
 uJd
 bsf
 rdy
@@ -97298,7 +97165,7 @@ byj
 bzZ
 bBJ
 bDn
-bFi
+vQK
 bGh
 bHu
 bHu
@@ -97795,15 +97662,15 @@ bea
 bnW
 bgM
 bih
-bnW
-bnW
-bnW
+bdd
+bdd
+bdd
 juV
-big
-big
+bGn
+bGn
 qFg
-cpG
-btP
+bVy
+bLr
 bUF
 bsI
 bsI
@@ -98052,7 +97919,7 @@ beb
 bfG
 bgL
 big
-bjA
+bgg
 big
 bjA
 bnX
@@ -98309,7 +98176,7 @@ bec
 bfI
 bgK
 big
-bjy
+blb
 big
 bjy
 bnY
@@ -98566,7 +98433,7 @@ bed
 bfJ
 bfI
 bfG
-bjy
+blb
 big
 bjy
 bnZ
@@ -98823,7 +98690,7 @@ bee
 bfK
 bfJ
 bfI
-bjy
+blb
 bfG
 bmv
 boa
@@ -99337,7 +99204,7 @@ beu
 bgx
 bhe
 bfK
-bfJ
+blA
 blx
 bmO
 bor
@@ -99626,8 +99493,8 @@ bUM
 bWg
 bXr
 bYB
-bXr
-caP
+bSm
+bSm
 cbZ
 cdB
 cff
@@ -100126,7 +99993,7 @@ bHt
 bGh
 bDI
 bES
-bGx
+bES
 bES
 bES
 bES
@@ -100366,7 +100233,7 @@ bmV
 bmV
 bmV
 bjU
-blA
+aYy
 bmV
 bsS
 bsI
@@ -100374,7 +100241,7 @@ bsI
 bsI
 bsI
 bsI
-buB
+bUF
 bsI
 bsI
 bwU
@@ -100874,7 +100741,7 @@ aYq
 aZF
 aXm
 bbX
-bcT
+aXH
 aXm
 bfN
 bgP
@@ -100888,7 +100755,7 @@ nDG
 bii
 bsU
 bsI
-buB
+bUF
 bsI
 bvW
 bwX
@@ -101131,7 +100998,7 @@ aYr
 aZG
 baB
 bbP
-cpn
+aYH
 bei
 bfO
 bgQ
@@ -101382,7 +101249,7 @@ aak
 aDr
 aGU
 aVp
-aWu
+aWt
 bmV
 aXm
 aXm
@@ -101645,7 +101512,7 @@ aYs
 aZH
 aXm
 bbR
-bcT
+aXH
 aXm
 bfP
 bgR
@@ -101659,7 +101526,7 @@ oEh
 bii
 bsU
 bsI
-buB
+bUF
 bsI
 nAD
 bwX
@@ -101902,7 +101769,7 @@ aYt
 aZI
 aXm
 bbS
-bcT
+aXH
 aXm
 bfQ
 bgS
@@ -101916,13 +101783,13 @@ bii
 bii
 bsI
 bsI
-buB
-bsI
-nAD
+bUF
+bWo
+bXY
 bxB
 vLh
 stL
-sPl
+cfA
 bDs
 bEW
 bGq
@@ -102159,7 +102026,7 @@ aYu
 aZJ
 baC
 bbP
-cpn
+aYH
 bej
 bfR
 bgT
@@ -102173,7 +102040,7 @@ bqD
 bii
 aJd
 bsI
-buB
+bUF
 bsI
 bvY
 bxq
@@ -102183,7 +102050,7 @@ bAc
 bAc
 bFk
 bNF
-bAc
+ofP
 pUx
 bwW
 bwW
@@ -102416,7 +102283,7 @@ aXm
 aXm
 aXm
 bbT
-bcT
+aXH
 aXm
 aXm
 aXm
@@ -102430,7 +102297,7 @@ bii
 bii
 bsX
 bsI
-buB
+bUF
 bsI
 bvZ
 bwX
@@ -102672,7 +102539,7 @@ bmV
 aYv
 aZK
 aXm
-bca
+aXs
 bcP
 aXm
 bfS
@@ -102705,8 +102572,8 @@ bNJ
 bPn
 exL
 bxJ
-bTk
-bUV
+bHn
+bLv
 hse
 bOQ
 bYK
@@ -102944,7 +102811,7 @@ bii
 bii
 bsZ
 bjW
-ofP
+cqu
 bjW
 eHp
 bxb
@@ -103201,7 +103068,7 @@ bqE
 bii
 btE
 bjW
-ofP
+cqu
 bjW
 eHp
 bxc
@@ -103458,7 +103325,7 @@ bii
 bii
 cXt
 bjW
-ofP
+cqu
 bjW
 eHp
 bxb
@@ -103967,12 +103834,12 @@ bik
 bik
 rrb
 bik
-bik
+bGx
 bqG
 bhf
 gGo
 bjW
-ofP
+cqu
 bjW
 dzf
 bxa
@@ -104194,7 +104061,7 @@ aqE
 bdS
 aGW
 aIp
-aJn
+aAi
 aAi
 aAi
 aAi
@@ -104205,7 +104072,7 @@ blp
 aNF
 bab
 blp
-aSF
+blp
 blp
 aUw
 aVH
@@ -104224,12 +104091,12 @@ bjL
 bjO
 bmF
 bik
-rrb
+bHf
 bqH
 bly
 bjW
 bjW
-ofP
+cqu
 bjW
 odr
 bxa
@@ -104481,12 +104348,12 @@ bjM
 bjR
 bmF
 bik
-bik
+bGx
 bqI
 bly
 bjW
 bjW
-ofP
+cqu
 bjW
 bwc
 bxd
@@ -104501,12 +104368,12 @@ bIX
 bPJ
 bxa
 kTC
-bNP
+hnV
 bQW
 bNP
 bMj
 bxJ
-xMa
+bWj
 bOQ
 aak
 bZZ
@@ -104738,12 +104605,12 @@ bjN
 bjR
 bmF
 bik
-bik
+bGx
 bqJ
 bly
 bjW
 bjW
-ofP
+cqu
 bjW
 qyu
 bxe
@@ -104758,7 +104625,7 @@ bIY
 bPJ
 bxa
 bMo
-bNP
+mrU
 bRk
 bSD
 bTA
@@ -105000,7 +104867,7 @@ bqK
 bly
 bjW
 bjW
-ofP
+cqu
 ccu
 qyu
 bxf
@@ -105257,7 +105124,7 @@ bik
 bmJ
 bjW
 bjW
-ofP
+cqu
 bjW
 qyu
 bxg
@@ -105277,7 +105144,7 @@ bQY
 bSw
 bTp
 bxJ
-bWl
+bWp
 bOQ
 bXv
 bXv
@@ -105771,7 +105638,7 @@ bik
 bmJ
 ccu
 bjW
-ofP
+cqu
 bjW
 qyu
 bxg
@@ -106285,7 +106152,7 @@ bqO
 bly
 bjW
 bjW
-bjW
+bwl
 bjW
 bwf
 bxd
@@ -106542,7 +106409,7 @@ bqP
 bly
 bjW
 bjW
-bjW
+bwl
 bjW
 cXy
 bxd
@@ -106562,7 +106429,7 @@ bxd
 bxd
 bxJ
 bxJ
-bWo
+bWp
 bOQ
 cab
 cae
@@ -106572,7 +106439,7 @@ cab
 cfu
 cgK
 chR
-cab
+kCL
 bXv
 bXs
 coH
@@ -106781,7 +106648,7 @@ aUv
 aVy
 bmV
 bew
-aYH
+aYz
 bmV
 baQ
 bcc
@@ -106799,7 +106666,7 @@ bqQ
 bly
 bjW
 bjW
-bjW
+bwl
 bjW
 bjW
 bxh
@@ -107056,7 +106923,7 @@ bBO
 bhf
 btd
 bjW
-bjW
+bwl
 bjW
 bwh
 bxd
@@ -107073,9 +106940,9 @@ bMl
 bNV
 bPx
 bMl
-bMl
+pbD
 bTv
-bSm
+bXr
 bWq
 sQI
 uys
@@ -107313,7 +107180,7 @@ bqV
 bhf
 cXu
 buc
-bjW
+bwl
 bvr
 bwi
 bxd
@@ -107332,7 +107199,7 @@ bPX
 bRr
 bSN
 bxJ
-bVy
+bHm
 bWp
 bOQ
 bZb
@@ -107803,7 +107670,7 @@ aIM
 alc
 alc
 alc
-alc
+aXu
 alc
 alc
 alc
@@ -107825,11 +107692,11 @@ bjW
 bjW
 vCx
 bjW
-bjW
-bjW
+bwl
+bwl
 fjZ
-bjW
-ccu
+bwl
+caP
 bjW
 byC
 bjW
@@ -108060,7 +107927,7 @@ apd
 alc
 alc
 alc
-alc
+aXu
 alc
 alc
 alc
@@ -108082,11 +107949,11 @@ bjW
 bjW
 bqT
 bjW
-bjW
+bwl
 bud
 buH
 bud
-bjW
+bwl
 bjW
 byD
 bjW
@@ -108279,18 +108146,18 @@ akc
 aeq
 alJ
 aft
-afG
-afG
-afG
+apN
+apN
+apN
 ajW
-afG
+apN
 baT
-alc
-alc
+aXu
+aXu
 auy
-alc
-alc
-alc
+aXu
+aXu
+aXu
 axZ
 ayM
 azt
@@ -108303,41 +108170,41 @@ aCl
 diw
 aCl
 aFg
-afG
+apN
 aHe
-afG
-afG
+apN
+apN
 aLU
-alc
-alc
-alc
-alc
-alc
-apd
-alc
-alc
-alc
-alc
-alc
-alc
-alc
-alc
+aXu
+aXu
+aXu
+aXu
+aXu
+aKB
+aXu
+aXu
+aXu
+aXu
+aXu
+aXu
+aXu
+aXu
 aXu
 aXu
 aXu
 bbf
-alc
-alb
-bjW
-bjW
-bjW
-bjW
-bjW
-bjW
-bjW
-bjW
-bjW
-bjW
+aXu
+bcJ
+bwl
+bwl
+bwl
+bwl
+bwl
+bwl
+bwl
+bwl
+bwl
+bwl
 jOz
 jOz
 bue
@@ -108538,7 +108405,7 @@ alc
 alc
 alc
 alc
-alc
+aXu
 apd
 alc
 aqV
@@ -108795,7 +108662,7 @@ amb
 amP
 aor
 alc
-alc
+ass
 apA
 aqa
 arj
@@ -108882,7 +108749,7 @@ ccD
 cbn
 ccD
 ceC
-bJe
+wmK
 bMM
 cie
 cjW
@@ -109311,7 +109178,7 @@ abc
 abc
 abc
 abc
-apN
+abc
 aqS
 aph
 anT
@@ -109339,8 +109206,8 @@ azU
 aKm
 aHX
 aHX
-aMI
-aKp
+aHX
+aJn
 aOo
 aSu
 aQr
@@ -109362,7 +109229,7 @@ bhg
 biq
 bjX
 blC
-cEx
+buB
 cEx
 bpE
 bqW
@@ -109396,7 +109263,7 @@ cag
 cbf
 bJp
 fET
-cfx
+bTG
 bJp
 chV
 cjO
@@ -109619,7 +109486,7 @@ bhh
 bir
 bjY
 bjZ
-bjZ
+bDP
 bjZ
 bjZ
 bqX
@@ -109662,8 +109529,8 @@ jEQ
 cnn
 coh
 cpk
-cAx
-cAx
+qXT
+qXT
 csO
 mar
 nAf
@@ -109876,7 +109743,7 @@ bhi
 bis
 bjZ
 bjZ
-bjZ
+bDP
 bjZ
 bjZ
 bsF
@@ -109910,7 +109777,7 @@ cai
 cbh
 ccs
 cea
-cfy
+bTG
 ccB
 cil
 wQM
@@ -110090,7 +109957,7 @@ abM
 avN
 awZ
 aax
-aye
+aHj
 avB
 psH
 azU
@@ -110137,11 +110004,11 @@ bmM
 bom
 kQG
 pGs
-bmK
-vxy
-bjW
-bjW
-bjW
+bIH
+bVM
+bwl
+bwl
+bwl
 bwn
 bxk
 byJ
@@ -110383,7 +110250,7 @@ aYO
 aYO
 aYN
 bcj
-bdd
+bdf
 aYK
 bgc
 bhk
@@ -110423,7 +110290,7 @@ bXA
 bXA
 bXA
 ccB
-nnm
+cem
 bTG
 bJp
 chZ
@@ -110433,8 +110300,8 @@ cmf
 lFZ
 coi
 xEW
-cqz
-crI
+csR
+pJD
 csR
 csR
 csR
@@ -110617,7 +110484,7 @@ aDL
 aEF
 aFD
 aEF
-aHj
+aEF
 aCV
 aak
 azU
@@ -111195,7 +111062,7 @@ cal
 cal
 ccB
 cem
-cfA
+bTG
 bJp
 cic
 cjU
@@ -112183,8 +112050,8 @@ aaa
 aaa
 ksu
 bdh
-bdf
-bgg
+cwu
+aZO
 aYK
 biy
 bkg
@@ -112447,19 +112314,19 @@ biz
 bkg
 bkg
 bmU
-bkg
+bDW
 bpJ
-fqs
-bse
-tyl
-bjW
+bIF
+bTk
+bWa
+bwl
 cqu
 bjW
 eHp
 bxm
 byM
 bAx
-byS
+csp
 bDG
 byS
 bGE
@@ -112711,12 +112578,12 @@ bkc
 tyl
 bjW
 cqu
-bjW
-eHp
+bwl
+cfx
 crF
-byN
-byN
-byN
+cfy
+cfy
+cfy
 bAC
 byN
 byN
@@ -112911,11 +112778,11 @@ aaa
 amB
 apY
 ara
-ass
 aCJ
 aCJ
 aCJ
-axi
+aCJ
+aCJ
 ays
 aym
 avZ
@@ -112972,7 +112839,7 @@ bjW
 eHp
 bxm
 byO
-byN
+cfy
 bBY
 bBY
 bBY
@@ -113168,7 +113035,7 @@ aaa
 amB
 aqo
 awY
-asy
+auT
 atB
 auT
 avS
@@ -113229,7 +113096,7 @@ bip
 bxl
 bxo
 byP
-byN
+cfy
 byN
 bDH
 byN
@@ -113750,8 +113617,8 @@ gnv
 bHW
 xfK
 bJs
-iqJ
-iqJ
+nNX
+nNX
 bOh
 bPB
 bRq
@@ -113938,7 +113805,7 @@ aaa
 aaa
 apj
 aqc
-arc
+asy
 asn
 ato
 ato
@@ -114196,7 +114063,7 @@ aow
 apj
 apj
 ard
-aso
+axi
 atm
 atm
 atm
@@ -117049,18 +116916,18 @@ aak
 aEd
 aRb
 brN
-aNc
+brN
 brN
 beG
 aPW
 aQI
 bbl
-aSP
+bbl
 bbl
 bbl
 bvL
 bwJ
-aXH
+aXy
 aEd
 baf
 bbq
@@ -117116,7 +116983,7 @@ cLo
 cLo
 cLo
 fNy
-csp
+cLo
 cLo
 cLo
 cLo
@@ -117313,7 +117180,7 @@ aQK
 aRh
 aRP
 aLS
-aTS
+aLS
 aLS
 aVR
 aLS
@@ -117343,7 +117210,7 @@ bxy
 byY
 byY
 bCw
-bDP
+byY
 byY
 byY
 byY
@@ -117355,7 +117222,7 @@ bQb
 bUz
 bUz
 nno
-bVM
+bUz
 bUz
 bUz
 bZt
@@ -117600,11 +117467,11 @@ bxI
 bzl
 bTO
 lET
-bDW
 lET
 lET
 lET
-bUq
+lET
+lET
 ekq
 bMF
 bxI
@@ -117861,7 +117728,7 @@ bxI
 bxI
 bxI
 bIn
-byY
+bWG
 bIn
 bxI
 bxI
@@ -118338,7 +118205,7 @@ aMR
 aNL
 aOw
 aPu
-bjc
+aMI
 bmL
 mCg
 dCZ
@@ -118595,7 +118462,7 @@ aMS
 aNM
 aOx
 aPt
-aUP
+aNc
 blz
 mCg
 kZC
@@ -118637,7 +118504,7 @@ bKN
 bze
 bOp
 hBi
-bQi
+htV
 bSS
 bTU
 bVC
@@ -118653,7 +118520,7 @@ ccH
 mZI
 ckg
 ckW
-cmv
+gyr
 cnB
 cov
 vUt
@@ -118852,7 +118719,7 @@ aNg
 aNZ
 aOU
 aPt
-aUP
+aNc
 blz
 mCg
 eNO
@@ -118907,7 +118774,7 @@ cfO
 cfO
 cfO
 ccH
-mZI
+dVC
 cap
 ckX
 cmw
@@ -119164,7 +119031,7 @@ cfP
 cfP
 cfP
 ccH
-mZI
+jaL
 ckh
 ckW
 cmx
@@ -119423,7 +119290,7 @@ ccQ
 ccQ
 ciA
 cap
-ckW
+wYn
 cmy
 bxx
 coy
@@ -119624,9 +119491,9 @@ aNP
 aOz
 aUP
 bem
-bqi
+aSP
 baa
-bqi
+aSP
 aUY
 bwd
 aXh
@@ -119879,7 +119746,7 @@ aMj
 aMW
 aNQ
 aOA
-bjc
+aMI
 bha
 aWV
 aSK
@@ -120130,7 +119997,7 @@ aEd
 aEd
 aEd
 aEd
-aKB
+aKA
 aEd
 aMz
 aNk
@@ -121199,7 +121066,7 @@ bzu
 bBf
 bCE
 bEg
-bFL
+nnm
 bGZ
 bIv
 bJL
@@ -123735,11 +123602,11 @@ aNf
 aNY
 aOF
 aQd
-blL
+aSF
 aEd
 aTe
 aUl
-aWw
+aUl
 aUl
 aUl
 aUl
@@ -123759,7 +123626,7 @@ bnG
 bnG
 brS
 aEd
-btn
+bWl
 btm
 buW
 btm
@@ -123998,7 +123865,7 @@ aTq
 bnG
 bnG
 bnG
-aXs
+bnG
 bnG
 bnG
 bai
@@ -124043,7 +123910,7 @@ bXR
 bXa
 bVL
 cbG
-bXV
+ccV
 gIu
 cfZ
 chj
@@ -124774,7 +124641,7 @@ aXQ
 aPX
 aXy
 cjT
-bcJ
+bgE
 bgE
 bgE
 bgE
@@ -124808,7 +124675,7 @@ bQd
 bRL
 bOr
 bUl
-bVN
+bVL
 bXU
 bZu
 caw
@@ -125037,7 +124904,7 @@ aUl
 aUl
 bhX
 aUl
-blb
+aUl
 bmy
 aQK
 boN
@@ -125571,11 +125438,11 @@ bxD
 bFK
 bHb
 bIu
-bIu
+xMa
 bLj
-bIu
-bIu
-bQd
+xMa
+xMa
+nIV
 bRL
 bTa
 jsy
@@ -125809,7 +125676,7 @@ aRf
 bhT
 bje
 bkM
-bmj
+bpB
 bnx
 bnx
 bmj
@@ -126339,7 +126206,7 @@ bxD
 bBC
 bCS
 bEy
-bGn
+bHe
 bHe
 bBc
 bJQ
@@ -126352,7 +126219,7 @@ nTn
 bUn
 bxD
 bCF
-bXY
+bBg
 bZz
 bJT
 cbL
@@ -127882,7 +127749,7 @@ bBi
 bst
 bEm
 bxD
-bHf
+aWG
 bIz
 fOk
 xKl
@@ -128139,7 +128006,7 @@ bst
 bst
 vCh
 bOO
-bBg
+bTe
 bIA
 bBg
 bBg

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -3017,6 +3017,7 @@
 /area/station/science/storage)
 "aQq" = (
 /obj/machinery/status_display/evac/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "aQr" = (
@@ -3758,10 +3759,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "aZu" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/light/directional/north,
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "aZA" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/light/directional/west,
@@ -3865,6 +3865,7 @@
 /obj/structure/sign/warning/radiation{
 	pixel_x = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "baX" = (
@@ -7866,6 +7867,7 @@
 	req_access_txt = "32";
 	space_dir = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "cai" = (
@@ -8665,6 +8667,11 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"cmQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "cnd" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -9668,6 +9675,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "cyE" = (
@@ -9871,6 +9879,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "cAO" = (
@@ -10805,16 +10814,8 @@
 /area/station/engineering/lobby)
 "cOZ" = (
 /obj/effect/landmark/xeno_spawn,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/turf/open/floor/iron,
+/area/station/maintenance/department/cargo)
 "cPj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -10876,9 +10877,9 @@
 /turf/closed/wall,
 /area/station/commons/dorms)
 "cQC" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/wood,
+/area/station/maintenance/port/aft)
 "cQH" = (
 /obj/structure/table,
 /obj/item/flashlight,
@@ -14804,7 +14805,7 @@
 "dTZ" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/port/aft)
 "dUk" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -15688,6 +15689,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "egf" = (
@@ -18977,7 +18979,6 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "faq" = (
@@ -20463,6 +20464,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "fsc" = (
@@ -21434,6 +21436,7 @@
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "fFV" = (
@@ -22139,7 +22142,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/mixing)
 "fOe" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -23597,7 +23599,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "ghw" = (
-/obj/structure/cable,
 /obj/machinery/door/window{
 	dir = 1;
 	name = "AI Core Door";
@@ -24035,6 +24036,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "gqi" = (
@@ -24572,7 +24574,6 @@
 	},
 /area/station/medical/abandoned)
 "gxn" = (
-/obj/structure/cable,
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/hallway";
 	name = "Hallway Turret Control";
@@ -24898,7 +24899,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
 	dir = 6
 	},
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/solars)
 "gBi" = (
@@ -26032,7 +26032,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "gOH" = (
-/obj/structure/cable,
 /obj/item/crowbar,
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -27521,6 +27520,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "hlg" = (
@@ -28025,7 +28025,6 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hsl" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
 	dir = 9
 	},
@@ -28184,6 +28183,7 @@
 	dir = 8;
 	name = "Command blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "htR" = (
@@ -28366,7 +28366,6 @@
 /area/station/hallway/primary/fore)
 "hwz" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "hwM" = (
@@ -29437,6 +29436,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "hJP" = (
@@ -29502,7 +29502,7 @@
 	dir = 8;
 	pixel_y = -32
 	},
-/obj/machinery/light/small/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "hKw" = (
@@ -30039,6 +30039,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "hSi" = (
@@ -32643,6 +32644,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "iCg" = (
@@ -33332,16 +33334,12 @@
 	dir = 4;
 	layer = 2.9
 	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai";
-	name = "AI Chamber APC";
-	pixel_y = -25
-	},
 /obj/machinery/flasher/directional/south{
 	id = "AI";
 	pixel_x = -11
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "iLU" = (
@@ -36011,6 +36009,7 @@
 	c_tag = "Engineering - SM Room SE";
 	network = list("ss13", "engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "jyg" = (
@@ -37733,7 +37732,6 @@
 	dir = 8;
 	name = "Atmos to Loop"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "jUj" = (
@@ -41176,6 +41174,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/structure/bed/maint,
 /obj/machinery/light_switch/directional/east,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "kMU" = (
@@ -41481,7 +41480,6 @@
 	dir = 8;
 	name = "Mix to Gas"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "kRZ" = (
@@ -42171,6 +42169,7 @@
 	dir = 1;
 	name = "Engine Coolant Bypass"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "lcR" = (
@@ -44413,9 +44412,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lGh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/floor/engine,
-/area/station/engineering/main)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "lGr" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -46759,10 +46759,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "mhk" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "mhn" = (
 /turf/closed/wall,
 /area/station/medical/medbay/central)
@@ -48198,6 +48198,7 @@
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "mAg" = (
@@ -48268,6 +48269,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "mAQ" = (
@@ -49227,6 +49229,7 @@
 /obj/structure/sign/warning/radiation{
 	pixel_x = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "mMb" = (
@@ -54072,6 +54075,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "obm" = (
@@ -55472,13 +55476,12 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/cmo)
 "ouN" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	name = "External Airlock"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ouW" = (
@@ -55501,6 +55504,7 @@
 /area/ai_monitored/command/storage/eva)
 "ovf" = (
 /obj/effect/landmark/navigate_destination/dockescpod3,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "ovs" = (
@@ -56988,7 +56992,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "oRe" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 1
 	},
 /turf/open/space/basic,
@@ -57021,6 +57025,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "oRK" = (
@@ -58306,10 +58311,9 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison/safe)
 "pkC" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/structure/grille/broken,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/maintenance/department/engine)
 "pkE" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Modules";
@@ -64410,7 +64414,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "qPC" = (
-/obj/machinery/modular_computer/console/preset/civilian{
+/obj/machinery/computer/rdconsole{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -74052,6 +74056,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "tsf" = (
@@ -74736,6 +74741,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/firecloset/full,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "tAe" = (
@@ -74750,9 +74756,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/atrium)
 "tAw" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/eighties,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "tAC" = (
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -76038,6 +76045,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "tVA" = (
@@ -77555,6 +77563,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "uql" = (
@@ -77576,6 +77585,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "uqJ" = (
@@ -79148,9 +79158,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "uMi" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "uMl" = (
 /obj/machinery/shower{
 	pixel_y = 25
@@ -79918,6 +79931,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "uWh" = (
@@ -80598,7 +80612,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "veD" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -81454,16 +81467,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/power/apc/highcap/ten_k{
-	dir = 4;
-	name = "Delivery Office APC";
-	pixel_x = 25
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "vqc" = (
@@ -83321,6 +83330,7 @@
 	c_tag = "Engineering - SM Room NE";
 	network = list("ss13", "engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "vSJ" = (
@@ -84698,7 +84708,6 @@
 	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wqx" = (
@@ -87684,9 +87693,11 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
 "xac" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/engineering/main)
 "xae" = (
 /obj/structure/cable,
@@ -88648,12 +88659,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "xkF" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/medical/virology";
-	dir = 4;
-	name = "Virology APC";
-	pixel_x = 25
-	},
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	name = "Virology air supply valve"
 	},
@@ -88665,6 +88670,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "xkL" = (
@@ -110218,7 +110224,7 @@ xRN
 qnP
 xRN
 lbk
-yel
+dTZ
 uyW
 lFp
 lFp
@@ -113034,7 +113040,7 @@ wAF
 jak
 nKe
 eAN
-slU
+cOZ
 dnh
 sEj
 yel
@@ -113993,7 +113999,7 @@ vDp
 pDA
 uOg
 irw
-aZu
+cSp
 oPL
 qOr
 soj
@@ -115104,25 +115110,25 @@ wqo
 hwz
 fae
 ouN
-mhk
-mhk
-mhk
-mhk
-mhk
+xdv
+xdv
+xdv
+xdv
+xdv
 xBY
 iQW
 xBY
 iQW
 iQW
 iQW
-mhk
-mhk
-mhk
-mhk
-mhk
-mhk
-xac
-cQC
+xdv
+xdv
+xdv
+xdv
+xdv
+xdv
+kOC
+mHl
 jGJ
 meK
 iAe
@@ -115365,14 +115371,14 @@ iQW
 iQW
 iQW
 iQW
-mhk
+xdv
 xBY
 iQW
 yju
 iQW
-mhk
-mhk
-mhk
+xdv
+xdv
+xdv
 yju
 dNL
 rbs
@@ -115622,12 +115628,12 @@ iQW
 iQW
 iQW
 iQW
-mhk
+xdv
 xBY
 iQW
 xBY
 iQW
-mhk
+xdv
 dNL
 rvb
 rvb
@@ -115879,12 +115885,12 @@ iQW
 iQW
 iQW
 iQW
-mhk
+xdv
 xBY
 yju
 xBY
 yju
-mhk
+xdv
 gBN
 tvJ
 rvb
@@ -116136,12 +116142,12 @@ yju
 yju
 yju
 yju
-mhk
+xdv
 vmD
 iQW
 xBY
 iQW
-mhk
+xdv
 dNL
 tvJ
 rvb
@@ -116393,12 +116399,12 @@ iQW
 iQW
 iQW
 iQW
-mhk
+xdv
 iQW
 iQW
 xBY
 iQW
-mhk
+xdv
 gBN
 rvb
 rvb
@@ -116637,7 +116643,7 @@ xRN
 jlm
 yel
 wUo
-gLP
+cQC
 faX
 sSK
 xRN
@@ -116650,12 +116656,12 @@ iQW
 iQW
 iQW
 iQW
-mhk
+xdv
 iQW
 iQW
 xBY
 yju
-mhk
+xdv
 dNL
 tvJ
 rvb
@@ -116907,12 +116913,12 @@ iQW
 iQW
 iQW
 iQW
-mhk
-mhk
-mhk
-mhk
-mhk
-mhk
+xdv
+xdv
+xdv
+xdv
+xdv
+xdv
 gBN
 tvJ
 rvb
@@ -117956,10 +117962,10 @@ ujk
 dCs
 mSI
 qWw
-qiQ
+tAw
 aQq
-wuD
-dCs
+uMi
+eJg
 tzQ
 kOC
 iQW
@@ -118217,7 +118223,7 @@ nZr
 nZr
 wuD
 chJ
-mSI
+cmQ
 kOC
 iQW
 vmD
@@ -118474,7 +118480,7 @@ wLY
 jQD
 bmx
 dCs
-mSI
+cmQ
 ouh
 yju
 sOe
@@ -118731,7 +118737,7 @@ wLY
 bZn
 uix
 jRE
-mSI
+cmQ
 ouh
 yju
 vmD
@@ -118988,7 +118994,7 @@ qEy
 fHE
 wgv
 dCs
-mSI
+cmQ
 ouh
 yju
 vmD
@@ -119759,7 +119765,7 @@ cdt
 cdt
 cwH
 dCs
-dCs
+eJg
 dCs
 tYd
 ouh
@@ -120005,8 +120011,8 @@ kOC
 xzl
 aMW
 gap
-lGh
-lGh
+gap
+gap
 baQ
 iBZ
 lcH
@@ -120016,7 +120022,7 @@ uqr
 uqr
 mSu
 dCs
-dCs
+eJg
 tOM
 tID
 ouh
@@ -120262,18 +120268,18 @@ kOC
 sGU
 qsr
 fOe
-eJg
+dCs
 gOH
-eJg
-eJg
+dCs
+dCs
 veD
-eJg
+dCs
 jUi
-eJg
-eJg
+dCs
+dCs
 kRY
 dCs
-dCs
+eJg
 tOM
 tID
 ouh
@@ -120528,9 +120534,9 @@ hJO
 oaZ
 hkZ
 cyA
-lQL
-dCs
-dCs
+xac
+eJg
+eJg
 hyj
 tID
 ouh
@@ -120773,7 +120779,7 @@ pGW
 bOQ
 swb
 vVh
-vVh
+lGh
 wjz
 ouh
 ouh
@@ -121030,7 +121036,7 @@ qlN
 wxh
 jhU
 vVh
-gKe
+mhk
 gKe
 iQW
 iQW
@@ -121541,8 +121547,8 @@ oEa
 oEa
 oEa
 uWb
-sdd
-sdd
+iaw
+iaw
 caf
 ovf
 rzw
@@ -121681,7 +121687,7 @@ yju
 yju
 yju
 vEN
-uMi
+sWA
 xNP
 vEN
 fJE
@@ -121796,12 +121802,12 @@ sdd
 sdd
 sdd
 sdd
-iaw
+sdd
 gld
 sdd
 cqJ
 gKe
-sdd
+pkC
 gKe
 iQW
 iQW
@@ -133824,7 +133830,7 @@ kgq
 iiY
 gzK
 ptu
-cOZ
+jCH
 ptu
 dMp
 mJZ
@@ -134794,7 +134800,7 @@ vtg
 iHi
 rvY
 oPz
-tAw
+iVj
 iVj
 oPz
 rvY
@@ -136873,7 +136879,7 @@ ycg
 doC
 oLT
 ygs
-pkC
+dHz
 ycg
 jpu
 vmT
@@ -141708,7 +141714,7 @@ dfy
 dNs
 tsq
 ijf
-oBu
+aZu
 huJ
 yec
 yec
@@ -142551,7 +142557,7 @@ iQW
 xBU
 dqQ
 wpj
-dTZ
+wpj
 cAq
 uYY
 xBU

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -9157,11 +9157,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"csW" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
 "csX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -13301,6 +13296,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"dxK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "dxV" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/britcup,
@@ -15059,9 +15059,6 @@
 /area/ai_monitored/turret_protected/aisat/atmos)
 "dWS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
@@ -34273,7 +34270,7 @@
 /area/station/medical/chemistry)
 "iYz" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/machinery/atmospherics/components/unary/passive_vent,
 /turf/open/space/basic,
 /area/station/medical/chemistry)
 "iYD" = (
@@ -118221,7 +118218,7 @@ nZr
 nZr
 wuD
 chJ
-csW
+dxK
 kOC
 iQW
 vmD
@@ -118478,7 +118475,7 @@ wLY
 jQD
 bmx
 dCs
-csW
+dxK
 ouh
 yju
 sOe
@@ -118735,7 +118732,7 @@ wLY
 bZn
 uix
 jRE
-csW
+dxK
 ouh
 yju
 vmD
@@ -118992,7 +118989,7 @@ qEy
 fHE
 wgv
 dCs
-csW
+dxK
 ouh
 yju
 vmD

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -10874,11 +10874,9 @@
 /turf/closed/wall,
 /area/station/commons/dorms)
 "cQC" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/iron,
+/area/station/maintenance/department/cargo)
 "cQH" = (
 /obj/structure/table,
 /obj/item/flashlight,
@@ -14803,8 +14801,8 @@
 /area/station/cargo/qm)
 "dTZ" = (
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/wood,
+/area/station/maintenance/port/aft)
 "dUk" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -28262,13 +28260,6 @@
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall,
 /area/station/science/xenobiology)
-"huO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
 "hvf" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -30595,7 +30586,7 @@
 /area/station/maintenance/starboard/fore)
 "iaw" = (
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "iax" = (
 /obj/structure/chair/wood/wings,
@@ -44415,9 +44406,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lGh" = (
-/obj/effect/landmark/xeno_spawn,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/department/engine)
 "lGr" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -46762,6 +46753,7 @@
 /area/station/maintenance/department/science)
 "mhk" = (
 /obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "mhn" = (
@@ -54390,11 +54382,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
-"odL" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
 "odU" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -58318,7 +58305,7 @@
 /area/station/security/prison/safe)
 "pkC" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "pkE" = (
@@ -61234,13 +61221,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/station/commons/fitness)
-"pXy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
 "pXF" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
@@ -71208,6 +71188,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
+"sBL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "sBS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -74768,8 +74755,7 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/atrium)
 "tAw" = (
-/obj/structure/cable,
-/obj/structure/closet/emcloset,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "tAC" = (
@@ -79170,9 +79156,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "uMi" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "uMl" = (
 /obj/machinery/shower{
 	pixel_y = 25
@@ -87702,7 +87689,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
 "xac" = (
-/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -88347,6 +88336,11 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
+"xht" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "xhE" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -110231,7 +110225,7 @@ xRN
 qnP
 xRN
 lbk
-lGh
+iaw
 uyW
 lFp
 lFp
@@ -113047,7 +113041,7 @@ wAF
 jak
 nKe
 eAN
-dTZ
+cQC
 dnh
 sEj
 yel
@@ -115507,11 +115501,11 @@ bfi
 bfi
 yju
 bfi
-aZu
+bfi
 bfi
 bfi
 xdv
-cQC
+bfi
 bfi
 vAZ
 iQW
@@ -116650,7 +116644,7 @@ xRN
 jlm
 yel
 wUo
-iaw
+dTZ
 faX
 sSK
 xRN
@@ -117969,9 +117963,9 @@ ujk
 dCs
 mSI
 qWw
-xac
+uMi
 aQq
-huO
+xac
 eJg
 tzQ
 kOC
@@ -118230,7 +118224,7 @@ nZr
 nZr
 wuD
 chJ
-odL
+xht
 kOC
 iQW
 vmD
@@ -118487,7 +118481,7 @@ wLY
 jQD
 bmx
 dCs
-odL
+xht
 ouh
 yju
 sOe
@@ -118744,7 +118738,7 @@ wLY
 bZn
 uix
 jRE
-odL
+xht
 ouh
 yju
 vmD
@@ -119001,7 +118995,7 @@ qEy
 fHE
 wgv
 dCs
-odL
+xht
 ouh
 yju
 vmD
@@ -120541,7 +120535,7 @@ hJO
 oaZ
 hkZ
 cyA
-pXy
+sBL
 eJg
 eJg
 hyj
@@ -120786,7 +120780,7 @@ pGW
 bOQ
 swb
 vVh
-pkC
+mhk
 wjz
 ouh
 ouh
@@ -121043,7 +121037,7 @@ qlN
 wxh
 jhU
 vVh
-tAw
+pkC
 gKe
 iQW
 iQW
@@ -121554,8 +121548,8 @@ oEa
 oEa
 oEa
 uWb
-mhk
-mhk
+lGh
+lGh
 caf
 ovf
 rzw
@@ -121814,7 +121808,7 @@ gld
 sdd
 cqJ
 gKe
-uMi
+tAw
 gKe
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -24,11 +24,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
-	name = "AI Hallway APC";
-	pixel_y = -25
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "aap" = (
@@ -1652,7 +1648,6 @@
 	name = "Supermatter Engine Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -1815,25 +1810,15 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "axL" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/aft";
-	dir = 8;
-	name = "Port Quarter Maintenance APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/structure/closet/emcloset,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "axR" = (
 /obj/structure/closet/toolcloset,
-/obj/machinery/power/apc{
-	areastring = "/area/commons/storage/tools";
-	dir = 1;
-	name = "Auxiliary Tool Storage APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "axU" = (
@@ -1859,12 +1844,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ayp" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/janitor";
-	dir = 8;
-	name = "Custodial Closet APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -1872,6 +1851,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "ayu" = (
@@ -2000,6 +1980,7 @@
 	dir = 1;
 	name = "Security red corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/security/checkpoint/medical)
 "aAv" = (
@@ -2470,12 +2451,6 @@
 /obj/structure/window{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/commons/storage/art";
-	dir = 1;
-	name = "Art Storage";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/structure/table,
 /obj/item/stack/pipe_cleaner_coil/random,
@@ -2485,6 +2460,7 @@
 /obj/item/stack/pipe_cleaner_coil/random,
 /obj/item/stack/pipe_cleaner_coil/random,
 /obj/item/paper_bin/construction,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/art)
 "aJn" = (
@@ -2806,11 +2782,6 @@
 /area/station/security/courtroom)
 "aOe" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/command/storage/eva";
-	name = "EVA Storage APC";
-	pixel_y = -25
-	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	name = "Command blue corner"
@@ -2826,6 +2797,7 @@
 	name = "Command blue corner"
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aOk" = (
@@ -3316,8 +3288,8 @@
 /area/station/security/courtroom)
 "aTk" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/construction)
+/turf/open/floor/iron,
+/area/station/commons/fitness)
 "aTM" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Pharmacy";
@@ -3609,14 +3581,8 @@
 /area/station/science/mixing)
 "aWD" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/medical";
-	dir = 8;
-	name = "Medbay Security APC";
-	pixel_x = -25
-	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/medical)
+/area/station/service/library/abandoned)
 "aWE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -3639,6 +3605,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "aWP" = (
@@ -3876,6 +3843,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "baI" = (
@@ -3885,15 +3853,11 @@
 /area/station/maintenance/fore)
 "baJ" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat";
-	name = "AI Satellite Exterior APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/east{
 	pixel_y = -32
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat)
 "baQ" = (
@@ -4042,14 +4006,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science)
 "bcA" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/main)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "bcD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -4756,6 +4715,7 @@
 	dir = 8;
 	name = "Security red corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "bms" = (
@@ -5071,12 +5031,6 @@
 /area/station/command/teleporter)
 "brN" = (
 /obj/machinery/computer/station_alert,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
-	dir = 1;
-	name = "AI Satellite Foyer APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -5092,6 +5046,7 @@
 	dir = 8;
 	name = "Command blue corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "brS" = (
@@ -5210,6 +5165,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bsL" = (
@@ -5264,13 +5220,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/security/detectives_office";
-	dir = 8;
-	name = "Detective's Office APC";
-	pixel_x = -25
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "buj" = (
@@ -5346,7 +5297,6 @@
 	name = "Laser Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -6579,6 +6529,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -6610,6 +6561,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bJo" = (
@@ -6877,11 +6829,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bNg" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/exam_room";
-	name = "Medbay Exam Room APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -6892,6 +6839,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bNk" = (
@@ -7069,7 +7017,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bPB" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -7083,6 +7030,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bPJ" = (
@@ -7694,6 +7642,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "bXs" = (
@@ -7955,17 +7904,12 @@
 /turf/open/floor/iron,
 /area/station/science)
 "caz" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/chapel/office";
-	dir = 8;
-	name = "Chapel Office APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/machinery/camera/directional/west{
 	c_tag = "Service - Chaplain Office";
 	network = list("ss13", "service")
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "caB" = (
@@ -8485,12 +8429,6 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/spawner/random/decoration/glowstick,
-/obj/machinery/power/apc{
-	areastring = "/area/service/library/abandoned";
-	dir = 1;
-	name = "Art Room APC";
-	pixel_y = 25
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "cjn" = (
@@ -8931,7 +8869,6 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -9054,14 +8991,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "cqr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/chapel/dock";
-	dir = 4;
-	name = "Space Burial APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "cqx" = (
@@ -9128,13 +9060,8 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "crJ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/engine/atmos";
-	dir = 8;
-	name = "Atmospherics Maint APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "crP" = (
@@ -9501,13 +9428,8 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "cww" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/medical";
-	dir = 8;
-	name = "Medbay Maint APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "cwx" = (
@@ -9682,13 +9604,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/department/medical)
 "cyk" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/starboard/fore";
-	dir = 8;
-	name = "Starboard Bow Solar APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "cyl" = (
@@ -9707,7 +9624,6 @@
 /area/station/security/checkpoint/medical)
 "cyp" = (
 /obj/structure/rack,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
@@ -10449,12 +10365,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cGJ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/entry";
-	dir = 4;
-	name = "Entry Hall APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -10463,6 +10373,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "cGY" = (
@@ -10674,7 +10585,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "cKe" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -10965,6 +10875,10 @@
 "cQw" = (
 /turf/closed/wall,
 /area/station/commons/dorms)
+"cQC" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "cQH" = (
 /obj/structure/table,
 /obj/item/flashlight,
@@ -11111,6 +11025,7 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
 "cSu" = (
@@ -11698,6 +11613,7 @@
 	color = "#f2c2e3";
 	name = "pink corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/library/abandoned)
 "cYE" = (
@@ -11775,6 +11691,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "daq" = (
@@ -11911,7 +11828,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction)
 "dbF" = (
@@ -12449,7 +12365,8 @@
 	dir = 4;
 	name = "Command blue corner"
 	},
-/obj/machinery/light_switch/directional/south,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "djG" = (
@@ -12977,13 +12894,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science)
 "dsN" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/port/fore";
-	dir = 8;
-	name = "Port Bow Solar APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "dsW" = (
@@ -13166,12 +13078,7 @@
 	dir = 1;
 	name = "Security red corner"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/brig";
-	dir = 4;
-	name = "Brig APC";
-	pixel_x = 25
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "duI" = (
@@ -13379,7 +13286,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/central)
 "dxt" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
@@ -13391,6 +13297,7 @@
 	},
 /obj/structure/cable/layer1,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "dxV" = (
@@ -13578,13 +13485,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "dAH" = (
-/obj/machinery/power/apc{
-	areastring = "/area/construction";
-	dir = 8;
-	name = "Construction Area APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/construction)
 "dAU" = (
@@ -13903,6 +13805,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "dGD" = (
@@ -14007,6 +13910,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "dIe" = (
@@ -14772,7 +14676,6 @@
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "dSy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -14931,7 +14834,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "dUH" = (
@@ -15084,17 +14986,11 @@
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "dWv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/tcommsat/computer";
-	name = "Telecomms Monitoring APC";
-	pixel_y = -25
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/turf/open/floor/vault,
+/area/station/command/bridge)
 "dWx" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 13
@@ -15576,6 +15472,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "ecg" = (
@@ -16180,13 +16078,8 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "ekk" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/library";
-	dir = 8;
-	name = "Library APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "eks" = (
@@ -16214,13 +16107,8 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/service/hydroponics";
-	dir = 1;
-	name = "Hydroponics APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "ekB" = (
@@ -16252,16 +16140,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ekS" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/port";
-	dir = 8;
-	name = "Port Hallway APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/hallway/primary/port)
 "eld" = (
@@ -16547,13 +16430,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "epe" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/tcommsat/server";
-	dir = 1;
-	name = "Telecomms Server APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "epm" = (
@@ -16696,12 +16574,6 @@
 /area/station/service/library)
 "esk" = (
 /obj/structure/rack,
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/engineering/main";
-	dir = 1;
-	name = "Engineering APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -16717,6 +16589,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
 /obj/item/clothing/glasses/meson/engine,
 /obj/machinery/light/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "esp" = (
@@ -16975,14 +16848,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "eve" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/port/aft)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/station/hallway/secondary/command)
 "evj" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/cable,
@@ -17174,7 +17043,6 @@
 "exF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction)
 "exG" = (
@@ -19055,11 +18923,6 @@
 /area/station/maintenance/fore)
 "eZZ" = (
 /obj/structure/table/glass,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/medbay/central";
-	name = "Stasis Room APC";
-	pixel_y = -25
-	},
 /obj/machinery/light_switch/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -19080,6 +18943,7 @@
 /obj/item/clothing/under/misc/pj/red,
 /obj/item/storage/box,
 /obj/item/blood_filter,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "faa" = (
@@ -19113,6 +18977,7 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "faq" = (
@@ -19953,6 +19818,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "flo" = (
@@ -20241,12 +20108,6 @@
 "fou" = (
 /obj/structure/table/glass,
 /obj/item/hand_labeler,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/pharmacy";
-	dir = 8;
-	name = "Pharmacy APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -20268,6 +20129,7 @@
 	name = "pharmacy shutters control";
 	req_access_txt = "5; 69"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fox" = (
@@ -20348,13 +20210,6 @@
 "fpn" = (
 /obj/structure/chair/comfy/brown{
 	color = "#87CEFA"
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/command/bridge";
-	dir = 1;
-	name = "Bridge APC";
-	pixel_y = 25
 	},
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/command)
@@ -20554,12 +20409,6 @@
 "frD" = (
 /obj/structure/table/glass,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/surgery";
-	dir = 8;
-	name = "Surgery A APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -20571,15 +20420,10 @@
 	dir = 1;
 	name = "Medical blue corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "frE" = (
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/cmo";
-	dir = 4;
-	name = "CMO's Office APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -20605,6 +20449,7 @@
 	name = "Chief Medical Officer's RC"
 	},
 /obj/machinery/pdapainter/medbay,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "frF" = (
@@ -20857,6 +20702,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "fvc" = (
@@ -21135,12 +20981,6 @@
 "fyJ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /mob/living/simple_animal/parrot/poly,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/command/heads_quarters/ce";
-	dir = 4;
-	name = "CE Office APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -21151,6 +20991,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "fzk" = (
@@ -21341,6 +21182,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "fBS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/command)
@@ -21399,6 +21243,7 @@
 	color = "#000000";
 	name = "dark corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "fDA" = (
@@ -21482,12 +21327,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "fEC" = (
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/miningdock";
-	dir = 1;
-	name = "Mining Dock APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21498,6 +21337,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "fEG" = (
@@ -21698,11 +21538,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "fHt" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/medbay";
-	name = "Medbay APC";
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -21723,6 +21558,7 @@
 	name = "Medical blue corner"
 	},
 /obj/effect/landmark/start/paramedic,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "fHD" = (
@@ -21912,6 +21748,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display/evac/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "fJm" = (
@@ -21939,12 +21776,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "fJF" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
-	dir = 8;
-	name = "Engineering Security APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -21966,6 +21797,7 @@
 	departmentType = 5;
 	name = "Engineering Post Requests Console"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "fJN" = (
@@ -22999,15 +22831,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "fYr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/construction/mining/aux_base";
-	dir = 8;
-	name = "Auxillary Base Construction APC";
-	pixel_x = -25
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/area/station/maintenance/department/cargo)
 "fYC" = (
 /obj/item/stack/medical/bruise_pack,
 /obj/effect/turf_decal/tile/blue{
@@ -24189,6 +24021,7 @@
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "gpG" = (
@@ -24270,7 +24103,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "gqx" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -24285,12 +24117,7 @@
 /area/station/medical/virology)
 "gqA" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/service/chapel";
-	dir = 4;
-	name = "Chapel APC";
-	pixel_x = 25
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/carpet/lone/star,
 /area/station/service/chapel)
 "gqU" = (
@@ -24432,7 +24259,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gtm" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24774,12 +24600,13 @@
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
-/obj/machinery/status_display/evac/directional/south,
 /obj/machinery/button/door/directional/east{
 	id = "aux_base_shutters";
 	name = "Public Shutters Control";
 	req_one_access_txt = "72"
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "gxq" = (
@@ -24891,6 +24718,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "gyQ" = (
@@ -25454,7 +25282,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "gHi" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
@@ -25705,17 +25532,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "gJE" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/bar";
-	name = "Bar APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "gJI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -26795,15 +26614,11 @@
 	dir = 8;
 	name = "Command blue corner"
 	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai_upload";
-	name = "Upload APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/structure/table,
 /obj/item/ai_module/reset,
 /obj/item/ai_module/supplied/quarantine,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "gWO" = (
@@ -26819,6 +26634,7 @@
 	req_access_txt = "38"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine/atmos)
 "gXd" = (
@@ -27040,12 +26856,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science)
 "gZa" = (
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/warehouse";
-	dir = 4;
-	name = "Cargo Warehouse APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -27132,6 +26942,7 @@
 	name = "Auxillary Base Construction";
 	req_one_access_txt = "72"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
 "haX" = (
@@ -27145,14 +26956,18 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "hbm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding{
+	color = "#4C3117";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/siding{
+	color = "#4C3117";
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/commons/fitness)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/lawoffice)
 "hbo" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_mindbreaker{
@@ -27193,6 +27008,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "hbN" = (
@@ -27246,6 +27062,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "hcG" = (
@@ -27409,6 +27226,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "hfy" = (
@@ -27439,6 +27257,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "hfS" = (
@@ -28082,12 +27901,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "hpL" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/storage";
-	dir = 4;
-	name = "Medbay Storage APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/tile/blue{
@@ -28099,6 +27912,7 @@
 	dir = 4;
 	name = "Medical blue corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "hqe" = (
@@ -28247,13 +28061,8 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "hsN" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/library/artgallery";
-	dir = 8;
-	name = "Art Gallery APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
 "hsS" = (
@@ -28458,12 +28267,6 @@
 /turf/closed/wall,
 /area/station/science/xenobiology)
 "hvf" = (
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/hos";
-	dir = 1;
-	name = "Head of Security's Office APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -28475,6 +28278,7 @@
 	dir = 1;
 	name = "Security red corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "hvq" = (
@@ -28529,6 +28333,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "hwh" = (
@@ -28561,6 +28366,7 @@
 /area/station/hallway/primary/fore)
 "hwz" = (
 /obj/machinery/light/small/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "hwM" = (
@@ -28756,13 +28562,13 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/art)
 "hyY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/cable/layer1,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "hzc" = (
@@ -29388,16 +29194,11 @@
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/gravity_generator";
-	dir = 8;
-	name = "Gravity Generator APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "hIk" = (
@@ -29593,11 +29394,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "hJG" = (
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/office";
-	name = "Cargo Office APC";
-	pixel_y = -25
-	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown,
@@ -29608,6 +29404,7 @@
 	dir = 8
 	},
 /obj/structure/closet/crate,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "hJH" = (
@@ -29745,12 +29542,6 @@
 "hKH" = (
 /obj/machinery/disposal/bin,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/commons/vacant_room/commissary";
-	dir = 8;
-	name = "Vacant Commissary APC";
-	pixel_x = -25
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -29760,6 +29551,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "hKL" = (
@@ -30696,6 +30488,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "hZs" = (
@@ -30798,12 +30591,6 @@
 /area/station/maintenance/starboard/fore)
 "iaw" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/atmospherics_engine";
-	dir = 4;
-	name = "Atmos Engine APC";
-	pixel_x = 25
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "iax" = (
@@ -31356,12 +31143,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "igW" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/warden";
-	dir = 8;
-	name = "Brig Control APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -31373,6 +31154,7 @@
 	dir = 1;
 	name = "Security red corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "igY" = (
@@ -31685,7 +31467,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay)
 "ikx" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -31869,6 +31650,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "inq" = (
@@ -31922,12 +31704,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "inW" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 4;
-	name = "Service Hall APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -31940,6 +31716,7 @@
 	dir = 8
 	},
 /obj/machinery/recharge_station,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "iod" = (
@@ -33775,6 +33552,7 @@
 	dir = 9
 	},
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "iNU" = (
@@ -33833,7 +33611,6 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "iPY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -33866,15 +33643,10 @@
 /area/station/engineering/transit_tube)
 "iQg" = (
 /obj/structure/rack,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/central";
-	dir = 1;
-	name = "Central Maintenance APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/item/storage/toolbox/emergency,
 /obj/item/stack/cable_coil,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "iQi" = (
@@ -34189,11 +33961,6 @@
 /turf/open/floor/plating,
 /area/station/science/mixing)
 "iVg" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/central";
-	name = "Central Primary Hallway APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34202,6 +33969,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "iVj" = (
@@ -35256,6 +35024,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "jlM" = (
@@ -35484,6 +35253,7 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "joj" = (
@@ -35791,12 +35561,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/upper)
 "jsk" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/abandoned_gambling_den";
-	name = "Abandoned Gambling Den APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "jsl" = (
@@ -35921,6 +35687,8 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "jtL" = (
@@ -36327,12 +36095,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "jzh" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/aft";
-	dir = 8;
-	name = "Aft Hall APC";
-	pixel_x = -25
-	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/cable,
 /obj/machinery/disposal/bin,
@@ -36342,6 +36104,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 9
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "jzl" = (
@@ -36560,6 +36323,8 @@
 /area/station/solars/port/aft)
 "jDs" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
 "jDD" = (
@@ -39277,6 +39042,7 @@
 	name = "Disposal Access";
 	req_access_txt = "12"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "klo" = (
@@ -39927,13 +39693,8 @@
 	network = list("cargo");
 	pixel_x = 30
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/supply";
-	dir = 1;
-	name = "Cargo Security APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "kvi" = (
@@ -40409,6 +40170,8 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Public - Vacant Office"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "kBw" = (
@@ -41100,6 +40863,7 @@
 /area/station/commons/locker)
 "kJo" = (
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "kJr" = (
@@ -42830,11 +42594,8 @@
 	dir = 4;
 	name = "Security red corner"
 	},
-/obj/machinery/door_timer{
-	id = "medcell";
-	name = "Medical Cell";
-	pixel_x = -32
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "lhR" = (
@@ -43212,12 +42973,8 @@
 /area/station/maintenance/fore)
 "lng" = (
 /obj/machinery/holopad/secure,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	name = "AI Satellite Interior APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "lni" = (
@@ -43255,6 +43012,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/command)
 "lnY" = (
@@ -44036,6 +43794,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lys" = (
@@ -44247,6 +44006,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "lAZ" = (
@@ -44254,7 +44014,6 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/rec)
 "lBo" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -44641,6 +44400,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "lGe" = (
@@ -45011,6 +44771,7 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/structure/fireaxecabinet/directional/south,
+/obj/structure/cable,
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "lJH" = (
@@ -45096,6 +44857,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "lJX" = (
@@ -45366,6 +45129,7 @@
 	name = "MiniSat Access";
 	req_access_txt = "65"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "lOs" = (
@@ -46720,6 +46484,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mek" = (
@@ -46993,18 +46759,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "mhk" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/lawoffice";
-	dir = 1;
-	name = "Law Office APC";
-	pixel_y = 25
-	},
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/turf/open/space/basic,
+/area/space/nearstation)
 "mhn" = (
 /turf/closed/wall,
 /area/station/medical/medbay/central)
@@ -47075,11 +46833,6 @@
 /area/station/engineering/main)
 "miV" = (
 /obj/structure/closet/toolcloset,
-/obj/machinery/power/apc{
-	areastring = "/area/commons/storage/primary";
-	name = "Primary Tool Storage APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -47096,6 +46849,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/effect/landmark/start/hangover/closet,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "miW" = (
@@ -47495,6 +47249,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "mmB" = (
@@ -48309,7 +48064,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction)
 "mxQ" = (
@@ -48609,6 +48363,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
 "mBv" = (
@@ -48802,6 +48557,8 @@
 	},
 /obj/item/kitchen/rollingpin,
 /obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "mEj" = (
@@ -49689,6 +49446,7 @@
 /area/station/service/chapel)
 "mPq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "mPE" = (
@@ -49768,6 +49526,7 @@
 	dir = 1
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "mQR" = (
@@ -50038,13 +49797,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/starboard/fore";
-	dir = 1;
-	name = "Starboard Bow Maintenance APC";
-	pixel_y = 25
-	},
 /obj/structure/barricade/wooden,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "mSI" = (
@@ -50982,6 +50736,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "nfh" = (
@@ -52365,13 +52120,8 @@
 	dir = 4;
 	name = "Medical blue corner"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/chemistry";
-	dir = 4;
-	name = "Chemistry APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "nxF" = (
@@ -52754,7 +52504,6 @@
 /turf/open/floor/iron,
 /area/station/science)
 "nCR" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
@@ -53157,6 +52906,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "nJe" = (
@@ -53482,13 +53232,8 @@
 "nNS" = (
 /obj/structure/table/wood,
 /obj/item/pizzabox/margherita,
-/obj/machinery/power/apc{
-	areastring = "/area/service/theater";
-	dir = 1;
-	name = "Theatre APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "nNU" = (
@@ -53670,6 +53415,7 @@
 	pixel_y = 4
 	},
 /obj/item/storage/box/ids,
+/obj/structure/cable,
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "nQM" = (
@@ -53699,20 +53445,17 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "nRE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
 	name = "dark corner"
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -54230,7 +53973,6 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 9
 	},
@@ -54511,6 +54253,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "ocM" = (
@@ -54960,12 +54703,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ojU" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/fore";
-	name = "Fore Maintenance APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "okc" = (
@@ -55258,6 +54997,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ooa" = (
@@ -55543,6 +55283,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "ors" = (
@@ -55588,12 +55329,6 @@
 /area/station/hallway/primary/central)
 "osi" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/engine_smes";
-	dir = 4;
-	name = "SMES room APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -55609,6 +55344,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "osB" = (
@@ -55617,6 +55353,7 @@
 "osO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "osW" = (
@@ -55741,6 +55478,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ouW" = (
@@ -55783,15 +55521,21 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "ovD" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/transit_tube";
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
 	dir = 1;
-	name = "Transit Tubes APC";
-	pixel_y = 25
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "ovF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -55851,7 +55595,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "owL" = (
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/command)
@@ -56209,12 +55952,6 @@
 /turf/open/floor/carpet/black,
 /area/station/service/bar)
 "oCA" = (
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/captain";
-	dir = 1;
-	name = "Captain's Office APC";
-	pixel_y = 25
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
@@ -56222,6 +55959,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain)
 "oCH" = (
@@ -56352,17 +56090,13 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "oEd" = (
-/obj/machinery/power/apc{
-	areastring = "/area/commons/dorms";
-	name = "Dormitories APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/chair/stool/directional/north,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oEI" = (
@@ -56677,7 +56411,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction)
 "oIl" = (
@@ -57190,12 +56923,6 @@
 /obj/structure/table,
 /obj/item/aicard,
 /obj/item/ai_module/reset,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/storage/tech";
-	dir = 8;
-	name = "Tech Storage APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -57207,10 +56934,10 @@
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "oQn" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -58520,12 +58247,19 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "pkf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/command)
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "pkj" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/item/soap/deluxe,
@@ -58608,12 +58342,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "pkQ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/engine";
-	dir = 8;
-	name = "Engineering Maint APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -58621,6 +58349,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "plb" = (
@@ -59097,7 +58826,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "prp" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -59112,6 +58840,7 @@
 	},
 /obj/structure/cable/layer1,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pry" = (
@@ -59942,6 +59671,8 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "pBi" = (
@@ -60257,6 +59988,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "pFC" = (
@@ -60652,7 +60384,6 @@
 	name = "Engineering Maintenance";
 	req_one_access_txt = "10;24"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
@@ -60824,6 +60555,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "pOr" = (
@@ -61168,6 +60900,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "pUi" = (
@@ -62024,12 +61757,6 @@
 	},
 /area/station/science/xenobiology)
 "qeF" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal";
-	dir = 8;
-	name = "Disposal APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/garbage,
 /obj/structure/disposalpipe/segment,
@@ -62074,15 +61801,14 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/starboard/fore)
 "qfV" = (
-/obj/machinery/power/apc{
-	areastring = "/area/commons/vacant_room/office";
-	dir = 8;
-	name = "Vacant Office APC";
-	pixel_x = -25
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "qfZ" = (
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat/service)
@@ -62163,12 +61889,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "qgs" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal/incinerator";
-	dir = 8;
-	name = "Incinerator APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -62183,6 +61903,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "qgw" = (
@@ -62237,17 +61958,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "qhm" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/break_room";
-	dir = 8;
-	name = "Break Room APC";
-	pixel_x = -25
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
-/area/station/maintenance/department/medical)
+/area/station/engineering/lobby)
 "qho" = (
 /obj/structure/chair/plastic{
 	dir = 1
@@ -62413,7 +62131,6 @@
 	pixel_y = 5
 	},
 /obj/item/pen/blue,
-/obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -62426,6 +62143,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/item/book/manual/wiki/engineering_guide,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "qiH" = (
@@ -62481,12 +62199,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qkf" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/hydroponics/garden";
-	dir = 8;
-	name = "Garden APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -62499,6 +62211,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "qki" = (
@@ -62690,14 +62403,22 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "qlP" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/command";
-	name = "Command Hallway APC";
-	pixel_y = -25
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/sign/warning/secure_area{
+	pixel_y = 32
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/central)
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "qlX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding{
@@ -62748,6 +62469,7 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "qnJ" = (
@@ -63155,6 +62877,7 @@
 	},
 /obj/machinery/holopad,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "qtu" = (
@@ -63184,7 +62907,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "qtD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -63531,7 +63253,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "qyh" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -64242,15 +63963,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "qIO" = (
-/obj/machinery/power/apc{
-	areastring = "/area/commons/locker";
-	dir = 1;
-	name = "Locker Room APC";
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "qIZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -64371,6 +64094,7 @@
 	dir = 5
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "qLg" = (
@@ -64476,12 +64200,6 @@
 /area/station/science/mixing)
 "qMj" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/security/brig";
-	dir = 4;
-	name = "Security Maint APC";
-	pixel_x = 25
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red{
@@ -64498,6 +64216,7 @@
 	dir = 1;
 	name = "Security red corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/brig)
 "qMt" = (
@@ -64892,7 +64611,6 @@
 	name = "Engine Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -64908,6 +64626,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "qTq" = (
@@ -64965,6 +64684,7 @@
 /obj/structure/sign/warning/engine_safety{
 	pixel_y = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "qUS" = (
@@ -65004,7 +64724,6 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "qVi" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -65355,6 +65074,7 @@
 	location = "Weights";
 	name = "Patrol Beacon"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "qZy" = (
@@ -65650,6 +65370,7 @@
 	c_tag = "Engineering - Foyer W";
 	network = list("ss13", "engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "rcp" = (
@@ -66400,13 +66121,8 @@
 "rma" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/status_display/ai/directional/east,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/service";
-	dir = 1;
-	name = "AI Satellite Service APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat/service)
 "rmc" = (
@@ -66823,7 +66539,6 @@
 /turf/open/floor/carpet/lone/star,
 /area/station/service/chapel)
 "rqT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -66837,6 +66552,7 @@
 	},
 /obj/structure/cable/layer1,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "rqV" = (
@@ -67132,12 +66848,6 @@
 "rvr" = (
 /obj/structure/table,
 /obj/item/paper/pamphlet/gateway,
-/obj/machinery/power/apc{
-	areastring = "/area/command/gateway";
-	dir = 8;
-	name = "Gateway APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -67149,6 +66859,7 @@
 	dir = 1;
 	name = "Command blue corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "rvE" = (
@@ -68316,12 +68027,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars)
 "rMc" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/command/nuke_storage";
-	dir = 4;
-	name = "Vault APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -68332,6 +68037,7 @@
 	color = "#4169E1";
 	name = "Command blue corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "rMd" = (
@@ -68604,6 +68310,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "rQz" = (
@@ -69795,6 +69502,7 @@
 	name = "Medical blue corner"
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "sgG" = (
@@ -71037,7 +70745,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "swu" = (
@@ -71157,6 +70865,8 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "sxG" = (
@@ -71191,6 +70901,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "syA" = (
@@ -71354,12 +71065,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "sAw" = (
-/obj/machinery/power/apc{
-	areastring = "/area/command/teleporter";
-	dir = 4;
-	name = "Teleporter APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -71370,6 +71075,7 @@
 	dir = 4;
 	name = "Command blue corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "sAE" = (
@@ -71521,7 +71227,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
@@ -72255,12 +71960,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "sMl" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/cryo";
-	dir = 4;
-	name = "Cryogenics APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -72280,6 +71979,7 @@
 	dir = 9
 	},
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
 "sMT" = (
@@ -72672,6 +72372,7 @@
 	},
 /obj/effect/landmark/navigate_destination/disposals,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "sTt" = (
@@ -73508,12 +73209,6 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "tgR" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/morgue";
-	dir = 1;
-	name = "Morgue APC";
-	pixel_y = 25
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -73528,6 +73223,7 @@
 	dir = 1;
 	name = "Medical blue corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "thp" = (
@@ -73994,12 +73690,6 @@
 /turf/closed/wall/r_wall,
 /area/station/science/mixing/chamber)
 "tmT" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/lobby";
-	dir = 1;
-	name = "Engineering Foyer APC";
-	pixel_y = 25
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -74012,6 +73702,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "tmY" = (
@@ -74112,14 +73803,10 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "tos" = (
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/hop";
-	name = "Head of Personnel APC";
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "toz" = (
@@ -74539,12 +74226,6 @@
 /area/station/commons/dorms)
 "ttB" = (
 /obj/structure/table,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/medbay/lobby";
-	dir = 1;
-	name = "Medbay Lobby APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -74564,6 +74245,7 @@
 	pixel_x = 9;
 	pixel_y = 2
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ttL" = (
@@ -75370,13 +75052,8 @@
 /area/station/hallway/primary/central)
 "tFT" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/power/apc{
-	areastring = "/area/service/library/printer";
-	dir = 4;
-	name = "Printer Room APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/wood,
 /area/station/service/library/printer)
 "tGh" = (
@@ -76124,13 +75801,8 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/machinery/power/apc{
-	areastring = "/area/service/library/private";
-	dir = 1;
-	name = "Private Study APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/wood,
 /area/station/service/library/private)
 "tSd" = (
@@ -76374,6 +76046,7 @@
 	dir = 4;
 	name = "Security red corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "tVJ" = (
@@ -76984,13 +76657,7 @@
 /turf/open/misc/grass,
 /area/station/science/genetics)
 "udo" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/kitchen";
-	name = "Kitchen APC";
-	pixel_y = -25
-	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -77407,6 +77074,8 @@
 	c_tag = "Cargo - Waste Disposal";
 	network = list("ss13", "cargo")
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "uja" = (
@@ -79333,8 +79002,8 @@
 /area/station/engineering/atmos)
 "uKI" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine)
 "uKN" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
@@ -79565,6 +79234,7 @@
 	dir = 1;
 	name = "Command blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "uNh" = (
@@ -79761,6 +79431,7 @@
 	dir = 4;
 	name = "Security red corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "uPf" = (
@@ -80540,16 +80211,11 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "uZI" = (
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/storage";
-	dir = 8;
-	name = "Cargo Bay APC";
-	pixel_x = -25
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/area/station/maintenance/department/engine)
 "uZL" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -80738,7 +80404,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vbw" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -81092,6 +80757,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "vgm" = (
@@ -81391,6 +81057,8 @@
 	},
 /obj/item/storage/fancy/candle_box,
 /obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/library/abandoned)
 "vja" = (
@@ -81779,6 +81447,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen/coldroom)
 "vqb" = (
@@ -81815,12 +81484,6 @@
 /area/station/maintenance/department/cargo)
 "vqi" = (
 /obj/structure/closet/secure_closet/quartermaster,
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/qm";
-	dir = 1;
-	name = "Quartermaster APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -81831,6 +81494,7 @@
 	},
 /obj/item/bedsheet/qm,
 /obj/machinery/light_switch/directional/east,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "vqp" = (
@@ -82377,12 +82041,6 @@
 /obj/structure/closet/secure_closet/contraband/heads,
 /obj/item/storage/secure/briefcase,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/customs";
-	dir = 8;
-	name = "Customs Desk APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -82399,6 +82057,7 @@
 	dir = 8;
 	name = "Command blue corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs)
 "vzw" = (
@@ -83034,15 +82693,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "vHK" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/courtroom";
-	name = "Courtroom APC";
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "vHW" = (
@@ -83494,6 +83149,7 @@
 	machinedir = 8;
 	pixel_x = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "vPV" = (
@@ -83522,7 +83178,6 @@
 	dir = 8;
 	name = "Gas to Cooling Loop"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "vQx" = (
@@ -83575,13 +83230,8 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "vQV" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/psychology";
-	dir = 4;
-	name = "Psychology APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/carpet/purple,
 /area/station/medical/psychology)
 "vRh" = (
@@ -83633,6 +83283,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "vSs" = (
@@ -83706,7 +83357,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/misc_lab)
 "vTc" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -84225,6 +83875,7 @@
 /area/station/service/hydroponics)
 "vZR" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "wab" = (
@@ -84744,6 +84395,7 @@
 "wkh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "wki" = (
@@ -84804,6 +84456,7 @@
 	req_access_txt = "32"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
 "wlt" = (
@@ -85045,6 +84698,7 @@
 	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wqx" = (
@@ -85619,15 +85273,19 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "wxn" = (
-/obj/machinery/power/apc{
-	areastring = "/area/commons/toilet/restrooms";
-	dir = 4;
-	name = "Dormitory Bathrooms APC";
-	pixel_x = 25
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/department/crew_quarters/dorms)
+/area/station/engineering/main)
 "wxw" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -85861,13 +85519,8 @@
 /obj/item/clothing/head/welding,
 /obj/item/wrench,
 /obj/item/crowbar,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/atmos";
-	dir = 1;
-	name = "AI Satellite Service APC";
-	pixel_y = 25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "wzB" = (
@@ -86417,6 +86070,8 @@
 	dir = 6
 	},
 /obj/effect/landmark/start/bartender,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "wGC" = (
@@ -86442,7 +86097,6 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wGT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -86792,18 +86446,13 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "wLr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/fore";
-	dir = 4;
-	name = "Fore Primary Hallway APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 5
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "wLu" = (
@@ -86823,6 +86472,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "wLF" = (
@@ -87330,12 +86980,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars)
 "wSb" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/office";
-	dir = 4;
-	name = "Security Office APC";
-	pixel_x = 25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -87346,6 +86990,7 @@
 	dir = 4;
 	name = "Security red corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/security/office)
 "wSc" = (
@@ -88039,9 +87684,10 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
 "xac" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/command)
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "xae" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/mess,
@@ -88766,6 +88412,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "xiy" = (
@@ -89021,7 +88668,6 @@
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "xkL" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -90708,12 +90354,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/abandoned";
-	name = "Abandoned Medbay APC";
-	pixel_y = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "xGE" = (
@@ -90873,12 +90515,6 @@
 /area/station/command/bridge)
 "xJu" = (
 /obj/machinery/flasher/portable,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/security/armory";
-	dir = 8;
-	name = "Armory APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -90895,6 +90531,7 @@
 	c_tag = "Security - Armory N";
 	network = list("ss13", "security")
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "xJA" = (
@@ -90993,7 +90630,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "xKV" = (
@@ -91014,12 +90650,6 @@
 "xLl" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/item/book/manual/wiki/atmospherics,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/atmos";
-	dir = 8;
-	name = "Atmospherics APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -91031,6 +90661,7 @@
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "xLm" = (
@@ -92108,6 +91739,7 @@
 	dir = 8;
 	sortType = 29
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "xZa" = (
@@ -92934,13 +92566,8 @@
 /area/station/service/chapel/dock)
 "yhr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/cargo";
-	dir = 8;
-	name = "Cargo Maint APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "yhu" = (
@@ -92962,13 +92589,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/exit/departure_lounge";
-	dir = 8;
-	name = "Escape Hallway APC";
-	pixel_x = -25
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "yiB" = (
@@ -106966,7 +106586,7 @@ bUn
 bUn
 sFO
 xRN
-eve
+xPA
 xRN
 xRN
 yel
@@ -113114,7 +112734,7 @@ uOg
 eqg
 kpU
 kpU
-qfV
+xSD
 kpU
 kpU
 tPU
@@ -114970,10 +114590,10 @@ jhm
 jhm
 yel
 xRN
-iQW
-iQW
-iQW
-iQW
+xBY
+xBY
+xBY
+xBY
 iQW
 vmD
 iQW
@@ -115189,7 +114809,7 @@ oIp
 hXE
 pwh
 aYQ
-uZI
+aYQ
 qiM
 uNh
 pda
@@ -115206,7 +114826,7 @@ wAF
 slU
 wAF
 vWG
-qRT
+fYr
 syk
 ocD
 bIY
@@ -115229,7 +114849,7 @@ xRN
 xRN
 iQW
 iQW
-iQW
+yju
 iQW
 iQW
 xBY
@@ -115410,7 +115030,7 @@ xSD
 vDp
 uOg
 cRH
-gJE
+tyN
 fDA
 mke
 qtp
@@ -115467,9 +115087,9 @@ tSe
 sEj
 hWf
 vgd
-xyq
-xyq
-xyq
+gJE
+gJE
+gJE
 pwz
 xRN
 xRN
@@ -115484,26 +115104,26 @@ wqo
 hwz
 fae
 ouN
-iQW
-iQW
-iQW
-iQW
-iQW
+mhk
+mhk
+mhk
+mhk
+mhk
 xBY
 iQW
 xBY
 iQW
 iQW
 iQW
-xdv
-xdv
-xdv
-xdv
-xdv
-xdv
-kOC
-mHl
-meK
+mhk
+mhk
+mhk
+mhk
+mhk
+mhk
+xac
+cQC
+jGJ
 meK
 iAe
 vmu
@@ -115726,7 +115346,7 @@ sEj
 oHZ
 xyq
 okQ
-xyq
+gJE
 bkA
 xRN
 pNI
@@ -115745,14 +115365,14 @@ iQW
 iQW
 iQW
 iQW
-iQW
+mhk
 xBY
 iQW
 yju
 iQW
-xdv
-xdv
-xdv
+mhk
+mhk
+mhk
 yju
 dNL
 rbs
@@ -115983,7 +115603,7 @@ fbt
 xzH
 xyq
 xaA
-xyq
+gJE
 bPp
 xRN
 dKa
@@ -116002,12 +115622,12 @@ iQW
 iQW
 iQW
 iQW
-yju
+mhk
 xBY
 iQW
 xBY
 iQW
-xdv
+mhk
 dNL
 rvb
 rvb
@@ -116240,7 +115860,7 @@ fwd
 kTb
 eYh
 gex
-xyq
+gJE
 sng
 xRN
 pNI
@@ -116259,12 +115879,12 @@ iQW
 iQW
 iQW
 iQW
-iQW
+mhk
 xBY
 yju
 xBY
 yju
-xdv
+mhk
 gBN
 tvJ
 rvb
@@ -116497,7 +116117,7 @@ fbt
 xzH
 xyq
 hkH
-xyq
+gJE
 vkV
 xRN
 pNI
@@ -116510,18 +116130,18 @@ xRN
 yel
 wGD
 xRN
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
+yju
+yju
+yju
+yju
+yju
+yju
+mhk
 vmD
 iQW
 xBY
 iQW
-xdv
+mhk
 dNL
 tvJ
 rvb
@@ -116754,7 +116374,7 @@ sEj
 kKH
 xyq
 xyq
-xyq
+gJE
 cqx
 xRN
 mMS
@@ -116773,12 +116393,12 @@ iQW
 iQW
 iQW
 iQW
-iQW
+mhk
 iQW
 iQW
 xBY
 iQW
-xdv
+mhk
 gBN
 rvb
 rvb
@@ -117030,12 +116650,12 @@ iQW
 iQW
 iQW
 iQW
-iQW
+mhk
 iQW
 iQW
 xBY
 yju
-xdv
+mhk
 dNL
 tvJ
 rvb
@@ -117287,12 +116907,12 @@ iQW
 iQW
 iQW
 iQW
-xdv
-xdv
-xdv
-xdv
-xdv
-xdv
+mhk
+mhk
+mhk
+mhk
+mhk
+mhk
 gBN
 tvJ
 rvb
@@ -117301,7 +116921,7 @@ ouh
 nUz
 cpo
 wGT
-bcA
+pSa
 gHi
 idu
 uJk
@@ -118070,7 +117690,7 @@ kOC
 kOC
 wzj
 sle
-rMR
+jIc
 kiF
 jRE
 hJs
@@ -118584,7 +118204,7 @@ rlH
 jsc
 ouh
 pre
-rMR
+jIc
 nau
 nZr
 nZr
@@ -118836,12 +118456,12 @@ pUS
 gMl
 kOC
 cyp
-uKI
+iJh
 gqx
 dSy
 avI
 lBo
-rMR
+jIc
 mSI
 jQD
 nFN
@@ -119076,10 +118696,10 @@ yel
 pnB
 xRN
 opB
-aTk
-aTk
+opB
+opB
 oIe
-aTk
+opB
 mxz
 qEz
 xcR
@@ -119095,7 +118715,7 @@ qTp
 bPB
 neR
 iNT
-jsc
+wxn
 ouh
 xzl
 wSg
@@ -119340,7 +118960,7 @@ nio
 dbq
 exF
 sCa
-qko
+ovD
 oQn
 kOC
 qvo
@@ -119597,7 +119217,7 @@ iQi
 eZz
 qvm
 xcR
-fQh
+pkf
 ikx
 dfB
 dfB
@@ -120368,7 +119988,7 @@ uqY
 wLL
 wLL
 xcR
-fQh
+pkf
 qVi
 tsy
 pVy
@@ -120507,7 +120127,7 @@ fOV
 gpB
 haV
 ink
-hOp
+xZD
 jFd
 pIK
 xZD
@@ -120882,7 +120502,7 @@ kOw
 gnP
 edw
 edw
-nEY
+qfV
 cKe
 gwV
 tsy
@@ -121139,7 +120759,7 @@ yfc
 dzi
 cxT
 aLF
-oNn
+qhm
 qtD
 qgI
 tsy
@@ -121274,7 +120894,7 @@ cUJ
 dsN
 vEN
 sWA
-fYr
+sWA
 exX
 jvE
 vEN
@@ -121399,7 +121019,7 @@ rAB
 xiq
 qyh
 gKe
-vVh
+uKI
 vVh
 vVh
 vVh
@@ -121653,10 +121273,10 @@ wzZ
 rSG
 vDJ
 rAB
-yeF
+qlP
 gtm
 pLK
-oEa
+uZI
 pkQ
 sdd
 sdd
@@ -121910,7 +121530,7 @@ pOu
 pOu
 fiR
 wHs
-fQh
+pkf
 vbw
 gKe
 gKe
@@ -122425,7 +122045,7 @@ edP
 nMa
 wHs
 fQh
-rXt
+qIO
 uEQ
 gKe
 uva
@@ -122564,9 +122184,9 @@ bvP
 toz
 rYS
 wQy
-rYS
+aWD
 cYA
-dnW
+msR
 mcb
 sts
 lbi
@@ -122821,7 +122441,7 @@ bvP
 toz
 rYS
 uFk
-rYS
+aWD
 kKY
 vEN
 uvj
@@ -122838,7 +122458,7 @@ vig
 hjX
 pJn
 cSt
-wxn
+hjX
 hjX
 hjX
 vEN
@@ -122872,7 +122492,7 @@ iMA
 ljF
 acT
 iQg
-qlP
+iNU
 acT
 eSF
 wzp
@@ -123898,7 +123518,7 @@ diS
 frI
 frI
 sLd
-frI
+ipw
 aHn
 lcX
 rhp
@@ -124155,7 +123775,7 @@ rJx
 xUX
 pMD
 ois
-ois
+dWv
 rPt
 hBf
 uRa
@@ -124412,7 +124032,7 @@ kXC
 jEX
 ulh
 frI
-frI
+ipw
 aHn
 dso
 jWS
@@ -124622,7 +124242,7 @@ kJl
 nEv
 qrV
 vEN
-qIO
+sWA
 uvj
 vEN
 tUY
@@ -124672,9 +124292,9 @@ vjM
 lJD
 vzw
 aCY
-jWS
+eve
 lnT
-cFa
+fBS
 nIj
 krk
 xdW
@@ -125183,7 +124803,7 @@ llW
 vvh
 kdh
 njN
-frI
+ipw
 cnw
 aCY
 bqN
@@ -125440,7 +125060,7 @@ osX
 xUn
 pbr
 cTY
-frI
+ipw
 civ
 mRl
 bTu
@@ -125697,7 +125317,7 @@ nkp
 vvh
 jcr
 sTi
-frI
+ipw
 dXS
 aCY
 ljr
@@ -126471,7 +126091,7 @@ frI
 iXM
 aHn
 gFG
-fBS
+jWS
 jWS
 cFa
 nIj
@@ -126673,7 +126293,7 @@ wLQ
 wLQ
 soh
 kYK
-pHB
+aTk
 mPq
 nIT
 osO
@@ -126728,7 +126348,7 @@ ois
 bbS
 fnM
 xZb
-pkf
+pGO
 pGO
 tJd
 ozW
@@ -126780,7 +126400,7 @@ iKp
 iKp
 rRQ
 ndt
-dWv
+wOO
 uIm
 ihO
 vsb
@@ -126930,7 +126550,7 @@ wLQ
 wLQ
 soh
 kYK
-pHB
+aTk
 mjd
 nId
 pHB
@@ -126985,7 +126605,7 @@ sLd
 frI
 aHn
 nuB
-xac
+rhp
 rhp
 eiR
 sBw
@@ -127187,7 +126807,7 @@ wLQ
 wLQ
 kdV
 keN
-hbm
+uZC
 rpD
 qxA
 rpD
@@ -127805,7 +127425,7 @@ rUO
 wXk
 avb
 avb
-avb
+hbm
 gWU
 xYX
 wOO
@@ -128578,7 +128198,7 @@ dyb
 huG
 sLf
 rRQ
-mhk
+uVg
 hlg
 uIm
 epe
@@ -129246,12 +128866,12 @@ gIb
 hfq
 iQa
 rvY
-ovD
-pXQ
-pXQ
+vzb
+vzb
+vzb
 iPY
-kvR
-kvR
+bcA
+bcA
 lrN
 pKQ
 rvY
@@ -134940,7 +134560,7 @@ kqZ
 kqZ
 ttg
 ttg
-aWD
+kqZ
 ttg
 ttg
 kqZ
@@ -138286,7 +137906,7 @@ mEP
 agG
 gxI
 fqa
-qhm
+gxI
 poR
 uZc
 uZc

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -8667,11 +8667,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"cmQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
 "cnd" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -9162,6 +9157,11 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"csW" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "csX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -64569,9 +64569,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qTa" = (
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Officer Beepsky"
-	},
+/mob/living/simple_animal/bot/secbot/beepsky/officer,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qTg" = (
@@ -118223,7 +118221,7 @@ nZr
 nZr
 wuD
 chJ
-cmQ
+csW
 kOC
 iQW
 vmD
@@ -118480,7 +118478,7 @@ wLY
 jQD
 bmx
 dCs
-cmQ
+csW
 ouh
 yju
 sOe
@@ -118737,7 +118735,7 @@ wLY
 bZn
 uix
 jRE
-cmQ
+csW
 ouh
 yju
 vmD
@@ -118994,7 +118992,7 @@ qEy
 fHE
 wgv
 dCs
-cmQ
+csW
 ouh
 yju
 vmD

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -3759,11 +3759,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "aZu" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/light/directional/north,
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "aZA" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/light/directional/west,
@@ -10045,6 +10043,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"cCB" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "cCQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -10810,9 +10813,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "cOZ" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/circuit/green,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/iron,
+/area/station/maintenance/department/cargo)
 "cPj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -10875,8 +10878,8 @@
 /area/station/commons/dorms)
 "cQC" = (
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/wood,
+/area/station/maintenance/port/aft)
 "cQH" = (
 /obj/structure/table,
 /obj/item/flashlight,
@@ -14801,7 +14804,7 @@
 /area/station/cargo/qm)
 "dTZ" = (
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "dUk" = (
 /obj/structure/chair/office{
@@ -30585,9 +30588,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "iaw" = (
-/obj/effect/landmark/xeno_spawn,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/department/engine)
 "iax" = (
 /obj/structure/chair/wood/wings,
 /obj/machinery/light/broken{
@@ -44407,6 +44410,7 @@
 /area/station/hallway/primary/port)
 "lGh" = (
 /obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "lGr" = (
@@ -46753,7 +46757,7 @@
 /area/station/maintenance/department/science)
 "mhk" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "mhn" = (
@@ -58304,8 +58308,7 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison/safe)
 "pkC" = (
-/obj/structure/cable,
-/obj/structure/closet/emcloset,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "pkE" = (
@@ -71188,13 +71191,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
-"sBL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
 "sBS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -74755,9 +74751,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/atrium)
 "tAw" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "tAC" = (
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -79156,7 +79153,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "uMi" = (
-/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -87689,7 +87688,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
 "xac" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -88336,11 +88335,6 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
-"xht" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
 "xhE" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -107783,7 +107777,7 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 iQW
 iQW
 iQW
@@ -108040,11 +108034,11 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 yju
-vmD
-vmD
-vmD
+bfi
+bfi
+bfi
 iQW
 iQW
 iQW
@@ -108297,7 +108291,7 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 adS
 bfi
 yju
@@ -108554,9 +108548,9 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 iQW
-vmD
+bfi
 yju
 htI
 fxL
@@ -108811,7 +108805,7 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 yju
 bfi
 yju
@@ -109068,9 +109062,9 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 iQW
-vmD
+bfi
 yju
 htI
 eOT
@@ -109325,7 +109319,7 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 yju
 bfi
 yju
@@ -109582,9 +109576,9 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 iQW
-vmD
+bfi
 yju
 htI
 hRm
@@ -109839,9 +109833,9 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 iQW
-vmD
+bfi
 yju
 htI
 dkX
@@ -110096,9 +110090,9 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 iQW
-vmD
+bfi
 yju
 htI
 ehT
@@ -110225,7 +110219,7 @@ xRN
 qnP
 xRN
 lbk
-iaw
+dTZ
 uyW
 lFp
 lFp
@@ -110352,10 +110346,10 @@ iQW
 iQW
 iQW
 iQW
-vmD
-vmD
-vmD
-vmD
+bfi
+bfi
+bfi
+bfi
 yju
 htI
 mKk
@@ -113041,7 +113035,7 @@ wAF
 jak
 nKe
 eAN
-cQC
+cOZ
 dnh
 sEj
 yel
@@ -114986,7 +114980,7 @@ iQW
 bfi
 bfi
 bfi
-aZu
+vAZ
 bfi
 bfi
 iQW
@@ -116644,7 +116638,7 @@ xRN
 jlm
 yel
 wUo
-dTZ
+cQC
 faX
 sSK
 xRN
@@ -117963,9 +117957,9 @@ ujk
 dCs
 mSI
 qWw
-uMi
+tAw
 aQq
-xac
+uMi
 eJg
 tzQ
 kOC
@@ -118224,7 +118218,7 @@ nZr
 nZr
 wuD
 chJ
-xht
+cCB
 kOC
 iQW
 vmD
@@ -118481,7 +118475,7 @@ wLY
 jQD
 bmx
 dCs
-xht
+cCB
 ouh
 yju
 sOe
@@ -118738,7 +118732,7 @@ wLY
 bZn
 uix
 jRE
-xht
+cCB
 ouh
 yju
 vmD
@@ -118995,7 +118989,7 @@ qEy
 fHE
 wgv
 dCs
-xht
+cCB
 ouh
 yju
 vmD
@@ -120535,7 +120529,7 @@ hJO
 oaZ
 hkZ
 cyA
-sBL
+xac
 eJg
 eJg
 hyj
@@ -120780,7 +120774,7 @@ pGW
 bOQ
 swb
 vVh
-mhk
+lGh
 wjz
 ouh
 ouh
@@ -121037,7 +121031,7 @@ qlN
 wxh
 jhU
 vVh
-pkC
+mhk
 gKe
 iQW
 iQW
@@ -121548,8 +121542,8 @@ oEa
 oEa
 oEa
 uWb
-lGh
-lGh
+iaw
+iaw
 caf
 ovf
 rzw
@@ -121808,7 +121802,7 @@ gld
 sdd
 cqJ
 gKe
-tAw
+pkC
 gKe
 iQW
 iQW
@@ -141715,7 +141709,7 @@ dfy
 dNs
 tsq
 ijf
-cOZ
+aZu
 huJ
 yec
 yec

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -31600,9 +31600,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
-/obj/structure/sign/departments/maint{
-	pixel_y = -32
-	},
+/obj/structure/sign/departments/exam_room/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "ind" = (
@@ -35402,6 +35400,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/sign/departments/maint/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "jqj" = (
@@ -42303,6 +42302,23 @@
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/station/tcommsat/server)
+"ldQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/departments/maint/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "led" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/purple{
@@ -64965,6 +64981,19 @@
 "qXz" = (
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"qXX" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/structure/sign/departments/maint/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "qYj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -121252,7 +121281,7 @@ odz
 qYQ
 mIB
 xdI
-dKp
+ldQ
 xRN
 eoK
 bws
@@ -134581,7 +134610,7 @@ rld
 uxN
 ykY
 brb
-aPe
+qXX
 xBU
 dqQ
 wpj

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -39911,7 +39911,7 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "kyO" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "kyT" = (
@@ -53386,7 +53386,7 @@
 /turf/open/floor/carpet/lone/star,
 /area/station/service/chapel)
 "nPY" = (
-/obj/machinery/smartfridge/chemistry,
+/obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
 /area/station/medical/pharmacy)
 "nQj" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -3759,9 +3759,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "aZu" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/circuit/green,
-/area/ai_monitored/turret_protected/ai)
+/obj/structure/lattice,
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aZA" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/light/directional/west,
@@ -10808,9 +10810,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "cOZ" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
+/obj/machinery/light/directional/north,
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "cPj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -10872,9 +10874,11 @@
 /turf/closed/wall,
 /area/station/commons/dorms)
 "cQC" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/wood,
-/area/station/maintenance/port/aft)
+/obj/structure/grille,
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cQH" = (
 /obj/structure/table,
 /obj/item/flashlight,
@@ -13296,11 +13300,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"dxK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
 "dxV" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/britcup,
@@ -14804,8 +14803,8 @@
 /area/station/cargo/qm)
 "dTZ" = (
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/turf/open/floor/iron,
+/area/station/maintenance/department/cargo)
 "dUk" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -28263,6 +28262,13 @@
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall,
 /area/station/science/xenobiology)
+"huO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "hvf" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -30588,9 +30594,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "iaw" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/wood,
+/area/station/maintenance/port/aft)
 "iax" = (
 /obj/structure/chair/wood/wings,
 /obj/machinery/light/broken{
@@ -44409,10 +44415,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lGh" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/area/station/maintenance/port/aft)
 "lGr" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -46757,7 +46762,6 @@
 /area/station/maintenance/department/science)
 "mhk" = (
 /obj/structure/cable,
-/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "mhn" = (
@@ -54386,6 +54390,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
+"odL" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "odU" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -58308,7 +58317,8 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison/safe)
 "pkC" = (
-/obj/machinery/light/small/directional/east,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "pkE" = (
@@ -61224,6 +61234,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/station/commons/fitness)
+"pXy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "pXF" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
@@ -74751,10 +74768,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/atrium)
 "tAw" = (
-/obj/machinery/light/directional/east,
 /obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "tAC" = (
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -79153,12 +79170,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "uMi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "uMl" = (
 /obj/machinery/shower{
 	pixel_y = 25
@@ -87688,9 +87702,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
 "xac" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -110219,7 +110231,7 @@ xRN
 qnP
 xRN
 lbk
-dTZ
+lGh
 uyW
 lFp
 lFp
@@ -113035,7 +113047,7 @@ wAF
 jak
 nKe
 eAN
-cOZ
+dTZ
 dnh
 sEj
 yel
@@ -113177,7 +113189,7 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 iQW
 cbK
 ePr
@@ -113434,7 +113446,7 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 yju
 cbK
 qxY
@@ -113691,7 +113703,7 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 yju
 cbK
 cbK
@@ -114205,8 +114217,8 @@ iQW
 iQW
 iQW
 iQW
-vmD
-vmD
+bfi
+bfi
 yju
 cbK
 cbK
@@ -114463,7 +114475,7 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 yju
 yju
 cbK
@@ -114720,7 +114732,7 @@ bDE
 iQW
 iQW
 iQW
-vmD
+bfi
 yju
 iQW
 yju
@@ -114977,12 +114989,12 @@ iQW
 iQW
 iQW
 iQW
-vmD
-vAZ
-vmD
-vAZ
-vmD
-vAZ
+bfi
+bfi
+bfi
+aZu
+bfi
+bfi
 iQW
 iQW
 iQW
@@ -115234,7 +115246,7 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 yju
 yju
 yju
@@ -115491,16 +115503,16 @@ iQW
 yju
 yju
 yju
-vmD
-vmD
+bfi
+bfi
 yju
-vmD
-vAZ
-vmD
-vmD
+bfi
+aZu
+bfi
+bfi
 xdv
-vmD
-vmD
+cQC
+bfi
 vAZ
 iQW
 iQW
@@ -116638,7 +116650,7 @@ xRN
 jlm
 yel
 wUo
-cQC
+iaw
 faX
 sSK
 xRN
@@ -117544,7 +117556,7 @@ iQW
 iQW
 iQW
 iQW
-vmD
+bfi
 yju
 xdv
 nxe
@@ -117957,9 +117969,9 @@ ujk
 dCs
 mSI
 qWw
-tAw
+xac
 aQq
-uMi
+huO
 eJg
 tzQ
 kOC
@@ -118218,7 +118230,7 @@ nZr
 nZr
 wuD
 chJ
-dxK
+odL
 kOC
 iQW
 vmD
@@ -118475,7 +118487,7 @@ wLY
 jQD
 bmx
 dCs
-dxK
+odL
 ouh
 yju
 sOe
@@ -118732,7 +118744,7 @@ wLY
 bZn
 uix
 jRE
-dxK
+odL
 ouh
 yju
 vmD
@@ -118989,7 +119001,7 @@ qEy
 fHE
 wgv
 dCs
-dxK
+odL
 ouh
 yju
 vmD
@@ -120529,7 +120541,7 @@ hJO
 oaZ
 hkZ
 cyA
-xac
+pXy
 eJg
 eJg
 hyj
@@ -120774,7 +120786,7 @@ pGW
 bOQ
 swb
 vVh
-lGh
+pkC
 wjz
 ouh
 ouh
@@ -121031,7 +121043,7 @@ qlN
 wxh
 jhU
 vVh
-mhk
+tAw
 gKe
 iQW
 iQW
@@ -121542,8 +121554,8 @@ oEa
 oEa
 oEa
 uWb
-iaw
-iaw
+mhk
+mhk
 caf
 ovf
 rzw
@@ -121802,7 +121814,7 @@ gld
 sdd
 cqJ
 gKe
-pkC
+uMi
 gKe
 iQW
 iQW
@@ -141709,7 +141721,7 @@ dfy
 dNs
 tsq
 ijf
-aZu
+cOZ
 huJ
 yec
 yec

--- a/fulp_modules/mapping/ruins/icemoon/beef_cytology.dmm
+++ b/fulp_modules/mapping/ruins/icemoon/beef_cytology.dmm
@@ -563,10 +563,6 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom,
 /area/ruin/powered/beefcyto)
-"AQ" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/ruin/powered/beefcyto)
 "AV" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/iron/cafeteria,
@@ -892,6 +888,9 @@
 /area/ruin/powered/beefcyto)
 "RF" = (
 /obj/machinery/light/floor,
+/obj/structure/sign/warning{
+	pixel_y = -32
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered/beefcyto)
 "RK" = (
@@ -1612,13 +1611,13 @@ Iz
 yD
 vA
 yD
-AQ
+pv
 xA
 SN
 jx
 DP
 kI
-AQ
+pv
 yD
 yD
 yD

--- a/fulp_modules/mapping/ruins/icemoon/beef_cytology.dmm
+++ b/fulp_modules/mapping/ruins/icemoon/beef_cytology.dmm
@@ -173,8 +173,11 @@
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "jz" = (
-/obj/item/wallframe/extinguisher_cabinet,
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "jX" = (
 /obj/machinery/light/floor,
@@ -248,6 +251,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "oB" = (
@@ -342,9 +346,8 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/ruin/powered/beefcyto)
 "sH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ice,
-/turf/open/space/basic,
+/obj/effect/spawner/structure/window/ice,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ruin/powered/beefcyto)
 "sR" = (
 /obj/machinery/biogenerator,
@@ -1582,8 +1585,8 @@ pv
 pv
 pv
 by
+pv
 jz
-Rx
 nP
 nP
 nP
@@ -1629,7 +1632,7 @@ bB
 bB
 bB
 gh
-rc
+sH
 GX
 nP
 nP
@@ -1672,11 +1675,11 @@ pv
 iB
 pg
 pv
-jz
+pv
 pv
 bB
 RQ
-rc
+sH
 LX
 nP
 nP
@@ -1723,7 +1726,7 @@ op
 pv
 pv
 bB
-rc
+sH
 GX
 nP
 nP
@@ -1768,9 +1771,9 @@ nP
 nP
 zc
 co
-rc
+sH
 bB
-rc
+sH
 pm
 nS
 Wk
@@ -1815,7 +1818,7 @@ QA
 nP
 nP
 ph
-rc
+sH
 bB
 pv
 pv
@@ -1862,7 +1865,7 @@ Ku
 nP
 nP
 ve
-rc
+sH
 bB
 WQ
 yD
@@ -1909,7 +1912,7 @@ wf
 nP
 nP
 Ek
-rc
+sH
 bB
 pv
 pv
@@ -1956,7 +1959,7 @@ nP
 nP
 Lo
 zg
-rc
+sH
 bB
 pv
 uy
@@ -2005,7 +2008,7 @@ jy
 pv
 pv
 bB
-rc
+sH
 cQ
 pD
 Kz
@@ -2052,7 +2055,7 @@ pv
 pv
 bB
 bB
-rc
+sH
 cQ
 Ay
 Kz
@@ -2130,11 +2133,11 @@ yD
 yD
 yD
 yD
-rc
+sH
 Em
 oB
 xF
-rc
+sH
 bB
 bB
 bB
@@ -2177,11 +2180,11 @@ yD
 yD
 yD
 Ed
-rc
+sH
 nP
 aI
 Cc
-rc
+sH
 bB
 nl
 bB
@@ -2365,11 +2368,11 @@ yD
 yD
 yD
 Ed
-rc
+sH
 nP
 aI
 Cc
-rc
+sH
 yD
 yD
 yD
@@ -2412,11 +2415,11 @@ DW
 yD
 yD
 yD
-rc
+sH
 Em
 dB
 xF
-rc
+sH
 aX
 yD
 yD

--- a/fulp_modules/mapping/ruins/space/beef_station.dmm
+++ b/fulp_modules/mapping/ruins/space/beef_station.dmm
@@ -2868,10 +2868,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "Up" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "beefstation-frontdoor"
-	},
 /obj/machinery/door/airlock/public,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/beef)
 "Uq" = (
@@ -2935,8 +2933,8 @@
 "Vz" = (
 /obj/machinery/door/airlock/public,
 /obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "beefstation-frontdoor"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/beef)
@@ -3641,7 +3639,7 @@ uq
 uq
 Iw
 Iw
-Iw
+Sa
 iv
 CM
 JD
@@ -3697,7 +3695,7 @@ SJ
 tD
 DF
 PH
-Iw
+Sa
 Iw
 Iw
 uq
@@ -3888,7 +3886,7 @@ Gc
 Gc
 Gc
 Gc
-Iw
+Sa
 Iw
 uq
 uq
@@ -5329,7 +5327,7 @@ uq
 uq
 uq
 Iw
-Iw
+Sa
 Ut
 du
 du

--- a/fulp_modules/mapping/ruins/space/beef_station.dmm
+++ b/fulp_modules/mapping/ruins/space/beef_station.dmm
@@ -4077,7 +4077,7 @@ NG
 Te
 eG
 Yv
-Iw
+Sa
 Iw
 Iw
 Iw
@@ -5389,7 +5389,7 @@ Or
 Or
 Gc
 yc
-Iw
+Sa
 Iw
 Iw
 uq

--- a/fulp_modules/mapping/shuttles/cargo/cargo_selene.dmm
+++ b/fulp_modules/mapping/shuttles/cargo/cargo_selene.dmm
@@ -2,13 +2,6 @@
 "b" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/supply)
-"c" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/supply)
 "e" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
@@ -77,10 +70,6 @@
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/plating/airless,
 /area/shuttle/supply)
-"r" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/supply)
 "s" = (
 /turf/template_noop,
 /area/template_noop)
@@ -100,45 +89,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	name = "Cargo Shuttle Air Refill"
-	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "x" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/supply)
-"D" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 10
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/supply)
-"H" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/supply)
-"K" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/supply)
-"S" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 6
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/supply)
-"V" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 9
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
@@ -159,7 +114,7 @@ s
 "}
 (2,1,1) = {"
 b
-K
+e
 e
 e
 e
@@ -173,7 +128,7 @@ t
 "}
 (3,1,1) = {"
 b
-c
+e
 e
 e
 e
@@ -189,9 +144,9 @@ u
 b
 w
 e
-S
-r
-H
+e
+e
+e
 e
 e
 e
@@ -201,9 +156,9 @@ u
 "}
 (5,1,1) = {"
 b
-D
-r
-V
+e
+e
+e
 e
 e
 e


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Selene Station

![image](https://user-images.githubusercontent.com/25415050/169348110-e667dabe-0dcc-474b-ae29-550b802ad3ca.png)

Missing wire and duplicate pipe (look at the blue pipe's tint on the right of the ghost)

![image](https://user-images.githubusercontent.com/25415050/169348178-a55dae3d-1162-4284-b167-143a2b44bcd1.png)

Duplicate pipe (smart pipe stacked on top of regular scrubber pipe on the same layer)

![image](https://user-images.githubusercontent.com/25415050/169348263-71945ae0-9284-45b5-9035-3bdece7bb8df.png)

These errors caused by the multilayer cable hub that connect SM output to SMES

Changed a few xeno spawns

![image](https://user-images.githubusercontent.com/25415050/169602035-299b8592-0aaa-48bb-ae8a-ed3965d2a6fe.png)

these catwalks looked off because there isn't any turf or lattice under some of these grilles

Replaced pharmacy's smart fridges with the preloaded kind (courtesy of Cook77 (zed oppenheimer (my friend) ) )

Replaced chem lab's chem heater with the kind thats preloaded with buffers

Adresses the missing signs that I found when figuring out [#67209](https://github.com/tgstation/tgstation/pull/67209)

Fixed the APCs for 
/area/station/hallway/secondary/exit/departure_lounge
/area/station/solars/aux/port
/area/station/solars/port/aft
/area/station/maintenance/disposal
/area/station/commons/vacant_room/office
/area/station/cargo/storage
/area/station/service/bar
/area/station/cargo/warehouse
/area/station/service/kitchen
/area/station/solars/port/fore
/area/station/service/library/abandoned
/area/station/engineering/atmospherics_engine
/area/station/command/bridge
/area/station/commons/locker
/area/station/commons/toilet/restrooms
/area/station/tcommsat/computer
/area/station/service/lawoffice
/area/station/engineering/transit_tube
/area/station/security/checkpoint/medical
/area/station/medical/break_room
/area/station/science/mixing/chamber
/area/station/solars/starboard/fore

## Heliostation

![image](https://user-images.githubusercontent.com/25415050/169348463-035badbb-8ad3-44c1-83af-dc190e3f6830.png)

Duplicate pipe under my ghost

Turbine air alarm wasn't actually connected to the turbine's scrubber.

![image](https://user-images.githubusercontent.com/25415050/169592444-9a245fdf-0f73-48e0-9d51-d6a537856b36.png)
![image](https://user-images.githubusercontent.com/25415050/169592446-05e8b6ff-ae85-40ff-947d-6ca58d915adc.png)
![image](https://user-images.githubusercontent.com/25415050/169592452-5cf5b3b0-ab9e-4abb-881d-53bf2703c207.png)

A bunch of xeno spawners were in locations they couldn't realistically move from as larvae

![image](https://user-images.githubusercontent.com/25415050/169592542-ff1d87ff-e61b-4fe6-a365-6698c90bbb8b.png)

Rogue nearstation area

![image](https://user-images.githubusercontent.com/25415050/169592569-e711f8ca-aa08-4163-b678-8d41ecd708d9.png)

These terminals always looked weird to me this is kind of a controversial change but i replaced them with machine frames on the tiles above

![image](https://user-images.githubusercontent.com/25415050/169592655-a3be4d9a-4c34-4653-8191-1507235a412f.png)

This isn't how SMES work

Fixes the APCs for
/area/station/solars/port/aft
/area/station/solars/port/fore
/area/station/service/chapel/monastery
/area/station/commons/vacant_room/office
/area/station/engineering/storage_shared
/area/station/service/abandoned_gambling_den
/area/station/security/checkpoint
/area/station/service/chapel
/area/station/service/janitor
/area/station/command/heads_quarters/ce
/area/station/commons/dorms
/area/station/commons/toilet
/area/station/service/hydroponics
/area/station/hallway/secondary/service
/area/station/service/kitchen
/area/station/commons/lounge
/area/station/engineering/storage/tech
/area/station/service/bar
/area/station/security/courtroom
/area/station/service/lawoffice
/area/station/security/detectives_office
/area/station/service/theater
/area/station/hallway/primary/fore
/area/station/hallway/primary/aft
/area/station/hallway/secondary/command
/area/station/commons/fitness/recreation
/area/station/service/hydroponics/garden
/area/station/commons/vacant_room/commissary
/area/station/security/checkpoint/supply
/area/station/command/heads_quarters/hop
/area/station/cargo/sorting
/area/station/cargo/warehouse
/area/station/commons/storage/tools
/area/station/service/library
/area/station/command/gateway
/area/station/hallway/primary/starboard
/area/station/service/library/private
/area/station/medical/morgue
/area/station/maintenance/fore/lesser
/area/station/medical/psychology
/area/station/medical/medbay/central
/area/station/maintenance/disposal
/area/station/command/heads_quarters/cmo
/area/station/medical/surgery/theatre
/area/station/science/xenobiology
/area/station/science/server
/area/station/science/storage
/area/station/science/robotics/mechbay
/area/station/science/robotics/lab
/area/station/medical/exam_room
/area/station/medical/pharmacy
/area/station/medical/treatment_center
/area/station/science/mixing
/area/station/medical/chemistry
/area/station/security/checkpoint/customs
/area/station/science/genetics
/area/station/solars/starboard/aft
/area/station/hallway/secondary/exit/departure_lounge

## Beef Station

![image](https://user-images.githubusercontent.com/25415050/169592711-d2c3975c-5a96-4567-b25a-5c2b5e0bb190.png)

we dont use those anymore

![image](https://user-images.githubusercontent.com/25415050/169596270-868f9f67-ae35-4515-b986-498a85240444.png)

Non-diagonal was missing there, causing the shower to be smooth'd open

![image](https://user-images.githubusercontent.com/25415050/169596946-ab16f962-8455-4825-a456-b98764e19658.png)

There's no benefit in using multi-cyclelink helpers over regular ones in this specific case

 ## Beef Cytology

![image](https://user-images.githubusercontent.com/25415050/169595962-d68bbfb6-6a55-46f9-90cf-6f343db11047.png)

The iced-over windows weren't using the spawner variant, saves on lines.

![image](https://user-images.githubusercontent.com/25415050/169596030-803ee11a-25e2-4614-a8b9-15724d996afb.png)

These ones had space under them instead of solid ground.

![image](https://user-images.githubusercontent.com/25415050/169597727-86341e2a-5136-47fa-8800-0ca83a6a2712.png)

These signs wouldn't actually be seen until the airlock is open due to their position, they're also inside the closed turf instead of displaced from the nearest open turf

![image](https://user-images.githubusercontent.com/25415050/169596059-875d0af7-3c43-4092-ba94-c40560969db5.png)

There were extinguisher cabinet frames (the item that you then attach to the walls instead of the wall mounts themselves) inside of the walls (not offset from the open tile's direction)

## Shuttles

![image](https://user-images.githubusercontent.com/25415050/169600231-925a749a-ae79-4c92-a440-bf0e2f1e3b53.png)

Large tanks hold a stupid amount of gas in them, passive vents try to equalize the pressure inside and outside, opening the valve for 10 seconds is enough to start killing anyone in the shuttle from overpressurization

## Changelog

 Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. 
You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. 
