### PR TITLE
Post-shuffle heliostation fixes

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -73424,6 +73424,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"sEC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "sFn" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/structure/crate,
@@ -74133,15 +74143,6 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"tth" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "ttD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -112265,7 +112266,7 @@ bMM
 bOA
 bPY
 icD
-tth
+sEC
 bVD
 bWv
 cmp

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -298,7 +298,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/fore)
 "aaW" = (
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -361,13 +360,13 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 30
 	},
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 5;
 	name = "engineering yellow"
 	},
-/obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/fore)
 "abj" = (
@@ -403,7 +402,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "abs" = (
-/obj/structure/cable,
 /obj/machinery/camera/directional/south{
 	c_tag = "Solar Control - Starboard Fore";
 	name = "Solars Camera";
@@ -414,14 +412,11 @@
 	dir = 10;
 	name = "engineering yellow"
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/fore)
 "abt" = (
 /obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	name = "engineering yellow"
@@ -597,9 +592,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/upper)
 "abO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/security/upper)
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "abU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -17063,6 +17064,8 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aRx" = (
@@ -17237,13 +17240,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aSe" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 8;
 	name = "engineering yellow"
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aSf" = (
@@ -17329,6 +17331,8 @@
 	dir = 4;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aSt" = (
@@ -17494,7 +17498,6 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "aTc" = (
-/obj/structure/cable,
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -17505,9 +17508,6 @@
 /area/station/maintenance/solars/port/fore)
 "aTd" = (
 /obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	name = "engineering yellow"
@@ -17831,6 +17831,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "aUg" = (
@@ -17930,10 +17931,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
-"aUs" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port/fore)
 "aUt" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -32587,7 +32584,6 @@
 	color = "#FFD700";
 	name = "engineering yellow"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "bKw" = (
@@ -44481,11 +44477,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"cpo" = (
-/obj/structure/cable,
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "cpp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -46598,18 +46589,15 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -30
 	},
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 9;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/aft)
-"cuH" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/engineering/engine_smes)
 "cuI" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
@@ -47114,6 +47102,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "cwa" = (
@@ -47239,9 +47228,6 @@
 /area/station/maintenance/solars/port/aft)
 "cwy" = (
 /obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 4;
@@ -47507,10 +47493,6 @@
 "cxj" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/starboard/aft)
-"cxk" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science)
 "cxm" = (
 /obj/machinery/power/solar_control{
 	dir = 4;
@@ -47807,7 +47789,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/transit_tube)
 "cxY" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	name = "engineering yellow"
@@ -47827,7 +47808,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cya" = (
-/obj/structure/cable,
 /obj/machinery/camera/directional/south{
 	c_tag = "Solar Control - Port Aft";
 	name = "Solars Camera";
@@ -47838,7 +47818,7 @@
 	dir = 6;
 	name = "engineering yellow"
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/aft)
 "cyb" = (
@@ -47934,15 +47914,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/aft)
 "cym" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 1;
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/aft)
 "cyn" = (
@@ -48156,7 +48133,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cyT" = (
-/obj/structure/cable,
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -48469,6 +48445,10 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/aft)
 "czE" = (
@@ -48669,7 +48649,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "cAl" = (
-/obj/structure/cable,
 /obj/machinery/camera/directional/east{
 	c_tag = "Solar Control - Starboard Aft";
 	name = "Solars Camera";
@@ -57584,11 +57563,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/cargo/miningoffice)
-"des" = (
-/obj/effect/spawner/random/trash/mess,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "deu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
@@ -67241,6 +67215,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/aft)
 "mHl" = (
@@ -67297,7 +67272,6 @@
 /turf/open/floor/engine,
 /area/station/command/bridge)
 "mJe" = (
-/obj/structure/cable,
 /obj/machinery/camera/directional/south{
 	c_tag = "Solar Control - Starboard Aft Maint";
 	name = "Solars Camera";
@@ -67977,6 +67951,9 @@
 	dir = 4;
 	name = "engineering yellow"
 	},
+/obj/machinery/light/directional/east,
+/obj/machinery/power/terminal,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/fore)
 "noW" = (
@@ -73424,16 +73401,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"sEC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "sFn" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/structure/crate,
@@ -75579,6 +75546,10 @@
 	dir = 1;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/aft)
 "uRV" = (
@@ -76996,6 +76967,7 @@
 	dir = 8;
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "wrR" = (
@@ -95070,7 +95042,7 @@ aaa
 aaa
 coT
 coT
-cuH
+coT
 cvW
 coT
 pMG
@@ -95780,7 +95752,7 @@ loG
 aSf
 aTd
 aUd
-aAi
+aCR
 aWl
 aAi
 bEn
@@ -96036,8 +96008,8 @@ aOa
 aRw
 aSs
 aTy
-aUs
-cpo
+bdS
+aCp
 aWl
 aXe
 bEn
@@ -112266,7 +112238,7 @@ bMM
 bOA
 bPY
 icD
-sEC
+abO
 bVD
 bWv
 cmp
@@ -112426,7 +112398,7 @@ aat
 abg
 nnS
 abX
-abO
+abM
 acs
 adg
 abM
@@ -129767,9 +129739,9 @@ bJT
 aZN
 bBg
 tsK
-des
+oAd
 mJe
-cxk
+bxD
 cyl
 czD
 cAO
@@ -130025,7 +129997,7 @@ aZN
 bTe
 bTe
 bTe
-bBg
+bTe
 mFL
 cym
 czE

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -65588,19 +65588,6 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
-"laS" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/lobby)
 "lbp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -73322,10 +73309,8 @@
 /obj/effect/landmark/navigate_destination/vault,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "sBs" = (
@@ -75140,6 +75125,19 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"utQ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/lobby)
 "uuo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -114599,7 +114597,7 @@ mXO
 czk
 hDw
 cBO
-laS
+utQ
 cEw
 qTK
 lim

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -50144,6 +50144,8 @@
 "cEw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cEx" = (
@@ -52425,6 +52427,12 @@
 "cJI" = (
 /obj/effect/turf_decal/siding/dark_blue,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "cJJ" = (
@@ -58319,9 +58327,18 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
 "dSK" = (
-/obj/machinery/airalarm/directional/west,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/cargo/lobby)
 "dTt" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig"
@@ -61274,6 +61291,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "heL" = (
@@ -65695,6 +65714,8 @@
 /area/station/security/brig/hallway)
 "lim" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "liq" = (
@@ -71719,6 +71740,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "qTU" = (
@@ -73297,6 +73320,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "sBs" = (
@@ -111220,7 +111245,7 @@ csG
 cma
 duA
 qGF
-dSK
+bJe
 bJe
 cug
 cug
@@ -114570,7 +114595,7 @@ mXO
 czk
 hDw
 cBO
-cGq
+dSK
 cEw
 qTK
 lim

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -55263,8 +55263,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination/minisat_access_ai,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cRz" = (
@@ -55412,8 +55411,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cSb" = (
@@ -55545,8 +55544,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cSs" = (
@@ -55589,8 +55588,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cSB" = (
@@ -55751,8 +55750,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "cSZ" = (
@@ -55864,8 +55863,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cTp" = (
@@ -55902,8 +55901,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "cTs" = (
@@ -55961,8 +55960,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cTC" = (
@@ -56191,8 +56190,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "cUv" = (
@@ -56243,8 +56241,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "cUF" = (

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -365,8 +365,13 @@
 	dir = 5;
 	name = "engineering yellow"
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/camera/directional/east{
+	c_tag = "Solar Control - Starboard Fore";
+	name = "Solars Camera";
+	network = list("ss13","engineering")
+	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/fore)
 "abj" = (
@@ -412,7 +417,8 @@
 	dir = 10;
 	name = "engineering yellow"
 	},
-/obj/structure/closet/emcloset,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/fore)
 "abt" = (
@@ -17064,8 +17070,8 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aRx" = (
@@ -17498,12 +17504,13 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "aTc" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 10;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aTd" = (
@@ -46595,8 +46602,13 @@
 	dir = 9;
 	name = "engineering yellow"
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/camera/directional/north{
+	c_tag = "Solar Control - Port Aft";
+	name = "Solars Camera";
+	network = list("ss13","engineering")
+	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/aft)
 "cuI" = (
@@ -47809,17 +47821,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cya" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Solar Control - Port Aft";
-	name = "Solars Camera";
-	network = list("ss13","engineering")
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 6;
 	name = "engineering yellow"
 	},
-/obj/structure/closet/emcloset,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/aft)
 "cyb" = (
@@ -48134,12 +48142,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cyT" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 5;
 	name = "engineering yellow"
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/aft)
 "cyV" = (
@@ -48873,7 +48882,7 @@
 	dir = 10;
 	name = "engineering yellow"
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/aft)
 "cAQ" = (

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -40441,6 +40441,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cfl" = (
@@ -74132,6 +74133,15 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"tth" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "ttD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -112255,7 +112265,7 @@ bMM
 bOA
 bPY
 icD
-bJe
+tth
 bVD
 bWv
 cmp

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -58327,18 +58327,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
 "dSK" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/hallway/primary/aft)
 "dTt" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig"
@@ -65597,6 +65588,19 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
+"laS" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/lobby)
 "lbp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -111236,7 +111240,7 @@ bJe
 rOd
 rOd
 rOd
-bJe
+dSK
 bXy
 lUI
 ckA
@@ -114595,7 +114599,7 @@ mXO
 czk
 hDw
 cBO
-dSK
+laS
 cEw
 qTK
 lim

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -55411,7 +55411,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
@@ -55588,7 +55587,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -55750,7 +55748,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
@@ -55901,7 +55898,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
@@ -55960,7 +55956,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -53190,14 +53190,11 @@
 	name = "Turbine Intake Pump"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
-"cLT" = (
 /obj/machinery/button/ignition/incinerator/atmos{
-	pixel_x = -6;
+	pixel_x = -36;
 	pixel_y = 1
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "cLX" = (
 /obj/machinery/camera/directional/west{
@@ -108433,7 +108430,7 @@ iMt
 iMt
 iMt
 iMt
-cLT
+iMt
 iMt
 iMt
 iMt

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -46193,6 +46193,7 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/status_display/ai/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "ctt" = (

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -55264,6 +55264,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination/minisat_access_ai,
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cRz" = (
@@ -55412,6 +55413,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cSb" = (
@@ -55544,6 +55546,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cSs" = (
@@ -55587,6 +55590,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cSB" = (
@@ -55748,6 +55752,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "cSZ" = (
@@ -55860,6 +55865,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cTp" = (
@@ -55897,6 +55903,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "cTs" = (
@@ -55955,6 +55962,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cTC" = (
@@ -56184,6 +56192,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "cUv" = (
@@ -56235,6 +56244,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "cUF" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Did some oopsies while fixing the merge conflicts on the heliostation shuffle PR. Also fixed/qol'd some other stuff while I was at it.

- Fixes air alarm over a door on the aft hallway
- Fixes the missing wire connecting the engineering foyer (and by extension the station) to the rest of engi
- Fixes the missing piping and wiring connecting to vault and grav gen
- Removes the wiring in grav gen that bypassed the SMES unit
- Removed under-wall wiring from all solars
- Added AI upload access requirements to the doors leading into the AI's chamber
- Adds a wire under the engineering console in the SMES room for AmpCheck to work properly.
- Makes the turbine igniter button be inside the room with a pixel offset rather than being on the wall itself, since it allowed people to interact with it from outside.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

