### PR TITLE
Miscelaneous Selenestation fixes and changes

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -466,9 +466,6 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "ahe" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
-	name = "waste release"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
@@ -476,14 +473,12 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ahi" = (
@@ -1186,11 +1181,9 @@
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/hop)
 "apO" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/mapping_helpers/dead_body_placer,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "apQ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -1877,12 +1870,9 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "axS" = (
-/obj/machinery/computer/atmos_control/mix_tank{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -4294,16 +4284,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "bgX" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bgY" = (
@@ -4993,9 +4976,8 @@
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
 "boW" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Port"
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -5713,22 +5695,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"byG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "CO2 Outlet Pump"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 8;
-	name = "dark corner"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "byQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6420,9 +6386,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bGf" = (
@@ -6894,13 +6857,10 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "bMe" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bMh" = (
@@ -7415,14 +7375,11 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/command)
 "bTw" = (
-/obj/machinery/computer/atmos_control/plasma_tank{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "bTA" = (
 /obj/item/trash/boritos,
@@ -8392,11 +8349,19 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "cgS" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix Outlet Pump"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/space/basic,
+/area/space/nearstation)
+"chd" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Plasma Tank";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "cho" = (
 /obj/machinery/holopad,
@@ -9433,8 +9398,11 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay)
 "cvc" = (
-/obj/machinery/air_sensor/mix_tank,
-/turf/open/floor/engine/vacuum,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cvK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9574,6 +9542,10 @@
 	color = "#FFD700";
 	dir = 4;
 	name = "Engineering yellow corner"
+	},
+/obj/machinery/airalarm/unlocked{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
@@ -10709,7 +10681,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "cKA" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/air_sensor/carbon_tank,
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "cKE" = (
@@ -10720,8 +10692,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "cKG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 5
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	dir = 4;
+	name = "plasma mixer"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -11546,6 +11519,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"cWr" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Mix Tank";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/engine/vacuum,
+/area/station/engineering/atmos)
 "cWB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
@@ -11984,12 +11964,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
-"dbP" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input{
-	dir = 1
-	},
-/turf/open/floor/engine/co2,
-/area/station/engineering/atmos)
 "dbQ" = (
 /obj/structure/table/reinforced,
 /obj/item/radio,
@@ -12645,12 +12619,12 @@
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "dmK" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dmP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -13999,6 +13973,13 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"dHB" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "dHI" = (
 /obj/item/stack/medical/gauze,
 /turf/open/floor/plating,
@@ -18382,17 +18363,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/rec)
 "ePt" = (
-/obj/machinery/computer/atmos_control/carbon_tank{
-	dir = 1
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 8;
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	name = "dark corner"
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -20146,8 +20122,11 @@
 /area/station/maintenance/starboard)
 "fmx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fmU" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -20431,8 +20410,7 @@
 /area/station/maintenance/port/aft)
 "fqc" = (
 /obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_one_access_txt = "10;24"
+	name = "Atmospherics External Access"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -21694,12 +21672,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"fHo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/carbon_output{
-	dir = 1
-	},
-/turf/open/floor/engine/co2,
-/area/station/engineering/atmos)
 "fHt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -21751,8 +21723,15 @@
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "fHS" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o{
-	dir = 1
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -22289,7 +22268,7 @@
 "fNk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
@@ -24958,11 +24937,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "gzZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix Outlet Pump"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gAc" = (
 /obj/structure/rack,
@@ -27969,9 +27952,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "hnL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -28928,7 +28908,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "hBt" = (
-/obj/effect/landmark/event_spawn,
+/obj/machinery/air_sensor/mix_tank,
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
 "hBN" = (
@@ -29828,10 +29808,9 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "hMP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix Outlet Pump"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -31680,9 +31659,9 @@
 /area/station/maintenance/port/aft)
 "ilH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ima" = (
 /obj/structure/cable,
 /obj/structure/grille/broken,
@@ -32996,9 +32975,9 @@
 /area/station/science/xenobiology)
 "iEQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "iES" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/crate,
@@ -33697,11 +33676,24 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "iOL" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
-/turf/open/space/basic,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iOS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -34002,6 +33994,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
+"iTB" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input{
+	dir = 1
+	},
+/turf/open/floor/engine/co2,
+/area/station/engineering/atmos)
 "iTT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -34964,9 +34962,20 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "jib" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "CO2 Outlet Pump"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 8;
+	name = "dark corner"
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jih" = (
 /obj/structure/bed,
@@ -36391,16 +36400,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "jCA" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jCC" = (
@@ -37024,9 +37027,9 @@
 /area/station/security/lockers)
 "jJQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jKe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -39177,11 +39180,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "klG" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "klI" = (
@@ -39713,21 +39714,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "ksC" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/machinery/light/directional/south,
+/obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 1;
+	dir = 8;
 	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
@@ -39985,8 +39976,14 @@
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
 "kwE" = (
-/obj/machinery/air_sensor/plasma_tank,
-/turf/open/floor/engine/plasma,
+/obj/machinery/computer/atmos_control/mix_tank{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kwI" = (
 /obj/effect/spawner/random/structure/crate,
@@ -42155,15 +42152,8 @@
 /turf/open/floor/carpet,
 /area/station/maintenance/fore)
 "kZJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 8;
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	name = "dark corner"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -43347,8 +43337,7 @@
 /area/station/maintenance/department/cargo)
 "lqj" = (
 /obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_one_access_txt = "10;24"
+	name = "Atmospherics External Access"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
@@ -43383,10 +43372,20 @@
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
 "lqB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
-/obj/machinery/meter,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Atmospherics S";
+	network = list("ss13","engineering")
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lqK" = (
@@ -43861,8 +43860,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "lxz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Pure to Port"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -45399,6 +45399,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"lPW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output{
+	dir = 1
+	},
+/turf/open/floor/engine/plasma,
+/area/station/engineering/atmos)
 "lQa" = (
 /obj/docking_port/stationary/mining_home/common{
 	dir = 8
@@ -45995,12 +46001,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"lWD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output{
-	dir = 1
-	},
-/turf/open/floor/engine/plasma,
-/area/station/engineering/atmos)
 "lWM" = (
 /obj/structure/cable,
 /obj/structure/sign/poster/official/work_for_a_future{
@@ -48054,10 +48054,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mwm" = (
@@ -49153,7 +49149,7 @@
 "mKj" = (
 /obj/structure/sign/warning/no_smoking/directional/south,
 /turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
+/area/station/maintenance/disposal/incinerator)
 "mKk" = (
 /turf/closed/wall,
 /area/station/security/execution/transfer)
@@ -50254,13 +50250,11 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "mYm" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix Outlet Pump"
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -51780,10 +51774,13 @@
 /turf/open/misc/grass,
 /area/station/hallway/secondary/entry)
 "nrX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+/obj/machinery/computer/atmos_control/plasma_tank{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nsn" = (
@@ -52327,20 +52324,7 @@
 	dir = 8;
 	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/machinery/light/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate{
-	name = "empty internals crate"
-	},
-/obj/item/tank/internals,
-/obj/item/tank/internals,
-/obj/item/tank/internals,
-/obj/item/tank/internals,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nzb" = (
@@ -52406,15 +52390,14 @@
 /turf/open/floor/iron,
 /area/station/security/prison/upper)
 "nAX" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
 	dir = 8;
-	name = "Engineering yellow corner"
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	name = "dark corner"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -52831,8 +52814,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "nHg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
+/obj/machinery/computer/atmos_control/carbon_tank{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 8;
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	name = "dark corner"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -53869,11 +53861,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "nXw" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/space/basic,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "nXz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -54783,9 +54773,25 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "oiY" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
+	name = "waste release"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ojh" = (
 /obj/effect/spawner/random/maintenance/two,
@@ -55066,9 +55072,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "onD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "onJ" = (
@@ -56114,12 +56127,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "oCS" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "oCW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
 	dir = 4
@@ -57333,10 +57344,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "oUI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/mix_output{
-	dir = 1
-	},
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "oUL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -61545,6 +61555,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"qaY" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - CO2 Tank";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/engine/co2,
+/area/station/engineering/atmos)
 "qbb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -62431,10 +62448,7 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "qkV" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - Plasma Tank";
-	network = list("ss13","engineering")
-	},
+/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "qll" = (
@@ -64100,11 +64114,11 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "qJv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qJx" = (
 /obj/machinery/airalarm/directional/south,
@@ -65102,6 +65116,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2O Outlet Pump"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qYQ" = (
@@ -65693,8 +65711,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "res" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -67497,10 +67515,29 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "rDN" = (
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	dir = 4;
-	name = "plasma mixer"
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	name = "empty internals crate"
+	},
+/obj/item/tank/internals,
+/obj/item/tank/internals,
+/obj/item/tank/internals,
+/obj/item/tank/internals,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rDS" = (
@@ -67798,6 +67835,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/plasmaman)
+"rHj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/carbon_output{
+	dir = 1
+	},
+/turf/open/floor/engine/co2,
+/area/station/engineering/atmos)
 "rHw" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/delivery,
@@ -68312,9 +68355,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "rPs" = (
-/obj/machinery/air_sensor/carbon_tank,
-/turf/open/floor/engine/co2,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "rPt" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -68513,7 +68559,7 @@
 /turf/closed/wall,
 /area/station/maintenance/department/engine/atmos)
 "rRV" = (
-/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/air_sensor/plasma_tank,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "rSw" = (
@@ -68951,12 +68997,12 @@
 /turf/open/floor/iron/white/side,
 /area/station/science/xenobiology)
 "rYa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/turf/open/space/basic,
+/area/space/nearstation)
 "rYo" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/purple{
@@ -70801,23 +70847,10 @@
 /area/station/commons/fitness)
 "svK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - Atmospherics S";
-	network = list("ss13","engineering")
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "svX" = (
 /obj/structure/cable,
@@ -70945,6 +70978,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
+"sxq" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "sxu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -72164,6 +72201,13 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
+"sOP" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "sOS" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -72301,12 +72345,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"sQF" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
-	dir = 1
-	},
-/turf/open/floor/engine/plasma,
-/area/station/engineering/atmos)
 "sQL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
