### PR TITLE
Removes the free Close Quarter Cooking skillchip from the prison shuttle

### DIFF
--- a/_maps/shuttles/prison_kitchen.dmm
+++ b/_maps/shuttles/prison_kitchen.dmm
@@ -4,7 +4,6 @@
 /area/shuttle/prison_shuttle)
 "c" = (
 /obj/structure/table/reinforced,
-/obj/item/skillchip/job/chef,
 /obj/item/book/manual/chef_recipes,
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/reagent_containers/glass/bowl,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It didn't even need the warden's permission to be used.

Fixes #674
Fixes #675

Having the skillchip only available through the shuttle instead of having it mapped onto the station is pointless as it's unusable without the station's json allowing for its use in the prison so no extra benefits is brought by using the proposed alternative.