### PR TITLE
Advanced mulligan no bludgeon and it says its one use in its description

### DIFF
--- a/fulp_modules/features/antagonists/infiltrators/infil_items.dm
+++ b/fulp_modules/features/antagonists/infiltrators/infil_items.dm
@@ -1,11 +1,12 @@
 /obj/item/adv_mulligan
 	name = "advanced mulligan"
-	desc = "Toxin that permanently changes your DNA into the one of last injected person. Use it on the victim to extract their DNA then inject it into yourself!"
+	desc = "A one use autoinjector with a toxin that permanently changes your DNA to the DNA of a previously injected person. Use it on the victim to extract their DNA then inject it into yourself!"
 	icon = 'icons/obj/syringe.dmi'
 	icon_state = "dnainjector0"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
+	item_flags = NOBLUDGEON
 	var/used = FALSE ///determines wether the injector is used up or nah
 	var/datum/weakref/store  ///the mob currently stored in the injector
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The description of the advanced mulligan now tells you that its one use and when you stab people with it you don't hit them with it visually like probably intended since its stealthy.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Mulligan is now actually stealthy and less confusing.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The advanced mulligan now tells you its one use.
fix: When you stab people with the advanced mulligan you won't hit them on the head with it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