@@ -72930,6 +72968,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"tcG" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
+	dir = 1
+	},
+/turf/open/floor/engine/plasma,
+/area/station/engineering/atmos)
 "tcI" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/brown{
@@ -73672,11 +73716,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "tlc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "tlf" = (
 /obj/structure/cable,
@@ -73801,9 +73845,9 @@
 /area/station/engineering/storage/tech)
 "tmp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "tms" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -75950,6 +75994,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"tRp" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "tRA" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -77190,9 +77241,12 @@
 /turf/open/floor/plating,
 /area/station/security/office)
 "uig" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "uiu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -80348,11 +80402,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "uZp" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uZq" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
@@ -80763,6 +80816,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"ves" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/mix_input{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/station/engineering/atmos)
 "vey" = (
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -84054,16 +84113,13 @@
 /area/station/maintenance/port/aft)
 "vZK" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 1
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "vZO" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - Mix Tank";
-	network = list("ss13","engineering")
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
 "vZP" = (
@@ -87690,7 +87746,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/maintenance/disposal/incinerator)
 "wXV" = (
 /obj/structure/table/glass,
 /obj/item/flashlight/lantern,
@@ -88011,12 +88067,11 @@
 /turf/open/floor/iron/white,
 /area/station/service/hydroponics)
 "xaV" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/mix_output{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/engine/vacuum,
+/area/station/engineering/atmos)
 "xaX" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -89480,10 +89535,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "xrM" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/mix_input{
-	dir = 1
-	},
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "xsc" = (
 /obj/effect/turf_decal/tile/bar{
@@ -91358,10 +91412,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "xTg" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - CO2 Tank";
-	network = list("ss13","engineering")
-	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "xTr" = (
@@ -92613,8 +92664,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "ygp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ygs" = (
@@ -127111,22 +127164,22 @@ xCX
 rpL
 xDM
 xDM
-xCX
-xCX
-xCX
-xCX
-fcU
+nVF
+nVF
+nVF
+nVF
+koK
 wXJ
-fcU
+koK
 mKj
 xCX
 fcU
 fcU
 fcU
+fcU
 xCX
-iOL
+rPs
 xPd
-iQW
 iQW
 tqS
 iQW
@@ -127382,7 +127435,7 @@ xYf
 ahe
 oiY
 nXw
-iQW
+rYa
 iQW
 iQW
 tqS
@@ -127636,16 +127689,17 @@ uBM
 uBM
 rKP
 ieh
-nAX
+wVc
+fHS
 xCX
 xCX
-yju
 yju
 yju
 tgq
 wwP
 wwP
-vZK
+wwP
+dHB
 iQW
 iQW
 yju
@@ -127653,7 +127707,6 @@ xdv
 xBY
 yju
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -127893,8 +127946,9 @@ mjs
 reQ
 ejZ
 wVc
-bMe
+wVc
 ksC
+iOL
 xCX
 yju
 hBb
@@ -127910,7 +127964,6 @@ xdv
 xBY
 iQW
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -128150,12 +128203,13 @@ xKb
 aPm
 pbm
 uBM
-cgS
+uBM
 hMP
 fmx
 tmp
 ilH
 oUI
+xaV
 pcj
 pcj
 hBb
@@ -128167,7 +128221,6 @@ xdv
 xBY
 yju
 bfi
-iQW
 iQW
 iQW
 iQW
@@ -128408,13 +128461,14 @@ wVc
 wVc
 wVc
 sEc
-axS
+wVc
+kwE
 ddg
-yju
+uZp
 fcU
-cvc
 hBt
 vZO
+cWr
 hBb
 tqS
 xdv
@@ -128422,7 +128476,6 @@ xBY
 xBY
 xBY
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -128661,15 +128714,16 @@ xVf
 xVf
 xVf
 ygp
-wVc
+oUE
 lxz
-uBM
+boW
 tje
 mwi
 uig
 iEQ
 jJQ
 xrM
+ves
 pcj
 pcj
 hBb
@@ -128678,7 +128732,6 @@ xdv
 xBY
 iQW
 yju
-iQW
 iQW
 iQW
 iQW
@@ -128917,12 +128970,13 @@ vEj
 wVc
 sEc
 wVc
-nrX
-boW
-ejZ
+sEc
+xUN
 wVc
-nHg
-svK
+cvc
+sEc
+kpv
+lqB
 xCX
 yju
 hBb
@@ -128935,7 +128989,6 @@ xdv
 xBY
 yju
 bfi
-iQW
 iQW
 iQW
 iQW
@@ -129174,16 +129227,17 @@ sml
 wVc
 xyc
 wVc
-xUN
-sEc
+wVc
+axS
+wVc
 fdZ
 wVc
-apO
 klG
 qJv
-iEQ
+svK
 jJQ
-sQF
+xrM
+tcG
 eqU
 eqU
 hBb
@@ -129192,7 +129246,6 @@ xdv
 bfi
 iQW
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -129431,25 +129484,25 @@ wtj
 wVc
 wVc
 wVc
+wVc
 xUN
 wVc
 fdZ
-sEc
+wVc
 kpv
-bTw
+nrX
 ddg
 yju
 fcU
-kwE
 rRV
 qkV
+chd
 hBb
 tqS
 xdv
 yju
 iQW
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -129688,16 +129741,17 @@ wVc
 wVc
 wVc
 sEc
+wVc
 xUN
 wVc
-rDN
-uBM
+cKG
 bFU
 mYm
 gzZ
-tmp
+tlc
 ilH
-lWD
+oUI
+lPW
 eqU
 eqU
 hBb
@@ -129707,7 +129761,6 @@ bfi
 iQW
 xBY
 yju
-iQW
 iQW
 iQW
 iQW
@@ -129945,12 +129998,13 @@ wVc
 wVc
 wVc
 wVc
-onD
-cKG
+wVc
+xUN
+wVc
 fdZ
 wVc
-kpv
 jCA
+nyQ
 xCX
 yju
 hBb
@@ -129963,7 +130017,6 @@ xdv
 xBY
 iQW
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -130204,14 +130257,15 @@ skq
 dlz
 eCo
 aom
+wVc
 fdZ
 wVc
-uZp
 kZJ
-uig
+nAX
 iEQ
 jJQ
-dbP
+xrM
+iTB
 mHZ
 mHZ
 hBb
@@ -130222,7 +130276,6 @@ iQW
 xBY
 xdv
 xdv
-iQW
 iQW
 iQW
 iQW
@@ -130461,23 +130514,23 @@ vUx
 wVc
 fdZ
 wHb
-lqB
 wVc
-tlc
-ePt
+dmK
+sEc
+kpv
+nHg
 ddg
 yju
 fcU
-rPs
 cKA
 xTg
+qaY
 hBb
 tqS
 xdv
 xBY
 iQW
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -130718,14 +130771,15 @@ vrm
 uBM
 pbm
 hpM
+boW
 pbm
-uBM
 bFU
-byG
+mYm
 jib
 oCS
-ilH
-fHo
+vZK
+oUI
+rHj
 mHZ
 mHZ
 hBb
@@ -130734,7 +130788,6 @@ xdv
 bfi
 iQW
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -130975,10 +131028,11 @@ cxy
 sqj
 swz
 tND
+bMe
 sqj
-fHS
 res
 bgX
+onD
 xCX
 yju
 hBb
@@ -130991,7 +131045,6 @@ xdv
 yju
 iQW
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -131234,8 +131287,9 @@ tpF
 oUL
 qYt
 hnL
-qYt
-nyQ
+ePt
+ktb
+rDN
 xCX
 yju
 yju
@@ -131243,12 +131297,11 @@ yju
 yju
 yju
 yju
-xaV
+sOP
 xdv
 bfi
 iQW
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -131489,9 +131542,10 @@ pOr
 ddg
 sFM
 awC
+bTw
 ddg
-rYa
 fNk
+ddg
 xCX
 xCX
 yju
@@ -131500,11 +131554,10 @@ yju
 yju
 yju
 yju
-xaV
+sOP
 xBY
 yju
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -131746,10 +131799,11 @@ pOL
 yju
 tfk
 jKj
-wwP
+cgS
 jls
 enV
 jls
+wwP
 jls
 lGj
 lGj
@@ -131757,11 +131811,10 @@ lGj
 lGj
 lGj
 lGj
-dmK
+tRp
 xBY
 iQW
 bfi
-iQW
 iQW
 iQW
 iQW
@@ -132008,6 +132061,7 @@ fcU
 uiu
 hBb
 yju
+yju
 xdv
 xBY
 iQW
@@ -132019,7 +132073,6 @@ iQW
 iQW
 iQW
 yju
-iQW
 iQW
 iQW
 iQW
@@ -132265,6 +132318,7 @@ nrf
 tdq
 hBb
 yju
+yju
 xdv
 xBY
 iQW
@@ -132276,7 +132330,6 @@ bfi
 yju
 yju
 yju
-iQW
 iQW
 iQW
 iQW
@@ -132423,7 +132476,7 @@ ygs
 ycg
 mCJ
 pmM
-pmM
+apO
 pmM
 bMM
 sJz
@@ -132522,6 +132575,7 @@ aAD
 rlA
 hBb
 yju
+yju
 xdv
 xBY
 iQW
@@ -132529,7 +132583,6 @@ vmD
 iQW
 xBY
 yju
-iQW
 iQW
 iQW
 iQW
@@ -132779,13 +132832,13 @@ awj
 rlA
 hBb
 yju
+yju
 xdv
 xBY
 iQW
 xBY
 yju
 xBY
-iQW
 iQW
 iQW
 iQW
@@ -133036,13 +133089,13 @@ hBb
 hBb
 hBb
 yju
+yju
 xdv
 xBY
 yju
 xBY
 iQW
 bfi
-iQW
 iQW
 iQW
 iQW
@@ -133292,6 +133345,7 @@ yju
 yju
 yju
 yju
+yju
 xdv
 xdv
 xBY
@@ -133299,8 +133353,7 @@ iQW
 xBY
 xdv
 xdv
-xdv
-iQW
+sxq
 iQW
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1863,6 +1863,12 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"axP" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
+	dir = 1
+	},
+/turf/open/floor/engine/plasma,
+/area/station/engineering/atmos)
 "axR" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/cable,
@@ -8356,13 +8362,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"chd" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - Plasma Tank";
-	network = list("ss13","engineering")
-	},
-/turf/open/floor/engine/plasma,
-/area/station/engineering/atmos)
 "cho" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
