### PR TITLE
Allows prisoners to use the prison budget

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -3532,7 +3532,7 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/computer/cargo/request/prison,
+/obj/machinery/modular_computer/console/preset/prison,
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
 	dir = 9;

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -53449,7 +53449,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "nRY" = (
-/obj/machinery/computer/cargo/request/prison{
+/obj/machinery/modular_computer/console/preset/prison{
 	dir = 8
 	},
 /turf/open/floor/iron/textured,

--- a/fulp_modules/features/prison/prison_cargo.dm
+++ b/fulp_modules/features/prison/prison_cargo.dm
@@ -1,15 +1,33 @@
-/obj/machinery/computer/cargo/request/prison
-	name = "prison supply console"
-	desc = "Used to request supplies from cargo."
-	icon_screen = "request"
-	circuit = /obj/item/circuitboard/computer/cargo
+/obj/machinery/modular_computer/console/preset/prison
+	name = "Prison Order Console"
+	var/obj/item/computer_hardware/card_slot/id_slot
 
-	contraband = TRUE
-	//The account this console processes and displays. Independent from the account the shuttle processes.
-	cargo_account = ACCOUNT_PRISON
+/obj/machinery/modular_computer/console/preset/prison/install_programs()
+	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]
+	hard_drive.store_file(new/datum/computer_file/program/budgetorders/prison())
 
-/obj/item/circuitboard/computer/cargo/request/prison
-	name = "Prison Supply Rquests Console (Computer Board)"
-	greyscale_colors = CIRCUIT_COLOR_SUPPLY
-	build_path = /obj/machinery/computer/cargo/request/prison
-	contraband = TRUE
+/obj/machinery/modular_computer/console/preset/prison/Initialize(mapload)
+	. = ..()
+	id_slot = cpu.all_components[MC_CARD]
+	id_slot.stored_card = new /obj/item/card/id/departmental_budget/prison
+
+/obj/item/card/id/departmental_budget/prison
+	name = "prison budget card"
+	desc = "Provides access to the prison budget."
+	department_ID = ACCOUNT_PRISON
+	department_name = ACCOUNT_PRISON_NAME
+
+/obj/item/card/id/departmental_budget/prison/Initialize()
+	. = ..()
+	registered_account?.account_job = /datum/job/prisoner
+
+/datum/computer_file/program/budgetorders/prison
+	filename = "orderapp-p"
+	filedesc = "NT IRN Prison Edition"
+	extended_desc = "Nanotrasen Internal Requisition Network interface for designed for supply orders to individuals under penal punishment."
+	usage_flags = PROGRAM_CONSOLE
+	available_on_ntnet = FALSE
+
+/datum/controller/subsystem/economy/Initialize(timeofday)
+	department_accounts += list(ACCOUNT_PRISON = ACCOUNT_PRISON_NAME)
+	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #679 

Replaces the request console with a modular console that has its own version of NT IRN and budget card inside. It having its own subtype only matters when its first initialized, if the CPU is ever deleted, the same functionality is obtained from simply asking HoS or QM for NT IRN to be installed on any tablet/laptop, the subtype is only needed to have it run on a console & create the ID. If the ID is destroyed no functionality other than being able to input money directly into the budget is lost, a regular prisoner ID running in a console under NT IRN will still use the prison budget.

Switch from request console to NT IRN modular computer has two side effects:
- Prisoners are unable to order themselves guns or any dangerous items a prisoner ID does not have access to.
- Prisoners are able to fuel the budget ID with their own money or credits obtained from any other ways (i.e customer robots)

![image](https://user-images.githubusercontent.com/25415050/175775606-451a9642-d6e7-4c4d-a680-038268cb3b55.png)
