### PR TITLE
Techweb-purchase able programs start locked and behind Command access

### DIFF
--- a/fulp_modules/Z_edits/science_edit.dm
+++ b/fulp_modules/Z_edits/science_edit.dm
@@ -1,0 +1,13 @@
+/obj/machinery/computer/rdconsole
+	//sets lock access to command
+	req_access = list(ACCESS_COMMAND)
+	//starts it off locked
+	locked = TRUE
+
+/datum/computer_file/program/science
+	//starts it off locked
+	locked = TRUE
+	//sets lock/download access to command
+	lock_access = ACCESS_COMMAND
+	required_access = list(ACCESS_COMMAND)
+	transfer_access = list(ACCESS_COMMAND)

--- a/fulp_modules/Z_edits/science_edit.dm
+++ b/fulp_modules/Z_edits/science_edit.dm
@@ -1,13 +1,21 @@
+/**
+ * Sets all places where techwebs can be purchased to start off locked
+ * and behind Command access, giving Command better control over
+ * research throughout a round.
+ */
+
+//RD console
 /obj/machinery/computer/rdconsole
 	//sets lock access to command
 	req_access = list(ACCESS_COMMAND)
 	//starts it off locked
 	locked = TRUE
 
+//Techweb app
 /datum/computer_file/program/science
-	//starts it off locked
-	locked = TRUE
 	//sets lock/download access to command
 	lock_access = ACCESS_COMMAND
 	required_access = list(ACCESS_COMMAND)
 	transfer_access = list(ACCESS_COMMAND)
+	//starts it off locked
+	locked = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4960,6 +4960,7 @@
 #include "fulp_modules\Z_edits\fulp_bans.dm"
 #include "fulp_modules\Z_edits\job_edits.dm"
 #include "fulp_modules\Z_edits\nightmare_edit.dm"
+#include "fulp_modules\Z_edits\science_edit.dm"
 #include "fulp_modules\Z_edits\upstream_bot.dm"
 #include "fulp_modules\Z_edits\antag_edits\changeling_spiders.dm"
 #include "fulp_modules\Z_edits\antag_edits\cult_stun.dm"


### PR DESCRIPTION
## About The Pull Request

Moves researching back to a Command job by locking it behind Command access, setting all consoles/programs to be locked by default.

Emagging still unlocks the RD console.

## Why It's Good For The Game

Command tries to cooperate and make sure research goes fine for everyone, but that's hard to do when everyone in science can research anything they want, whenever they want. Instant gratification isn't always good, especially when it takes away the ability for command to manage their department.

Fixes situations like this
![image](https://user-images.githubusercontent.com/53777086/206769646-b81d978f-a53f-4332-881e-ef4e0d290209.png)

## Changelog

:cl:
balance: Techweb-purchasing apps now start locked and require Command access (or an emag) to unlock.
/:cl: