### PR TITLE
Fixes Ventrue getting infinite levels

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/clans/clan_tremere.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/clans/clan_tremere.dm
@@ -66,7 +66,7 @@
 		bloodsuckerdatum.owner.current.balloon_alert(bloodsuckerdatum.owner.current, "upgraded [choice]!")
 		to_chat(bloodsuckerdatum.owner.current, span_notice("You have upgraded [choice]!"))
 
-	finalize_spend_rank(bloodsuckerdatum, cost_rank)
+	finalize_spend_rank(bloodsuckerdatum, cost_rank, blood_cost)
 
 /datum/bloodsucker_clan/tremere/on_favorite_vassal(datum/source, datum/antagonist/vassal/vassaldatum, mob/living/bloodsucker)
 	var/datum/action/cooldown/spell/shapeshift/bat/batform = new()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/clans/clan_ventrue.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/clans/clan_ventrue.dm
@@ -75,7 +75,7 @@
 				SEND_SIGNAL(bloodsuckerdatum.owner.current, COMSIG_ADD_MOOD_EVENT, "madevamp", /datum/mood_event/madevamp)
 			vassaldatum.set_vassal_level(target)
 
-	finalize_spend_rank(bloodsuckerdatum, cost_rank)
+	finalize_spend_rank(bloodsuckerdatum, cost_rank, blood_cost)
 
 /datum/bloodsucker_clan/ventrue/on_favorite_vassal(datum/source, datum/antagonist/vassal/vassaldatum, mob/living/bloodsucker)
 	to_chat(bloodsucker, span_announce("* Bloodsucker Tip: You can now upgrade your Favorite Vassal by buckling them onto a Candelabrum!"))


### PR DESCRIPTION
## About The Pull Request

It wasn't passing blood_cost in their args, so they never actually removed bloodsucker blood when using blood to level up instead of a level.

## Why It's Good For The Game

No more infinite levels.
