### PR TITLE
Adds support for non-range checking powers

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/_powers_targeted.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/_powers_targeted.dm
@@ -2,7 +2,9 @@
 /datum/action/bloodsucker/targeted
 	power_flags = BP_AM_TOGGLE
 
-	var/target_range = 99
+	///If set, how far the target has to be for the power to work.
+	var/target_range
+	///Message sent to chat when clicking on the power, before you use it.
 	var/prefire_message = ""
 	///Most powers happen the moment you click. Some, like Mesmerize, require time and shouldn't cost you if they fail.
 	var/power_activates_immediately = TRUE
@@ -58,11 +60,12 @@
 
 /// Check if valid target meets conditions
 /datum/action/bloodsucker/targeted/proc/CheckCanTarget(atom/target_atom)
-	// Out of Range
-	if(!(target_atom in view(target_range, owner)))
-		if(target_range > 1) // Only warn for range if it's greater than 1. Brawn doesn't need to announce itself.
-			owner.balloon_alert(owner, "out of range.")
-		return FALSE
+	if(target_range)
+		// Out of Range
+		if(!(target_atom in view(target_range, owner)))
+			if(target_range > 1) // Only warn for range if it's greater than 1. Brawn doesn't need to announce itself.
+				owner.balloon_alert(owner, "out of range.")
+			return FALSE
 	return istype(target_atom)
 
 /// Click Target

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/lunge.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/lunge.dm
@@ -15,7 +15,6 @@
 	purchase_flags = BLOODSUCKER_CAN_BUY|VASSAL_CAN_BUY
 	bloodcost = 10
 	cooldown = 10 SECONDS
-	target_range = 6
 	power_activates_immediately = FALSE
 
 /datum/action/bloodsucker/targeted/lunge/CheckCanUse(mob/living/carbon/user)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/_powers_tremere.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/_powers_tremere.dm
@@ -21,7 +21,6 @@
 	power_flags = BP_AM_TOGGLE|BP_AM_STATIC_COOLDOWN
 	purchase_flags = TREMERE_CAN_BUY
 	// Targeted stuff
-	target_range = 99
 	power_activates_immediately = FALSE
 
 	///The upgraded version of this Power. 'null' means it's the max level.


### PR DESCRIPTION
## About The Pull Request

Adds in support for powers that don't need to range check whatever they're hitting.

## Why It's Good For The Game

Some powers let you click wherever you want and don't need a range check, and before this was done by setting it to 99, which I think is just absurd. Lunge also set it to how many tiles a person can see, however, widescreen broke that because suddenly people saw more than just 6 tiles away. This aims to fix that permanently by just removing both those cases and just simply not checking distance if it isn't necessary.

This will also be useful for https://github.com/fulpstation/fulpstation/pull/860