### PR TITLE
Removes statue from gold spawns

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -10,6 +10,7 @@
 	gender = NEUTER
 	combat_mode = TRUE
 	mob_biotypes = MOB_HUMANOID
+	gold_core_spawnable = NO_SPAWN
 
 	response_help_continuous = "touches"
 	response_help_simple = "touch"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mentors and a yellow remarked in public chat (most visited channel) that people are able to unintentionally spawn in 50,000 hp mobs that are also able to deal 80 brute damage and less than 24h after tgu got merged someone's already managed to abuse it and murderbone as an unkillable god of death through the least amount of work possible in the form of xenobio gold core, fix is open at tg but I don't really want to wait hoping no one else uses a gold extract for an entire month because we all know xenobio players so it's probably better to fix it ASAP?