### PR TITLE
Bruhspace event text is restored to mith's version

### DIFF
--- a/fulp_modules/features/events/bruhspace_anomaly.dm
+++ b/fulp_modules/features/events/bruhspace_anomaly.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/bruh_moment
-	name = "Bruh Moment"
+	name = "Bruhspace Anomaly"
 	typepath = /datum/round_event/bruh_moment
 	weight = 10
 	max_occurrences = 1
@@ -12,4 +12,4 @@
 		all_players.say("bruh")
 
 /datum/round_event/bruh_moment/announce(fake)
-	priority_announce("An incoming Bruh Moment has been detected. Please stand by.", "Anomaly Alert")
+	priority_announce("NanoTrasen is issuing a Bruh Moment warning. Please stand by.", "Anomaly Alert")

--- a/fulp_modules/features/events/bruhspace_anomaly.dm
+++ b/fulp_modules/features/events/bruhspace_anomaly.dm
@@ -12,4 +12,4 @@
 		all_players.say("bruh")
 
 /datum/round_event/bruh_moment/announce(fake)
-	priority_announce("NanoTrasen is issuing a Bruh Moment warning. Please stand by.", "Anomaly Alert")
+	priority_announce("Nanotrasen is issuing a Bruh Moment warning. Please stand by.", "Anomaly Alert")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
After moko said in discord that bruhspace anomaly was a funnier name, I decided to make this. Restores bruhspace event text to Mith's version at https://github.com/TheSwain/Fulpstation/pull/81 (thank you John for bringing this event back)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
It's more familiar for the people who remember the original event.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: bruhspace anomaly event text is restored to Mith's version
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
