### PR TITLE
Fixes Infiltrator huds

### DIFF
--- a/fulp_modules/features/antagonists/infiltrators/infil_ruleset.dm
+++ b/fulp_modules/features/antagonists/infiltrators/infil_ruleset.dm
@@ -30,7 +30,7 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/infiltrator/generate_ruleset_body(mob/applicant)
 	var/mob/living/carbon/human/infiltrator = create_infiltrator(pick(spawn_locs))
-	infiltrator.key = applicant.key
+	applicant.mind.transfer_to(infiltrator)
 	infiltrator.mind.add_antag_datum(/datum/antagonist/traitor/infiltrator)
 
 	message_admins("[ADMIN_LOOKUPFLW(infiltrator)] has been made into an infiltrator by the midround ruleset.")

--- a/fulp_modules/features/antagonists/infiltrators/infil_ruleset.dm
+++ b/fulp_modules/features/antagonists/infiltrators/infil_ruleset.dm
@@ -29,15 +29,14 @@
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/infiltrator/generate_ruleset_body(mob/applicant)
-	var/mob/living/carbon/human/infiltrator = create_infiltrator(pick(spawn_locs))
-	applicant.mind.transfer_to(infiltrator)
-	infiltrator.mind.add_antag_datum(/datum/antagonist/traitor/infiltrator)
+	var/datum/mind/player_mind = new /datum/mind(applicant.key)
+	player_mind.active = TRUE
+
+	var/mob/living/carbon/human/infiltrator = new(pick(spawn_locs))
+	player_mind.transfer_to(infiltrator)
+	player_mind.add_antag_datum(/datum/antagonist/traitor/infiltrator)
 
 	message_admins("[ADMIN_LOOKUPFLW(infiltrator)] has been made into an infiltrator by the midround ruleset.")
 	log_game("DYNAMIC: [key_name(infiltrator)] was spawned as an infiltrator by the midround ruleset.")
-	return infiltrator
-
-/proc/create_infiltrator(spawn_loc)
-	var/mob/living/carbon/human/infiltrator = new(spawn_loc)
 	return infiltrator
 

--- a/fulp_modules/features/antagonists/infiltrators/infil_ruleset.dm
+++ b/fulp_modules/features/antagonists/infiltrators/infil_ruleset.dm
@@ -29,10 +29,10 @@
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/infiltrator/generate_ruleset_body(mob/applicant)
-	var/datum/mind/player_mind = new /datum/mind(applicant.key)
+	var/datum/mind/player_mind = applicant.mind
 	player_mind.active = TRUE
 
-	var/mob/living/carbon/human/infiltrator = new(pick(spawn_locs))
+	var/mob/living/carbon/human/infiltrator = new (pick(spawn_locs))
 	player_mind.transfer_to(infiltrator)
 	player_mind.add_antag_datum(/datum/antagonist/traitor/infiltrator)
 


### PR DESCRIPTION
## About The Pull Request

The antag hud is only set on ``transfer_to()``.

``transfer_to()` also handles moving the mind into the new body, and setting the key. Setting your key to the new body's key is bad practice already, so it's bad that we do it. The hud not working is a side effect of that.

Now Infiltrators properly get their Antag huds, for Admins and roundend.

I did test in game, and this is a problem upstream as well, because Admin's Click+Drag to enter bodies does the same thing, and yes, creating a human and entering it manually will not get an Antag HUD, for ANY antagonist except Team antagonists, who make their own hud on their antag's New.

![image](https://user-images.githubusercontent.com/53777086/181124897-8ce20e17-4534-473a-97f9-367b7e9b2cb8.png)
