### PR TITLE
Removed a door, fixed Captains offices access and HoP flash 

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -7919,8 +7919,7 @@
 /obj/machinery/button/flasher{
 	id = "hopflash";
 	pixel_x = 35;
-	pixel_y = -7;
-	req_one_access_txt = "57"
+	pixel_y = -7
 	},
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 8
@@ -11225,7 +11224,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
+/obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
 "aCl" = (
@@ -60194,12 +60193,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/work)
-"fXJ" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "fXO" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -61469,7 +61462,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/directional/north{
 	c_tag = "Security - Warden's Office";
-	network = list("ss13", "security")
+	network = list("ss13","security")
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
@@ -123245,7 +123238,7 @@ aak
 aak
 aOq
 aHx
-fXJ
+aHx
 bhJ
 gMT
 aEd


### PR DESCRIPTION

## About The Pull Request
Removed a door to space because there were three doors in a row. Fixed access where you only needed teleporter access to get into captains office and also fixed the HoP flash so it works.

## Why It's Good For The Game


## Changelog




