### PR TITLE
Fixes Tremere auspex range

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/auspex.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/auspex.dm
@@ -48,7 +48,7 @@
 		Click any area up to teleport there, ending the Power."
 	bloodcost = 15
 	cooldown = 8 SECONDS
-	target_range = 6
+	target_range = 9
 
 /datum/action/bloodsucker/targeted/tremere/auspex/advanced
 	name = "Level 4: Auspex"
@@ -63,7 +63,7 @@
 	background_icon_state_off = "tremere_power_gold_off"
 	bloodcost = 20
 	cooldown = 6 SECONDS
-	target_range = 6
+	target_range = 9
 
 /datum/action/bloodsucker/targeted/tremere/auspex/advanced/two
 	name = "Level 5: Auspex"


### PR DESCRIPTION
## About The Pull Request
Changes auspex teleport range at levels 3-5. Changes range from 6 tiles to 9 tiles. This brings it closer to the wiki's description of the power (https://wiki.fulp.gg/en/Bloodsucker).

This is a followup to a bug report I made about a month ago: https://discord.com/channels/279359975250198528/587000604547874826/1040732505449439283
## Why It's Good For The Game
As previously stated, it makes the power perform closer to the wiki's description, preventing confusion among players. Also, there isn't really any reason to arbitrarily cap the teleportation at 6 tiles range, when normal player view is 9 tiles.
## Changelog
ShadowAKT:cl:
fix: Fix Bloodsucker "auspex" range
/:cl:
