### PR TITLE
Heliostation QOL Changes, Mostly Medbay

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -68077,6 +68077,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"niU" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "njb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -129220,7 +129226,7 @@ pdO
 sOo
 huw
 cmq
-aRf
+niU
 aOG
 aaa
 aaa

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -14193,6 +14193,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/button/door/directional/west{
+	id = "Virology Breach";
+	name = "Virology Breach Prevention";
+	req_access = list("virology")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aJJ" = (
@@ -16506,7 +16511,17 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
 "aPN" = (
-/obj/machinery/chem_master,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
@@ -16847,16 +16862,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aQT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/chemistry)
 "aQU" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
@@ -16881,6 +16889,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aQX" = (
@@ -17499,21 +17510,6 @@
 /turf/open/space/basic,
 /area/space)
 "aSZ" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/cup/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 7;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/cup/bottle/epinephrine{
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
@@ -17521,6 +17517,7 @@
 /obj/structure/sign/poster/official/safety_eye_protection{
 	pixel_x = -32
 	},
+/obj/machinery/chem_master,
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
 "aTb" = (
@@ -19046,7 +19043,6 @@
 	pixel_x = 4;
 	pixel_y = -4
 	},
-/obj/item/reagent_containers/dropper,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -19064,9 +19060,6 @@
 /area/station/medical/chemistry)
 "aXR" = (
 /obj/structure/rack,
-/obj/item/book/manual/wiki/grenades,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/book/manual/wiki/plumbing,
 /obj/item/construction/plumbing,
 /obj/item/construction/plumbing,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -19484,14 +19477,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aZk" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Medbay - Chemistry West";
-	name = "Chemistry Camera";
-	network = list("ss13","medbay")
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "aZm" = (
@@ -19747,6 +19736,7 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/medical2,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/medical/surgery/theatre)
 "aZR" = (
@@ -19874,10 +19864,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bak" = (
-/obj/machinery/light/directional/west,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay - Chemistry West";
+	name = "Chemistry Camera";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -20493,7 +20487,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/item/radio/intercom/directional/west,
+/obj/machinery/defibrillator_mount/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/medical/surgery/theatre)
 "bcp" = (
@@ -20547,14 +20541,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"bcz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemlock3";
-	name = "Grenade Testing Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/medical/chemistry)
 "bcA" = (
 /obj/structure/sign/plaques/kiddie/badger{
 	pixel_y = -28
@@ -21416,9 +21402,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemlock3";
-	name = "Grenade Testing Shutters"
+/obj/machinery/door/poddoor/preopen{
+	name = "Grenade Testing Shutters";
+	id = "chemlock3"
 	},
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
@@ -25588,6 +25574,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "brh" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 8
 	},
@@ -27587,6 +27574,10 @@
 	id = "roboticsshut";
 	name = "Robotics Privacy Shutters"
 	},
+/obj/structure/desk_bell{
+	pixel_x = -7;
+	pixel_y = -1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "bxx" = (
@@ -28396,6 +28387,10 @@
 	dir = 1;
 	id = "rnd";
 	name = "Research Lab Shutters"
+	},
+/obj/structure/desk_bell{
+	pixel_x = -7;
+	pixel_y = -1
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
@@ -49532,6 +49527,11 @@
 "cCu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/button/door/directional/south{
+	name = "Radiation Chamber Shutters";
+	id = "engsm";
+	req_access = list("engineering")
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cCv" = (
@@ -58009,7 +58009,6 @@
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "dsw" = (
-/obj/structure/table/glass,
 /obj/item/hemostat,
 /obj/item/cautery,
 /obj/item/circular_saw{
@@ -58017,6 +58016,7 @@
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/item/radio/intercom/directional/south,
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "dsU" = (
@@ -58093,8 +58093,14 @@
 	},
 /area/station/cargo/miningoffice)
 "dwR" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "dzf" = (
@@ -59282,11 +59288,11 @@
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "eWm" = (
-/obj/structure/table/glass,
 /obj/item/book/manual/wiki/surgery,
 /obj/item/reagent_containers/medigel/sterilizine,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/airalarm/directional/west,
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "eWM" = (
@@ -60210,6 +60216,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"fPi" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "fPm" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -60248,11 +60259,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "fRf" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "surgeryb";
-	name = "Surgery Privacy Door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Surgery Privacy Shutters";
+	id = "surgeryb"
+	},
 /turf/open/floor/plating,
 /area/station/medical/surgery/aft)
 "fRs" = (
@@ -61068,6 +61079,14 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
+"gOL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	name = "Virology Breach Prevention";
+	id = "Virology Breach"
+	},
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "gOT" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
@@ -61365,6 +61384,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"hbY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Surgery Privacy Shutters";
+	id = "surgerya";
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Surgery Privacy Shutters";
+	id = "surgeryb";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/medical/surgery/aft)
 "hcM" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -61780,12 +61813,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "hty" = (
-/obj/structure/table/glass,
 /obj/item/surgical_drapes,
 /obj/item/scalpel,
 /obj/item/retractor,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/firealarm/directional/south,
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "htO" = (
@@ -61813,7 +61846,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hvV" = (
@@ -62081,7 +62116,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "hEH" = (
-/obj/structure/table/glass,
 /obj/item/surgical_drapes,
 /obj/item/scalpel,
 /obj/item/retractor,
@@ -62090,6 +62124,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "hEL" = (
@@ -62421,6 +62456,16 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/machinery/button/door/directional/east{
+	id = "surgerya";
+	name = "Surgery Privacy Button";
+	req_access = list("surgery")
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Medbay - Surgery A";
+	name = "Surgery A Camera";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "hTK" = (
@@ -62595,6 +62640,16 @@
 /obj/effect/turf_decal/bot_white{
 	color = "#52B4E9"
 	},
+/obj/machinery/button/door/directional/west{
+	id = "surgeryb";
+	name = "Surgery Privacy Button";
+	req_access = list("surgery")
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay - Surgery B";
+	name = "Surgery B Camera";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "iaG" = (
@@ -62722,11 +62777,11 @@
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "iiB" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "surgerya";
-	name = "Surgery Privacy Door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Surgery Privacy Shutters";
+	id = "surgerya"
+	},
 /turf/open/floor/plating,
 /area/station/medical/surgery/aft)
 "iiF" = (
@@ -65275,14 +65330,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "kDe" = (
-/obj/machinery/door/poddoor{
-	id = "engstorage";
-	name = "Engineering Secure Storage Lockdown"
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 4;
 	name = "engineering yellow"
+	},
+/obj/machinery/door/poddoor{
+	id = "engstorage";
+	name = "Engineering Secure Storage Lockdown"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
@@ -65363,13 +65418,19 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
+/obj/machinery/camera/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kII" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/maintenance/department/medical)
+"kIW" = (
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kJn" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -65815,10 +65876,10 @@
 /area/station/maintenance/department/science/xenobiology)
 "lfj" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/table/glass,
 /obj/item/hemostat,
 /obj/item/cautery,
 /obj/item/radio/intercom/directional/south,
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "lfk" = (
@@ -66398,6 +66459,14 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"lJv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	name = "Grenade Testing Shutters";
+	id = "chemlock3"
+	},
+/turf/open/floor/plating,
+/area/station/medical/chemistry)
 "lJM" = (
 /obj/structure/table/glass,
 /obj/item/clothing/glasses/hud/health,
@@ -66912,16 +66981,12 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Medbay - Chemistry East";
-	name = "Chemistry Camera";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/button/door/directional/east{
 	id = "chemlock2";
 	name = "Chemistry Breach Prevention";
 	req_access = list("plumbing")
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "mkq" = (
@@ -67859,18 +67924,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "neh" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Medbay - Surgery B";
-	name = "Surgery B Camera";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
-	},
-/obj/machinery/button/door/directional/west{
-	id = "surgeryb";
-	name = "Surgery Privacy Button";
-	req_access = list("surgery")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
@@ -68818,6 +68873,11 @@
 	},
 /turf/open/floor/vault,
 /area/station/command/bridge)
+"nST" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "nTn" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -69204,18 +69264,8 @@
 "ojw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
-/obj/machinery/camera/directional/east{
-	c_tag = "Medbay - Surgery A";
-	name = "Surgery A Camera";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
-	},
-/obj/machinery/button/door/directional/east{
-	id = "surgerya";
-	name = "Surgery Privacy Button";
-	req_access = list("surgery")
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
@@ -71357,6 +71407,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"qrG" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qsr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 4
@@ -72213,11 +72267,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "rif" = (
-/obj/structure/table/glass,
 /obj/item/book/manual/wiki/surgery,
 /obj/item/reagent_containers/medigel/sterilizine,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "rit" = (
@@ -74819,6 +74873,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"tOW" = (
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "tQo" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 8
@@ -76804,6 +76864,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vRJ" = (
@@ -77337,6 +77398,12 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"wxr" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "wxs" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -120679,7 +120746,7 @@ bts
 wLA
 wLA
 wvl
-wLA
+hbY
 wLA
 wLA
 btm
@@ -124770,7 +124837,7 @@ aNa
 aNU
 bdK
 mPd
-aQT
+blz
 piO
 piO
 aFR
@@ -127323,11 +127390,11 @@ aaa
 aaa
 aaa
 aEe
-aHa
-aHa
+gOL
+gOL
 aEe
-aHa
-aHa
+gOL
+gOL
 aEe
 iYc
 lJM
@@ -128350,7 +128417,7 @@ aaa
 aaa
 aaa
 aaa
-aHa
+gOL
 aGp
 aJo
 aJI
@@ -128607,7 +128674,7 @@ aaa
 aaa
 aaa
 aaa
-aHa
+gOL
 aGM
 gSj
 aKd
@@ -128895,8 +128962,8 @@ aQK
 aPX
 uYl
 aPX
-aQK
-aQK
+aPX
+aPX
 aQK
 aQK
 lqP
@@ -129152,9 +129219,9 @@ bak
 pdO
 sOo
 huw
+cmq
+aRf
 aOG
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -129406,12 +129473,12 @@ dHE
 dHE
 dHE
 dHE
+dHE
 tah
+aRf
 aRf
 wxQ
 aOG
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -129665,10 +129732,10 @@ aRf
 aRf
 aRf
 aRf
+aRf
+aRf
 wxQ
 aOG
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -129914,7 +129981,7 @@ bxH
 dHE
 oPB
 dHE
-dHE
+nST
 aKl
 aRf
 aRf
@@ -129922,10 +129989,10 @@ aRf
 aRf
 aRf
 aRf
-dwR
+aRf
+aRf
+fPi
 aOG
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -130171,18 +130238,18 @@ aRf
 rfK
 aRf
 hXQ
-aRf
-sVA
+qrG
+dwR
 aRf
 aRf
 aRf
 kxr
 kuP
+kuP
+kuP
 teS
 wxQ
 aOG
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -130435,11 +130502,11 @@ aSm
 nzh
 kps
 kps
+qrG
+wxr
 bqs
 wxQ
 aOG
-aaa
-aaa
 aaa
 aaa
 bsp
@@ -130665,11 +130732,11 @@ aaa
 aaa
 aaa
 aEe
-aHa
-aHa
-aHa
-aHa
-aHa
+gOL
+gOL
+gOL
+gOL
+gOL
 aEe
 aaa
 aaa
@@ -130690,13 +130757,13 @@ nJA
 aRf
 aRf
 est
-kps
-kps
+aQT
+tOW
+wxr
+qrG
 bqs
 wxQ
 aOG
-aaa
-aaa
 aaa
 aaa
 bsp
@@ -130934,8 +131001,8 @@ aaa
 aaa
 aOG
 aOG
-bbx
-bbx
+lJv
+lJv
 aOG
 bhV
 fNG
@@ -130947,13 +131014,13 @@ aKK
 nzh
 cmq
 rHP
+kIW
+qrG
 kps
 kps
 bqs
 wxQ
 aOG
-aaa
-aaa
 aaa
 aaa
 cek
@@ -131193,7 +131260,7 @@ aOG
 aHc
 aHc
 aRt
-bcz
+lJv
 ygL
 aRf
 aRf
@@ -131206,11 +131273,11 @@ aRf
 aRf
 fEB
 vTh
+vTh
+vTh
 uhm
 wxQ
 aOG
-aaa
-aaa
 aaa
 aaa
 bsp
@@ -131450,7 +131517,7 @@ aHc
 aHc
 aHc
 aRt
-bcz
+lJv
 nFh
 bmo
 uSW
@@ -131464,10 +131531,10 @@ aRf
 aRf
 aRf
 aRf
-dwR
+aRf
+aRf
+fPi
 aOG
-aDH
-aDH
 aDH
 aDH
 bsp
@@ -131702,7 +131769,7 @@ aaa
 aaa
 aaa
 aaa
-bbx
+lJv
 aHc
 aPO
 aHc
@@ -131721,10 +131788,10 @@ aRf
 aRf
 aRf
 aRf
+aRf
+aRf
 wxQ
 aOG
-aaa
-aaa
 aaa
 aaa
 bsp
@@ -131964,7 +132031,7 @@ aHc
 aHc
 aHc
 aRt
-bcz
+lJv
 wVl
 aRf
 aRf
@@ -131976,12 +132043,12 @@ uSW
 uSW
 uSW
 uSW
+uSW
 kWC
+aRf
 aRf
 wxQ
 aOG
-aak
-aak
 aak
 aak
 cek
@@ -132221,8 +132288,10 @@ aOG
 aHc
 aHc
 aRt
-bcz
+lJv
 bqk
+aSm
+aSm
 aSm
 aSm
 aSm
@@ -132237,8 +132306,6 @@ aSm
 wqI
 xiV
 aOG
-aaa
-aaa
 aaa
 aaa
 bsp
@@ -132476,26 +132543,26 @@ aaa
 aaa
 aOG
 aOG
-bbx
-bbx
+lJv
+lJv
 aOG
 aOG
 aOG
 cgn
 cgn
 cgn
-aOG
+cgn
+cgn
 aOG
 aOG
 cgn
 cgn
 cgn
+cgn
+cgn
 aOG
 aOG
 aOG
-aOG
-aak
-aak
 aak
 aak
 bsp


### PR DESCRIPTION
This is a handful of quality of life changes I have made to Heliostation, mostly to medbay. For real this time because I had unneccessary commits in the other one.

- A button has been added to control the radiation shutters for the SM chamber.
- Desk bells have been added to Robotics and Research desks.
- A window and shutter has been added between Surgery rooms A and B. The shutters are also now proper shutters rather than blast doors.
- Directional access was added leading out of the chemisty/virology access hallway. Those coming out of maintenance will no longer have to travel all the way around to enter central medbay.
- Glass tables in surgery rooms have been reinforced so that squirmy patients won't destroy them as easily.
- The Surgical theater has been fitted with a defibrillator mount.
- Virology has been fitted with a set of blast doors to prevent breaches. Your monkeys will no longer be easy prey for wandering spacecarp.
- The grenade testing chamber in the chemistry lab has been fitted with blast doors on the exterior windows.
- The plumbing space of the chemistry lab has been expanded south by two rows of tiles.
- Other minor changes have been made to the chemistry lab. The ChemMaster 3000 and glass work table have been swapped. There is now only one set of textbooks included with the plumbing tools. A single beaker and dropper have been removed.