### PR TITLE
Fixes Ventrue bloodsuckers using blood when not levelling up

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -513,7 +513,7 @@
 #define PURCHASE_TREMERE "Tremere"
 #define PURCHASE_DEFAULT "Default"
 
-/datum/antagonist/bloodsucker/proc/SpendRank(mob/living/carbon/human/target, spend_rank = TRUE)
+/datum/antagonist/bloodsucker/proc/SpendRank(mob/living/carbon/human/target, spend_rank = TRUE, spend_blood = FALSE)
 	set waitfor = FALSE
 
 	var/datum/antagonist/vassal/vassaldatum = target?.mind.has_antag_datum(/datum/antagonist/vassal)
@@ -613,6 +613,8 @@
 	bloodsucker_level++
 	if(spend_rank)
 		bloodsucker_level_unspent--
+	if(spend_blood)
+		bloodsucker_blood_volume -= 550
 
 	// Ranked up enough? Let them join a Clan.
 	if(bloodsucker_level == 3)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_crypt.dm
@@ -582,7 +582,6 @@
 			var/rank_response = show_radial_menu(user, src, rank_options, radius = 36, require_near = TRUE)
 			switch(rank_response)
 				if("Yes")
-					bloodsuckerdatum.bloodsucker_blood_volume -= 550
 					bloodsuckerdatum.SpendRank(target, spend_rank = FALSE)
 					return
 		else


### PR DESCRIPTION
## About The Pull Request

Ventrue Bloodsuckers now only lose the blood spent to upgrade, when they actually spend it. If they cancel out they will no longer be charged.