@@ -8676,6 +8675,13 @@
 	network = list("ss13","engineering")
 	},
 /turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
+"clC" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Mix Tank";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
 "clM" = (
 /obj/effect/turf_decal/tile/blue{
@@ -9064,6 +9070,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"cqe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/carbon_output{
+	dir = 1
+	},
+/turf/open/floor/engine/co2,
+/area/station/engineering/atmos)
 "cqf" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable,
@@ -10811,6 +10823,13 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"cNI" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "cOb" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -11519,13 +11538,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"cWr" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - Mix Tank";
-	network = list("ss13","engineering")
-	},
-/turf/open/floor/engine/vacuum,
-/area/station/engineering/atmos)
 "cWB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
@@ -13973,13 +13985,6 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"dHB" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "dHI" = (
 /obj/item/stack/medical/gauze,
 /turf/open/floor/plating,
@@ -22384,6 +22389,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
+"fOQ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/mix_input{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/station/engineering/atmos)
 "fOS" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/yellow{
@@ -27983,6 +27994,12 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"hnU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output{
+	dir = 1
+	},
+/turf/open/floor/engine/plasma,
+/area/station/engineering/atmos)
 "hoo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -33994,12 +34011,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
-"iTB" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input{
-	dir = 1
-	},
-/turf/open/floor/engine/co2,
-/area/station/engineering/atmos)
 "iTT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -45399,12 +45410,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"lPW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output{
-	dir = 1
-	},
-/turf/open/floor/engine/plasma,
-/area/station/engineering/atmos)
 "lQa" = (
 /obj/docking_port/stationary/mining_home/common{
 	dir = 8
@@ -52399,6 +52404,7 @@
 	color = "#000000";
 	name = "dark corner"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nBa" = (
@@ -56631,6 +56637,10 @@
 "oKi" = (
 /turf/closed/wall,
 /area/station/medical/medbay)
+"oKp" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "oKD" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -61555,13 +61565,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"qaY" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - CO2 Tank";
-	network = list("ss13","engineering")
-	},
-/turf/open/floor/engine/co2,
-/area/station/engineering/atmos)
 "qbb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -64118,6 +64121,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qJx" = (
@@ -67835,12 +67839,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/plasmaman)
-"rHj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/carbon_output{
-	dir = 1
-	},
-/turf/open/floor/engine/co2,
-/area/station/engineering/atmos)
 "rHw" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/delivery,
@@ -70978,10 +70976,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
-"sxq" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
 "sxu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -71578,6 +71572,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science)
+"sFW" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input{
+	dir = 1
+	},
+/turf/open/floor/engine/co2,
+/area/station/engineering/atmos)
+"sFZ" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - CO2 Tank";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/engine/co2,
+/area/station/engineering/atmos)
 "sGf" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -72201,13 +72208,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
-"sOP" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "sOS" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -72968,12 +72968,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
-"tcG" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
-	dir = 1
-	},
-/turf/open/floor/engine/plasma,
-/area/station/engineering/atmos)
 "tcI" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/brown{
@@ -75994,13 +75988,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"tRp" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "tRA" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -80816,12 +80803,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"ves" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/mix_input{
-	dir = 1
-	},
-/turf/open/floor/engine/vacuum,
-/area/station/engineering/atmos)
 "vey" = (
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -82491,6 +82472,13 @@
 	pixel_y = 7
 	},
 /turf/open/floor/plating/airless,
