### PR TITLE
Fixes Helio Fax Machine Placement Problems

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -395,14 +395,14 @@
 /area/station/security/prison)
 "abe" = (
 /obj/machinery/firealarm/directional/east,
-/obj/structure/bed/dogbed/runtime,
-/obj/item/toy/cattoy,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/bed/dogbed/runtime,
+/obj/item/toy/cattoy,
 /mob/living/simple_animal/pet/cat/runtime,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
@@ -14612,15 +14612,19 @@
 /obj/item/computer_disk/medical,
 /obj/item/computer_disk/medical,
 /obj/item/computer_disk/medical,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/toy/figure/cmo,
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "aOu" = (
 /obj/structure/table/reinforced/rglass,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/glasses/hud/health,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/item/radio/intercom/directional/south,
-/obj/item/toy/figure/cmo,
+/obj/machinery/fax{
+	fax_name = "Chief Medical Officer's Office";
+	name = "Chief Medical Officer's Fax Machine"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "aOv" = (
@@ -14642,12 +14646,7 @@
 /area/station/command/heads_quarters/cmo)
 "aOx" = (
 /obj/structure/cable,
-/obj/structure/table/reinforced/rglass,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/fax{
-	fax_name = "Chief Medical Officer's Office";
-	name = "Chief Medical Officer's Fax Machine"
-	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "aOz" = (
@@ -14859,6 +14858,7 @@
 "aPa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
+/obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "aPc" = (
@@ -16298,13 +16298,10 @@
 /area/station/service/lawoffice)
 "aTt" = (
 /obj/structure/table/wood,
-/obj/machinery/fax{
-	fax_name = "Law Office";
-	name = "Law Office Fax Machine"
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
+/obj/item/folder/yellow,
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "aTu" = (
@@ -16357,7 +16354,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "aTA" = (
-/obj/item/kirbyplants/random,
+/obj/structure/table/wood,
+/obj/machinery/fax{
+	fax_name = "Law Office";
+	name = "Law Office Fax Machine"
+	},
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "aTF" = (
@@ -16983,6 +16984,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "aVJ" = (
@@ -58644,7 +58646,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/beer{
 	desc = "Whatever it is, it reeks of foul, putrid froth.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing = 15);
+	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing=15);
 	name = "Delta-Down";
 	pixel_x = 5;
 	pixel_y = 5

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -16356,8 +16356,8 @@
 "aTA" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
-	fax_name = "Law Office";
-	name = "Law Office Fax Machine"
+	fax_name = "South Law Office";
+	name = "South Law Office Fax Machine"
 	},
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
@@ -67345,6 +67345,14 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"nuP" = (
+/obj/structure/table/wood,
+/obj/machinery/fax{
+	fax_name = "North Law Office";
+	name = "North Law Office Fax Machine"
+	},
+/turf/open/floor/wood,
+/area/station/service/lawoffice)
 "nvh" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -109266,7 +109274,7 @@ aNu
 aOm
 aPa
 aQx
-aTA
+nuP
 aOm
 aTA
 bsy


### PR DESCRIPTION
Fixes Heliostation's Law office fax machine being public, and fixes CMO's PDA painter from being inaccessible due to the fax machine's placement.
## About The Pull Request
Addresses issues #847 and #845 on Helio by moving the placements of their fax machines, and adding an extra fax machine to the law office.

Goes from this:
![image](https://user-images.githubusercontent.com/107831677/205865019-48fc0a97-bb55-48c5-aa31-ff110e6129bd.png)
To this:
![image](https://user-images.githubusercontent.com/107831677/205864949-dc9869bf-712f-46eb-8f39-deca04c199e8.png)

And here's the law office:
![image](https://user-images.githubusercontent.com/107831677/205865196-b12158c9-dc8d-4460-9101-3ba25627a65d.png)
## Why It's Good For The Game
If the CMO doesn't have access to their PDA painter how else will they demote all the Walter White's that blow up chemistry for the 80th time? On a serious note, without access to the PDA painter, CMO can't do PDA changes within their own department, so I'd argue its fairly important. Also lawyers can no longer be impersonated using their fax, since their fax is no longer open to the public.
## Changelog
:cl:
fix: fixed CMO's PDA painter being inaccessible
fix: fixed the law office's fax machine being public
add: added two machines to the individual law offices
/:cl:
