### PR TITLE
Removes the Selene RD office firelock

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -78011,7 +78011,6 @@
 /obj/machinery/door/airlock/command{
 	name = "Server Room"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 6
 	},


### PR DESCRIPTION
Since the change to firelocks they'll now check both their sides for bad atmos as opposed to before where it was the fire alarm thatd determine that. This meant the Selene's R&D server room's firelock triggered everytime at roundstart.