### PR TITLE
Felinids, or anyone trying to become a felinid, now start with brain damage

### DIFF
--- a/fulp_modules/Z_edits/felinid_edit.dm
+++ b/fulp_modules/Z_edits/felinid_edit.dm
@@ -1,5 +1,5 @@
 /datum/species/human/felinid
-	changesource_flags = MIRROR_BADMIN | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
+	changesource_flags = MIRROR_BADMIN | MIRROR_PRIDE | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	var/brain_damage_to_give = 199
 	var/give_traumas = TRUE
 
@@ -13,7 +13,7 @@
 
 /datum/species/human/felinid/nobraindamage
 	id = "felinid-nobraindamage"
-	changesource_flags = MIRROR_BADMIN
+	changesource_flags = MIRROR_BADMIN | MIRROR_MAGIC | ERT_SPAWN
 	brain_damage_to_give = 0
 	give_traumas = FALSE
 

--- a/fulp_modules/Z_edits/felinid_edit.dm
+++ b/fulp_modules/Z_edits/felinid_edit.dm
@@ -1,0 +1,49 @@
+/datum/species/human/felinid
+	changesource_flags = MIRROR_BADMIN | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
+	var/brain_damage_to_give = 199
+	var/give_traumas = TRUE
+
+/datum/species/human/felinid/on_species_gain(mob/living/carbon/felifriend, datum/species/old_species, pref_load)
+	. = ..()
+	if(brain_damage_to_give)
+		felifriend.setOrganLoss(ORGAN_SLOT_BRAIN, brain_damage_to_give) //Fuck you
+	if(give_traumas)
+		felifriend.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_LOBOTOMY) //Fuck you even more
+		felifriend.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_LOBOTOMY)
+
+/datum/species/human/felinid/nobraindamage
+	id = "felinid-nobraindamage"
+	changesource_flags = MIRROR_BADMIN
+	brain_damage_to_give = 0
+	give_traumas = FALSE
+
+/obj/item/clothing/head/kitty
+	desc = "A pair of kitty ears. Meow! Prone to causing the user to behave more absent-minded."
+	equip_delay_other = 20 MINUTES
+	equip_delay_self = 5 SECONDS
+	clothing_flags = SNUG_FIT | ANTI_TINFOIL_MANEUVER | DANGEROUS_OBJECT
+	clothing_traits = list(TRAIT_UNINTELLIGIBLE_SPEECH, TRAIT_CLUMSY, TRAIT_DUMB)
+
+/obj/item/clothing/head/kitty/proc/at_peace_check(mob/user)
+	if(iscarbon(user))
+		var/mob/living/carbon/carbon_user = user
+		if(src == carbon_user.head)
+			to_chat(user, span_warning("You feel at peace as a cat. <b style='color:pink'>Why would you want anything else?</b>"))
+			return TRUE
+	return FALSE
+
+/obj/item/clothing/head/kitty/attack_hand(mob/user, list/modifiers)
+	if(at_peace_check(user))
+		return
+	return ..()
+
+/obj/item/clothing/head/kitty/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	if(at_peace_check(usr))
+		return
+	return ..()
+
+/obj/item/clothing/head/kitty/equipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	if(slot != ITEM_SLOT_HEAD)
+		return
+	user.adjustOrganLoss(ORGAN_SLOT_BRAIN, 75, 199)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4616,6 +4616,7 @@
 #include "fulp_modules\Z_edits\antag_objectives.dm"
 #include "fulp_modules\Z_edits\christmas.dm"
 #include "fulp_modules\Z_edits\economy_edit.dm"
+#include "fulp_modules\Z_edits\felinid_edit.dm"
 #include "fulp_modules\Z_edits\fulp_bans.dm"
 #include "fulp_modules\Z_edits\heart.dm"
 #include "fulp_modules\Z_edits\job_edits.dm"


### PR DESCRIPTION
## The Pull Request

Felinids now start with 199 brain damage and are given a roundstart severe and mild trauma, apart from the ones they'll get from the brain damage.
Furthermore, wearing cat ears will now make you clumsy, dumb and make you slur your speech occassionally - this, on top of getting 75 brain damage every time you wear it (with a cap of 199). If you have any ideas of what to add (reasonable within traits) to this as to discourage it more, feel free.

## Why It's Good For The Game

This was requested by the admins in [our feature request forum](https://forum.fulp.gg/t/felinids-start-with-brain-damage/1910/84).
This should heavily discourage anyone from trying to seek becoming a felinid.
i've added several failsafes that should stop the abuse of the cat ears (such as only you being the one able to equip them, not being able to be thrown onto people's heads, and having an absurd long time to equip on others, making it impossible unless you're blatantly griefing).

## Changelog


:cl:
imageadd: Felinids now have brain damage
/:cl:
