### PR TITLE
Nerfs SeleneStation's medbay maints' crate

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -51842,7 +51842,7 @@
 /area/station/service/theater)
 "ntA" = (
 /obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance/eight,
+/obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "ntI" = (


### PR DESCRIPTION
Some joker put a x8 maintenance loot spawner over a crate spawner which can spawn as a mini fridge that has a low storage capacity & that makes it all shit itself

![image](https://user-images.githubusercontent.com/25415050/178570699-602a17df-e6f6-4bf1-9c74-d064a9d07261.png)