### PR TITLE
Medipen Reagent Display

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -138,10 +138,27 @@
 
 /obj/item/reagent_containers/hypospray/medipen/examine()
 	. = ..()
-	if(reagents?.reagent_list.len)
-		. += span_notice("It is currently loaded.")
+	if(length(reagents?.reagent_list))
+		var/reagent_text = ""
+
+		if(length(reagents.reagent_list) == 1)
+			var/datum/reagent/first = reagents.reagent_list[1]
+			reagent_text = first.name
+
+		else
+			var/len = reagents.reagent_list.len
+			var/list/reagent_names_list = list()
+			for(var/i in 1 to (len - 2))
+				var/datum/reagent/reagent_object = reagents.reagent_list[i]
+				reagent_names_list += "[reagent_object.name], "
+			var/datum/reagent/last_reagent = reagents.reagent_list[len]
+			var/datum/reagent/second_to_last_reagent = reagents.reagent_list[len - 1]
+			reagent_names_list += "[second_to_last_reagent.name] and [last_reagent.name]"
+			reagent_text = reagent_names_list.Join("")
+
+		. += span_notice("Theres a small LCD screen on a side of the medipen which reads, 'WARNING: This medipen contains [reagent_text]. Do not use if allergic to any listed chemicals.' in small text.") //cheapskates at nanotrasen couldnt ball out for LED
 	else
-		. += span_notice("It is spent.")
+		. += span_notice("Theres a blank LCD screen on the side.")
 
 /obj/item/reagent_containers/hypospray/medipen/stimpack //goliath kiting
 	name = "stimpack medipen"
@@ -253,7 +270,7 @@
 
 /obj/item/reagent_containers/hypospray/medipen/survival/luxury
 	name = "luxury medipen"
-	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 60u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of very hard enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE."
+	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 60u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of very hard enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE." //clueless
 	icon_state = "luxpen"
 	inhand_icon_state = "atropen"
 	base_icon_state = "luxpen"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nanotrasen is rolling out their new and improved Medipen Casing 2.0! This all new casing comes with a fancy new LCD screen on the side of the pen which displays the chemicals inside (legally required after the court ruling of Nanotrasen V Hennington) in an attempt to reduce allergic attacks onboard their station due to not properly advertising the contents of their issued medipens.

Thanks to Rohesie#4152 for teaching me a bunch of stuff about DM, couldn't have done this without him.

## Why It's Good For The Game

As stated above everybody hates when they think they're gonna get a free few points from taking a medical allergy, then being on the verge of crit and popping their epi-pen, only to have a vicious allergic reaction do to the 3u of formaldehyde contained inside, who would've known that the epinephrine pen contained something that wasn't epinephrine? Shocking, I know. This update changes that, now before popping your medipen, the advanced (recycled pregnancy test parts) will scan the chemicals contained inside the pen and display them on the side of the pen. The hypo spray chassis has not received the same remodel

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Changed how the descriptions of medi-pens work.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
