### PR TITLE
Modsuit Utility Modules

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -41845,16 +41845,12 @@
 /area/station/engineering/storage)
 "cjf" = (
 /obj/structure/rack,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	name = "engineering yellow"
 	},
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cjg" = (
@@ -68191,6 +68187,11 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/light_switch/directional/south,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "nmi" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -29846,10 +29846,6 @@
 /area/station/maintenance/port/aft)
 "kcg" = (
 /obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /obj/item/storage/box/syringes,
 /obj/item/reagent_containers/cup/bottle/epinephrine{
 	pixel_x = 7;
@@ -29867,6 +29863,8 @@
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 4
 	},
+/obj/item/storage/box/rxglasses,
+/obj/item/hand_labeler,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "kcB" = (
@@ -47734,10 +47732,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "pWn" = (
-/obj/structure/closet/crate/solarpanel_small,
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/engineering/anticorner,
+/obj/structure/rack,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "pWs" = (
@@ -66856,18 +66856,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "wyW" = (
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rxglasses,
-/obj/item/hand_labeler,
 /obj/item/gun/syringe,
 /obj/item/gun/syringe,
-/obj/structure/table,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 1
 	},
+/obj/structure/rack,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "wzj" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I noticed Helio and Selene did not have plasma stabilizer and thermal regulator modules in engineering like most other stations do. Both stations will now have one of each available at round start. I also did the same for Selene's medbay as it was also missing these modules. Very minor changes were made to make things look tidy. Selene engineering won't start with a spare solars crate. Selene medical storage won't start with boxes of beakers and body bags.

## Why It's Good For The Game

Now lizards and plasmamen don't have to go begging to robotics to be able to use their department provided modsuits.

## Changelog
🆑 
add: plasma stabilizer and thermal regulator added to Selene Engineering and Medbay and Helio Engineering
remove: removed roundstart solar crate in Selene engineering
remove: removed round start beaker and body bag boxes in Selene medbay storage
/🆑