### PR TITLE
ORM Windoor

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -50245,6 +50245,11 @@
 	output_dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/window/left/directional/west{
+	dir = 4;
+	name = "Ore Redemption";
+	req_access = list("cargo")
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "cEA" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4818,6 +4818,11 @@
 	dir = 8;
 	name = "Ore Redemtion Window"
 	},
+/obj/machinery/door/window/left/directional/west{
+	dir = 4;
+	name = "Ore Redemption";
+	req_access = list("cargo")
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "apM" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -37253,11 +37253,6 @@
 "mtq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/left/directional/west{
-	dir = 2;
-	name = "Cargo Desk";
-	req_access = list("cargo")
-	},
 /obj/item/paper_bin{
 	pixel_x = 6
 	},
@@ -37267,6 +37262,11 @@
 /obj/structure/desk_bell{
 	pixel_x = -7;
 	pixel_y = 10
+	},
+/obj/machinery/door/window/left/directional/west{
+	dir = 2;
+	name = "Cargo Desk";
+	req_access = list("cargo")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -44290,6 +44290,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
+/obj/machinery/door/window/left/directional/west{
+	dir = 2;
+	name = "Ore Redemption";
+	req_access = list("cargo")
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "oNI" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a windoor to inner side of the ORM that requires cargo access to open. This affects Helio, Selene, and Pubby.

## Why It's Good For The Game

It will now take more than a just wrench for any bozo to break into the cargo bay.

## Changelog
🆑
Add: windoors added behind ORM
/🆑