### PR TITLE
Flow doesn't cost blood anymore

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/fortitude.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/fortitude.dm
@@ -83,3 +83,5 @@
 	name = "Flow"
 	desc = "Use the arts to Flow, giving shove and stun immunity, as well as brute, burn, dismember and pierce resistance. You cannot run while this is active."
 	purchase_flags = HUNTER_CAN_BUY
+	bloodcost = 0
+	constant_bloodcost = 0


### PR DESCRIPTION
## About The Pull Request

Accident, Monster hunter's ability isn't supposed to cost blood.
