### PR TITLE
Fixes our CI, Putting on cat ears gives just a bit more brain damage

### DIFF
--- a/fulp_modules/Z_edits/felinid_edit.dm
+++ b/fulp_modules/Z_edits/felinid_edit.dm
@@ -28,7 +28,7 @@
 	if(iscarbon(user))
 		var/mob/living/carbon/carbon_user = user
 		if(src == carbon_user.head)
-			to_chat(user, span_warning("You feel at peace as a cat. <b style='color:pink'>Why would you want anything else?</b>"))
+			to_chat(user, span_warning("<b style='color:pink'>You feel unwilling to remove [src].</b>"))
 			return TRUE
 	return FALSE
 
@@ -46,4 +46,7 @@
 	. = ..()
 	if(slot != ITEM_SLOT_HEAD)
 		return
-	user.adjustOrganLoss(ORGAN_SLOT_BRAIN, 75, 199)
+	user.adjustOrganLoss(ORGAN_SLOT_BRAIN, 100, 199)
+
+/mob/living/carbon/human/species/felinid
+	race = /datum/species/human/felinid/nobraindamage


### PR DESCRIPTION
## About The Pull Request

CI error was caused by felinids spawning with the aphasia brain trauma which when qdeleted runtimes lol
Also the kitty ears give you 100 instead of 75 brain damage now i think it improves the game a bit

## Why It's Good For The Game


## Changelog

:cl:
sounddel: Ci doesn't fail anymore
/:cl:
