### PR TITLE
Selene Medbay QOL

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -207,7 +207,7 @@
 /area/station/hallway/primary/aft)
 "adQ" = (
 /obj/docking_port/stationary/random{
-	id = "pod_lavaland2";
+	shuttle_id = "pod_lavaland2";
 	name = "lavaland"
 	},
 /turf/open/space/basic,
@@ -255,8 +255,8 @@
 	dir = 8;
 	dwidth = 5;
 	height = 7;
-	id = "supply_home";
 	name = "Cargo Bay";
+	shuttle_id = "cargo_home";
 	width = 12
 	},
 /turf/open/space/basic,
@@ -989,24 +989,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"arg" = (
-/obj/machinery/door_timer{
-	id = "Cell 4";
-	name = "Cell 4";
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/brig)
 "art" = (
 /obj/structure/cable,
 /obj/structure/chair/stool/directional/north,
@@ -1386,6 +1368,9 @@
 /area/station/engineering/atmos)
 "axd" = (
 /obj/structure/reagent_dispensers/cooking_oil,
+/obj/item/toy/figure/chef{
+	pixel_y = 10
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "axf" = (
@@ -1664,9 +1649,9 @@
 	dir = 8
 	},
 /obj/structure/rack,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
 /obj/item/crowbar,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aCk" = (
@@ -1956,7 +1941,6 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Cooling Loop to Gas"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "aIZ" = (
@@ -3984,23 +3968,6 @@
 	layer = 2.9
 	},
 /obj/structure/filingcabinet,
-/obj/machinery/door_timer{
-	id = "engcell";
-	name = "Engineering Cell";
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/security/anticorner{
-	dir = 1
-	},
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/structure/filingcabinet,
 /obj/effect/turf_decal/tile/security/anticorner{
 	dir = 1
 	},
@@ -4416,9 +4383,9 @@
 	dir = 8;
 	dwidth = 5;
 	height = 17;
-	id = "arrivals_stationary";
 	name = "selene arrivals";
 	roundstart_template = /datum/map_template/shuttle/arrival/fulp/selene;
+	shuttle_id = "arrival_stationary";
 	width = 11
 	},
 /turf/open/space/basic,
@@ -5343,17 +5310,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/medical/half,
 /obj/structure/table/glass,
-/obj/item/clothing/under/misc/pj/blue,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/toy/figure/md,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
-/obj/structure/table/glass,
 /obj/item/clothing/under/misc/pj/blue{
 	pixel_x = 5
 	},
@@ -6260,18 +6216,6 @@
 	},
 /obj/structure/table/glass,
 /obj/item/clothing/suit/jacket/straight_jacket,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/ears/earmuffs,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/item/clothing/suit/jacket/straight_jacket,
 /obj/item/clothing/glasses/eyepatch,
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/ears/earmuffs,
@@ -6331,6 +6275,7 @@
 /obj/effect/turf_decal/tile/security/half{
 	dir = 8
 	},
+/obj/item/toy/figure/secofficer,
 /turf/open/floor/iron,
 /area/station/security/office)
 "ccw" = (
@@ -6928,21 +6873,11 @@
 "coy" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
-	id = "pod_lavaland1";
+	shuttle_id = "pod_lavaland1";
 	name = "lavaland"
 	},
 /turf/open/space/basic,
 /area/space)
-"coA" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "coL" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
@@ -7523,6 +7458,7 @@
 /obj/effect/turf_decal/tile/security/half{
 	dir = 4
 	},
+/obj/item/toy/figure/warden,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "cxT" = (
@@ -8981,15 +8917,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"cWu" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/engine,
-/area/station/medical/pharmacy)
 "cWB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
@@ -10014,6 +9941,9 @@
 /obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 4
 	},
+/obj/item/toy/figure/mime{
+	pixel_y = 14
+	},
 /turf/open/floor/iron/white,
 /area/station/service/theater)
 "dpS" = (
@@ -10970,6 +10900,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"dHW" = (
+/obj/structure/table/wood/fancy,
+/obj/item/toy/figure/wizard,
+/turf/open/floor/carpet,
+/area/station/maintenance/fore)
 "dHX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11117,7 +11052,7 @@
 	dir = 8;
 	dwidth = 4;
 	height = 9;
-	id = "aux_base_zone";
+	shuttle_id = "aux_base_zone";
 	name = "aux base zone";
 	roundstart_template = /datum/map_template/shuttle/aux_base/default;
 	width = 9
@@ -11208,10 +11143,11 @@
 "dLu" = (
 /obj/structure/table,
 /obj/item/newspaper,
-/obj/item/toy/figure/chemist,
+/obj/item/toy/figure/md,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 8
 	},
+/obj/item/toy/figure/paramedic,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "dLw" = (
@@ -11222,30 +11158,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "dLN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_timer{
-	id = "scicell";
-	name = "Science Cell";
-	pixel_y = -30
-	},
-/obj/item/paper_bin,
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/security/half{
-	dir = 8
-	},
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/folder/red,
@@ -12808,15 +12720,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "enn" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Pharmacy Maintenance"
+	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
 /obj/effect/turf_decal/tile/medical/opposingcorners,
-/obj/machinery/door/airlock/maintenance{
-	name = "Pharmacy Maintenance"
-	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard)
 "enI" = (
@@ -13337,6 +13249,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "evT" = (
@@ -14068,16 +13981,13 @@
 /turf/open/floor/plating,
 /area/station/commons/fitness)
 "eKF" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -14916,27 +14826,9 @@
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 8
 	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/cup/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = -3
-	},
 /obj/item/reagent_containers/cup/bottle/multiver,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/structure/table/glass,
-/obj/machinery/light_switch/directional/west,
-/obj/structure/cable,
-/obj/item/storage/box,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
-	},
+/obj/item/reagent_containers/cup/bottle/epinephrine,
+/obj/item/reagent_containers/syringe,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "faa" = (
@@ -15168,22 +15060,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "fdi" = (
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Security - West Cells";
-	network = list("ss13","security")
-	},
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -15982,16 +15858,16 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "fqm" = (
+/obj/structure/rack,
+/obj/item/book/manual/wiki/grenades,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/book/manual/wiki/plumbing,
+/obj/item/construction/plumbing,
+/obj/item/construction/plumbing,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/construction/plumbing,
-/obj/item/construction/plumbing,
-/obj/item/book/manual/wiki/plumbing,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/book/manual/wiki/grenades,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "fqq" = (
@@ -17069,19 +16945,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "fIu" = (
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/security/half,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -17785,6 +17648,10 @@
 /area/station/hallway/secondary/service)
 "fUp" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/item/toy/figure/dsquad{
+	pixel_y = 11;
+	pixel_x = -1
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "fUs" = (
@@ -18647,7 +18514,7 @@
 /obj/machinery/chem_dispenser,
 /obj/structure/sign/departments/chemistry/directional/north,
 /turf/open/floor/engine,
-/area/station/medical/chemistry)
+/area/space/nearstation)
 "giQ" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -20236,6 +20103,7 @@
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/item/toy/figure/virologist,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "gKv" = (
@@ -20534,6 +20402,9 @@
 /obj/effect/turf_decal/tile/prison/half,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"gOd" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "gOz" = (
 /obj/structure/cable,
 /obj/machinery/camera{
@@ -20968,6 +20839,10 @@
 	},
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
+	},
+/obj/item/toy/figure/miner{
+	pixel_y = 16;
+	pixel_x = 6
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -21454,6 +21329,10 @@
 "hfm" = (
 /obj/machinery/chem_mass_spec,
 /obj/effect/turf_decal/tile/medical/half,
+/obj/item/toy/figure/chemist{
+	pixel_x = 7;
+	pixel_y = -1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "hfo" = (
@@ -21587,8 +21466,7 @@
 "hhx" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/medicine,
-/obj/item/modular_computer/tablet/preset/advanced/command,
-/obj/item/toy/figure/cmo,
+/obj/item/modular_computer/tablet/pda/heads,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "hhz" = (
@@ -23305,8 +23183,13 @@
 /area/station/science/xenobiology)
 "hNk" = (
 /obj/structure/table/wood,
-/obj/item/toy/figure/syndie,
+/obj/item/toy/figure/syndie{
+	pixel_x = 7
+	},
 /obj/structure/cable,
+/obj/item/toy/figure/curator{
+	pixel_x = -7
+	},
 /turf/open/floor/carpet/donk,
 /area/station/service/library/printer)
 "hNq" = (
@@ -24505,15 +24388,6 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced/rglass,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
-/obj/structure/table/reinforced/rglass,
 /obj/item/book/manual/wiki/surgery,
 /obj/item/blood_filter,
 /turf/open/floor/iron/white,
@@ -24543,12 +24417,16 @@
 	c_tag = "Medical - Psychology";
 	network = list("ss13","medbay")
 	},
+/obj/item/toy/figure/psychologist{
+	pixel_y = 16;
+	pixel_x = 4
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "iiY" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/engine,
-/area/station/medical/chemistry)
+/area/space/nearstation)
 "iiZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/engineering,
@@ -25168,13 +25046,13 @@
 /area/station/hallway/primary/aft)
 "iuj" = (
 /obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Chemistry Lab Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /obj/effect/turf_decal/tile/medical/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Chemistry Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard)
 "iuq" = (
@@ -25401,6 +25279,7 @@
 "iyv" = (
 /obj/structure/window/reinforced,
 /obj/machinery/chem_master,
+/obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "iyx" = (
@@ -26661,8 +26540,6 @@
 	id = "pharmacy_shutters";
 	name = "Pharmacy Shutters"
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "iVL" = (
@@ -27398,16 +27275,13 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "jlb" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/space/nearstation)
 "jlh" = (
 /obj/structure/chair{
 	dir = 8
@@ -28780,8 +28654,8 @@
 	dir = 8;
 	dwidth = 11;
 	height = 22;
-	id = "whiteship_home";
 	name = "SS13: Whiteship dock";
+	shuttle_id = "whiteship_home";
 	width = 35
 	},
 /turf/open/space/basic,
@@ -29374,8 +29248,8 @@
 	dir = 8;
 	dwidth = 2;
 	height = 13;
-	id = "ferry_home";
 	name = "port bay 2";
+	shuttle_id = "ferry_home";
 	width = 5
 	},
 /turf/open/space/basic,
@@ -29847,6 +29721,9 @@
 /area/station/command/heads_quarters/qm)
 "jYl" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
+/obj/item/toy/figure/chaplain{
+	pixel_y = 16
+	},
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "jYA" = (
@@ -30016,10 +29893,6 @@
 /area/station/maintenance/port/aft)
 "kcg" = (
 /obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /obj/item/storage/box/syringes,
 /obj/item/reagent_containers/cup/bottle/epinephrine{
 	pixel_x = 7;
@@ -30033,10 +29906,11 @@
 	pixel_x = 6;
 	pixel_y = -3
 	},
-/obj/structure/table,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 4
 	},
+/obj/item/storage/box/rxglasses,
+/obj/item/hand_labeler,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "kcB" = (
@@ -30350,10 +30224,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "kgq" = (
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
@@ -31450,7 +31324,7 @@
 "kyO" = (
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/engine,
-/area/station/medical/chemistry)
+/area/station/maintenance/starboard)
 "kyT" = (
 /obj/structure/sign/directions/supply{
 	dir = 8
@@ -31729,12 +31603,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/primary/port)
 "kCt" = (
-/obj/structure/grille,
 /obj/structure/cable,
-/obj/structure/window{
-	dir = 8
+/obj/effect/spawner/structure/window/hollow/directional{
+	dir = 10
 	},
-/obj/structure/window,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "kCu" = (
@@ -32372,9 +32244,7 @@
 /obj/effect/turf_decal/tile/medical{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
-	color = "#FF0000"
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kMi" = (
@@ -34124,9 +33994,8 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "lth" = (
-/obj/structure/grille,
 /obj/structure/cable,
-/obj/structure/window{
+/obj/effect/spawner/structure/window/hollow/directional{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -34563,6 +34432,10 @@
 /area/station/security/checkpoint/medical)
 "lAZ" = (
 /obj/machinery/vending/games,
+/obj/item/toy/figure/prisoner{
+	pixel_y = -13;
+	pixel_x = -8
+	},
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/rec)
 "lBo" = (
@@ -35800,6 +35673,7 @@
 /turf/open/misc/grass,
 /area/station/service/hydroponics/garden)
 "lUO" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/medical{
 	dir = 8
 	},
@@ -36889,8 +36763,8 @@
 	dir = 8;
 	dwidth = 14;
 	height = 28;
-	id = "emergency_home";
 	name = "emergency evac bay";
+	shuttle_id = "emergency_home";
 	width = 15
 	},
 /turf/open/space/basic,
@@ -39890,24 +39764,6 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"njC" = (
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/brig)
 "njG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
 	dir = 1
@@ -41267,12 +41123,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "nHl" = (
-/obj/machinery/camera{
-	c_tag = "Medical - Viro Monkey Pen";
-	dir = 10;
-	network = list("ss13","medbay")
-	},
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/machinery/camera{
+	c_tag = "Public - Arrivals N";
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "nHm" = (
@@ -41638,7 +41493,7 @@
 "nNV" = (
 /obj/docking_port/stationary/random{
 	dir = 2;
-	id = "pod_lavaland4";
+	shuttle_id = "pod_lavaland4";
 	name = "lavaland"
 	},
 /turf/open/space/basic,
@@ -43330,7 +43185,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "ory" = (
@@ -44137,7 +43994,7 @@
 /obj/structure/sign/poster/contraband/syndicate_pistol{
 	pixel_x = -32
 	},
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "oHe" = (
@@ -44343,6 +44200,10 @@
 "oKZ" = (
 /obj/structure/dresser,
 /obj/item/storage/secure/safe/directional/east,
+/obj/item/toy/figure/captain{
+	pixel_y = 14;
+	pixel_x = -1
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain)
 "oLj" = (
@@ -45379,32 +45240,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
-"pdK" = (
-/obj/machinery/door_timer{
-	id = "Cell 5";
-	name = "Cell 5";
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/brig)
 "pdP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
 	dir = 4
@@ -45485,11 +45320,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "peO" = (
-/obj/structure/grille,
 /obj/structure/cable,
-/obj/structure/window,
-/obj/structure/window{
-	dir = 4
+/obj/effect/spawner/structure/window/hollow/directional{
+	dir = 6
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
@@ -46960,6 +46793,7 @@
 /area/station/maintenance/department/science)
 "pEH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "pEL" = (
@@ -47928,10 +47762,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "pWn" = (
-/obj/structure/closet/crate/solarpanel_small,
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/engineering/anticorner,
+/obj/structure/rack,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "pWs" = (
@@ -48433,6 +48269,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"qfq" = (
+/obj/item/toy/katana,
+/obj/item/toy/figure/ninja{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
+/area/station/maintenance/department/medical)
 "qfP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -48881,9 +48727,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "qmi" = (
-/obj/structure/grille,
 /obj/structure/cable,
-/obj/structure/window,
+/obj/effect/spawner/structure/window/hollow/directional,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "qmj" = (
@@ -48896,9 +48741,8 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance)
 "qmy" = (
-/obj/structure/grille,
 /obj/structure/cable,
-/obj/structure/window{
+/obj/effect/spawner/structure/window/hollow/directional{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -48942,14 +48786,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qnM" = (
-/obj/structure/grille,
 /obj/structure/cable,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 1;
-	layer = 3
+/obj/effect/spawner/structure/window/hollow/directional{
+	dir = 5
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
@@ -49826,6 +49665,9 @@
 	pixel_y = 10
 	},
 /obj/effect/turf_decal/tile/random/fourcorners,
+/obj/item/toy/figure/clown{
+	pixel_x = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/service/theater)
 "qDP" = (
@@ -51123,20 +50965,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/blood_filter,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/structure/table/glass,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/gloves,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer/wound,
-/obj/effect/turf_decal/tile/medical/half,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rbr" = (
@@ -51291,6 +51119,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"rdl" = (
+/obj/item/toy/figure/janitor{
+	pixel_y = 1;
+	pixel_x = -5
+	},
+/turf/closed/wall,
+/area/station/maintenance/fore)
 "rdy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -51555,15 +51390,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
 "rhM" = (
-/obj/structure/grille,
 /obj/structure/cable,
-/obj/structure/window{
+/obj/effect/spawner/structure/window/hollow/end{
 	dir = 4
 	},
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "rhX" = (
@@ -53467,16 +53297,6 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced/rglass,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/item/book/manual/wiki/surgery,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/obj/structure/table/reinforced/rglass,
 /obj/item/blood_filter,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
@@ -54006,7 +53826,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "rZv" = (
-/obj/structure/table,
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_y = 2
@@ -56446,6 +56265,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"sMj" = (
+/obj/structure/table,
+/obj/item/toy/figure/assistant,
+/turf/open/floor/carpet/purple,
+/area/station/commons/dorms)
 "sMl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -56542,17 +56366,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "sOX" = (
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
-/obj/machinery/defibrillator_mount{
-	pixel_y = 28
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 1
 	},
@@ -58696,15 +58509,9 @@
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "tBe" = (
-/obj/structure/grille,
 /obj/structure/cable,
-/obj/structure/window,
-/obj/structure/window{
+/obj/effect/spawner/structure/window/hollow/end{
 	dir = 8
-	},
-/obj/structure/window{
-	dir = 1;
-	layer = 3
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
@@ -60431,6 +60238,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"ugV" = (
+/obj/machinery/mech_bay_recharge_port{
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/toy/figure/borg{
+	pixel_y = 10;
+	pixel_x = 3
+	},
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
 "ugZ" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/gun/ballistic/revolver/russian,
@@ -60851,32 +60671,6 @@
 "upK" = (
 /turf/closed/wall,
 /area/station/service/library/private)
-"upN" = (
-/obj/machinery/door_timer{
-	id = "Cell 6";
-	name = "Cell 6";
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/brig)
 "upW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -61152,11 +60946,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "usI" = (
-/obj/structure/grille,
 /obj/structure/cable,
-/obj/structure/window{
-	dir = 1;
-	layer = 3
+/obj/effect/spawner/structure/window/hollow/directional{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
@@ -61222,7 +61014,6 @@
 /area/station/maintenance/department/engine)
 "utF" = (
 /obj/structure/table/wood,
-/obj/item/toy/figure/curator,
 /obj/item/toy/mecha/marauder{
 	pixel_y = 10
 	},
@@ -61779,14 +61570,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "uEs" = (
-/obj/structure/grille,
 /obj/structure/cable,
-/obj/structure/window{
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window{
-	dir = 8
+/obj/effect/spawner/structure/window/hollow/directional{
+	dir = 9
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
@@ -62461,6 +62247,10 @@
 "uQR" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
+/obj/item/toy/figure/detective{
+	pixel_y = 14;
+	pixel_x = -7
+	},
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "uRa" = (
@@ -63898,11 +63688,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
+/obj/effect/turf_decal/tile/medical/opposingcorners{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -64834,18 +64621,6 @@
 /turf/open/misc/grass,
 /area/station/security/prison/garden)
 "vFW" = (
-/obj/structure/window/reinforced,
-/obj/structure/closet/secure_closet/security/cargo,
-/obj/machinery/door_timer{
-	id = "cargocell";
-	name = "Cargo Cell";
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/security/anticorner,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/effect/turf_decal/tile/security/anticorner,
@@ -66099,9 +65874,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "wga" = (
@@ -66453,7 +66225,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/space/nearstation)
 "wnb" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/machinery/light/directional/east,
@@ -67128,18 +66900,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "wyW" = (
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rxglasses,
-/obj/item/hand_labeler,
 /obj/item/gun/syringe,
 /obj/item/gun/syringe,
-/obj/structure/table,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 1
 	},
+/obj/structure/rack,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "wzj" = (
@@ -69146,17 +68914,6 @@
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "xee" = (
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
-/obj/machinery/defibrillator_mount{
-	pixel_y = 28
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 4
 	},
@@ -71605,7 +71362,7 @@
 /obj/structure/window/reinforced,
 /obj/item/plunger,
 /turf/open/floor/engine,
-/area/station/medical/chemistry)
+/area/space/nearstation)
 "xTW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -72510,7 +72267,6 @@
 /area/station/security/warden)
 "ygo" = (
 /obj/structure/chair/sofa/right,
-/obj/item/toy/figure/paramedic,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 1
@@ -88101,7 +87857,7 @@ ozx
 meT
 eZY
 eDz
-ozx
+dHW
 hxt
 lkz
 uOg
@@ -99397,7 +99153,7 @@ qpr
 uOg
 tVk
 vDp
-uOg
+rdl
 faa
 oxb
 uLs
@@ -105283,7 +105039,7 @@ cQw
 nBf
 mYb
 odm
-nuS
+sMj
 oEd
 qAr
 dYi
@@ -107157,7 +106913,7 @@ xbi
 nVn
 nVn
 nVn
-pdK
+bzu
 fdi
 nVn
 nVn
@@ -108185,8 +107941,8 @@ uhW
 nVn
 nVn
 nVn
-upN
-njC
+bzu
+ezW
 nVn
 nVn
 nVn
@@ -109214,7 +108970,7 @@ nVn
 nVn
 nVn
 eyZ
-arg
+ezW
 nVn
 nVn
 nVn
@@ -112021,7 +111777,7 @@ uaz
 fou
 daY
 ihF
-uaz
+ihF
 uaz
 hVO
 hnk
@@ -113579,7 +113335,7 @@ yjZ
 xaG
 hnE
 xaG
-teh
+ugV
 wgH
 jFD
 vYy
@@ -113814,7 +113570,7 @@ ykY
 fNJ
 aPe
 nPY
-cWu
+gcB
 iyv
 sGj
 etD
@@ -114334,12 +114090,12 @@ fFV
 wpj
 hfS
 xaG
-hVO
-hVO
+xaG
+gOd
 kgq
 ptu
-coA
-goE
+lUO
+rEP
 ptu
 ptu
 ptu
@@ -114592,12 +114348,12 @@ rTC
 rTC
 lFT
 oHc
-hVO
+xaG
 wmI
 ptu
 ptu
 lUO
-xXq
+goE
 goE
 tAW
 tCK
@@ -115107,7 +114863,7 @@ xaG
 wnX
 lFT
 xaG
-hVO
+gOd
 hVO
 jCH
 ani
@@ -117125,7 +116881,7 @@ pvt
 jTX
 vzb
 rvY
-mLg
+qfq
 mLg
 lKW
 mLg

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -5326,6 +5326,7 @@
 /obj/structure/table/glass,
 /obj/item/clothing/under/misc/pj/blue,
 /obj/item/clothing/under/misc/pj/red,
+/obj/item/toy/figure/md,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bNk" = (
@@ -11160,7 +11161,6 @@
 "dLu" = (
 /obj/structure/table,
 /obj/item/newspaper,
-/obj/item/toy/figure/md,
 /obj/item/toy/figure/chemist,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 8

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -18514,7 +18514,7 @@
 /obj/machinery/chem_dispenser,
 /obj/structure/sign/departments/chemistry/directional/north,
 /turf/open/floor/engine,
-/area/space/nearstation)
+/area/station/medical/chemistry)
 "giQ" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -20402,9 +20402,6 @@
 /obj/effect/turf_decal/tile/prison/half,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"gOd" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "gOz" = (
 /obj/structure/cable,
 /obj/machinery/camera{
@@ -24426,7 +24423,7 @@
 "iiY" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/engine,
-/area/space/nearstation)
+/area/station/medical/chemistry)
 "iiZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/engineering,
@@ -25054,7 +25051,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/maintenance/starboard)
+/area/station/medical/chemistry)
 "iuq" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -27281,7 +27278,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/space/nearstation)
+/area/station/medical/chemistry)
 "jlh" = (
 /obj/structure/chair{
 	dir = 8
@@ -31324,7 +31321,7 @@
 "kyO" = (
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/engine,
-/area/station/maintenance/starboard)
+/area/station/medical/chemistry)
 "kyT" = (
 /obj/structure/sign/directions/supply{
 	dir = 8
@@ -43296,10 +43293,6 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/main)
-"ouk" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "oum" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment{
@@ -66225,7 +66218,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/space/nearstation)
+/area/station/medical/chemistry)
 "wnb" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/machinery/light/directional/east,
@@ -71362,7 +71355,7 @@
 /obj/structure/window/reinforced,
 /obj/item/plunger,
 /turf/open/floor/engine,
-/area/space/nearstation)
+/area/station/medical/chemistry)
 "xTW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -114091,7 +114084,7 @@ wpj
 hfS
 xaG
 xaG
-gOd
+hVO
 kgq
 ptu
 lUO
@@ -114348,7 +114341,7 @@ rTC
 rTC
 lFT
 oHc
-xaG
+hVO
 wmI
 ptu
 ptu
@@ -114862,8 +114855,8 @@ kLj
 xaG
 wnX
 lFT
-xaG
-gOd
+hVO
+hVO
 hVO
 jCH
 ani
@@ -117173,7 +117166,7 @@ duU
 xgZ
 cbF
 mrA
-ouk
+wuo
 vKu
 wpj
 ajJ

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -71772,10 +71772,6 @@
 /obj/effect/turf_decal/tile/security/half,
 /turf/open/floor/iron,
 /area/station/security/brig)
-"xYL" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/station/medical/chemistry)
 "xYU" = (
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
@@ -114920,7 +114916,7 @@ xaG
 wnX
 lFT
 xaG
-xYL
+hVO
 hVO
 jCH
 ani

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -998,6 +998,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "art" = (
@@ -3985,6 +3992,18 @@
 /obj/effect/turf_decal/tile/security/anticorner{
 	dir = 1
 	},
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/tile/security/anticorner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "bsl" = (
@@ -5327,6 +5346,21 @@
 /obj/item/clothing/under/misc/pj/blue,
 /obj/item/clothing/under/misc/pj/red,
 /obj/item/toy/figure/md,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/tile/medical/half,
+/obj/structure/table/glass,
+/obj/item/clothing/under/misc/pj/blue{
+	pixel_x = 5
+	},
+/obj/item/clothing/under/misc/pj/red{
+	pixel_x = -5
+	},
+/obj/item/toy/figure/md,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bNk" = (
@@ -6226,6 +6260,19 @@
 	},
 /obj/structure/table/glass,
 /obj/item/clothing/suit/jacket/straight_jacket,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/ears/earmuffs,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/medical/anticorner{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/item/clothing/suit/jacket/straight_jacket,
+/obj/item/clothing/glasses/eyepatch,
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/iron/white,
@@ -11195,6 +11242,25 @@
 /obj/effect/turf_decal/tile/security/half{
 	dir = 8
 	},
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/folder/red,
+/obj/item/pen,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/security/half{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "dLS" = (
@@ -14859,6 +14925,18 @@
 	pixel_y = -3
 	},
 /obj/item/reagent_containers/cup/bottle/multiver,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/table/glass,
+/obj/machinery/light_switch/directional/west,
+/obj/structure/cable,
+/obj/item/storage/box,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/tile/medical/anticorner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "faa" = (
@@ -15094,6 +15172,17 @@
 	id = "Cell 2";
 	name = "Cell 2";
 	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Security - West Cells";
+	network = list("ss13","security")
+	},
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16018,6 +16107,9 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 4
+	},
+/obj/item/toy/figure/cmo{
+	pixel_y = 10
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
@@ -16981,6 +17073,14 @@
 	id = "Cell 1";
 	name = "Cell 1";
 	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/security/half,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24405,6 +24505,17 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced/rglass,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/medical/half{
+	dir = 4
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/item/book/manual/wiki/surgery,
+/obj/item/blood_filter,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "iiO" = (
@@ -39788,6 +39899,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "njG" = (
@@ -45253,9 +45371,11 @@
 "pdG" = (
 /obj/structure/table/optable,
 /obj/machinery/light/directional/north,
-/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 1
+	},
+/obj/machinery/defibrillator_mount{
+	pixel_y = 28
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
@@ -45264,6 +45384,17 @@
 	id = "Cell 5";
 	name = "Cell 5";
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
 	dir = 4
@@ -50993,6 +51124,19 @@
 	dir = 4
 	},
 /obj/item/blood_filter,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/table/glass,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/gloves,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer/wound,
+/obj/effect/turf_decal/tile/medical/half,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rbr" = (
@@ -53323,6 +53467,17 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced/rglass,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/item/book/manual/wiki/surgery,
+/obj/effect/turf_decal/tile/medical/half{
+	dir = 8
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/item/blood_filter,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "rQu" = (
@@ -56394,6 +56549,15 @@
 	pixel_y = 28
 	},
 /obj/structure/table/reinforced/rglass,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/effect/turf_decal/tile/medical/anticorner{
+	dir = 1
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "sPf" = (
@@ -60700,6 +60864,17 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "upW" = (
@@ -64666,6 +64841,13 @@
 	name = "Cargo Cell";
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/tile/security/anticorner,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/window/reinforced,
+/obj/structure/closet/secure_closet/security/cargo,
 /obj/effect/turf_decal/tile/security/anticorner,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
@@ -68971,6 +69153,15 @@
 	pixel_y = 28
 	},
 /obj/structure/table/reinforced/rglass,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/effect/turf_decal/tile/medical/anticorner{
+	dir = 4
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "xek" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1656,6 +1656,10 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/rack,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/crowbar,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aCk" = (
@@ -2870,6 +2874,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/medical/opposingcorners,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aXd" = (
@@ -4943,10 +4948,13 @@
 /turf/open/space/basic,
 /area/station/solars/port/fore)
 "bGV" = (
-/obj/structure/closet/crate/medical,
-/obj/item/stack/medical/suture,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	name = "Virology Breach Prevention";
+	id = "Virology Breach"
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/medical/virology)
 "bGW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
 	dir = 6
@@ -5315,6 +5323,9 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/medical/half,
+/obj/structure/table/glass,
+/obj/item/clothing/under/misc/pj/blue,
+/obj/item/clothing/under/misc/pj/red,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bNk" = (
@@ -6212,6 +6223,10 @@
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/clothing/suit/jacket/straight_jacket,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/ears/earmuffs,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "cbH" = (
@@ -6871,12 +6886,12 @@
 /turf/open/space/basic,
 /area/space)
 "coA" = (
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/medical{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -6884,10 +6899,11 @@
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
-/obj/item/toy/figure/cmo,
 /obj/effect/turf_decal/trimline/blue/end{
 	color = "#FFD700"
 	},
+/obj/item/stamp/denied,
+/obj/item/stamp/cmo,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "coM" = (
@@ -8917,6 +8933,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"cWu" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/engine,
+/area/station/medical/pharmacy)
 "cWB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
@@ -10543,9 +10568,6 @@
 /area/station/commons/dorms)
 "dAC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -12196,7 +12218,7 @@
 /area/station/engineering/lobby)
 "edD" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
 "edP" = (
@@ -12720,15 +12742,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "enn" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Pharmacy Maintenance"
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
 /obj/effect/turf_decal/tile/medical/opposingcorners,
+/obj/machinery/door/airlock/maintenance{
+	name = "Pharmacy Maintenance"
+	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard)
 "enI" = (
@@ -12804,6 +12826,7 @@
 /obj/effect/turf_decal/tile/medical/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "eoh" = (
@@ -13979,19 +14002,16 @@
 /turf/open/floor/plating,
 /area/station/commons/fitness)
 "eKF" = (
-/obj/structure/rack,
-/obj/item/book/manual/wiki/grenades,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/book/manual/wiki/plumbing,
-/obj/item/construction/plumbing,
-/obj/item/construction/plumbing,
-/obj/structure/sign/departments/chemistry/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -14825,14 +14845,20 @@
 /obj/structure/table/glass,
 /obj/machinery/light_switch/directional/west,
 /obj/structure/cable,
-/obj/item/clothing/under/misc/pj/blue,
-/obj/item/clothing/under/misc/pj/red,
 /obj/item/storage/box,
-/obj/item/blood_filter,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 8
 	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/cup/bottle/multiver,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "faa" = (
@@ -15867,11 +15893,16 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "fqm" = (
-/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
+/obj/structure/rack,
+/obj/item/construction/plumbing,
+/obj/item/construction/plumbing,
+/obj/item/book/manual/wiki/plumbing,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/book/manual/wiki/grenades,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "fqq" = (
@@ -15963,13 +15994,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "frD" = (
-/obj/structure/table/glass,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 8
 	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "frE" = (
@@ -18512,6 +18543,11 @@
 	},
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
+"giO" = (
+/obj/machinery/chem_dispenser,
+/obj/structure/sign/departments/chemistry/directional/north,
+/turf/open/floor/engine,
+/area/station/medical/chemistry)
 "giQ" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -18735,10 +18771,10 @@
 /turf/open/floor/plating,
 /area/station/construction)
 "goE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "gpa" = (
@@ -21056,6 +21092,15 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"gZy" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "gZY" = (
 /obj/machinery/holopad,
 /obj/effect/mapping_helpers/ianbirthday,
@@ -21443,6 +21488,7 @@
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/medicine,
 /obj/item/modular_computer/tablet/preset/advanced/command,
+/obj/item/toy/figure/cmo,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "hhz" = (
@@ -21647,11 +21693,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "hmE" = (
-/obj/structure/table/glass,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/firealarm/directional/south,
-/obj/item/defibrillator,
 /obj/effect/turf_decal/tile/medical/anticorner,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "hmH" = (
@@ -22482,9 +22530,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -24355,11 +24400,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "iiw" = (
-/obj/structure/table/glass,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 4
 	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "iiO" = (
@@ -25010,6 +25055,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"iuj" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/medical/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Chemistry Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/turf/open/floor/iron/white,
+/area/station/maintenance/starboard)
 "iuq" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -25234,7 +25290,6 @@
 "iyv" = (
 /obj/structure/window/reinforced,
 /obj/machinery/chem_master,
-/obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "iyx" = (
@@ -26495,6 +26550,8 @@
 	id = "pharmacy_shutters";
 	name = "Pharmacy Shutters"
 	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "iVL" = (
@@ -26691,7 +26748,7 @@
 /area/station/medical/chemistry)
 "iYz" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
 /turf/open/space/basic,
 /area/station/medical/chemistry)
 "iYD" = (
@@ -27230,9 +27287,14 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "jlb" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "jlh" = (
@@ -29192,7 +29254,6 @@
 "jPB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
@@ -29516,8 +29577,6 @@
 /obj/item/book/manual/wiki/medicine,
 /obj/effect/turf_decal/tile/medical/half,
 /obj/item/toy/plush/lizard_plushie,
-/obj/item/paper_bin,
-/obj/item/pen,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jUT" = (
@@ -29938,10 +29997,10 @@
 "kdu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/duct,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "kdw" = (
@@ -30180,8 +30239,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "kgq" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kgr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
@@ -31895,13 +31960,14 @@
 "kGK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/medical/opposingcorners{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -32178,7 +32244,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "kLZ" = (
-/obj/machinery/atmospherics/components/binary/valve/digital,
 /obj/machinery/airalarm/all_access{
 	dir = 4;
 	frequency = 1450;
@@ -32195,6 +32260,9 @@
 	},
 /obj/effect/turf_decal/tile/medical{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
+	color = "#FF0000"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -35458,10 +35526,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "lSA" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Medical - Chemistry Lab W";
 	network = list("ss13","medbay")
@@ -35625,13 +35689,10 @@
 /turf/open/misc/grass,
 /area/station/service/hydroponics/garden)
 "lUO" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+/obj/effect/turf_decal/tile/medical{
+	dir = 8
 	},
-/obj/item/plunger,
-/turf/open/floor/engine,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "lUR" = (
 /obj/structure/table/glass,
@@ -36025,6 +36086,10 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	name = "Virology Breach Prevention";
+	id = "Virology Breach"
+	},
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "mah" = (
@@ -39084,9 +39149,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mYo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	frequency = 1450
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
@@ -39850,7 +39914,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nlz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "nlB" = (
@@ -40576,14 +40640,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "nxC" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/suture,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard)
 "nxF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -41733,6 +41793,7 @@
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "nSI" = (
@@ -43151,9 +43212,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "ory" = (
@@ -43263,11 +43322,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "ouk" = (
-/obj/structure/sign/poster/contraband/syndicate_pistol{
-	pixel_x = -32
-	},
+/obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/space/nearstation)
 "oum" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment{
@@ -43958,6 +44015,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"oHc" = (
+/obj/structure/sign/poster/contraband/syndicate_pistol{
+	pixel_x = -32
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "oHe" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -44470,7 +44534,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "oRm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /turf/open/floor/engine,
@@ -46503,7 +46567,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/navigate_destination/chemfactory,
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
@@ -47861,11 +47924,11 @@
 /turf/closed/wall,
 /area/station/hallway/primary/central)
 "pYW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "pZd" = (
@@ -50744,6 +50807,11 @@
 /obj/item/storage/box/masks,
 /obj/item/storage/box/bodybags,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/machinery/button/door/directional/south{
+	name = "Virology Breach Prevention";
+	req_access = list("virology");
+	id = "Virology Breach"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "qZe" = (
@@ -50921,6 +50989,10 @@
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer/wound,
 /obj/effect/turf_decal/tile/medical/half,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/blood_filter,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rbr" = (
@@ -51539,6 +51611,9 @@
 /area/station/maintenance/port/aft)
 "rld" = (
 /obj/effect/turf_decal/tile/medical/half,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rlq" = (
@@ -53242,12 +53317,12 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard)
 "rQt" = (
-/obj/structure/table/glass,
 /obj/machinery/airalarm/directional/west,
 /obj/item/book/manual/wiki/surgery,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 8
 	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "rQu" = (
@@ -54926,7 +55001,12 @@
 "srC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "srH" = (
@@ -56307,10 +56387,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "sOX" = (
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 1
 	},
+/obj/machinery/defibrillator_mount{
+	pixel_y = 28
+	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "sPf" = (
@@ -58443,9 +58526,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "tBd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8;
-	frequency = 1450
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
@@ -63176,8 +63258,6 @@
 "vgr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -63640,6 +63720,15 @@
 /area/station/command/bridge)
 "vpa" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/medical{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "vpA" = (
@@ -64782,6 +64871,10 @@
 "vKs" = (
 /turf/closed/wall,
 /area/station/construction)
+"vKu" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "vKz" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/landmark/event_spawn,
@@ -65424,11 +65517,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "vXl" = (
-/obj/structure/table/glass,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 4
 	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "vXr" = (
@@ -65824,9 +65917,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
@@ -66224,7 +66314,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/obj/structure/cable,
+/obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "woa" = (
@@ -67220,7 +67310,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "wEn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -68126,7 +68216,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
 /turf/open/floor/engine,
@@ -68874,10 +68964,13 @@
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "xee" = (
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 4
 	},
+/obj/machinery/defibrillator_mount{
+	pixel_y = 28
+	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "xek" = (
@@ -70456,6 +70549,9 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/medical/half,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xDU" = (
@@ -71314,6 +71410,11 @@
 /obj/effect/turf_decal/tile/prison,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
+"xTO" = (
+/obj/structure/window/reinforced,
+/obj/item/plunger,
+/turf/open/floor/engine,
+/area/station/medical/chemistry)
 "xTW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -71671,6 +71772,10 @@
 /obj/effect/turf_decal/tile/security/half,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"xYL" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/station/medical/chemistry)
 "xYU" = (
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
@@ -111729,7 +111834,7 @@ uaz
 fou
 daY
 ihF
-ihF
+uaz
 uaz
 hVO
 hnk
@@ -111991,7 +112096,7 @@ eof
 eKT
 qZE
 ptu
-jlb
+ptu
 ptu
 ptu
 ptu
@@ -112247,10 +112352,10 @@ wzS
 jCH
 ptu
 ptu
-ptu
-jlb
-ptu
+ani
 pYu
+oOO
+oOO
 oOO
 oOO
 xEW
@@ -112507,7 +112612,7 @@ ptu
 vpa
 dAC
 qFr
-jCH
+ptu
 ptu
 ptu
 pOG
@@ -112759,8 +112864,8 @@ jPB
 pAF
 kGK
 vgr
-goE
-srC
+sTN
+sTN
 srC
 hCz
 rqV
@@ -113016,12 +113121,12 @@ hfm
 lkG
 eKF
 fqm
-nxC
-tAW
-tAW
 rEP
 ptu
 jCH
+ptu
+ptu
+ptu
 ptu
 stZ
 pOG
@@ -113271,14 +113376,14 @@ cmr
 cUe
 gbD
 hVO
-hVO
-hVO
-hVO
 ijY
 rlq
 jCH
 ptu
 jCH
+ptu
+ptu
+ptu
 ptu
 tBj
 oen
@@ -113522,20 +113627,20 @@ ykY
 fNJ
 aPe
 nPY
-gcB
+cWu
 iyv
 sGj
 etD
 iNH
 hVO
-yju
-yju
-hVO
-kgq
+giO
 iiY
 jCH
 ptu
 jCH
+ptu
+ptu
+ptu
 ptu
 dMp
 pOG
@@ -113785,14 +113890,14 @@ enn
 xaG
 xaG
 xaG
-xBU
-yju
-hVO
 kyO
-lUO
+xTO
 jCH
 ptu
 jCH
+ptu
+ptu
+ptu
 ptu
 dMp
 pOG
@@ -114041,15 +114146,15 @@ qrj
 fFV
 wpj
 hfS
-xeH
-xBU
-yju
+xaG
 hVO
 hVO
-coA
-qZE
+kgq
 ptu
-jCH
+coA
+goE
+ptu
+ptu
 ptu
 dMp
 pOG
@@ -114299,14 +114404,14 @@ rFc
 rTC
 rTC
 lFT
-xBU
-xBU
-yju
+oHc
 hVO
 wmI
 ptu
 ptu
+lUO
 xXq
+goE
 tAW
 tCK
 xjk
@@ -114556,11 +114661,11 @@ xOX
 xaG
 xaG
 ajJ
-ouk
-xBU
-yju
-hVO
-jCH
+rUs
+iuj
+jlb
+gZy
+rEP
 ptu
 ptu
 ptu
@@ -114814,8 +114919,8 @@ kLj
 xaG
 wnX
 lFT
-xBU
-yju
+xaG
+xYL
 hVO
 jCH
 ani
@@ -116612,7 +116717,7 @@ hpL
 rRL
 aWP
 xaG
-wpj
+fHF
 wpj
 mQR
 xBU
@@ -116869,8 +116974,8 @@ mrA
 mrA
 mrA
 xaG
-xBU
-bGV
+nxC
+fHF
 ind
 kyU
 slm
@@ -117125,8 +117230,8 @@ duU
 xgZ
 cbF
 mrA
-yju
-xBU
+ouk
+vKu
 wpj
 ajJ
 igb
@@ -121737,7 +121842,7 @@ uCZ
 mpH
 tsD
 aio
-fiV
+bGV
 iQW
 iQW
 yju
@@ -122245,7 +122350,7 @@ iQW
 iQW
 iQW
 iQW
-fiV
+bGV
 fOh
 ygZ
 vEF
@@ -123013,7 +123118,7 @@ iQW
 vmD
 iQW
 iQW
-fiV
+bGV
 aOT
 tpi
 jhI
@@ -123025,7 +123130,7 @@ jNf
 rdg
 rdg
 ubw
-fiV
+bGV
 iQW
 iQW
 vmD
@@ -123270,7 +123375,7 @@ iQW
 yju
 iQW
 iQW
-fiV
+bGV
 lrF
 uJD
 gOP
@@ -123282,7 +123387,7 @@ iVl
 oWL
 qNs
 ubw
-fiV
+bGV
 iQW
 iQW
 xBY
@@ -125331,9 +125436,9 @@ iQW
 iQW
 iQW
 nit
-fiV
+bGV
 mab
-fiV
+bGV
 nit
 iQW
 iQW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This renovates Selene Station's medbay a bit to hopefully remedy some issues I've noticed.
- A disposal bin was added to medbay central.
- Surgery rooms have been fitted with defibrillator mounts and the glass tables have been reinforced.
- The exam room now has tables with a straight jacket, earmuffs, blindfold, and various other items.
- Stamps have been added to CMO's office.
- The chemistry lab has been slightly expanded. There is now an airlock leading directly into maintenance, the disposal bin has been moved a bit more out of the way, and the scrubber pipes coming from the smoke room have been moved to the correct layer.
- Virology has been with fitted breach prevention doors. Virologists will also be provided with handcuffs for their test subjects as most stations do.

## Changlelog
🆑
qol: disposal bin to central
qol: defibrillator mount in surgery
balance: reinforced glass tables in surgery
add: straight jacket, earmuffs, blindfold, pajamas to exam room
fix: stamp to cmo office
fix: smoke room scrubber pipes on 2nd layer instead of 3rd
balance: chemlab beeger
qol: chemlab maintenance access
balance: virology blast doors
qol: virology has handcuffs now
fix: I moved an action figure to the exam room C:
balance: blood filter removed from central and added to surgery
fix: a camera in virology was floating off a wall
/🆑