### PR TITLE
Fixes two typos in the description and name of a jumpsuit

### DIFF
--- a/fulp_modules/features/halloween/2021/costumes.dm
+++ b/fulp_modules/features/halloween/2021/costumes.dm
@@ -560,8 +560,8 @@
  */
 
 /obj/item/clothing/under/color/thirsty_suit
-	name = "thirsy flower jumpsuit"
-	desc = "A dark green jumpsuit that represents a thirty flower's stem."
+	name = "thirsty flower jumpsuit"
+	desc = "A dark green jumpsuit that represents a thirsty flower's stem."
 	greyscale_colors = "#128512"
 
 /obj/item/clothing/head/costume_2021/thirsty_hat


### PR DESCRIPTION
## About The Pull Request

Fixes two typos that referred to the jumpsuit as a "thirsy flower jumpsuit" and a "thirty flower jumpsuit" respectively

## Why It's Good For The Game

Typos bad spelling good

## Changelog

:cl:
spellcheck: fixes two typos
/:cl: