### PR TITLE
medipen reagent display 2.0

### DIFF
--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -231,26 +231,36 @@ Primarily used in reagents/reaction_agents
 	return list("[taste_description]" = 1)
 
 /**
- * Used when you want the default reagents purity to be equal to the normal effects
- * (i.e. if default purity is 0.75, and your reacted purity is 1, then it will return 1.33)
+ * Input a reagent_list, outputs pretty readable text!
+ * Default output will be formatted as
+ * * water, 5 | silicon, 6 | soup, 4 | space lube, 8
  *
- * Arguments
- * * normalise_num_to - what number/purity value you're normalising to. If blank it will default to the compile value of purity for this chem
- * * creation_purity - creation_purity override, if desired. This is the purity of the reagent that you're normalising from.
+ * * names_only will remove the amount displays, showing
+ * * water | silicon | soup | space lube
+ *
+ * * join_text will alter the text between reagents
+ * * setting to ", " will result in
+ * * water, 5, silicon, 6, soup, 4, space lube, 8
+ *
+ * * final_and should be combined with the above. will format as
+ * * water, 5, silicon, 6, soup, 4, and space lube, 8
+ *
+ * * capitalize_names will result in
+ * * Water, 5 | Silicon, 6 | Soup, 4 | Space lube, 8
+ *
+ * * * use (reagent_list, TRUE, ", ", TRUE, TRUE) for the formatting
+ * * * Water, Silicon, Soup, and Space Lube
  */
-/datum/reagent/proc/normalise_creation_purity(normalise_num_to, creation_purity)
-	if(!normalise_num_to)
-		normalise_num_to = initial(purity)
-	if(!creation_purity)
-		creation_purity = src.creation_purity
-	return creation_purity / normalise_num_to
-
-/proc/pretty_string_from_reagent_list(list/reagent_list)
+/proc/pretty_string_from_reagent_list(list/reagent_list, names_only, join_text = " | ", final_and, capitalize_names)
 	//Convert reagent list to a printable string for logging etc
 	var/list/rs = list()
+	var/reagents_left = reagent_list.len
+	var/intial_list_length = reagents_left
 	for (var/datum/reagent/R in reagent_list)
-		rs += "[R.name], [R.volume]"
+		reagents_left--
+		if(final_and && intial_list_length > 1 && reagents_left == 0)
+			rs += "and [capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
+		else
+			rs += "[capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
 
-	return rs.Join(" | ")
-
-
+	return rs.Join(join_text)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -138,10 +138,16 @@
 
 /obj/item/reagent_containers/hypospray/medipen/examine()
 	. = ..()
-	if(reagents?.reagent_list.len)
-		. += span_notice("It is currently loaded.")
+	if (old_text)     //if old_text = true have the old examine text, if otherwise have the new examine text
+		if (length(reagents?.reagent_list))
+			. += span_notice("It is loaded.")
+		else
+			. += span_notice("It is spent.")
 	else
-		. += span_notice("It is spent.")
+		if(length(reagents?.reagent_list))
+			. += span_notice("There\'s a small LCD screen on the side of the medipen which reads, 'WARNING: This medipen contains [pretty_string_from_reagent_list(reagents.reagent_list, TRUE, ", ", TRUE, TRUE)]. Do not use if allergic to any listed chemicals.' in small text.") //cheapskates at nanotrasen couldnt ball out for LED
+		else
+			. += span_notice("There\'s a blank LCD screen on the side of the medipen.")
 
 /obj/item/reagent_containers/hypospray/medipen/stimpack //goliath kiting
 	name = "stimpack medipen"
@@ -276,6 +282,7 @@
 	inhand_icon_state = "snail"
 	base_icon_state = "snail"
 	list_reagents = list(/datum/reagent/snail = 10)
+	old_text = TRUE
 
 /obj/item/reagent_containers/hypospray/medipen/magillitis
 	name = "experimental autoinjector"
@@ -296,6 +303,7 @@
 	list_reagents = list(/datum/reagent/drug/pumpup = 15)
 	icon_state = "maintenance"
 	base_icon_state = "maintenance"
+	old_text = TRUE
 
 /obj/item/reagent_containers/hypospray/medipen/ekit
 	name = "emergency first-aid autoinjector"


### PR DESCRIPTION
Adds new reagent examine text and updates how petty_string_from_reagent_list works (for the better)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds new reagent examine text and updates how petty_string_from_reagent_list works.

Oranges didn't like how I presented my PR on TG so he closed it, I made this for fulp anyway

## Why It's Good For The Game

Now, everybody hates when they take the allergy quirk and say, "Oh this pen is surely safe to use with my allergy, right?", then being on the verge of crit and popping their epi-pen, only to have a vicious allergic reaction do to the 3u of formaldehyde contained inside, who would've known that the epinephrine pen contained something that wasn't epinephrine? Shocking, I know. This update changes that, now before popping your medipen, the advanced scanners inside the pen (recycled pregnancy test parts) will scan the chemicals contained inside the pen and display them on the side of the pen. The hypospray chassis and combat medipens have not received the same remodel, due to it being far too expensive for the aforementioned models.
![image](https://user-images.githubusercontent.com/91508746/188486160-a8dc940e-e278-4aa3-afad-18963bb93c3d.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Changed how medipen examine text works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->