+/area/space/nearstation)
+"vCd" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
 /area/space/nearstation)
 "vCq" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -86766,6 +86754,13 @@
 "wLY" = (
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"wMb" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "wMg" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/light_switch/directional/west{
@@ -89581,6 +89576,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"xtb" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Plasma Tank";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/engine/plasma,
+/area/station/engineering/atmos)
 "xte" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Post - Engineering";
@@ -127699,7 +127701,7 @@ tgq
 wwP
 wwP
 wwP
-dHB
+wMb
 iQW
 iQW
 yju
@@ -128468,7 +128470,7 @@ uZp
 fcU
 hBt
 vZO
-cWr
+clC
 hBb
 tqS
 xdv
@@ -128723,7 +128725,7 @@ uig
 iEQ
 jJQ
 xrM
-ves
+fOQ
 pcj
 pcj
 hBb
@@ -129237,7 +129239,7 @@ qJv
 svK
 jJQ
 xrM
-tcG
+axP
 eqU
 eqU
 hBb
@@ -129496,7 +129498,7 @@ yju
 fcU
 rRV
 qkV
-chd
+xtb
 hBb
 tqS
 xdv
@@ -129751,7 +129753,7 @@ gzZ
 tlc
 ilH
 oUI
-lPW
+hnU
 eqU
 eqU
 hBb
@@ -130265,7 +130267,7 @@ nAX
 iEQ
 jJQ
 xrM
-iTB
+sFW
 mHZ
 mHZ
 hBb
@@ -130524,7 +130526,7 @@ yju
 fcU
 cKA
 xTg
-qaY
+sFZ
 hBb
 tqS
 xdv
@@ -130779,7 +130781,7 @@ jib
 oCS
 vZK
 oUI
-rHj
+cqe
 mHZ
 mHZ
 hBb
@@ -131297,7 +131299,7 @@ yju
 yju
 yju
 yju
-sOP
+vCd
 xdv
 bfi
 iQW
@@ -131554,7 +131556,7 @@ yju
 yju
 yju
 yju
-sOP
+vCd
 xBY
 yju
 xBY
@@ -131811,7 +131813,7 @@ lGj
 lGj
 lGj
 lGj
-tRp
+cNI
 xBY
 iQW
 bfi
@@ -133353,7 +133355,7 @@ iQW
 xBY
 xdv
 xdv
-sxq
+oKp
 iQW
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -7562,10 +7562,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
-"bVR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/prison/mess)
 "bVW" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/status_display/ai/directional/south,
@@ -13470,6 +13466,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"dzc" = (
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "dzi" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -13646,9 +13645,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"dBM" = (
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
 "dBP" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -23809,9 +23805,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"gkb" = (
-/turf/closed/wall,
-/area/station/maintenance/department/science/xenobiology)
 "gkj" = (
 /obj/structure/closet/secure_closet/courtroom,
 /obj/item/megaphone{
@@ -27721,6 +27714,13 @@
 /obj/item/bedsheet/medical,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
+"hlM" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/cafeteria)
 "hlN" = (
 /obj/structure/window,
 /obj/structure/bed/roller,
@@ -29207,10 +29207,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
-"hFr" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "hFs" = (
 /obj/structure/barricade/wooden/crude,
 /obj/structure/spider/stickyweb,
@@ -32432,6 +32428,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
+"iwN" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "ixa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -36299,10 +36299,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
-"jAh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "jAt" = (
 /obj/structure/rack,
 /obj/item/crowbar,
@@ -39659,6 +39655,9 @@
 /obj/item/stock_parts/cell/empty,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"krO" = (
+/turf/closed/wall/r_wall,
+/area/station/security/prison/mess)
 "krV" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -45692,6 +45691,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
+"lSR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison/mess)
 "lSZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -57669,9 +57672,6 @@
 /obj/effect/spawner/random/clothing/mafia_outfit,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"oZt" = (
-/turf/closed/wall/r_wall,
-/area/station/security/prison/mess)
 "oZy" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/tile/red{
@@ -66146,6 +66146,9 @@
 "rjH" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/bomb)
+"rjS" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/science/xenobiology)
 "rkd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -68289,6 +68292,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"rMX" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/station/engineering/supermatter/room)
 "rNi" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -70155,6 +70164,9 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"sni" = (
+/turf/closed/wall,
+/area/station/maintenance/department/science/xenobiology)
 "snx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -78822,6 +78834,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
+"uCL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "uCN" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Test Chamber";
@@ -81389,9 +81405,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"vlk" = (
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "vlr" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -83953,6 +83966,9 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/exit/departure_lounge)
+"vXy" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "vXE" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -85424,12 +85440,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"wuW" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
 "wuZ" = (
 /obj/machinery/computer/atmos_control/nitrogen_tank{
 	dir = 8
@@ -89339,9 +89349,6 @@
 	},
 /turf/open/floor/carpet/donk,
 /area/station/service/library/printer)
-"xon" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science/xenobiology)
 "xoq" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/griddle,
@@ -90708,7 +90715,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/cafeteria)
+/area/station/service/bar/atrium)
 "xIm" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/disposal/bin,
@@ -110643,8 +110650,8 @@ stv
 qsA
 yeW
 txp
-oZt
-oZt
+krO
+krO
 iQW
 iQW
 iQW
@@ -110901,7 +110908,7 @@ wJZ
 jIT
 koX
 qDR
-oZt
+krO
 yju
 yju
 yju
@@ -111672,7 +111679,7 @@ wQl
 xWh
 wDX
 btC
-oZt
+krO
 yju
 yju
 yju
@@ -111929,7 +111936,7 @@ fiI
 vIi
 hEm
 ohi
-oZt
+krO
 yju
 yju
 yju
@@ -112181,7 +112188,7 @@ ueH
 sbQ
 yeW
 vEv
-bVR
+lSR
 wTn
 yeW
 wDX
@@ -112438,7 +112445,7 @@ cUA
 pyW
 hky
 iEV
-bVR
+lSR
 wZd
 yeW
 yeW
@@ -112695,12 +112702,12 @@ ueH
 sBf
 ueH
 gOc
-bVR
+lSR
 xax
 yeW
 yeW
 dON
-oZt
+krO
 yju
 yju
 yju
@@ -112952,12 +112959,12 @@ paX
 uXn
 paX
 wsY
-bVR
+lSR
 mrt
 yjj
 ihX
-oZt
-oZt
+krO
+krO
 iQW
 iQW
 iQW
@@ -115056,12 +115063,12 @@ qTi
 kPu
 vnk
 vGm
-xIh
+hlM
 bxB
 bxB
 bxB
 uxc
-xIh
+hlM
 dZV
 auf
 xlJ
@@ -115134,17 +115141,17 @@ yju
 iQW
 yju
 iQW
-dBM
-dBM
-dBM
-hFr
-hFr
-dBM
-hFr
-hFr
-dBM
-dBM
-dBM
+vXy
+vXy
+vXy
+iwN
+iwN
+vXy
+iwN
+iwN
+vXy
+vXy
+vXy
 iQW
 vmD
 iQW
@@ -115313,12 +115320,12 @@ eQT
 kPu
 vnk
 vGm
-xIh
-xIh
+hlM
+hlM
 jlh
 bxB
-xIh
-xIh
+hlM
+hlM
 dZV
 awa
 xlJ
@@ -115391,8 +115398,8 @@ xdv
 xdv
 xdv
 xdv
-dBM
-vlk
+vXy
+dzc
 jGJ
 meK
 iAe
@@ -115401,7 +115408,7 @@ vTz
 meK
 meK
 xPm
-dBM
+vXy
 yju
 bfi
 iQW
@@ -115571,7 +115578,7 @@ kPu
 vnk
 hcn
 fpv
-xIh
+hlM
 exi
 npo
 aAK
@@ -115648,17 +115655,17 @@ dNL
 rbs
 dNL
 rbs
-dBM
+vXy
 cUb
 jGJ
 meK
-vlk
-vlk
-vlk
+dzc
+dzc
+dzc
 meK
 jGJ
 xPm
-dBM
+vXy
 yju
 bfi
 iQW
@@ -115832,8 +115839,8 @@ dDC
 mCM
 lbc
 cBt
-xIh
-xIh
+hlM
+hlM
 ykj
 tsG
 xfE
@@ -115905,7 +115912,7 @@ eEn
 lFt
 moa
 lFt
-dBM
+vXy
 asT
 jGJ
 jGJ
@@ -115915,7 +115922,7 @@ jGJ
 jGJ
 jGJ
 ugc
-dBM
+vXy
 iQW
 vmD
 iQW
@@ -116086,12 +116093,12 @@ vnk
 vGm
 gKw
 xIh
-xIh
+hlM
 gLK
 dAU
 nMv
-xIh
-xIh
+hlM
+hlM
 unw
 xjz
 kMx
@@ -116162,7 +116169,7 @@ sgO
 lFt
 moa
 lFt
-dBM
+vXy
 hiY
 jGJ
 meK
@@ -116172,7 +116179,7 @@ meK
 meK
 jGJ
 miB
-dBM
+vXy
 yju
 bfi
 iQW
@@ -116344,11 +116351,11 @@ fLl
 fZc
 fZc
 qOu
-xIh
+hlM
 jlh
-xIh
-xIh
-xIh
+hlM
+hlM
+hlM
 xlJ
 ivr
 kMx
@@ -116419,17 +116426,17 @@ eEn
 lFt
 moa
 lFt
-dBM
-vlk
+vXy
+dzc
 fbo
 mfq
 qcZ
-vlk
+dzc
 xUh
 wCn
 asd
 uFW
-dBM
+vXy
 iQW
 bfi
 vmD
@@ -116601,10 +116608,10 @@ tRI
 tRI
 cSN
 jot
-xIh
-xIh
-xIh
-xIh
+hlM
+hlM
+hlM
+hlM
 fbs
 xlJ
 lGe
@@ -116676,17 +116683,17 @@ rbs
 gBN
 isd
 lFt
-dBM
-vlk
+vXy
+dzc
 kNJ
 meK
-vlk
-vlk
-vlk
+dzc
+dzc
+dzc
 meK
 frX
 kgz
-dBM
+vXy
 yju
 yju
 iQW
@@ -116930,23 +116937,23 @@ dNL
 tvJ
 rvb
 eEn
-hFr
-hFr
+iwN
+iwN
 fbd
-dBM
-hFr
+vXy
+iwN
 bvE
-dBM
-hFr
-hFr
-hFr
-dBM
+vXy
+iwN
+iwN
+iwN
+vXy
 hSg
-hFr
-dBM
-dBM
-dBM
-dBM
+iwN
+vXy
+vXy
+vXy
+vXy
 yju
 bfi
 yju
@@ -117187,7 +117194,7 @@ gBN
 tvJ
 rvb
 sgO
-hFr
+iwN
 nUz
 cpo
 wGT
@@ -117203,7 +117210,7 @@ nHs
 yfw
 uuV
 fXe
-dBM
+vXy
 iQW
 vmD
 iQW
@@ -117444,7 +117451,7 @@ dNL
 tvJ
 rvb
 eEn
-hFr
+iwN
 xzl
 vQu
 dCs
@@ -117460,7 +117467,7 @@ dCs
 rgs
 dCs
 vWn
-hFr
+iwN
 xdv
 vmD
 iQW
@@ -117717,7 +117724,7 @@ hAB
 wVC
 fqq
 jge
-wuW
+rMX
 xdv
 vmD
 iQW
@@ -117974,7 +117981,7 @@ vlZ
 ogN
 dCs
 xEJ
-hFr
+iwN
 xdv
 bfi
 yju
@@ -118215,7 +118222,7 @@ nma
 iJU
 mxY
 vnq
-hFr
+iwN
 vnF
 xKO
 bCG
@@ -118231,7 +118238,7 @@ aQq
 uMi
 eJg
 tzQ
-dBM
+vXy
 iQW
 vmD
 iQW
@@ -118472,7 +118479,7 @@ esk
 iJh
 rlH
 jsc
-hFr
+iwN
 pre
 jIc
 nau
@@ -118488,7 +118495,7 @@ nZr
 wuD
 chJ
 cCB
-dBM
+vXy
 iQW
 vmD
 iQW
@@ -118745,7 +118752,7 @@ jQD
 bmx
 dCs
 cCB
-hFr
+iwN
 yju
 sOe
 yju
@@ -118986,7 +118993,7 @@ bPB
 neR
 iNT
 wxn
-hFr
+iwN
 xzl
 wSg
 mSI
@@ -119002,7 +119009,7 @@ bZn
 uix
 jRE
 cCB
-hFr
+iwN
 yju
 vmD
 iQW
@@ -119259,7 +119266,7 @@ fHE
 wgv
 dCs
 cCB
-hFr
+iwN
 yju
 vmD
 iQW
@@ -119500,7 +119507,7 @@ atj
 iJh
 uxL
 adV
-hFr
+iwN
 xgS
 jIc
 eJg
@@ -119516,9 +119523,9 @@ nZr
 hzo
 dCs
 jyc
-dBM
-dBM
-dBM
+vXy
+vXy
+vXy
 iQW
 vmD
 iQW
@@ -119757,7 +119764,7 @@ dVf
 vvU
 vvU
 tnt
-hFr
+iwN
 iNw
 jIc
 eJg
@@ -119775,7 +119782,7 @@ pjw
 mAJ
 ejE
 ixa
-dBM
+vXy
 iQW
 vmD
 yju
@@ -120014,7 +120021,7 @@ kOC
 qza
 qza
 kOC
-dBM
+vXy
 mjB
 gkN
 bbr
@@ -120032,7 +120039,7 @@ dCs
 eJg
 dCs
 tYd
-hFr
+iwN
 yju
 bfi
 yju
@@ -120271,7 +120278,7 @@ ubX
 dhq
 dhq
 gwQ
-dBM
+vXy
 xzl
 aMW
 gap
@@ -120289,7 +120296,7 @@ dCs
 eJg
 tOM
 tID
-hFr
+iwN
 iQW
 vmD
 iQW
@@ -120528,7 +120535,7 @@ swk
 mHl
 mHl
 eoh
-dBM
+vXy
 sGU
 qsr
 fOe
@@ -120546,7 +120553,7 @@ dCs
 eJg
 tOM
 tID
-hFr
+iwN
 yju
 vmD
 iQW
@@ -120785,7 +120792,7 @@ swk
 mHl
 mHl
 rlW
-dBM
+vXy
 uqd
 gqe
 oRG
@@ -120803,7 +120810,7 @@ eJg
 eJg
 hyj
 tID
-hFr
+iwN
 yju
 vmD
 iQW
@@ -121045,22 +121052,22 @@ swb
 vVh
 lGh
 wjz
-hFr
-hFr
-dBM
-hFr
-hFr
-hFr
-hFr
+iwN
+iwN
+vXy
+iwN
+iwN
+iwN
+iwN
 lVj
-dBM
+vXy
 ujk
 lQL
 dCs
 dCs
 vxu
 tID
-hFr
+iwN
 yju
 bfi
 yju
@@ -121310,14 +121317,14 @@ iQW
 iQW
 iQW
 tqS
-dBM
+vXy
 mLs
 vQM
 cSu
 riU
 riU
 lZr
-dBM
+vXy
 iQW
 vmD
 iQW
@@ -121567,14 +121574,14 @@ iQW
 iQW
 iQW
 tqS
-dBM
-dBM
+vXy
+vXy
 ouh
-hFr
-hFr
-hFr
-dBM
-dBM
+iwN
+iwN
+iwN
+vXy
+vXy
 iQW
 vmD
 iQW
@@ -134928,11 +134935,11 @@ yju
 yju
 yju
 yju
-xon
-jAh
+rjS
+uCL
 rrH
-jAh
-xon
+uCL
+rjS
 iQW
 yju
 iQW
@@ -135184,12 +135191,12 @@ xdv
 xdv
 xdv
 xdv
-xon
-xon
+rjS
+rjS
 gTb
 gvw
 pzi
-xon
+rjS
 avy
 avy
 avy
@@ -135441,12 +135448,12 @@ yju
 iQW
 yju
 iQW
-xon
+rjS
 bVk
 uVv
 yfZ
 pNJ
-xon
+rjS
 uUc
 bLO
 dep
@@ -135698,12 +135705,12 @@ yju
 yju
 yju
 yju
-jAh
+uCL
 eio
 uDW
 wPW
 aip
-xon
+rjS
 xmr
 kHl
 dep
@@ -135955,12 +135962,12 @@ avy
 ikL
 avy
 avy
-xon
-xon
-gkb
+rjS
+rjS
+sni
 iLM
-gkb
-xon
+sni
+rjS
 eHJ
 xzi
 qDP
@@ -139553,12 +139560,12 @@ avy
 ikL
 avy
 avy
-xon
-xon
-gkb
+rjS
+rjS
+sni
 aKf
-gkb
-xon
+sni
+rjS
 rsw
 lbW
 wVH
@@ -139815,7 +139822,7 @@ kiX
 vRv
 pWa
 fgN
-xon
+rjS
 xmr
 xmr
 dep
@@ -140067,12 +140074,12 @@ gBN
 aLd
 kyu
 isd
-xon
+rjS
 gvX
 rZt
 puX
 qHO
-xon
+rjS
 nqn
 sty
 dep
@@ -140324,12 +140331,12 @@ neC
 tam
 ipn
 vmv
-xon
-xon
+rjS
+rjS
 bRT
 tac
 wrD
-xon
+rjS
 avy
 avy
 avy
@@ -140582,11 +140589,11 @@ isd
 gBN
 isd
 yju
-xon
-jAh
+rjS
+uCL
 lZt
-jAh
-xon
+uCL
+rjS
 iQW
 yju
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -540,7 +540,7 @@
 /obj/effect/spawner/random/maintenance/three,
 /obj/structure/closet,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "aiz" = (
 /turf/closed/wall,
 /area/station/cargo/miningoffice)
@@ -1310,7 +1310,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "asf" = (
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
@@ -1409,7 +1409,7 @@
 "asT" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "atc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -1557,7 +1557,7 @@
 /obj/effect/spawner/random/vending/colavend,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "auu" = (
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -1627,7 +1627,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "avg" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -1696,7 +1696,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "avL" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
@@ -1737,7 +1737,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "awj" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - N2O Tank";
@@ -1979,7 +1979,7 @@
 	pixel_x = 5
 	},
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "azw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -2079,7 +2079,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "aAO" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -2475,7 +2475,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "aIZ" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -2595,7 +2595,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "aKs" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
@@ -2814,7 +2814,7 @@
 	dir = 10
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "aNf" = (
 /obj/machinery/flasher/directional/north{
 	id = "hopflash"
@@ -3092,7 +3092,7 @@
 /obj/machinery/status_display/evac/directional/east,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "aQr" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage{
@@ -3209,7 +3209,7 @@
 /area/station/command/heads_quarters/cmo)
 "aRM" = (
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "aRO" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -3888,7 +3888,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "baF" = (
 /obj/effect/turf_decal/box,
 /obj/effect/landmark/blobstart,
@@ -3921,7 +3921,7 @@
 /obj/structure/sign/warning/radiation/directional/west,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "baX" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/north{
@@ -3963,7 +3963,7 @@
 /obj/machinery/meter,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "bbx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -4026,7 +4026,7 @@
 	dir = 10
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "bco" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced,
@@ -4254,7 +4254,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "bgP" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/command{
@@ -4680,7 +4680,7 @@
 "blH" = (
 /obj/structure/chair,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "blJ" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular,
@@ -4791,7 +4791,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "bmG" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
@@ -5292,7 +5292,7 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "btG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -5378,7 +5378,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "bvG" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/purple{
@@ -5618,7 +5618,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "bxC" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -5995,7 +5995,7 @@
 "bBg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "bBh" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
@@ -6128,7 +6128,7 @@
 	dir = 9
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "bCH" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -6267,7 +6267,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "bEv" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -6772,7 +6772,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "bKl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -7298,7 +7298,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "bRV" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -7514,7 +7514,7 @@
 /obj/machinery/atmospherics/components/tank/air,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "bVm" = (
 /obj/structure/table/wood,
 /obj/item/stack/package_wrap{
@@ -7562,6 +7562,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
+"bVR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison/mess)
 "bVW" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/status_display/ai/directional/south,
@@ -8204,7 +8208,7 @@
 	name = "External Gas to Loop"
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "cdu" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -8434,7 +8438,7 @@
 "chJ" = (
 /obj/item/wrench,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "chM" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -8717,7 +8721,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "cmr" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -8969,7 +8973,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "cpq" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/tcomms_all,
@@ -9235,7 +9239,7 @@
 	network = list("ss13","service")
 	},
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "csR" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/tile/neutral{
@@ -9577,7 +9581,7 @@
 	name = "Mix Bypass"
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "cwI" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -9768,7 +9772,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "cyE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -9972,7 +9976,7 @@
 /obj/machinery/meter,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "cAO" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -10057,7 +10061,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "cBw" = (
 /obj/structure/table,
 /obj/item/food/fishmeat/carp{
@@ -10135,7 +10139,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "cCQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -10150,7 +10154,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "cCY" = (
 /obj/structure/table,
 /obj/item/knife,
@@ -11053,7 +11057,7 @@
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "cRF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -11130,7 +11134,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "cSM" = (
 /turf/closed/wall,
 /area/station/science/robotics/mechbay)
@@ -11138,7 +11142,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/glass/reinforced,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "cSP" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -11297,7 +11301,7 @@
 	network = list("ss13","engineering")
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "cUd" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -12950,7 +12954,7 @@
 /area/station/security/prison)
 "drB" = (
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "drK" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/tubes,
@@ -13618,7 +13622,7 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "dAV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
@@ -13642,6 +13646,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"dBM" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "dBP" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -13662,7 +13669,7 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "dCs" = (
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "dCB" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -13726,7 +13733,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "dDL" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -14011,7 +14018,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "dHX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14420,7 +14427,7 @@
 "dMI" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "dML" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -14535,7 +14542,7 @@
 	},
 /obj/item/radio/intercom/prison/directional/south,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "dPb" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -15088,7 +15095,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "dWv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -15421,7 +15428,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "eaB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -15807,7 +15814,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "egf" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -16003,7 +16010,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "eip" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/misc/grass,
@@ -16143,7 +16150,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/meter,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "ejG" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #2";
@@ -17127,7 +17134,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "exs" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -17707,7 +17714,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "eGf" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/tile/green,
@@ -17902,7 +17909,7 @@
 "eJg" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "eJk" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Server Room";
@@ -17985,7 +17992,7 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "eKB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -18216,7 +18223,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "eMT" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -19228,7 +19235,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "fbn" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Arrivals Dock"
@@ -19244,7 +19251,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "fbp" = (
 /obj/machinery/power/solar_control{
 	dir = 1;
@@ -19263,7 +19270,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "fbt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -19497,7 +19504,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "feX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -19746,7 +19753,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "fhz" = (
 /obj/machinery/airlock_sensor/incinerator_ordmix{
 	pixel_x = -24
@@ -19811,7 +19818,7 @@
 	},
 /obj/machinery/processor,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "fiR" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -20366,7 +20373,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "fpA" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -20442,7 +20449,7 @@
 	name = "Output Release"
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "fqH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -20607,7 +20614,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "fsc" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -21575,7 +21582,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "fFV" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -21659,7 +21666,7 @@
 "fHh" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "fHk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -21726,7 +21733,7 @@
 "fHR" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "fHS" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/yellow{
@@ -22111,7 +22118,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "fLs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -22308,7 +22315,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "fOh" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/tile/green,
@@ -22822,7 +22829,7 @@
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "fWn" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
@@ -22904,7 +22911,7 @@
 /obj/item/poster/random_contraband,
 /obj/item/toy/spinningtoy,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "fXj" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -23076,7 +23083,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "fZd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -23191,7 +23198,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "gaq" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -23802,6 +23809,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"gkb" = (
+/turf/closed/wall,
+/area/station/maintenance/department/science/xenobiology)
 "gkj" = (
 /obj/structure/closet/secure_closet/courtroom,
 /obj/item/megaphone{
@@ -23815,7 +23825,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "gkV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
@@ -23951,7 +23961,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "gmT" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -24166,7 +24176,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "gqi" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
@@ -24494,7 +24504,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "gvA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -24511,7 +24521,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "gvM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -24531,7 +24541,7 @@
 "gvX" = (
 /obj/machinery/atmospherics/components/tank/carbon_dioxide,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "gvZ" = (
 /obj/structure/rack,
 /turf/open/floor/iron,
@@ -25419,7 +25429,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "gHm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -25754,7 +25764,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "gKy" = (
 /obj/structure/table,
 /obj/item/gun/energy/laser/practice,
@@ -25907,7 +25917,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "gLM" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty{
@@ -26144,7 +26154,7 @@
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "gOb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -26191,7 +26201,7 @@
 "gOH" = (
 /obj/item/crowbar,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "gOP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/green,
@@ -26426,7 +26436,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/wrench,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "gTm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -27098,7 +27108,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
 /turf/open/floor/iron,
-/area/station/maintenance/department/crew_quarters/dorms)
+/area/station/construction/mining/aux_base)
 "haX" = (
 /obj/structure/rack,
 /obj/item/stack/rods/twentyfive,
@@ -27184,7 +27194,7 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "hcv" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/medical_all,
@@ -27591,7 +27601,7 @@
 /obj/machinery/power/emitter,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "hja" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/space/basic,
@@ -27678,7 +27688,7 @@
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "hlg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -28685,7 +28695,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "hyl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -28764,7 +28774,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "hzE" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -28787,7 +28797,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "hAm" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/apron,
@@ -28833,7 +28843,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/meter,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "hAC" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
@@ -29119,7 +29129,7 @@
 	},
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "hEw" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -29197,6 +29207,10 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
+"hFr" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "hFs" = (
 /obj/structure/barricade/wooden/crude,
 /obj/structure/spider/stickyweb,
@@ -29488,7 +29502,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "hJi" = (
 /obj/structure/rack,
 /obj/item/electronics/apc,
@@ -29533,7 +29547,7 @@
 	dir = 10
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "hJz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29599,7 +29613,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "hJP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29713,7 +29727,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "hLl" = (
 /obj/structure/window/reinforced,
 /obj/item/radio/intercom/directional/east,
@@ -30093,7 +30107,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "hQT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -30181,7 +30195,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "hSi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -30987,7 +31001,7 @@
 	},
 /obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "idB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -31399,7 +31413,7 @@
 	},
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "iiw" = (
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/east,
@@ -32378,7 +32392,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "iwI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -32427,7 +32441,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "ixc" = (
 /obj/machinery/door/airlock/research{
 	name = "Circuit Testing Lab"
@@ -32628,7 +32642,7 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/wirecutters,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "iAn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/circuit,
@@ -32746,7 +32760,7 @@
 /obj/machinery/meter,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "iCg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -33421,7 +33435,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "iLN" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -33589,7 +33603,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "iNz" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -34851,7 +34865,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "jgy" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -35095,7 +35109,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "jlm" = (
 /obj/structure/table/wood,
 /obj/item/trash/can/food/peaches,
@@ -35425,7 +35439,7 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "joy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -35448,7 +35462,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "joQ" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -35681,7 +35695,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "jsk" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -35700,7 +35714,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "jsD" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing"
@@ -36078,7 +36092,7 @@
 	},
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "jwV" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -36141,7 +36155,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "jyg" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /mob/living/simple_animal/butterfly,
@@ -36175,7 +36189,7 @@
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/restaurant_portal/bar,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "jyK" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -36285,6 +36299,10 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"jAh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "jAt" = (
 /obj/structure/rack,
 /obj/item/crowbar,
@@ -36339,7 +36357,7 @@
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "jBK" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -36721,7 +36739,7 @@
 "jGJ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "jGO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -36895,7 +36913,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "jIp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -36944,7 +36962,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "jJc" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
@@ -37617,7 +37635,7 @@
 "jRE" = (
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "jRH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -37868,7 +37886,7 @@
 	name = "Atmos to Loop"
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "jUj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
@@ -37894,7 +37912,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "jUK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip{
@@ -38773,7 +38791,7 @@
 "kgz" = (
 /obj/structure/reflector/single,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "kgA" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/tile/yellow{
@@ -38851,7 +38869,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "khR" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
@@ -38952,7 +38970,7 @@
 	name = "Cooling Loop Bypass"
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "kiJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -38984,7 +39002,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "kiY" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom/directional/north{
@@ -39465,7 +39483,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "kpa" = (
 /obj/machinery/computer/atmos_control/air_tank{
 	dir = 8
@@ -39550,7 +39568,7 @@
 "kqb" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "kql" = (
 /obj/item/trash/raisins,
 /obj/machinery/light/small/directional/west,
@@ -40894,7 +40912,7 @@
 	dir = 9
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "kHl" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
@@ -41270,7 +41288,7 @@
 	},
 /obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "kMq" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -41345,7 +41363,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "kOe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -41451,7 +41469,7 @@
 "kPu" = (
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/glass/reinforced,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "kPy" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -41604,7 +41622,7 @@
 	name = "Mix to Gas"
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "kRZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -42200,7 +42218,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "lbi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -42286,7 +42304,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "lcR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -43221,7 +43239,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "lpe" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -44154,7 +44172,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "lBt" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -45463,7 +45481,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "lQU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -45887,7 +45905,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "lVp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46220,14 +46238,14 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "lZt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "lZy" = (
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -46341,7 +46359,7 @@
 	},
 /obj/effect/landmark/start/mime,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "maG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -46620,7 +46638,7 @@
 /area/station/service/chapel)
 "meK" = (
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "meO" = (
 /obj/machinery/stasis,
 /obj/machinery/defibrillator_mount{
@@ -46697,7 +46715,7 @@
 "mfq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "mfF" = (
 /obj/machinery/door/airlock/command{
 	name = "Gateway Access"
@@ -46934,7 +46952,7 @@
 /obj/structure/reflector/double,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "miV" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/cable,
@@ -47057,7 +47075,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "mjN" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -47716,7 +47734,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "mrw" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -47737,7 +47755,7 @@
 	filter_type = list(/datum/gas/nitrogen)
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "mrV" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -47764,7 +47782,7 @@
 /obj/item/radio/intercom/directional/south,
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "mrY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -48368,7 +48386,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "mAQ" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -48577,7 +48595,7 @@
 	},
 /obj/effect/spawner/xmastree,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "mCV" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/siding/thinplating,
@@ -49264,7 +49282,7 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "mLB" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/effect/turf_decal/tile/green{
@@ -49298,7 +49316,7 @@
 /obj/structure/sign/warning/radiation/directional/west,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "mMb" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -49828,7 +49846,7 @@
 /obj/structure/cable,
 /obj/machinery/meter,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "mSF" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -49857,7 +49875,7 @@
 "mSI" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "mSK" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -49884,7 +49902,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "mTc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -50422,7 +50440,7 @@
 "nau" = (
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "naD" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -50479,7 +50497,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "nbL" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office"
@@ -51502,7 +51520,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "npr" = (
 /obj/structure/chair,
 /turf/open/floor/iron/white,
@@ -52428,7 +52446,7 @@
 /obj/effect/spawner/random/entertainment/gambling,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "nBf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -52882,7 +52900,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "nHM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53219,7 +53237,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "nMC" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -53730,7 +53748,7 @@
 	dir = 9
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "nUT" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -54176,7 +54194,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "obm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -54341,7 +54359,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "ocC" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/cable,
@@ -54671,7 +54689,7 @@
 	dir = 5
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "ogU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/duct,
@@ -54700,7 +54718,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "ohI" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/small/directional/north,
@@ -54956,7 +54974,7 @@
 "omC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "omE" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/misc/grass,
@@ -56262,7 +56280,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "oEY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -57150,7 +57168,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "oRK" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -57310,7 +57328,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "oTX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -57348,7 +57366,8 @@
 	},
 /obj/machinery/button/door/directional/south{
 	id = "engsm";
-	name = "Radiation Shutters Control"
+	name = "Radiation Shutters Control";
+	req_access = list("engineering")
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/engine,
@@ -57436,7 +57455,7 @@
 /obj/structure/cable,
 /obj/item/card/id/advanced/prisoner/chef,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "oVu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -57650,6 +57669,9 @@
 /obj/effect/spawner/random/clothing/mafia_outfit,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"oZt" = (
+/turf/closed/wall/r_wall,
+/area/station/security/prison/mess)
 "oZy" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/tile/red{
@@ -58359,7 +58381,7 @@
 	name = "Gas to Mix"
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "pjy" = (
 /obj/machinery/computer/shuttle/mining/common{
 	dir = 4
@@ -58975,7 +58997,7 @@
 	},
 /obj/item/geiger_counter,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "prp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -59247,7 +59269,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "pvb" = (
 /obj/structure/reagent_dispensers/plumbed,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -59586,7 +59608,7 @@
 "pzi" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "pzn" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -60129,7 +60151,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "pFt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
 	dir = 4
@@ -60504,7 +60526,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "pKa" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -60704,7 +60726,7 @@
 /area/station/maintenance/port/aft)
 "pNJ" = (
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "pOj" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/duct,
@@ -60974,7 +60996,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "pSe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -61136,7 +61158,7 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "pUQ" = (
 /obj/effect/turf_decal/tile{
 	color = "#FFFFFF";
@@ -61267,7 +61289,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "pWb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -61770,7 +61792,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "qda" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -62086,7 +62108,7 @@
 /obj/structure/table/wood,
 /obj/item/instrument/saxophone,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "qgY" = (
 /obj/structure/toilet{
 	dir = 1
@@ -62305,7 +62327,7 @@
 "qiQ" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "qji" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -62939,7 +62961,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "qsA" = (
 /obj/structure/closet/crate/secure/gear{
 	desc = "Contains the most important part of any Chef.";
@@ -62956,7 +62978,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "qsG" = (
 /obj/structure/chair/comfy/brown{
 	color = "#EFB341";
@@ -63813,7 +63835,7 @@
 /obj/structure/closet/crate/bin,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "qDZ" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron/grimy,
@@ -63986,7 +64008,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "qGW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -64055,7 +64077,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "qIt" = (
 /obj/machinery/telecomms/server/presets/command,
 /obj/effect/turf_decal/tile/blue{
@@ -64500,7 +64522,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "qOB" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -65008,7 +65030,7 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/sign/warning/radiation/directional/east,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "qWA" = (
 /obj/machinery/air_sensor/oxygen_tank,
 /turf/open/floor/engine/o2,
@@ -65443,7 +65465,7 @@
 "rbx" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "rbz" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock"
@@ -65819,7 +65841,7 @@
 	name = "Output to Waste"
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "rgC" = (
 /obj/structure/table,
 /obj/item/grenade/chem_grenade/smart_metal_foam{
@@ -66041,7 +66063,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "rjc" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -66427,7 +66449,7 @@
 "rnP" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "rnT" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/misc/grass,
@@ -66702,7 +66724,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "rrK" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -67649,18 +67671,21 @@
 /obj/machinery/button/door/directional/south{
 	id = "atmos";
 	name = "Atmospherics Lockdown";
-	pixel_x = 10
+	pixel_x = 10;
+	req_access = list("atmospherics")
 	},
 /obj/machinery/button/door/directional/south{
 	desc = "A remote control-switch for secure storage.";
 	id = "Secure Storage";
-	name = "Engineering Secure Storage"
+	name = "Engineering Secure Storage";
+	req_access = list("engine_equip")
 	},
 /obj/machinery/button/door/directional/south{
 	desc = "A remote control-switch for the engineering security doors.";
 	id = "Engineering";
 	name = "Engineering Lockdown";
-	pixel_x = -10
+	pixel_x = -10;
+	req_access = list("engineering")
 	},
 /obj/structure/cable,
 /obj/machinery/keycard_auth{
@@ -68263,7 +68288,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "rNi" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -69086,7 +69111,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/meter,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "rZv" = (
 /obj/structure/table,
 /obj/structure/table,
@@ -69553,7 +69578,7 @@
 "sfF" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "sfO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -69961,7 +69986,7 @@
 /obj/item/clothing/glasses/meson/engine,
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "slm" = (
 /obj/effect/spawner/random/trash/janitor_supplies,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -70646,7 +70671,7 @@
 /obj/item/storage/bag/tray/cafeteria,
 /obj/item/storage/bag/tray/cafeteria,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "sty" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine,
@@ -71106,7 +71131,7 @@
 /obj/structure/table/wood,
 /obj/item/toy/figure/bartender,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "szl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -71685,7 +71710,7 @@
 	dir = 10
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "sHp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -72807,7 +72832,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "tam" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -73040,7 +73065,7 @@
 /area/station/maintenance/department/medical)
 "tdo" = (
 /turf/closed/wall,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "tdq" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/nitrous_input{
 	dir = 8
@@ -74260,7 +74285,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "tsf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -74359,7 +74384,7 @@
 	},
 /obj/effect/landmark/start/clown,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "tsD" = (
 /obj/structure/table/glass,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -74386,7 +74411,7 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "tsJ" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
@@ -74598,7 +74623,7 @@
 	},
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "tvJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space/basic,
@@ -74756,7 +74781,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "tyd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -74940,7 +74965,7 @@
 /obj/structure/closet/firecloset/full,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "tAe" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -74951,12 +74976,12 @@
 	},
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "tAw" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "tAC" = (
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -75424,7 +75449,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "tIK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75753,7 +75778,7 @@
 "tOM" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "tPc" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -76012,7 +76037,7 @@
 "tRI" = (
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/glass/reinforced,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "tRY" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -76256,7 +76281,7 @@
 /obj/item/radio/intercom/directional/east,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "tVA" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -76497,7 +76522,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "tYe" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1;
@@ -76508,7 +76533,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "tYh" = (
 /obj/structure/cable,
 /obj/machinery/navbeacon{
@@ -77114,7 +77139,7 @@
 "ugc" = (
 /obj/structure/reflector/double,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "ugj" = (
 /obj/effect/turf_decal/arrows/white,
 /turf/open/floor/iron,
@@ -77251,7 +77276,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "uiB" = (
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit/green,
@@ -77301,7 +77326,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "ujt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -77631,7 +77656,7 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "unK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -77763,7 +77788,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "uql" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -77785,7 +77810,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "uqJ" = (
 /obj/structure/table,
 /obj/machinery/door/firedoor/border_only{
@@ -78365,7 +78390,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "uuZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/sign/poster/contraband/random{
@@ -78506,7 +78531,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "uxd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -78887,7 +78912,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "uEg" = (
 /obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/plating,
@@ -78997,7 +79022,7 @@
 	network = list("ss13","engineering")
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "uGq" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/security{
@@ -79149,7 +79174,7 @@
 	dir = 9
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "uJo" = (
 /obj/structure/table,
 /obj/item/mmi,
@@ -79370,7 +79395,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "uMl" = (
 /obj/machinery/shower{
 	pixel_y = 25
@@ -80109,7 +80134,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "uVW" = (
 /obj/structure/chair{
 	dir = 8
@@ -80828,7 +80853,7 @@
 "veD" = (
 /obj/machinery/holopad,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "veF" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes{
@@ -81354,7 +81379,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "vkV" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/tile/brown,
@@ -81364,6 +81389,9 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"vlk" = (
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "vlr" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -81431,7 +81459,7 @@
 "vlZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "vml" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -81480,7 +81508,7 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "vmv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -81528,7 +81556,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "vnq" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/yellow{
@@ -81588,7 +81616,7 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "vnG" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -81951,7 +81979,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "vtJ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -82062,7 +82090,7 @@
 /area/station/hallway/secondary/service)
 "vvC" = (
 /turf/closed/wall,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "vvG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -82131,11 +82159,11 @@
 	layer = 2.9
 	},
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "vxu" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "vxS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -82668,7 +82696,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "vEF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
 	dir = 4
@@ -82856,7 +82884,7 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "vGN" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -82992,7 +83020,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "vIr" = (
 /obj/structure/closet/crate,
 /obj/item/circuitboard/machine/recharger,
@@ -83025,7 +83053,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "vJf" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -83370,7 +83398,7 @@
 	},
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/grimy,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "vPn" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 1";
@@ -83425,7 +83453,7 @@
 	name = "Gas to Cooling Loop"
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "vQx" = (
 /obj/structure/chair{
 	dir = 8
@@ -83455,7 +83483,7 @@
 	dir = 10
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "vQR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -83502,7 +83530,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "vRI" = (
 /obj/item/paper/crumpled/muddy,
 /turf/open/floor/iron/grimy,
@@ -83562,7 +83590,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "vSJ" = (
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
@@ -83667,7 +83695,7 @@
 /obj/item/flashlight,
 /obj/item/wrench,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "vTD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -83816,7 +83844,7 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "vWG" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -84431,7 +84459,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "wgw" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -85090,7 +85118,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "wrN" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/cable,
@@ -85114,7 +85142,7 @@
 	},
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "wsg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
 	dir = 4
@@ -85370,7 +85398,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "wuF" = (
 /turf/closed/wall,
 /area/station/maintenance/disposal)
@@ -85396,6 +85424,12 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"wuW" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/station/engineering/supermatter/room)
 "wuZ" = (
 /obj/machinery/computer/atmos_control/nitrogen_tank{
 	dir = 8
@@ -85707,7 +85741,7 @@
 "wzj" = (
 /obj/structure/sign/poster/official/safety_eye_protection,
 /turf/closed/wall/r_wall,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "wzl" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -85969,7 +86003,7 @@
 "wCn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "wCq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -86144,7 +86178,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "wEc" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/pump,
@@ -86335,7 +86369,7 @@
 	network = list("ss13","engineering")
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "wGW" = (
 /turf/open/floor/wood,
 /area/station/maintenance/starboard)
@@ -86573,7 +86607,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "wKd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
@@ -87067,7 +87101,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "wPX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -87102,7 +87136,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "wQm" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/landmark/start/shaft_miner,
@@ -87263,7 +87297,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "wSp" = (
 /obj/structure/grille,
 /obj/structure/sign/poster/contraband/kss13,
@@ -87386,7 +87420,7 @@
 	},
 /obj/machinery/oven,
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "wTs" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -87509,7 +87543,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "wVD" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple{
@@ -87825,7 +87859,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "wZf" = (
 /obj/machinery/door/airlock/virology{
 	name = "Virology Quarters A"
@@ -87933,7 +87967,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "xae" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/mess,
@@ -88012,7 +88046,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "xaA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -88477,7 +88511,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "xgW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -88978,7 +89012,7 @@
 "xlJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "xlK" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -89305,6 +89339,9 @@
 	},
 /turf/open/floor/carpet/donk,
 /area/station/service/library/printer)
+"xon" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/science/xenobiology)
 "xoq" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/griddle,
@@ -89409,7 +89446,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "xpH" = (
 /obj/machinery/door/airlock{
 	id_tag = "Green Dorm";
@@ -89544,7 +89581,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "xsk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -89974,7 +90011,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "xzs" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /obj/effect/turf_decal/tile/yellow{
@@ -90065,7 +90102,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "xAf" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -90255,7 +90292,7 @@
 "xCS" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "xCX" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
@@ -90425,7 +90462,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "xEK" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -90660,7 +90697,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "xHE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/iron/dark,
@@ -90671,7 +90708,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "xIm" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/disposal/bin,
@@ -90868,7 +90905,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "xKV" = (
 /obj/structure/closet/crate,
 /obj/item/seeds/cannabis,
@@ -91200,7 +91237,7 @@
 "xPm" = (
 /obj/structure/reflector/box,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "xPw" = (
 /obj/structure/window,
 /obj/machinery/door/firedoor/border_only,
@@ -91247,7 +91284,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "xQv" = (
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/grimy,
@@ -91424,7 +91461,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "xTt" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/tile/yellow{
@@ -91462,7 +91499,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "xTW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -91480,7 +91517,7 @@
 "xUh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "xUn" = (
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/tile/blue{
@@ -91710,7 +91747,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "xWv" = (
 /obj/structure/rack,
 /obj/item/stack/rods/fifty,
@@ -92498,7 +92535,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "yfc" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/aft)
@@ -92567,7 +92604,7 @@
 	network = list("ss13","engineering")
 	},
 /turf/open/floor/engine,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "yfx" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/effect/turf_decal/tile/blue{
@@ -92624,7 +92661,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "ygj" = (
 /obj/structure/table,
 /obj/item/razor,
@@ -92888,7 +92925,7 @@
 	name = "Prison Orange"
 	},
 /turf/open/floor/iron,
-/area/station/security/prison/upper)
+/area/station/security/prison/mess)
 "yju" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -92936,7 +92973,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "ykl" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -93024,7 +93061,7 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/atrium)
+/area/station/service/cafeteria)
 "ylZ" = (
 /turf/open/floor/iron/textured,
 /area/station/security/prison/work)
@@ -110606,8 +110643,8 @@ stv
 qsA
 yeW
 txp
-nlD
-nlD
+oZt
+oZt
 iQW
 iQW
 iQW
@@ -110864,7 +110901,7 @@ wJZ
 jIT
 koX
 qDR
-nlD
+oZt
 yju
 yju
 yju
@@ -111635,7 +111672,7 @@ wQl
 xWh
 wDX
 btC
-nlD
+oZt
 yju
 yju
 yju
@@ -111892,7 +111929,7 @@ fiI
 vIi
 hEm
 ohi
-nlD
+oZt
 yju
 yju
 yju
@@ -112144,7 +112181,7 @@ ueH
 sbQ
 yeW
 vEv
-ykN
+bVR
 wTn
 yeW
 wDX
@@ -112401,7 +112438,7 @@ cUA
 pyW
 hky
 iEV
-ykN
+bVR
 wZd
 yeW
 yeW
@@ -112658,12 +112695,12 @@ ueH
 sBf
 ueH
 gOc
-ykN
+bVR
 xax
 yeW
 yeW
 dON
-nlD
+oZt
 yju
 yju
 yju
@@ -112915,12 +112952,12 @@ paX
 uXn
 paX
 wsY
-ykN
+bVR
 mrt
 yjj
 ihX
-nlD
-nlD
+oZt
+oZt
 iQW
 iQW
 iQW
@@ -115097,17 +115134,17 @@ yju
 iQW
 yju
 iQW
-kOC
-kOC
-kOC
-ouh
-ouh
-kOC
-ouh
-ouh
-kOC
-kOC
-kOC
+dBM
+dBM
+dBM
+hFr
+hFr
+dBM
+hFr
+hFr
+dBM
+dBM
+dBM
 iQW
 vmD
 iQW
@@ -115354,8 +115391,8 @@ xdv
 xdv
 xdv
 xdv
-kOC
-mHl
+dBM
+vlk
 jGJ
 meK
 iAe
@@ -115364,7 +115401,7 @@ vTz
 meK
 meK
 xPm
-kOC
+dBM
 yju
 bfi
 iQW
@@ -115611,17 +115648,17 @@ dNL
 rbs
 dNL
 rbs
-kOC
+dBM
 cUb
 jGJ
 meK
-mHl
-mHl
-mHl
+vlk
+vlk
+vlk
 meK
 jGJ
 xPm
-kOC
+dBM
 yju
 bfi
 iQW
@@ -115868,7 +115905,7 @@ eEn
 lFt
 moa
 lFt
-kOC
+dBM
 asT
 jGJ
 jGJ
@@ -115878,7 +115915,7 @@ jGJ
 jGJ
 jGJ
 ugc
-kOC
+dBM
 iQW
 vmD
 iQW
@@ -116125,7 +116162,7 @@ sgO
 lFt
 moa
 lFt
-kOC
+dBM
 hiY
 jGJ
 meK
@@ -116135,7 +116172,7 @@ meK
 meK
 jGJ
 miB
-kOC
+dBM
 yju
 bfi
 iQW
@@ -116382,17 +116419,17 @@ eEn
 lFt
 moa
 lFt
-kOC
-mHl
+dBM
+vlk
 fbo
 mfq
 qcZ
-mHl
+vlk
 xUh
 wCn
 asd
 uFW
-kOC
+dBM
 iQW
 bfi
 vmD
@@ -116639,17 +116676,17 @@ rbs
 gBN
 isd
 lFt
-kOC
-mHl
+dBM
+vlk
 kNJ
 meK
-mHl
-mHl
-mHl
+vlk
+vlk
+vlk
 meK
 frX
 kgz
-kOC
+dBM
 yju
 yju
 iQW
@@ -116893,23 +116930,23 @@ dNL
 tvJ
 rvb
 eEn
-ouh
-ouh
+hFr
+hFr
 fbd
-kOC
-ouh
+dBM
+hFr
 bvE
-kOC
-ouh
-ouh
-ouh
-kOC
+dBM
+hFr
+hFr
+hFr
+dBM
 hSg
-ouh
-kOC
-kOC
-kOC
-kOC
+hFr
+dBM
+dBM
+dBM
+dBM
 yju
 bfi
 yju
@@ -117150,7 +117187,7 @@ gBN
 tvJ
 rvb
 sgO
-ouh
+hFr
 nUz
 cpo
 wGT
@@ -117166,7 +117203,7 @@ nHs
 yfw
 uuV
 fXe
-kOC
+dBM
 iQW
 vmD
 iQW
@@ -117407,7 +117444,7 @@ dNL
 tvJ
 rvb
 eEn
-ouh
+hFr
 xzl
 vQu
 dCs
@@ -117423,7 +117460,7 @@ dCs
 rgs
 dCs
 vWn
-ouh
+hFr
 xdv
 vmD
 iQW
@@ -117592,12 +117629,12 @@ gxq
 fkM
 jTk
 uYK
-tdo
-tdo
-tdo
-tdo
-tdo
-tdo
+hZp
+hZp
+hZp
+hZp
+hZp
+hZp
 hZp
 mYH
 aAj
@@ -117680,7 +117717,7 @@ hAB
 wVC
 fqq
 jge
-xPd
+wuW
 xdv
 vmD
 iQW
@@ -117937,7 +117974,7 @@ vlZ
 ogN
 dCs
 xEJ
-ouh
+hFr
 xdv
 bfi
 yju
@@ -118178,7 +118215,7 @@ nma
 iJU
 mxY
 vnq
-ouh
+hFr
 vnF
 xKO
 bCG
@@ -118194,7 +118231,7 @@ aQq
 uMi
 eJg
 tzQ
-kOC
+dBM
 iQW
 vmD
 iQW
@@ -118435,7 +118472,7 @@ esk
 iJh
 rlH
 jsc
-ouh
+hFr
 pre
 jIc
 nau
@@ -118451,7 +118488,7 @@ nZr
 wuD
 chJ
 cCB
-kOC
+dBM
 iQW
 vmD
 iQW
@@ -118708,7 +118745,7 @@ jQD
 bmx
 dCs
 cCB
-ouh
+hFr
 yju
 sOe
 yju
@@ -118949,7 +118986,7 @@ bPB
 neR
 iNT
 wxn
-ouh
+hFr
 xzl
 wSg
 mSI
@@ -118965,7 +119002,7 @@ bZn
 uix
 jRE
 cCB
-ouh
+hFr
 yju
 vmD
 iQW
@@ -119222,7 +119259,7 @@ fHE
 wgv
 dCs
 cCB
-ouh
+hFr
 yju
 vmD
 iQW
@@ -119463,7 +119500,7 @@ atj
 iJh
 uxL
 adV
-ouh
+hFr
 xgS
 jIc
 eJg
@@ -119479,9 +119516,9 @@ nZr
 hzo
 dCs
 jyc
-kOC
-kOC
-kOC
+dBM
+dBM
+dBM
 iQW
 vmD
 iQW
@@ -119720,7 +119757,7 @@ dVf
 vvU
 vvU
 tnt
-ouh
+hFr
 iNw
 jIc
 eJg
@@ -119738,7 +119775,7 @@ pjw
 mAJ
 ejE
 ixa
-kOC
+dBM
 iQW
 vmD
 yju
@@ -119977,7 +120014,7 @@ kOC
 qza
 qza
 kOC
-kOC
+dBM
 mjB
 gkN
 bbr
@@ -119995,7 +120032,7 @@ dCs
 eJg
 dCs
 tYd
-ouh
+hFr
 yju
 bfi
 yju
@@ -120234,7 +120271,7 @@ ubX
 dhq
 dhq
 gwQ
-kOC
+dBM
 xzl
 aMW
 gap
@@ -120252,7 +120289,7 @@ dCs
 eJg
 tOM
 tID
-ouh
+hFr
 iQW
 vmD
 iQW
@@ -120491,7 +120528,7 @@ swk
 mHl
 mHl
 eoh
-kOC
+dBM
 sGU
 qsr
 fOe
@@ -120509,7 +120546,7 @@ dCs
 eJg
 tOM
 tID
-ouh
+hFr
 yju
 vmD
 iQW
@@ -120748,7 +120785,7 @@ swk
 mHl
 mHl
 rlW
-kOC
+dBM
 uqd
 gqe
 oRG
@@ -120766,7 +120803,7 @@ eJg
 eJg
 hyj
 tID
-ouh
+hFr
 yju
 vmD
 iQW
@@ -121008,22 +121045,22 @@ swb
 vVh
 lGh
 wjz
-ouh
-ouh
-kOC
-ouh
-ouh
-ouh
-ouh
+hFr
+hFr
+dBM
+hFr
+hFr
+hFr
+hFr
 lVj
-kOC
+dBM
 ujk
 lQL
 dCs
 dCs
 vxu
 tID
-ouh
+hFr
 yju
 bfi
 yju
@@ -121273,14 +121310,14 @@ iQW
 iQW
 iQW
 tqS
-kOC
+dBM
 mLs
 vQM
 cSu
 riU
 riU
 lZr
-kOC
+dBM
 iQW
 vmD
 iQW
@@ -121530,14 +121567,14 @@ iQW
 iQW
 iQW
 tqS
-kOC
-kOC
+dBM
+dBM
 ouh
-ouh
-ouh
-ouh
-kOC
-kOC
+hFr
+hFr
+hFr
+dBM
+dBM
 iQW
 vmD
 iQW
@@ -130239,7 +130276,7 @@ rRQ
 rRQ
 rRQ
 rRQ
-xQc
+rRQ
 blK
 ydR
 wVc
@@ -134891,11 +134928,11 @@ yju
 yju
 yju
 yju
-avy
-ikL
+xon
+jAh
 rrH
-ikL
-avy
+jAh
+xon
 iQW
 yju
 iQW
@@ -135147,12 +135184,12 @@ xdv
 xdv
 xdv
 xdv
-avy
-avy
+xon
+xon
 gTb
 gvw
 pzi
-avy
+xon
 avy
 avy
 avy
@@ -135404,12 +135441,12 @@ yju
 iQW
 yju
 iQW
-avy
+xon
 bVk
 uVv
 yfZ
 pNJ
-avy
+xon
 uUc
 bLO
 dep
@@ -135661,12 +135698,12 @@ yju
 yju
 yju
 yju
-ikL
+jAh
 eio
 uDW
 wPW
 aip
-avy
+xon
 xmr
 kHl
 dep
@@ -135918,12 +135955,12 @@ avy
 ikL
 avy
 avy
-avy
-avy
-uye
+xon
+xon
+gkb
 iLM
-uye
-avy
+gkb
+xon
 eHJ
 xzi
 qDP
@@ -139516,12 +139553,12 @@ avy
 ikL
 avy
 avy
-avy
-avy
-uye
+xon
+xon
+gkb
 aKf
-uye
-avy
+gkb
+xon
 rsw
 lbW
 wVH
@@ -139778,7 +139815,7 @@ kiX
 vRv
 pWa
 fgN
-avy
+xon
 xmr
 xmr
 dep
@@ -140030,12 +140067,12 @@ gBN
 aLd
 kyu
 isd
-avy
+xon
 gvX
 rZt
 puX
 qHO
-avy
+xon
 nqn
 sty
 dep
@@ -140287,12 +140324,12 @@ neC
 tam
 ipn
 vmv
-avy
-avy
+xon
+xon
 bRT
 tac
 wrD
-avy
+xon
 avy
 avy
 avy
@@ -140545,11 +140582,11 @@ isd
 gBN
 isd
 yju
-avy
-ikL
+xon
+jAh
 lZt
-ikL
-avy
+jAh
+xon
 iQW
 yju
 iQW

--- a/_maps/selenestation.json
+++ b/_maps/selenestation.json
@@ -11,7 +11,7 @@
 	},
 	"job_changes": {
 		"Cook": {
-			"additional_cqc_areas": ["/area/station/service/bar/atrium", "/area/station/service/hydroponics", "/area/station/security/prison/upper"]
+			"additional_cqc_areas": ["/area/station/service/cafeteria", "/area/station/service/hydroponics", "/area/station/security/prison/mess"]
 		},
 		"Prisoner": {
 			"spawn_positions": 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Includes and should be limited to:

- Added a body spawner in the morgue
- Added an outlet pump for the n2o tank in atmospherics
- Added an air alarm to the incinerator/turbine room
- Slightly changed atmospherics, extending it one tile down in size to better accommodate the previously missing piping
- Fixed the atmoshpheric space access airlocks to let atmos technicians pass
- Several area changes (mostly the same as the helio PR, additionally the plating floor rooms in xenobio are now considered xeno maints, bar atrium relabelled to cafeterial. Json changes to go along with this.)
- Button fixes (same as the helio PR)



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->