### PR TITLE
Renames Toxins cameras

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -30443,7 +30443,7 @@
 	pixel_x = 11
 	},
 /obj/machinery/camera/directional/north{
-	c_tag = "Research Airlock";
+	c_tag = "Science - Access";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -31084,7 +31084,7 @@
 /area/station/maintenance/department/science)
 "bBf" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "Robotics NE";
+	c_tag = "Science - Robotics NE";
 	name = "Robotics Camera";
 	network = list("ss13","rd")
 	},
@@ -33296,7 +33296,7 @@
 /area/station/science/lab)
 "bGV" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "R&D Camera";
+	c_tag = "Science - Research & Development";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -34323,7 +34323,7 @@
 /area/station/science/research)
 "bJG" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "Research Hall - Security Post";
+	c_tag = "Science - Hall North";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -34343,7 +34343,7 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /obj/machinery/camera/directional/north{
-	c_tag = "Security Post - Science";
+	c_tag = "Science - Security Post";
 	name = "Security Post Camera";
 	network = list("ss13","rd")
 	},
@@ -34848,7 +34848,7 @@
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
 /obj/machinery/camera/directional/south{
-	c_tag = "Robotics SW";
+	c_tag = "Science - Robotics SW";
 	name = "Robotics Camera";
 	network = list("ss13","rd")
 	},
@@ -35006,7 +35006,7 @@
 /obj/item/kitchen/fork/plastic,
 /obj/item/knife/plastic,
 /obj/machinery/camera/directional/north{
-	c_tag = "Research Break Room";
+	c_tag = "Science - Break Room";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -35052,7 +35052,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/east{
-	c_tag = "Genetics";
+	c_tag = "Science - Genetics";
 	name = "Genetics Camera";
 	network = list("ss13","rd")
 	},
@@ -36102,7 +36102,7 @@
 /area/station/science/research)
 "bOt" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "Research Hall - West";
+	c_tag = "Science - Hall West";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -37385,7 +37385,7 @@
 /area/station/science/research)
 "bRA" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "Research Hall - Server Room";
+	c_tag = "Science - Server Room Hall";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -38493,7 +38493,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/directional/south{
-	c_tag = "Research Hall - Genetics";
+	c_tag = "Science - Genetics Hall";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -38600,7 +38600,7 @@
 /obj/item/folder/white,
 /obj/item/pen,
 /obj/machinery/camera/directional/north{
-	c_tag = "R&D Server Room";
+	c_tag = "Science - Server Room";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -40314,7 +40314,7 @@
 	name = "research purple"
 	},
 /obj/machinery/camera/directional/south{
-	c_tag = "Circuit Lab";
+	c_tag = "Science - Circuit Lab";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -41039,7 +41039,7 @@
 /area/station/command/heads_quarters/rd)
 "cbA" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Research Hall - Toxins";
+	c_tag = "Science - Ordnance Hall";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -42610,7 +42610,7 @@
 "cfL" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/camera/directional/west{
-	c_tag = "Toxins Storage";
+	c_tag = "Science - Ordnance Storage";
 	name = "Ordnance Storage Camera";
 	network = list("ss13","rd")
 	},
@@ -44691,7 +44691,7 @@
 /area/station/science/research)
 "ckX" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "Research Hall - Xenobiology";
+	c_tag = "Science - Xenobiology Hall";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -45509,7 +45509,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/directional/south{
-	c_tag = "Research Hall - Testing";
+	c_tag = "Science - Hall South";
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
@@ -45753,7 +45753,7 @@
 "cnl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/directional/south{
-	c_tag = "Research Director";
+	c_tag = "Science - Research Director Office";
 	name = "RD Camera";
 	network = list("ss13","rd")
 	},
@@ -45919,7 +45919,7 @@
 "cnD" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/camera/directional/west{
-	c_tag = "Testing Lab W";
+	c_tag = "Science - Testing Lab W";
 	name = "Testing Lab Camera";
 	network = list("ss13","rd","test")
 	},
@@ -46961,7 +46961,7 @@
 /area/station/engineering/engine_smes)
 "cpT" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "Testing Lab E";
+	c_tag = "Science - Testing Lab E";
 	name = "Testing Lab Camera";
 	network = list("ss13","rd","test")
 	},
@@ -48389,7 +48389,7 @@
 /area/station/science/xenobiology)
 "ctg" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "Xenobiology - Main";
+	c_tag = "Science - Xenobiology Central";
 	name = "Xenobiology Camera";
 	network = list("ss13","rd","xeno")
 	},
@@ -48915,7 +48915,7 @@
 /area/station/science/xenobiology)
 "cuy" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "Xenobiology - Test Chamber";
+	c_tag = "Science - Xenobiology Test Chamber";
 	name = "Xenobiology Camera";
 	network = list("ss13","rd","xeno")
 	},
@@ -50388,7 +50388,7 @@
 /area/station/science/xenobiology)
 "cyh" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Xenobiology - Freezer";
+	c_tag = "Science - Xenobiology Freezer";
 	name = "Xenobiology Camera";
 	network = list("ss13","rd","xeno")
 	},
@@ -52565,7 +52565,7 @@
 /area/station/engineering/main)
 "cDG" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "Xenobiology - Pen #7";
+	c_tag = "Science - Pen #7";
 	name = "Xenobiology Camera";
 	network = list("ss13","rd","xeno")
 	},
@@ -53757,7 +53757,7 @@
 /area/station/cargo/miningoffice)
 "cGP" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Xenobiology - Pen #2";
+	c_tag = "Science - Pen #2";
 	name = "Xenobiology Camera";
 	network = list("ss13","rd","xeno")
 	},
@@ -55835,7 +55835,7 @@
 /area/station/maintenance/disposal/incinerator)
 "cLk" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "Xenobiology - Pen #9";
+	c_tag = "Science - Pen #9";
 	name = "Xenobiology Camera";
 	network = list("ss13","rd","xeno")
 	},
@@ -56059,7 +56059,7 @@
 /area/station/engineering/atmos)
 "cLX" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Xenobiology - Pen #4";
+	c_tag = "Science - Pen #4";
 	name = "Xenobiology Camera";
 	network = list("ss13","rd","xeno")
 	},
@@ -56712,7 +56712,7 @@
 /area/station/science/xenobiology)
 "cNC" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "Xenobiology - Hallway";
+	c_tag = "Science - Xenobiology South";
 	name = "Xenobiology Camera";
 	network = list("ss13","rd","xeno")
 	},
@@ -56945,7 +56945,7 @@
 /area/station/engineering/lobby)
 "cOg" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "Xenobiology - Pen #11";
+	c_tag = "Science - Pen #11";
 	name = "Xenobiology Camera";
 	network = list("ss13","rd","xeno")
 	},
@@ -60113,7 +60113,7 @@
 /area/station/maintenance/department/cargo)
 "cXc" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "Toxins Hallway";
+	c_tag = "Science - Launch Access";
 	name = "Ordnance Lab Camera";
 	network = list("ss13","rd")
 	},
@@ -65397,7 +65397,7 @@
 /area/station/science/research)
 "jBI" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Toxins Launch";
+	c_tag = "Science - Ordnance Launch";
 	name = "Ordnance Launch Camera";
 	network = list("ss13","rd")
 	},
@@ -72568,7 +72568,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/north{
-	c_tag = "Ordnance Lab N";
+	c_tag = "Science - Ordnance Lab N";
 	name = "science camera";
 	network = list("ss13","rd")
 	},


### PR DESCRIPTION
Changes to ordnance instead.

Also renames all science's cameras' c_tag to be prefixed with Science - because its just easier to use camera consoles that way