### PR TITLE
Helio White ship

### DIFF
--- a/_maps/heliostation.json
+++ b/_maps/heliostation.json
@@ -6,7 +6,7 @@
 	"shuttles": {
 		"cargo": "cargo_helio",
 		"ferry": "ferry_fancy",
-		"whiteship": "whiteship_meta",
+		"whiteship": "whiteship_helio",
 		"emergency": "emergency_helio"
 	},
 	"job_changes": {

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -121,10 +121,6 @@
 "jV" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/cargo)
-"kp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/medbay)
 "kq" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/engine,
@@ -741,7 +737,7 @@ Oo
 Oo
 fk
 yQ
-kp
+dh
 is
 rJ
 rJ

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -686,8 +686,8 @@
 /turf/open/floor/wood,
 /area/shuttle/abandoned/engine)
 "Gi" = (
-/obj/machinery/door/airlock/alarmlock,
 /obj/structure/cable,
+/obj/machinery/door/airlock/public/glass,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
 "Gp" = (

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -122,8 +122,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/cargo)
 "kp" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/open/floor/engine/air,
 /area/shuttle/abandoned/medbay)
 "kq" = (
 /obj/machinery/chem_heater,
@@ -234,9 +233,6 @@
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
-"xr" = (
-/turf/open/floor/engine/air,
-/area/shuttle/abandoned/medbay)
 "ym" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -645,7 +641,7 @@ Oo
 Oo
 Oo
 jV
-Pb
+LP
 bF
 Pb
 Pb
@@ -699,7 +695,7 @@ Oo
 Oo
 fk
 fk
-kp
+KJ
 oW
 oW
 oW
@@ -903,7 +899,7 @@ rJ
 RJ
 rJ
 rJ
-xr
+kp
 rJ
 rJ
 jV

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -239,10 +239,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
-"xM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/wall,
-/area/shuttle/abandoned/medbay)
 "ym" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -765,7 +761,7 @@ Oo
 fk
 DB
 jy
-xM
+dh
 AN
 rJ
 rJ
@@ -793,7 +789,7 @@ fk
 LP
 jy
 jy
-xM
+dh
 PQ
 rJ
 YX
@@ -821,7 +817,7 @@ DB
 hU
 jy
 UI
-xM
+dh
 rJ
 rJ
 mG
@@ -849,7 +845,7 @@ Sg
 vb
 jy
 Rr
-xM
+dh
 rJ
 Pw
 rJ
@@ -877,7 +873,7 @@ Sg
 qx
 jy
 UI
-xM
+dh
 rJ
 JK
 rJ
@@ -905,7 +901,7 @@ Sg
 Sh
 Rq
 Sh
-xM
+dh
 rJ
 JK
 rJ

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -443,7 +443,7 @@
 /area/shuttle/abandoned/medbay)
 "Sg" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/closed/wall,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/bar)
 "Sh" = (
 /obj/effect/spawner/structure/window,

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -1,85 +1,155 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ar" = (
 /obj/structure/table/wood/fancy/black,
-/obj/machinery/light/directional/east,
+/obj/machinery/recharger,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
 "ax" = (
-/obj/structure/bed/dogbed,
-/obj/item/clothing/neck/petcollar,
-/turf/open/floor/carpet/purple,
-/area/shuttle/abandoned/crew)
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/shuttle/abandoned/engine)
 "aE" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
+"bp" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"bA" = (
+/obj/structure/fermenting_barrel,
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "bF" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/engine,
+/obj/machinery/vending/hydroseeds,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "bL" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/engine)
+"bM" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/cell_charger,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "bQ" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/purple,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/crew)
 "bU" = (
-/obj/machinery/plumbing/tank,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/abandoned/engine)
 "ct" = (
-/mob/living/simple_animal/hostile/pirate/ranged/space,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
+/turf/open/floor/wood,
+/area/shuttle/abandoned/engine)
 "cy" = (
-/obj/machinery/smartfridge/drying_rack,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
 "cL" = (
-/turf/open/floor/carpet/purple,
-/area/shuttle/abandoned/crew)
-"dh" = (
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
+/area/shuttle/abandoned/crew)
+"cX" = (
+/mob/living/simple_animal/hostile/pirate/melee/space,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
+"dh" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"dn" = (
+/obj/machinery/light/floor,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/cargo)
 "dX" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
+"ed" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "em" = (
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned/cargo)
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
 "ey" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/dress/skirt,
-/obj/item/clothing/under/dress/skirt,
-/obj/item/clothing/under/dress/skirt,
-/obj/item/clothing/under/dress/striped,
-/turf/open/floor/carpet/purple,
-/area/shuttle/abandoned/crew)
+/obj/structure/cable,
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
+"eU" = (
+/obj/machinery/vending/cola/sodie,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "fk" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/bar)
+"fI" = (
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "gw" = (
 /obj/machinery/smartfridge/drying_rack,
-/turf/open/floor/engine,
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"gO" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "gY" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
 "hd" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/pai_card,
-/obj/machinery/light/directional/west,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
-"hE" = (
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/engine,
+"he" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/random{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"hq" = (
+/obj/machinery/chem_master,
+/obj/machinery/light/floor,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "hU" = (
 /obj/structure/table/wood,
@@ -89,7 +159,9 @@
 /area/shuttle/abandoned/bar)
 "if" = (
 /obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/engine,
+/obj/machinery/light/floor,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "is" = (
 /obj/item/plunger,
@@ -107,7 +179,7 @@
 /area/shuttle/abandoned/engine)
 "jr" = (
 /obj/machinery/biogenerator,
-/turf/open/floor/engine,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "jy" = (
 /turf/open/floor/wood,
@@ -122,16 +194,51 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/cargo)
 "kp" = (
-/turf/open/floor/engine/air,
-/area/shuttle/abandoned/medbay)
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
 "kq" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "ku" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
 "kM" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/food/salt,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
+"lq" = (
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/cargo)
+"ls" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/turf/open/floor/oldshuttle,
+/area/shuttle/abandoned/bar)
+"mc" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/construction/rcd/loaded,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"mD" = (
+/obj/structure/closet/crate/trashcart/laundry,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"mG" = (
+/obj/effect/decal/cleanable/ants,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
+"mW" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/docking_port/mobile{
@@ -149,44 +256,59 @@
 	width = 33
 	},
 /obj/structure/fans/tiny,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"ls" = (
-/mob/living/simple_animal/pet/cat/space,
-/turf/open/floor/oldshuttle,
-/area/shuttle/abandoned/bar)
-"mD" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/storage/belt/utility/full/engi,
-/obj/item/storage/belt/medical,
-/obj/item/construction/rcd/loaded,
-/turf/open/floor/carpet/purple,
-/area/shuttle/abandoned/crew)
-"mG" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"mW" = (
-/obj/machinery/light/floor,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
 "nm" = (
-/obj/structure/sink,
 /obj/item/razor,
+/obj/item/knife/combat/survival,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
+"ok" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/crew)
+"oE" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"oT" = (
+/obj/structure/bed{
+	dir = 8
+	},
+/obj/item/bedsheet/cosmos{
+	dir = 8
+	},
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
 "oW" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"pj" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
+"ph" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "pG" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"pS" = (
+/obj/structure/table/wood,
+/obj/item/storage/medkit,
+/obj/item/ammo_box/magazine/internal/boltaction/pipegun,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "pY" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light/directional/east,
@@ -196,54 +318,130 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
+"qz" = (
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"qQ" = (
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"qU" = (
+/obj/machinery/power/smes/engineering{
+	charge = 1e+006
+	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/crew)
 "rn" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/purple,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/turf_decal,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
+"rv" = (
+/obj/structure/cable,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
 "rJ" = (
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"rP" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "sA" = (
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
+"tf" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "uj" = (
-/obj/machinery/power/shuttle_engine/propulsion/burst,
+/obj/machinery/power/shuttle_engine/large,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
+"uB" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"uJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "uY" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/suit/sl,
-/obj/item/clothing/under/misc/assistantformal,
-/obj/item/clothing/under/misc/bouncer,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/clothing/under/misc/pj/blue,
-/turf/open/floor/carpet/purple,
+/obj/machinery/door/airlock/titanium/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/crew)
 "vb" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"vJ" = (
-/obj/machinery/vending/hydronutrients,
-/obj/machinery/light/directional/north,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"wO" = (
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"ym" = (
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/turf/open/floor/carpet/purple,
-/area/shuttle/abandoned/crew)
-"yw" = (
-/obj/machinery/chem_master,
-/obj/machinery/light/floor,
+"wy" = (
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"wK" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/plumbing/pill_press,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"wO" = (
+/obj/machinery/vending/hydronutrients,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"wU" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"xc" = (
+/obj/item/seeds/cannabis,
+/obj/item/seeds/amanita,
+/obj/structure/table/reinforced,
+/obj/item/seeds/cannabis/rainbow,
+/obj/item/reagent_containers/cup/bucket,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"xr" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned/cargo)
+"xE" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"xM" = (
+/obj/structure/sign/poster/contraband/lusty_xenomorph,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/medbay)
+"ym" = (
+/obj/structure/window/reinforced/shuttle,
+/turf/open/space/basic,
+/area/shuttle/abandoned/medbay)
+"yw" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "yL" = (
+/obj/item/organ/external/tail/lizard,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
 "yN" = (
@@ -256,15 +454,20 @@
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "zj" = (
-/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/turf_decal/box/white,
+/obj/machinery/plumbing/synthesizer,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/medbay)
 "zx" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/wood,
 /area/shuttle/abandoned/engine)
 "zA" = (
-/obj/machinery/chem_dispenser/fullupgrade,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Aj" = (
@@ -274,13 +477,27 @@
 /obj/structure/closet/secure_closet/chemical/heisenberg{
 	req_access = null
 	},
+/obj/item/stack/ore/bluespace_crystal/artificial,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"Al" = (
+/mob/living/simple_animal/pet/cat/space,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
 "AN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"Bh" = (
+/obj/structure/fermenting_barrel,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"Bl" = (
+/obj/machinery/power/shuttle_engine/propulsion/burst,
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned/cargo)
 "Br" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
@@ -289,17 +506,40 @@
 "Ca" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/medbay)
+"Cj" = (
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "CC" = (
-/obj/machinery/plumbing/grinder_chemical,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
+"CE" = (
+/obj/machinery/rnd/production/protolathe/department/medical,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"CF" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/crew)
+"Dx" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/cargo)
 "DB" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/bar)
-"Eg" = (
-/mob/living/simple_animal/hostile/pirate/melee/space,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
 "Fc" = (
 /obj/machinery/shower,
 /turf/open/floor/oldshuttle,
@@ -312,14 +552,40 @@
 /area/shuttle/abandoned/crew)
 "Gh" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/wood,
 /area/shuttle/abandoned/engine)
 "Gi" = (
 /obj/machinery/door/airlock/alarmlock,
+/obj/structure/cable,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
 "Gp" = (
-/obj/machinery/light/directional/south,
+/mob/living/simple_animal/hostile/pirate/melee/space,
+/obj/structure/cable,
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"Gu" = (
+/obj/structure/cable,
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/sunglasses/chemical,
+/obj/item/clothing/glasses/sunglasses/chemical,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"Gv" = (
+/obj/structure/table/wood,
+/obj/item/gun/ballistic/rifle/boltaction/pipegun,
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"Gw" = (
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "GQ" = (
@@ -327,63 +593,116 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/medbay)
 "Hu" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/engine,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "HV" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/engine,
+/obj/structure/window/reinforced/shuttle,
+/turf/open/space/basic,
 /area/shuttle/abandoned/engine)
+"HZ" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "Iw" = (
 /obj/structure/toilet,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
 "Jl" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/shoes/sandal,
-/turf/open/floor/carpet/purple,
+/obj/machinery/computer/monitor{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/crew)
 "JD" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/shuttle/abandoned/bar)
+"JI" = (
+/obj/structure/cable,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/crew)
 "JK" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
+/obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"JS" = (
+/obj/structure/cable,
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "KC" = (
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/machinery/light/floor,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "KJ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/medbay)
+"KM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/item/paper/fluff/stations/soap,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "La" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
+"Lf" = (
+/obj/machinery/light/directional/south,
+/obj/structure/dresser,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"LH" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/under/misc/pj/blue,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
 "LP" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/cargo)
 "Mi" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/carpet/purple,
+/obj/structure/bed{
+	dir = 8
+	},
+/obj/item/bedsheet/random{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
 "MP" = (
-/obj/machinery/rnd/production/protolathe/department/medical,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Nv" = (
-/obj/machinery/plumbing/synthesizer,
+/obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"NN" = (
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/crew)
+"Og" = (
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
 "Oj" = (
-/obj/machinery/power/shuttle_engine/large,
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned/cargo)
+/obj/effect/turf_decal/bot_white/left,
+/obj/machinery/plumbing/reaction_chamber/chem,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "Oo" = (
 /turf/template_noop,
 /area/template_noop)
@@ -391,13 +710,21 @@
 /obj/machinery/computer/shuttle,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
+"OD" = (
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/crew)
 "Pb" = (
-/turf/open/floor/engine,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "Pc" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/west,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "Pr" = (
 /obj/structure/table/reinforced,
@@ -406,23 +733,48 @@
 /area/shuttle/abandoned/medbay)
 "Pw" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"PL" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"PO" = (
+/obj/machinery/chem_dispenser/fullupgrade,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "PQ" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/silver,
-/obj/item/storage/backpack/chemistry,
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = 24
+	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"Qn" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"QF" = (
+/obj/machinery/chem_heater,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "Rg" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Rq" = (
 /obj/machinery/door/airlock/public/glass,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
 "Rr" = (
@@ -432,19 +784,37 @@
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "RJ" = (
-/obj/machinery/plumbing/liquid_pump,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"RT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "Sg" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
+"Sh" = (
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "Sm" = (
 /obj/machinery/light/directional/north,
+/obj/structure/sink,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
+"SB" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/gold,
+/obj/item/stack/sheet/mineral/silver,
+/obj/item/storage/backpack/chemistry,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "SK" = (
 /obj/machinery/door/airlock/titanium,
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/bar)
 "TF" = (
@@ -459,63 +829,93 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
+"UL" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"UW" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "Vl" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet/purple,
-/area/shuttle/abandoned/crew)
+/obj/structure/sign/poster/contraband/smoke,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/cargo)
 "Vw" = (
 /obj/structure/window/reinforced/shuttle,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Vx" = (
-/obj/item/toy/cattoy,
-/turf/open/floor/carpet/purple,
-/area/shuttle/abandoned/crew)
-"VD" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/decal/cleanable/blood/footprints,
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering"
+	},
 /turf/open/floor/engine,
+/area/shuttle/abandoned/crew)
+"Vy" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/plumbing/tank,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"VD" = (
+/obj/machinery/light/floor,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "Wq" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"Wy" = (
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "WR" = (
 /obj/structure/window/reinforced/shuttle,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
 "WT" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
 "Xw" = (
-/obj/item/seeds/cannabis,
-/obj/item/seeds/amanita,
-/obj/structure/table/reinforced,
-/obj/item/seeds/cannabis/rainbow,
-/turf/open/floor/engine,
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "YX" = (
-/obj/machinery/light/floor,
+/mob/living/simple_animal/hostile/pirate/ranged/space,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Zh" = (
 /obj/machinery/door/airlock/titanium/glass,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Zn" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "Zq" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/obj/structure/sign/warning/chem_diamond{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "ZB" = (
-/obj/structure/bed,
-/obj/item/bedsheet/cosmos,
-/obj/item/toy/plush/nukeplushie,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/crew)
 
 (1,1,1) = {"
@@ -560,14 +960,14 @@ Oo
 Oo
 Oo
 jV
-LP
+Vl
 La
 La
-Pb
+KC
 Pc
 La
-Pb
-pj
+Wy
+Xw
 jV
 Oo
 Oo
@@ -589,12 +989,12 @@ Oo
 jV
 LP
 wO
+Hu
+Hu
+KC
 Pb
-Pb
-Pb
-Pb
-Eg
-Pb
+Hu
+Hu
 Xw
 jV
 Oo
@@ -615,15 +1015,15 @@ Oo
 Oo
 jV
 LP
-vJ
+Hu
+Hu
+Hu
+Hu
+dn
 Pb
-Pb
-Pb
-Pb
-Pb
-Pb
-Wq
+xE
 LP
+jV
 jV
 Oo
 Oo
@@ -644,14 +1044,14 @@ jV
 LP
 bF
 Pb
+Wq
 Pb
-Pb
-Pb
-Pb
-Pb
-cy
+Bh
+Dx
+xc
 LP
 jV
+Oo
 Oo
 Oo
 Oo
@@ -670,15 +1070,15 @@ Oo
 Ca
 KJ
 jr
-rJ
-rJ
-rJ
-rJ
-rJ
-rJ
+Gp
+MP
+fI
+wy
+bA
+qz
 gw
-KJ
-jV
+Ca
+Oo
 Oo
 Oo
 Oo
@@ -696,18 +1096,18 @@ Oo
 fk
 fk
 KJ
-oW
-oW
-oW
-oW
+Ca
+Ca
 oW
 Zh
 oW
-oW
-oW
-oW
-jV
-jV
+Ca
+gO
+ph
+bp
+Ca
+Bl
+xr
 Oo
 Oo
 Oo
@@ -723,20 +1123,20 @@ Oo
 Oo
 fk
 yQ
-oW
+Ca
 is
 rJ
 rJ
-rJ
-rJ
-rJ
-rJ
+RJ
+RJ
+Ca
+QF
 kq
-rJ
-zA
-jV
+PO
+Ca
+xr
 uj
-em
+Oo
 Oo
 Oo
 Oo
@@ -750,21 +1150,21 @@ Oo
 Oo
 fk
 DB
-jy
-oW
-AN
+mG
+Ca
 rJ
 rJ
 rJ
-rJ
-rJ
-rJ
+Nv
+RJ
+Ca
+HZ
 dh
-rJ
-Rg
-jV
-em
-Oj
+KM
+Ca
+xr
+xr
+Oo
 Oo
 Oo
 Oo
@@ -777,22 +1177,22 @@ Oo
 Oo
 fk
 LP
+em
 jy
-jy
-oW
+Ca
 PQ
 rJ
-YX
 rJ
 rJ
-rJ
-rJ
+RJ
+Ca
+hq
 yw
-rJ
-gY
-jV
-em
-em
+SB
+Ca
+Bl
+xr
+Oo
 Oo
 Oo
 Oo
@@ -805,22 +1205,22 @@ bL
 bL
 DB
 hU
-jy
+ey
 UI
-oW
+xM
+rJ
+zj
 rJ
 rJ
-mG
-rJ
-rJ
-rJ
-rJ
-rJ
-rJ
-rJ
-jV
-uj
-em
+RJ
+Ca
+HZ
+dh
+wy
+Ca
+Oo
+Oo
+Oo
 Oo
 Oo
 Oo
@@ -833,19 +1233,19 @@ bL
 zx
 Sg
 vb
-jy
+gY
 Rr
-oW
+Ca
 rJ
 Pw
 rJ
 rJ
-rJ
-rJ
-rJ
-rJ
-rJ
-rJ
+RJ
+Ca
+gO
+rP
+bp
+Ca
 jV
 jV
 jV
@@ -858,29 +1258,29 @@ Oo
 bL
 bL
 bL
-yN
+ax
 Sg
 qx
-jy
+gY
 UI
-oW
-rJ
+Ca
+pG
 JK
+YX
 rJ
-ct
-rJ
-rJ
-rJ
-rJ
-rJ
-rJ
-jV
+RJ
+Ca
+HZ
+yw
+uJ
+Ca
+oE
 Hu
-Pb
+pS
 jV
-jV
-jV
-jV
+Oo
+Oo
+Oo
 "}
 (14,1,1) = {"
 HV
@@ -888,55 +1288,55 @@ hd
 yN
 yN
 Sg
-sA
+fk
 Rq
-sA
-oW
+fk
+ym
 rJ
 JK
 rJ
-rJ
+Oj
 RJ
-rJ
-rJ
-kp
-rJ
-rJ
+oW
+Gu
+cX
+wy
+Ca
+Qn
+Hu
+qQ
 jV
-Pb
-Pb
-Pb
-Pb
-Pb
-jV
+Oo
+Oo
+Oo
 "}
 (15,1,1) = {"
 HV
 Ov
 dX
-yN
+bU
 SK
-sA
-sA
-sA
+cy
+kp
+rn
 Zh
-rJ
-JK
-rJ
-rJ
-rJ
-rJ
+RJ
+zA
+RJ
+Rg
+Gw
+PL
 Zn
-hE
-hE
-hE
+yw
+yw
+ed
 VD
 KC
 if
 mW
-Pb
-mW
-kM
+Oo
+Oo
+Oo
 "}
 (16,1,1) = {"
 HV
@@ -945,54 +1345,54 @@ yN
 iQ
 WR
 sA
-sA
+kM
 sA
 Vw
 rJ
+zj
 rJ
-Nv
-rJ
-rJ
-rJ
-rJ
-rJ
-rJ
-rJ
+Sh
+Gw
+oW
+JS
+yw
+wy
+Ca
+uB
+RT
+UW
 jV
-Pb
-Pb
-Pb
-Pb
-Pb
-jV
+Oo
+Oo
+Oo
 "}
 (17,1,1) = {"
 bL
 bL
 bL
-yN
+ct
 WR
 Br
-sA
+cy
 pY
 Vw
 rJ
+AN
 rJ
-rJ
-rJ
-rJ
-rJ
+Sh
+RJ
+Ca
 Zq
-rJ
-rJ
-rJ
+wU
+wy
+Ca
+tf
+Cj
+Gv
 jV
-Hu
-Pb
-jV
-jV
-jV
-jV
+Oo
+Oo
+Oo
 "}
 (18,1,1) = {"
 Oo
@@ -1005,15 +1405,15 @@ Gi
 JD
 FD
 pG
-rJ
-bU
-rJ
+AN
 rJ
 rJ
-rJ
-rJ
-rJ
-rJ
+RJ
+Ca
+gO
+ph
+bp
+Ca
 jV
 jV
 jV
@@ -1036,15 +1436,15 @@ rJ
 rJ
 rJ
 rJ
-rJ
-rJ
+RJ
+Ca
 CC
-rJ
-rJ
-rJ
-jV
-uj
-em
+UL
+bM
+Ca
+Oo
+Oo
+Oo
 Oo
 Oo
 Oo
@@ -1063,16 +1463,16 @@ FD
 TF
 rJ
 YX
-ct
 rJ
-rJ
-rJ
-YX
-rJ
-rJ
-jV
-em
-Oj
+Rg
+Ca
+HZ
+yw
+mc
+Ca
+Bl
+xr
+Oo
 Oo
 Oo
 Oo
@@ -1092,15 +1492,15 @@ Pr
 rJ
 rJ
 rJ
-rJ
-rJ
-rJ
-rJ
-rJ
-Gp
-jV
-em
-em
+Vy
+Ca
+HZ
+yw
+CE
+Ca
+xr
+uj
+Oo
 Oo
 Oo
 Oo
@@ -1120,15 +1520,15 @@ Aj
 rJ
 rJ
 rJ
-rJ
-rJ
-rJ
-rJ
-rJ
-MP
-jV
-uj
-em
+wK
+Ca
+HZ
+dh
+Hu
+Ca
+xr
+xr
+Oo
 Oo
 Oo
 Oo
@@ -1148,14 +1548,14 @@ WT
 WT
 WT
 WT
-WT
-zj
-WT
-WT
-WT
-WT
+rv
 jV
+eU
+lq
+Hu
 jV
+Bl
+xr
 Oo
 Oo
 Oo
@@ -1173,16 +1573,16 @@ Oo
 Oo
 jV
 LP
-ax
-cL
-Vx
-cL
-cL
-Jl
-uY
-ey
-ku
 Gf
+Gf
+Vx
+JI
+Gf
+Gf
+uY
+Gf
+Gf
+Oo
 Oo
 Oo
 Oo
@@ -1204,14 +1604,14 @@ jV
 ku
 cL
 cL
-cL
-cL
-cL
-cL
-cL
-rn
-ku
+NN
 Gf
+he
+ok
+he
+LP
+Gf
+Oo
 Oo
 Oo
 Oo
@@ -1230,16 +1630,16 @@ Oo
 Oo
 Oo
 Gf
-ku
+Jl
 bQ
-cL
-cL
-cL
-cL
-cL
-cL
-Vl
+CF
+Gf
+aE
+OD
+aE
+Lf
 ku
+Gf
 Gf
 Oo
 Oo
@@ -1260,14 +1660,14 @@ Oo
 Oo
 Gf
 ku
-cL
-cL
-cL
-cL
-cL
-cL
-cL
-cL
+qU
+Gf
+aE
+ZB
+Al
+aE
+LH
+Gf
 Gf
 Oo
 Oo
@@ -1289,12 +1689,12 @@ Oo
 Oo
 Gf
 ku
-ym
-cL
+Gf
+oT
 ZB
 Mi
 aE
-cL
+Og
 mD
 Gf
 Oo

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -204,9 +204,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
 "uj" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/power/shuttle_engine/propulsion/burst,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
@@ -232,12 +229,6 @@
 "wO" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"xr" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
 "ym" = (
 /obj/structure/bed,
@@ -442,11 +433,11 @@
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Sg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "Sh" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
 "Sm" = (
@@ -733,7 +724,7 @@ Oo
 Oo
 fk
 yQ
-dh
+oW
 is
 rJ
 rJ
@@ -761,7 +752,7 @@ Oo
 fk
 DB
 jy
-dh
+oW
 AN
 rJ
 rJ
@@ -773,7 +764,7 @@ dh
 rJ
 Rg
 jV
-xr
+em
 Oj
 Oo
 Oo
@@ -789,7 +780,7 @@ fk
 LP
 jy
 jy
-dh
+oW
 PQ
 rJ
 YX
@@ -801,7 +792,7 @@ yw
 rJ
 gY
 jV
-xr
+em
 em
 Oo
 Oo
@@ -817,7 +808,7 @@ DB
 hU
 jy
 UI
-dh
+oW
 rJ
 rJ
 mG
@@ -845,7 +836,7 @@ Sg
 vb
 jy
 Rr
-dh
+oW
 rJ
 Pw
 rJ
@@ -873,7 +864,7 @@ Sg
 qx
 jy
 UI
-dh
+oW
 rJ
 JK
 rJ
@@ -901,7 +892,7 @@ Sg
 Sh
 Rq
 Sh
-dh
+oW
 rJ
 JK
 rJ
@@ -1081,7 +1072,7 @@ YX
 rJ
 rJ
 jV
-xr
+em
 Oj
 Oo
 Oo
@@ -1109,7 +1100,7 @@ rJ
 rJ
 Gp
 jV
-xr
+em
 em
 Oo
 Oo

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -134,7 +134,6 @@
 /area/shuttle/abandoned/crew)
 "kM" = (
 /obj/machinery/door/airlock/shuttle,
-/obj/structure/firelock_frame/heavy,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/docking_port/mobile{
 	callTime = 250;
@@ -150,6 +149,7 @@
 	shuttle_id = "whiteship";
 	width = 33
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
 "ls" = (
@@ -462,7 +462,6 @@
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
 "SK" = (
-/obj/structure/firelock_frame/heavy,
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/bar)
@@ -492,7 +491,6 @@
 /area/shuttle/abandoned/crew)
 "VD" = (
 /obj/machinery/door/airlock/public/glass,
-/obj/structure/firelock_frame/heavy,
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -4,20 +4,19 @@
 /obj/machinery/recharger,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
+"aw" = (
+/obj/machinery/rnd/production/protolathe/department/medical,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "ax" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/window/reinforced/shuttle,
+/obj/item/food/pizza/meat,
+/turf/open/space/basic,
 /area/shuttle/abandoned/engine)
 "aE" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
-"aG" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/storage/belt/utility/full/engi,
-/obj/item/construction/rcd/loaded,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "bF" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/iron/smooth,
@@ -32,40 +31,30 @@
 /turf/open/floor/engine,
 /area/shuttle/abandoned/crew)
 "bU" = (
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/shuttle/abandoned/engine)
+/obj/item/pizzabox,
+/turf/template_noop,
+/area/template_noop)
 "ct" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "cy" = (
-/turf/open/floor/wood,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
+"cC" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "cL" = (
 /turf/open/floor/engine,
 /area/shuttle/abandoned/crew)
-"di" = (
-/mob/living/simple_animal/pet/cat/space,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
-"dJ" = (
-/obj/effect/turf_decal{
-	dir = 1
+"dI" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/sunglasses/chemical,
-/obj/item/clothing/glasses/sunglasses/chemical,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"dO" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/decal/cleanable/blood/footprints,
 /obj/structure/cable,
-/turf/open/floor/engine,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "dX" = (
 /obj/structure/chair/comfy/shuttle{
@@ -75,33 +64,30 @@
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
 "em" = (
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/shuttle/abandoned/bar)
-"ey" = (
 /obj/machinery/airalarm/all_access{
 	dir = 1;
 	pixel_y = 24
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
-/area/shuttle/abandoned/bar)
-"eR" = (
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/engine)
+"ey" = (
+/turf/open/floor/wood,
+/area/shuttle/abandoned/engine)
+"eN" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"fh" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "fk" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/bar)
-"ft" = (
-/obj/machinery/power/shuttle_engine/propulsion/burst,
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned/cargo)
-"gg" = (
-/obj/effect/decal/cleanable/dirt,
+"fy" = (
+/obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "gw" = (
@@ -111,23 +97,21 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
+"gT" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/construction/rcd/loaded,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "gY" = (
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
 "hd" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/pai_card,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
-"hg" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/silver,
-/obj/item/storage/backpack/chemistry,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "hU" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
@@ -140,11 +124,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
-"ik" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/plumbing/tank,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
 "is" = (
 /obj/item/plunger,
 /obj/item/clothing/glasses/science,
@@ -155,6 +134,15 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"it" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/random{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
 "iQ" = (
 /mob/living/simple_animal/hostile/pirate/melee/space,
 /turf/open/floor/carpet/royalblack,
@@ -172,23 +160,16 @@
 /obj/item/soap/homemade,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"jT" = (
-/obj/structure/table/wood,
-/obj/item/gun/ballistic/rifle/boltaction/pipegun,
-/obj/effect/turf_decal/box/white/corners,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "jV" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/cargo)
-"kh" = (
-/obj/machinery/vending/cola/sodie,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "kp" = (
-/obj/effect/decal/cleanable/food/salt,
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = 24
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "kq" = (
 /obj/machinery/light/floor,
@@ -198,8 +179,13 @@
 "ku" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
+"kL" = (
+/obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "kM" = (
-/obj/effect/decal/cleanable/ants,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "ls" = (
@@ -209,28 +195,20 @@
 /obj/structure/cable,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"lR" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
-	},
+"lY" = (
+/obj/machinery/light/directional/south,
+/obj/structure/dresser,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/crew)
 "mD" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
 "mG" = (
-/obj/effect/turf_decal,
+/obj/effect/decal/cleanable/food/salt,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
-"mM" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "mW" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -251,18 +229,37 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
+"mY" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "nm" = (
 /obj/item/razor,
 /obj/item/knife/combat/survival,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
+"nt" = (
+/mob/living/simple_animal/pet/cat/space,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
 "oW" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"pE" = (
-/obj/machinery/door/airlock/titanium/glass,
+"pp" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"pA" = (
+/obj/effect/turf_decal{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
@@ -275,58 +272,71 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
+"qs" = (
+/obj/structure/bed{
+	dir = 8
+	},
+/obj/item/bedsheet/cosmos{
+	dir = 8
+	},
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"qw" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/gold,
+/obj/item/stack/sheet/mineral/silver,
+/obj/item/storage/backpack/chemistry,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "qx" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "rn" = (
-/obj/structure/window/reinforced/shuttle,
-/turf/open/space/basic,
-/area/shuttle/abandoned/medbay)
-"rG" = (
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
+/obj/effect/decal/cleanable/ants,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
 "rJ" = (
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"rL" = (
-/obj/structure/table/wood,
-/obj/item/storage/medkit,
-/obj/item/ammo_box/magazine/internal/boltaction/pipegun,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
-	},
+"rU" = (
+/obj/machinery/light/floor,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/crew)
+"sh" = (
+/obj/machinery/chem_master,
+/obj/machinery/light/floor,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/medbay)
 "sA" = (
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
-"sL" = (
-/obj/structure/fermenting_barrel,
-/obj/effect/turf_decal{
-	dir = 4
-	},
+"sO" = (
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
-"tU" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
+"sQ" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/under/misc/pj/blue,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"tt" = (
+/obj/effect/turf_decal{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "uj" = (
 /obj/machinery/power/shuttle_engine/large,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
-"uV" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
+"uA" = (
+/obj/machinery/vending/cola/sodie,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "uY" = (
 /obj/machinery/door/airlock/titanium/glass,
 /obj/structure/cable,
@@ -337,49 +347,50 @@
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"vC" = (
-/obj/structure/fermenting_barrel,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"vE" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/iron/smooth,
+"vS" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/crew)
+"wk" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "wO" = (
 /obj/machinery/vending/hydronutrients,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
+"wV" = (
+/obj/item/seeds/cannabis,
+/obj/item/seeds/amanita,
+/obj/structure/table/reinforced,
+/obj/item/seeds/cannabis/rainbow,
+/obj/item/reagent_containers/cup/bucket,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "xr" = (
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
-"xF" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
-	},
+"xz" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/medbay)
+"xL" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/plumbing/pill_press,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "xM" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/medbay)
-"yj" = (
-/obj/structure/bed{
-	dir = 8
-	},
-/obj/item/bedsheet/cosmos{
-	dir = 8
-	},
-/obj/item/toy/plush/nukeplushie,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
 "ym" = (
-/obj/effect/turf_decal/box/white,
-/obj/machinery/plumbing/synthesizer,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
+/obj/effect/turf_decal,
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
 "yw" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -399,12 +410,18 @@
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "zj" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
+/obj/structure/window/reinforced/shuttle,
+/turf/open/space/basic,
+/area/shuttle/abandoned/medbay)
+"zw" = (
+/obj/effect/turf_decal{
+	dir = 1
 	},
-/obj/effect/turf_decal/box/white,
-/obj/structure/cable,
-/turf/open/floor/engine,
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/sunglasses/chemical,
+/obj/item/clothing/glasses/sunglasses/chemical,
+/obj/structure/desk_bell,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "zx" = (
 /obj/machinery/light/directional/west,
@@ -412,19 +429,22 @@
 /area/shuttle/abandoned/engine)
 "zA" = (
 /obj/effect/turf_decal/box/white,
+/obj/machinery/plumbing/synthesizer,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"zE" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/cell_charger,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"zN" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
+"zU" = (
+/obj/machinery/power/smes/engineering{
+	charge = 1e+006
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
+/turf/open/floor/engine,
+/area/shuttle/abandoned/crew)
+"Ac" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "Aj" = (
 /obj/item/storage/box/syringes/variety,
 /obj/item/storage/box/syringes,
@@ -435,45 +455,28 @@
 /obj/item/stack/ore/bluespace_crystal/artificial,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"Ak" = (
-/obj/item/seeds/cannabis,
-/obj/item/seeds/amanita,
-/obj/structure/table/reinforced,
-/obj/item/seeds/cannabis/rainbow,
-/obj/item/reagent_containers/cup/bucket,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "AN" = (
-/mob/living/simple_animal/hostile/pirate/melee/space,
-/obj/effect/turf_decal{
+/obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"AU" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"AX" = (
-/obj/machinery/power/smes/engineering{
-	charge = 1e+006
-	},
+/obj/effect/turf_decal/box/white,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
+/area/shuttle/abandoned/medbay)
 "Br" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
+"BZ" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "Ca" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/medbay)
-"Cu" = (
-/obj/machinery/light/directional/south,
-/obj/structure/dresser,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
 "CC" = (
 /obj/machinery/airalarm/all_access{
 	dir = 1;
@@ -481,14 +484,31 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
-"De" = (
-/obj/machinery/chem_master,
-/obj/machinery/light/floor,
+"Di" = (
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/crew)
+"DA" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "DB" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/bar)
+"Es" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"EV" = (
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
 "Fc" = (
 /obj/machinery/shower,
 /turf/open/floor/oldshuttle,
@@ -496,16 +516,8 @@
 "FD" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/shuttle/abandoned/medbay)
-"FV" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"FZ" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
-	},
+"Ga" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "Gf" = (
@@ -521,12 +533,9 @@
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
 "Gp" = (
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
+/area/shuttle/abandoned/medbay)
 "GQ" = (
 /obj/structure/mirror,
 /turf/closed/wall/mineral/titanium,
@@ -534,33 +543,28 @@
 "Hu" = (
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"HL" = (
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
 "HV" = (
 /obj/structure/window/reinforced/shuttle,
 /turf/open/space/basic,
 /area/shuttle/abandoned/engine)
+"Ik" = (
+/obj/structure/table/wood,
+/obj/item/gun/ballistic/rifle/boltaction/pipegun,
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "Iw" = (
 /obj/structure/toilet,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"IB" = (
-/mob/living/simple_animal/hostile/pirate/melee/space,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
 "Jl" = (
-/obj/effect/turf_decal{
-	dir = 4
-	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"JB" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/decal/cleanable/blood/footprints,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "JD" = (
 /turf/closed/wall/mineral/titanium/interior,
@@ -572,9 +576,10 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"JR" = (
+"Kw" = (
+/obj/effect/turf_decal/box/white/corners,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/cargo)
 "KC" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -587,10 +592,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"LL" = (
-/obj/effect/turf_decal/bot_white/left,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
 "LP" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/cargo)
@@ -605,55 +606,42 @@
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
 "MP" = (
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"Nj" = (
-/obj/effect/turf_decal/box/white/corners,
+/mob/living/simple_animal/hostile/pirate/melee/space,
+/obj/effect/turf_decal{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/medbay)
 "Nv" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/machinery/plumbing/reaction_chamber/chem,
+/obj/machinery/computer/monitor{
+	dir = 8
+	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"Nw" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/clothing/under/misc/pj/blue,
-/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
+"Oe" = (
+/obj/machinery/power/shuttle_engine/propulsion/burst,
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned/cargo)
 "Oj" = (
-/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/engine,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Oo" = (
 /turf/template_noop,
 /area/template_noop)
-"Oq" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "Ov" = (
 /obj/machinery/computer/shuttle,
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
-"ON" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
-	},
+"OO" = (
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"OZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
-/obj/item/paper/fluff/stations/soap,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "Pb" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
@@ -664,11 +652,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"Pi" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/plumbing/pill_press,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
 "Pr" = (
 /obj/structure/table/reinforced,
 /obj/item/pipe_dispenser,
@@ -686,10 +669,16 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"Qo" = (
+/mob/living/simple_animal/hostile/pirate/melee/space,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "Rg" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/medbay)
 "Rq" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
@@ -702,43 +691,54 @@
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "RJ" = (
+/obj/effect/turf_decal/bot_white/left,
+/obj/machinery/plumbing/reaction_chamber/chem,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
-"RO" = (
-/obj/machinery/rnd/production/protolathe/department/medical,
-/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Sg" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "Sh" = (
-/obj/structure/sign/poster/contraband/smoke,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/cargo)
+/obj/effect/turf_decal/bot_white/left,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "Sm" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sink,
 /obj/structure/cable,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
+"SG" = (
+/obj/structure/sign/poster/contraband/smoke,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/cargo)
+"SJ" = (
+/obj/structure/table/wood,
+/obj/item/storage/medkit,
+/obj/item/ammo_box/magazine/internal/boltaction/pipegun,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "SK" = (
 /obj/machinery/door/airlock/titanium,
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/bar)
-"Td" = (
-/obj/machinery/chem_dispenser/fullupgrade,
-/turf/open/floor/iron/smooth,
+"Tb" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/plumbing/tank,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"To" = (
+"TD" = (
+/obj/effect/turf_decal{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
-"TE" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "TF" = (
 /obj/structure/table/reinforced,
@@ -748,27 +748,31 @@
 /obj/item/stack/ducts/fifty,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"TS" = (
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = -24
+"TZ" = (
+/obj/structure/fermenting_barrel,
+/obj/effect/turf_decal{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/medbay)
+"Uo" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/item/paper/fluff/stations/soap,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "UI" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"Vl" = (
-/obj/effect/decal/cleanable/dirt,
+"UV" = (
+/obj/machinery/chem_heater,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"Vp" = (
-/obj/machinery/power/apc/auto_name/directional/south,
+/area/shuttle/abandoned/medbay)
+"Vl" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
+/area/shuttle/abandoned/cargo)
 "Vw" = (
 /obj/structure/window/reinforced/shuttle,
 /turf/open/floor/engine,
@@ -786,27 +790,39 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "Wq" = (
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/crew)
+"WI" = (
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "WR" = (
 /obj/structure/window/reinforced/shuttle,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
 "WT" = (
+/obj/item/wheelchair,
 /turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"Xg" = (
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "Xw" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"YJ" = (
-/obj/machinery/light/floor,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/crew)
+"YV" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/cell_charger,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "YX" = (
 /mob/living/simple_animal/hostile/pirate/ranged/space,
 /turf/open/floor/engine,
@@ -829,18 +845,16 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
+"Zy" = (
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "ZB" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/shuttle/abandoned/crew)
-"ZI" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/random{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
 
 (1,1,1) = {"
@@ -885,13 +899,13 @@ Oo
 Oo
 Oo
 jV
-Sh
+SG
 La
 La
 KC
 Pc
 La
-TS
+Xg
 Xw
 jV
 Oo
@@ -946,7 +960,7 @@ Hu
 Hu
 VD
 Hu
-Oq
+OO
 LP
 jV
 jV
@@ -969,11 +983,11 @@ jV
 LP
 bF
 Pb
-Vl
+Ga
 Hu
-vC
+kL
 KC
-Ak
+wV
 LP
 jV
 Oo
@@ -995,12 +1009,12 @@ Oo
 Ca
 KJ
 jr
-AN
-Jl
-Wq
-JR
-sL
-rG
+MP
+Oj
+TD
+sO
+TZ
+pA
 gw
 Ca
 Oo
@@ -1027,11 +1041,11 @@ oW
 Zh
 oW
 Ca
-AU
-pE
-uV
+cC
+fh
+Es
 Ca
-ft
+Oe
 xr
 Oo
 Oo
@@ -1055,9 +1069,9 @@ rJ
 ct
 rJ
 Ca
-vE
+UV
 kq
-Td
+fy
 Ca
 xr
 uj
@@ -1075,17 +1089,17 @@ Oo
 Oo
 fk
 DB
-kM
+rn
 Ca
 rJ
 rJ
 rJ
-MP
+Rg
 rJ
 Ca
-JR
+sO
 yw
-OZ
+Uo
 Ca
 xr
 xr
@@ -1102,7 +1116,7 @@ Oo
 Oo
 fk
 LP
-ey
+kp
 jy
 Ca
 PQ
@@ -1111,11 +1125,11 @@ rJ
 ct
 rJ
 Ca
-De
+sh
 yw
-hg
+qw
 Ca
-ft
+Oe
 xr
 Oo
 Oo
@@ -1125,23 +1139,23 @@ Oo
 "}
 (11,1,1) = {"
 Oo
-Oo
+bU
 bL
 bL
 DB
 hU
-ey
+kp
 UI
 xM
 rJ
-ym
+zA
 rJ
 ct
 rJ
 Ca
-JR
+sO
 yw
-JR
+sO
 Ca
 Oo
 Oo
@@ -1158,7 +1172,7 @@ bL
 zx
 Sg
 vb
-gY
+kM
 Rr
 Ca
 rJ
@@ -1167,9 +1181,9 @@ rJ
 ct
 rJ
 Ca
-AU
-pE
-uV
+cC
+fh
+Es
 Ca
 jV
 jV
@@ -1183,10 +1197,10 @@ Oo
 bL
 bL
 bL
-bU
+em
 Sg
 qx
-gY
+kM
 UI
 Ca
 pG
@@ -1195,13 +1209,13 @@ YX
 ct
 rJ
 Ca
-JR
+sO
 yw
-gg
+xz
 Ca
-xF
+mY
 Hu
-rL
+SJ
 jV
 Oo
 Oo
@@ -1210,51 +1224,51 @@ Oo
 (14,1,1) = {"
 HV
 hd
-ax
+cy
 yN
 Sg
 fk
 Rq
 fk
-rn
+zj
 rJ
 JK
 rJ
-Nv
+RJ
 rJ
 oW
-dJ
-IB
-JR
+zw
+Qo
+sO
 Ca
-FZ
+pp
 Hu
-Nj
+Kw
 jV
 Oo
 Oo
 Oo
 "}
 (15,1,1) = {"
-HV
+ax
 Ov
 dX
-ax
+cy
 SK
-em
-em
-mG
+gY
+gY
+ym
 Zh
 ct
-zj
+AN
 ct
-Oj
+Sh
 ct
-dO
+JB
 Zn
 yw
 yw
-TE
+eN
 VD
 KC
 if
@@ -1266,26 +1280,26 @@ Oo
 (16,1,1) = {"
 HV
 ar
-ax
+cy
 iQ
 WR
 sA
-kp
+mG
 sA
 Vw
 rJ
-ym
+zA
 rJ
-Oj
+Sh
 rJ
 oW
-FV
+tt
 yw
-JR
+sO
 Ca
-ON
-Vl
-lR
+BZ
+Ga
+Ac
 jV
 Oo
 Oo
@@ -1295,25 +1309,25 @@ Oo
 bL
 bL
 bL
-cy
+ey
 WR
 Br
-em
+gY
 pY
 Vw
 rJ
-zA
+Gp
 rJ
-Oj
+Sh
 rJ
 Ca
 Zq
-tU
-JR
+dI
+sO
 Ca
-mM
-eR
-jT
+DA
+Zy
+Ik
 jV
 Oo
 Oo
@@ -1330,14 +1344,14 @@ Gi
 JD
 FD
 pG
-zA
+Gp
 rJ
 ct
 rJ
 Ca
-AU
-pE
-uV
+cC
+fh
+Es
 Ca
 jV
 jV
@@ -1364,8 +1378,8 @@ ct
 rJ
 Ca
 CC
-zN
-zE
+wk
+YV
 Ca
 Oo
 Oo
@@ -1389,13 +1403,13 @@ TF
 rJ
 YX
 ct
-LL
+WI
 Ca
-JR
+sO
 yw
-aG
+gT
 Ca
-ft
+Oe
 xr
 Oo
 Oo
@@ -1417,11 +1431,11 @@ Pr
 rJ
 rJ
 ct
-ik
+Tb
 Ca
-JR
+sO
 yw
-RO
+aw
 Ca
 xr
 uj
@@ -1445,9 +1459,9 @@ Aj
 rJ
 rJ
 ct
-Pi
+xL
 Ca
-JR
+sO
 yw
 Hu
 Ca
@@ -1470,16 +1484,16 @@ fk
 jV
 LP
 WT
-WT
-WT
-Rg
-WT
+Jl
+Jl
+Vl
+Jl
 jV
-kh
+uA
 VD
 Hu
 jV
-ft
+Oe
 xr
 Oo
 Oo
@@ -1528,12 +1542,12 @@ Oo
 jV
 ku
 cL
-RJ
+Wq
 cL
 Gf
-ZI
+it
 ZB
-ZI
+it
 LP
 Gf
 Oo
@@ -1555,14 +1569,14 @@ Oo
 Oo
 Oo
 Gf
-Gp
+Nv
 bQ
-Vp
+vS
 Gf
 aE
-YJ
-To
-Cu
+rU
+Di
+lY
 ku
 Gf
 Gf
@@ -1585,13 +1599,13 @@ Oo
 Oo
 Gf
 ku
-AX
+zU
 Gf
-To
+Di
 ZB
-di
-To
-Nw
+nt
+Di
+sQ
 Gf
 Gf
 Oo
@@ -1615,11 +1629,11 @@ Oo
 Gf
 ku
 Gf
-yj
+qs
 ZB
 Mi
 aE
-HL
+EV
 mD
 Gf
 Oo

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -65,11 +65,19 @@
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
 "cL" = (
-/turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
+/obj/structure/table/reinforced,
+/obj/item/construction/plumbing,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/effect/turf_decal{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "dI" = (
 /obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -163,19 +171,17 @@
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "if" = (
-/obj/effect/decal/cleanable/blood/footprints,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/cargo)
-"is" = (
-/obj/item/plunger,
-/obj/item/clothing/glasses/science,
-/obj/item/storage/box/beakers/bluespace,
-/obj/item/storage/box/beakers/variety,
-/obj/structure/closet/secure_closet/chemical/heisenberg{
-	req_access = null
+/obj/effect/turf_decal{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"is" = (
+/obj/effect/turf_decal{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "it" = (
 /obj/structure/bed{
@@ -191,16 +197,14 @@
 "iX" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "jl" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/crew)
 "jr" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/iron,
@@ -229,12 +233,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"kq" = (
-/obj/machinery/light/floor,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
 "ku" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
@@ -281,7 +279,7 @@
 "mD" = (
 /obj/structure/bed/dogbed,
 /obj/machinery/light/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/shuttle/abandoned/crew)
 "mG" = (
 /obj/effect/decal/cleanable/food/salt,
@@ -361,7 +359,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/shuttle/abandoned/medbay)
@@ -379,9 +377,6 @@
 "qe" = (
 /obj/machinery/door/airlock/titanium/glass,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "qs" = (
@@ -395,6 +390,13 @@
 /turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
 "qw" = (
+/obj/item/storage/box/syringes/variety,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/pillbottles,
+/obj/structure/closet/secure_closet/chemical/heisenberg{
+	req_access = null
+	},
+/obj/item/stack/ore/bluespace_crystal/artificial,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
@@ -406,7 +408,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/curtain/bounty,
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/shuttle/abandoned/crew)
 "rb" = (
 /mob/living/simple_animal/hostile/pirate/ranged/space,
@@ -512,9 +514,6 @@
 "xz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/shower/directional/north,
-/obj/effect/turf_decal{
-	dir = 8
-	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "xJ" = (
@@ -593,16 +592,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"Aj" = (
-/obj/item/storage/box/syringes/variety,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/pillbottles,
-/obj/structure/closet/secure_closet/chemical/heisenberg{
-	req_access = null
-	},
-/obj/item/stack/ore/bluespace_crystal/artificial,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
 "Aq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -610,7 +599,7 @@
 /area/shuttle/abandoned/medbay)
 "AN" = (
 /obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/box/white,
 /obj/structure/cable,
@@ -645,14 +634,6 @@
 /obj/item/food/grown/grapes,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
-"Cr" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = 24
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "CC" = (
 /obj/machinery/airalarm/all_access{
 	dir = 1;
@@ -682,7 +663,7 @@
 /area/shuttle/abandoned/medbay)
 "EV" = (
 /obj/item/toy/cattoy,
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/shuttle/abandoned/crew)
 "Fc" = (
 /obj/item/soap/homemade,
@@ -765,7 +746,7 @@
 /area/shuttle/abandoned/bar)
 "JK" = (
 /obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
@@ -799,9 +780,6 @@
 /obj/item/stack/sheet/mineral/silver,
 /obj/item/storage/backpack/chemistry,
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/turf_decal{
-	dir = 10
-	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Mi" = (
@@ -815,13 +793,6 @@
 /obj/effect/turf_decal/tile/dark,
 /turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
-"Mp" = (
-/obj/structure/cable,
-/obj/effect/turf_decal{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
 "MM" = (
 /obj/structure/sign/poster/official/safety_eye_protection,
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -849,7 +820,7 @@
 /obj/item/bedsheet/cosmos{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/shuttle/abandoned/crew)
 "Oo" = (
 /turf/template_noop,
@@ -888,11 +859,6 @@
 /obj/effect/decal/cleanable/food/plant_smudge,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
-"Pr" = (
-/obj/structure/table/reinforced,
-/obj/item/pipe_dispenser,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
 "Pw" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/effect/turf_decal/box/white,
@@ -945,10 +911,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"Sg" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/bar)
 "Sh" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/structure/cable,
@@ -974,6 +936,7 @@
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
 	},
+/obj/item/storage/medkit/fire,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "SK" = (
@@ -998,14 +961,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/shuttle/abandoned/medbay)
-"TF" = (
-/obj/structure/table/reinforced,
-/obj/item/construction/plumbing,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "TZ" = (
 /obj/structure/fermenting_barrel,
@@ -1101,6 +1056,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/emergency,
 /obj/machinery/cell_charger,
+/obj/item/pipe_dispenser,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "YX" = (
@@ -1124,8 +1080,8 @@
 	pixel_y = 32
 	},
 /obj/structure/table/reinforced,
-/obj/item/storage/medkit/fire,
-/obj/item/storage/medkit/fire,
+/obj/item/storage/box/beakers/bluespace,
+/obj/item/plunger,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Zy" = (
@@ -1346,14 +1302,14 @@ Oo
 fk
 yQ
 Ca
-is
+rJ
 rJ
 rJ
 iX
 rJ
 Ca
 UV
-kq
+oe
 fy
 Ca
 xr
@@ -1436,9 +1392,9 @@ rJ
 ct
 rJ
 Ca
-Cr
-oe
-qw
+Es
+fh
+Es
 Ca
 Oo
 Oo
@@ -1453,7 +1409,7 @@ Oo
 Oo
 bL
 zx
-Sg
+WR
 vb
 PQ
 Rr
@@ -1464,9 +1420,9 @@ rJ
 ct
 Aq
 Ca
-Es
-fh
-Es
+cL
+if
+is
 Ca
 jV
 jV
@@ -1481,7 +1437,7 @@ bL
 bL
 bL
 em
-Sg
+WR
 qx
 kM
 lx
@@ -1493,7 +1449,7 @@ ct
 rJ
 MM
 LY
-Mp
+yw
 xz
 Ca
 mY
@@ -1509,7 +1465,7 @@ HV
 hd
 cy
 yN
-Sg
+fk
 fk
 Rq
 fk
@@ -1554,7 +1510,7 @@ Wb
 eN
 KC
 KC
-if
+KC
 mW
 Oo
 Oo
@@ -1630,7 +1586,7 @@ pG
 Gp
 rJ
 ct
-jl
+rJ
 Ca
 Es
 fh
@@ -1682,7 +1638,7 @@ DB
 Sm
 yL
 FD
-TF
+rJ
 rJ
 rb
 ct
@@ -1710,7 +1666,7 @@ fk
 DB
 jG
 FD
-Pr
+rJ
 rJ
 rJ
 ct
@@ -1738,7 +1694,7 @@ Oo
 fk
 Fc
 FD
-Aj
+rJ
 rJ
 rJ
 ct
@@ -1826,7 +1782,7 @@ jV
 ku
 sQ
 Wq
-cL
+Wq
 Gf
 it
 ZB
@@ -1888,7 +1844,7 @@ Di
 AS
 nt
 qB
-ZB
+jl
 Oj
 Gf
 Oo

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -121,6 +121,10 @@
 "jV" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/cargo)
+"kp" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/medbay)
 "kq" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/engine,
@@ -230,6 +234,9 @@
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
+"xr" = (
+/turf/open/floor/engine/air,
+/area/shuttle/abandoned/medbay)
 "ym" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -436,10 +443,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"Sh" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/cafeteria,
-/area/shuttle/abandoned/bar)
 "Sm" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/oldshuttle,
@@ -642,7 +645,7 @@ Oo
 Oo
 Oo
 jV
-LP
+Pb
 bF
 Pb
 Pb
@@ -696,7 +699,7 @@ Oo
 Oo
 fk
 fk
-KJ
+kp
 oW
 oW
 oW
@@ -889,9 +892,9 @@ hd
 yN
 yN
 Sg
-Sh
+sA
 Rq
-Sh
+sA
 oW
 rJ
 JK
@@ -900,7 +903,7 @@ rJ
 RJ
 rJ
 rJ
-rJ
+xr
 rJ
 rJ
 jV

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -650,6 +650,7 @@
 /area/shuttle/abandoned/medbay)
 "EV" = (
 /obj/item/toy/cattoy,
+/obj/item/cigbutt/roach,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/crew)
 "Fc" = (
@@ -861,11 +862,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
-"Rf" = (
-/obj/item/cigbutt/roach,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/crew)
 "Rg" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/gibs/up,
@@ -1456,7 +1452,7 @@ fk
 fk
 Rq
 fk
-Vw
+Ca
 rJ
 JK
 rJ
@@ -1858,7 +1854,7 @@ Gf
 qs
 ep
 Mi
-Rf
+ku
 EV
 mD
 Gf

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -1,0 +1,1352 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ar" = (
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/abandoned/engine)
+"ax" = (
+/obj/structure/bed/dogbed,
+/obj/item/clothing/neck/petcollar,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"aE" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"bF" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"bL" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/engine)
+"bQ" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"bU" = (
+/obj/machinery/plumbing/tank,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"ct" = (
+/mob/living/simple_animal/hostile/pirate/ranged/space,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"cy" = (
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"cL" = (
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"dh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"dX" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/abandoned/engine)
+"em" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned/cargo)
+"ey" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/dress/skirt,
+/obj/item/clothing/under/dress/skirt,
+/obj/item/clothing/under/dress/skirt,
+/obj/item/clothing/under/dress/striped,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"fk" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/bar)
+"gw" = (
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"gY" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"hd" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/pai_card,
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/abandoned/engine)
+"hE" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"hU" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
+"if" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"is" = (
+/obj/item/plunger,
+/obj/item/clothing/glasses/science,
+/obj/item/storage/box/beakers/bluespace,
+/obj/item/storage/box/beakers/variety,
+/obj/structure/closet/secure_closet/chemical/heisenberg{
+	req_access = null
+	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"iQ" = (
+/mob/living/simple_animal/hostile/pirate/melee/space,
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/abandoned/engine)
+"jr" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"jy" = (
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
+"jG" = (
+/obj/machinery/shower,
+/obj/structure/curtain,
+/obj/item/soap/homemade,
+/turf/open/floor/oldshuttle,
+/area/shuttle/abandoned/bar)
+"jV" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/cargo)
+"kp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/medbay)
+"kq" = (
+/obj/machinery/chem_heater,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"ku" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/crew)
+"kM" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/structure/firelock_frame/heavy,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/docking_port/mobile{
+	callTime = 250;
+	can_move_docking_ports = 1;
+	dir = 2;
+	dwidth = 11;
+	height = 17;
+	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	name = "Salvage Ship";
+	port_direction = 8;
+	preferred_direction = 4;
+	shuttle_id = "whiteship";
+	width = 33
+	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"ls" = (
+/mob/living/simple_animal/pet/cat/space,
+/turf/open/floor/oldshuttle,
+/area/shuttle/abandoned/bar)
+"mD" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/storage/belt/medical,
+/obj/item/construction/rcd/loaded,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"mG" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"mW" = (
+/obj/machinery/light/floor,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"nm" = (
+/obj/structure/sink,
+/obj/item/razor,
+/turf/open/floor/oldshuttle,
+/area/shuttle/abandoned/bar)
+"oW" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"pj" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"pG" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"pY" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
+"qx" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
+"rn" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/cargo)
+"rJ" = (
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"sA" = (
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
+"uj" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/power/shuttle_engine/propulsion/burst,
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned/cargo)
+"uY" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/suit/sl,
+/obj/item/clothing/under/misc/assistantformal,
+/obj/item/clothing/under/misc/bouncer,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/under/misc/pj/blue,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"vb" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
+"vJ" = (
+/obj/machinery/vending/hydronutrients,
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"wO" = (
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"xr" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned/cargo)
+"xM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/closed/wall,
+/area/shuttle/abandoned/medbay)
+"ym" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"yw" = (
+/obj/machinery/chem_master,
+/obj/machinery/light/floor,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"yL" = (
+/turf/open/floor/oldshuttle,
+/area/shuttle/abandoned/bar)
+"yN" = (
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/abandoned/engine)
+"yQ" = (
+/obj/structure/closet/crate/bin,
+/obj/item/reagent_containers/hypospray/medipen/pumpup,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
+"zj" = (
+/obj/machinery/door/airlock/titanium/glass,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"zx" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/abandoned/engine)
+"zA" = (
+/obj/machinery/chem_dispenser/fullupgrade,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Aj" = (
+/obj/item/storage/box/syringes/variety,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/pillbottles,
+/obj/structure/closet/secure_closet/chemical/heisenberg{
+	req_access = null
+	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"AN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Br" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
+"Ca" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/medbay)
+"CC" = (
+/obj/machinery/plumbing/grinder_chemical,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"DB" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/bar)
+"Eg" = (
+/mob/living/simple_animal/hostile/pirate/melee/space,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"Fc" = (
+/obj/machinery/shower,
+/turf/open/floor/oldshuttle,
+/area/shuttle/abandoned/bar)
+"FD" = (
+/turf/closed/wall/mineral/titanium/interior,
+/area/shuttle/abandoned/medbay)
+"Gf" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/crew)
+"Gh" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/abandoned/engine)
+"Gi" = (
+/obj/machinery/door/airlock/alarmlock,
+/turf/open/floor/oldshuttle,
+/area/shuttle/abandoned/bar)
+"Gp" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"GQ" = (
+/obj/structure/mirror,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/medbay)
+"Hu" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"HV" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/engine)
+"Iw" = (
+/obj/structure/toilet,
+/turf/open/floor/oldshuttle,
+/area/shuttle/abandoned/bar)
+"Jl" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/shoes/sandal,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"JD" = (
+/turf/closed/wall/mineral/titanium/interior,
+/area/shuttle/abandoned/bar)
+"JK" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"KC" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/machinery/light/floor,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"KJ" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/medbay)
+"La" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"LP" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/cargo)
+"Mi" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"MP" = (
+/obj/machinery/rnd/production/protolathe/department/medical,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Nv" = (
+/obj/machinery/plumbing/synthesizer,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Oj" = (
+/obj/machinery/power/shuttle_engine/large,
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned/cargo)
+"Oo" = (
+/turf/template_noop,
+/area/template_noop)
+"Ov" = (
+/obj/machinery/computer/shuttle,
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/abandoned/engine)
+"Pb" = (
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"Pc" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light/directional/west,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"Pr" = (
+/obj/structure/table/reinforced,
+/obj/item/pipe_dispenser,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Pw" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"PQ" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/gold,
+/obj/item/stack/sheet/mineral/silver,
+/obj/item/storage/backpack/chemistry,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Rg" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Rq" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
+"Rr" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/tarot,
+/obj/item/storage/box/donkpockets/donkpocketberry,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
+"RJ" = (
+/obj/machinery/plumbing/liquid_pump,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Sg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/closed/wall,
+/area/shuttle/abandoned/bar)
+"Sh" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
+"Sm" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/oldshuttle,
+/area/shuttle/abandoned/bar)
+"SK" = (
+/obj/structure/firelock_frame/heavy,
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/abandoned/bar)
+"TF" = (
+/obj/structure/table/reinforced,
+/obj/item/construction/plumbing,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"UI" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
+"Vl" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"Vw" = (
+/obj/structure/window/reinforced/shuttle,
+/turf/closed/wall,
+/area/shuttle/abandoned/medbay)
+"Vx" = (
+/obj/item/toy/cattoy,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+"VD" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/structure/firelock_frame/heavy,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"Wq" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"WR" = (
+/obj/structure/window/reinforced/shuttle,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
+"WT" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"Xw" = (
+/obj/item/seeds/cannabis,
+/obj/item/seeds/amanita,
+/obj/structure/table/reinforced,
+/obj/item/seeds/cannabis/rainbow,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"YX" = (
+/obj/machinery/light/floor,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Zh" = (
+/obj/machinery/door/airlock/titanium/glass,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Zn" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Zq" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"ZB" = (
+/obj/structure/bed,
+/obj/item/bedsheet/cosmos,
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/carpet/purple,
+/area/shuttle/abandoned/crew)
+
+(1,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+jV
+Oo
+Oo
+Oo
+Oo
+"}
+(2,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+jV
+LP
+La
+La
+Pb
+Pc
+La
+Pb
+pj
+jV
+Oo
+Oo
+Oo
+Oo
+"}
+(3,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+jV
+LP
+wO
+Pb
+Pb
+Pb
+Pb
+Eg
+Pb
+Xw
+jV
+Oo
+Oo
+Oo
+Oo
+"}
+(4,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+jV
+LP
+vJ
+Pb
+Pb
+Pb
+Pb
+Pb
+Pb
+Wq
+LP
+jV
+Oo
+Oo
+Oo
+Oo
+"}
+(5,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+jV
+LP
+bF
+Pb
+Pb
+Pb
+Pb
+Pb
+Pb
+cy
+LP
+jV
+Oo
+Oo
+Oo
+Oo
+Oo
+"}
+(6,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Ca
+KJ
+jr
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+gw
+KJ
+jV
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+"}
+(7,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+fk
+fk
+KJ
+oW
+oW
+oW
+oW
+oW
+Zh
+oW
+oW
+oW
+oW
+jV
+jV
+Oo
+Oo
+Oo
+Oo
+Oo
+"}
+(8,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+fk
+yQ
+kp
+is
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+kq
+rJ
+zA
+jV
+uj
+em
+Oo
+Oo
+Oo
+Oo
+"}
+(9,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+fk
+DB
+jy
+xM
+AN
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+dh
+rJ
+Rg
+jV
+xr
+Oj
+Oo
+Oo
+Oo
+Oo
+"}
+(10,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+fk
+LP
+jy
+jy
+xM
+PQ
+rJ
+YX
+rJ
+rJ
+rJ
+rJ
+yw
+rJ
+gY
+jV
+xr
+em
+Oo
+Oo
+Oo
+Oo
+"}
+(11,1,1) = {"
+Oo
+Oo
+bL
+bL
+DB
+hU
+jy
+UI
+xM
+rJ
+rJ
+mG
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+jV
+uj
+em
+Oo
+Oo
+Oo
+Oo
+"}
+(12,1,1) = {"
+Oo
+Oo
+bL
+zx
+Sg
+vb
+jy
+Rr
+xM
+rJ
+Pw
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+jV
+jV
+jV
+jV
+Oo
+Oo
+Oo
+"}
+(13,1,1) = {"
+bL
+bL
+bL
+yN
+Sg
+qx
+jy
+UI
+xM
+rJ
+JK
+rJ
+ct
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+jV
+Hu
+Pb
+jV
+jV
+jV
+jV
+"}
+(14,1,1) = {"
+HV
+hd
+yN
+yN
+Sg
+Sh
+Rq
+Sh
+xM
+rJ
+JK
+rJ
+rJ
+RJ
+rJ
+rJ
+rJ
+rJ
+rJ
+jV
+Pb
+Pb
+Pb
+Pb
+Pb
+jV
+"}
+(15,1,1) = {"
+HV
+Ov
+dX
+yN
+SK
+sA
+sA
+sA
+Zh
+rJ
+JK
+rJ
+rJ
+rJ
+rJ
+Zn
+hE
+hE
+hE
+VD
+KC
+if
+mW
+Pb
+mW
+kM
+"}
+(16,1,1) = {"
+HV
+ar
+yN
+iQ
+WR
+sA
+sA
+sA
+Vw
+rJ
+rJ
+Nv
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+jV
+Pb
+Pb
+Pb
+Pb
+Pb
+jV
+"}
+(17,1,1) = {"
+bL
+bL
+bL
+yN
+WR
+Br
+sA
+pY
+Vw
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+Zq
+rJ
+rJ
+rJ
+jV
+Hu
+Pb
+jV
+jV
+jV
+jV
+"}
+(18,1,1) = {"
+Oo
+Oo
+bL
+Gh
+JD
+JD
+Gi
+JD
+FD
+pG
+rJ
+bU
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+jV
+jV
+jV
+jV
+Oo
+Oo
+Oo
+"}
+(19,1,1) = {"
+Oo
+Oo
+bL
+bL
+DB
+Iw
+ls
+nm
+GQ
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+CC
+rJ
+rJ
+rJ
+jV
+uj
+em
+Oo
+Oo
+Oo
+Oo
+"}
+(20,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+fk
+DB
+Sm
+yL
+FD
+TF
+rJ
+YX
+ct
+rJ
+rJ
+rJ
+YX
+rJ
+rJ
+jV
+xr
+Oj
+Oo
+Oo
+Oo
+Oo
+"}
+(21,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+fk
+DB
+jG
+FD
+Pr
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+Gp
+jV
+xr
+em
+Oo
+Oo
+Oo
+Oo
+"}
+(22,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+fk
+Fc
+FD
+Aj
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+rJ
+MP
+jV
+uj
+em
+Oo
+Oo
+Oo
+Oo
+"}
+(23,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+fk
+jV
+LP
+WT
+WT
+WT
+WT
+WT
+zj
+WT
+WT
+WT
+WT
+jV
+jV
+Oo
+Oo
+Oo
+Oo
+Oo
+"}
+(24,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+jV
+LP
+ax
+cL
+Vx
+cL
+cL
+Jl
+uY
+ey
+ku
+Gf
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+"}
+(25,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+jV
+ku
+cL
+cL
+cL
+cL
+cL
+cL
+cL
+rn
+ku
+Gf
+Oo
+Oo
+Oo
+Oo
+Oo
+"}
+(26,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Gf
+ku
+bQ
+cL
+cL
+cL
+cL
+cL
+cL
+Vl
+ku
+Gf
+Oo
+Oo
+Oo
+Oo
+"}
+(27,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Gf
+ku
+cL
+cL
+cL
+cL
+cL
+cL
+cL
+cL
+Gf
+Oo
+Oo
+Oo
+Oo
+"}
+(28,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Gf
+ku
+ym
+cL
+ZB
+Mi
+aE
+cL
+mD
+Gf
+Oo
+Oo
+Oo
+Oo
+"}
+(29,1,1) = {"
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Oo
+Gf
+Gf
+Gf
+Gf
+Gf
+Gf
+Gf
+Gf
+Gf
+Oo
+Oo
+Oo
+Oo
+"}

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -318,10 +318,8 @@
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "sQ" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/clothing/under/misc/pj/blue,
-/turf/open/floor/iron/smooth,
+/obj/machinery/computer/monitor,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/crew)
 "tt" = (
 /obj/effect/turf_decal{
@@ -613,23 +611,18 @@
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Nv" = (
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/cargo)
 "Oe" = (
 /obj/machinery/power/shuttle_engine/propulsion/burst,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
 "Oj" = (
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/under/misc/pj/blue,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/crew)
 "Oo" = (
 /turf/template_noop,
 /area/template_noop)
@@ -640,10 +633,6 @@
 /area/shuttle/abandoned/engine)
 "OO" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"Pb" = (
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "Pc" = (
@@ -954,10 +943,10 @@ Oo
 Oo
 jV
 LP
-Pb
-Hu
-Hu
-Hu
+KC
+Nv
+Nv
+Nv
 VD
 Hu
 OO
@@ -982,7 +971,7 @@ Oo
 jV
 LP
 bF
-Pb
+KC
 Ga
 Hu
 kL
@@ -1010,7 +999,7 @@ Ca
 KJ
 jr
 MP
-Oj
+pA
 TD
 sO
 TZ
@@ -1035,12 +1024,12 @@ Oo
 fk
 fk
 KJ
-Ca
-Ca
+KJ
+KJ
 oW
 Zh
 oW
-Ca
+KJ
 cC
 fh
 Es
@@ -1208,7 +1197,7 @@ JK
 YX
 ct
 rJ
-Ca
+KJ
 sO
 yw
 xz
@@ -1320,7 +1309,7 @@ Gp
 rJ
 Sh
 rJ
-Ca
+KJ
 Zq
 dI
 sO
@@ -1541,7 +1530,7 @@ Oo
 Oo
 jV
 ku
-cL
+sQ
 Wq
 cL
 Gf
@@ -1569,7 +1558,7 @@ Oo
 Oo
 Oo
 Gf
-Nv
+ku
 bQ
 vS
 Gf
@@ -1605,8 +1594,8 @@ Di
 ZB
 nt
 Di
-sQ
-Gf
+Di
+Oj
 Gf
 Oo
 Oo

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -296,21 +296,22 @@
 "mW" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fans/tiny,
 /obj/docking_port/mobile{
 	callTime = 250;
 	can_move_docking_ports = 1;
+	dheight = 7;
 	dir = 2;
-	dwidth = 11;
+	dwidth = 7;
 	height = 17;
 	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "Salvage Ship";
-	port_direction = 8;
-	preferred_direction = 4;
+	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
+	name = "Mining Shuttle";
+	port_direction = 4;
+	preferred_direction = 8;
 	shuttle_id = "whiteship";
-	width = 33
+	width = 13
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
 "mY" = (

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -465,7 +465,7 @@
 /area/shuttle/abandoned/crew)
 "Vw" = (
 /obj/structure/window/reinforced/shuttle,
-/turf/closed/wall,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Vx" = (
 /obj/item/toy/cattoy,

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -9,17 +9,33 @@
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "ax" = (
-/obj/structure/window/reinforced/shuttle,
 /obj/item/food/pizza/meat,
-/turf/open/space/basic,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "aE" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/random{
+	dir = 4
+	},
+/obj/item/clothing/glasses/thermal/eyepatch,
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
+"aN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"aR" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/glass,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/cargo)
 "bF" = (
 /obj/machinery/vending/hydroseeds,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
 "bL" = (
 /turf/closed/wall/mineral/titanium,
@@ -34,6 +50,12 @@
 /obj/item/pizzabox,
 /turf/template_noop,
 /area/template_noop)
+"bY" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/end,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/cargo)
 "ct" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -42,10 +64,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
-"cC" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "cL" = (
 /turf/open/floor/engine,
 /area/shuttle/abandoned/crew)
@@ -70,13 +88,28 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/abandoned/engine)
+"ep" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/carpet,
+/area/shuttle/abandoned/crew)
 "ey" = (
 /turf/open/floor/wood,
 /area/shuttle/abandoned/engine)
 "eN" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"eX" = (
+/obj/machinery/light/directional/north{
+	dir = 2
+	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "fh" = (
 /obj/machinery/door/airlock/titanium/glass,
@@ -88,6 +121,7 @@
 /area/shuttle/abandoned/bar)
 "fy" = (
 /obj/machinery/chem_dispenser/fullupgrade,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "gw" = (
@@ -95,12 +129,22 @@
 /obj/effect/turf_decal{
 	dir = 4
 	},
+/turf/open/floor/iron,
+/area/shuttle/abandoned/medbay)
+"gC" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
+"gH" = (
+/obj/item/storage/backpack/satchel/flat,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "gT" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/storage/belt/utility/full/engi,
 /obj/item/construction/rcd/loaded,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "gY" = (
@@ -120,7 +164,6 @@
 /area/shuttle/abandoned/bar)
 "if" = (
 /obj/effect/decal/cleanable/blood/footprints,
-/obj/machinery/light/floor,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
@@ -136,30 +179,45 @@
 /area/shuttle/abandoned/medbay)
 "it" = (
 /obj/structure/bed{
-	dir = 4
+	dir = 8
 	},
-/obj/item/bedsheet/random{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
+/obj/item/bedsheet/random,
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
 "iQ" = (
 /mob/living/simple_animal/hostile/pirate/melee/space,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
+"iX" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"jl" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "jr" = (
 /obj/machinery/biogenerator,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/medbay)
 "jy" = (
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "jG" = (
-/obj/machinery/shower,
 /obj/structure/curtain,
-/obj/item/soap/homemade,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
+"jO" = (
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "jV" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/cargo)
@@ -174,15 +232,20 @@
 "kq" = (
 /obj/machinery/light/floor,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "ku" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
+"kB" = (
+/obj/machinery/vending/cola/sodie,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "kL" = (
 /obj/structure/fermenting_barrel,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
 "kM" = (
 /obj/structure/cable,
@@ -195,20 +258,43 @@
 /obj/structure/cable,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"lY" = (
-/obj/machinery/light/directional/south,
-/obj/structure/dresser,
-/turf/open/floor/iron/smooth,
+"lx" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
+"lM" = (
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
+"lY" = (
+/obj/structure/table/wood,
+/obj/item/plate,
+/obj/item/food/full_english,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned/bar)
+"ms" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "mD" = (
-/obj/structure/closet/crate/trashcart/laundry,
-/turf/open/floor/iron/smooth,
+/obj/structure/bed/dogbed,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
 "mG" = (
 /obj/effect/decal/cleanable/food/salt,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
+"mM" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/under/misc/pj/blue,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned/cargo)
 "mW" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -242,18 +328,31 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
+"nq" = (
+/mob/living/basic/cockroach,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/food/plant_smudge,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/cargo)
 "nt" = (
 /mob/living/simple_animal/pet/cat/space,
-/turf/open/floor/iron/smooth,
+/obj/structure/cable,
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
-"oW" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/engine,
+"oe" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
+"oD" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/cargo)
 "pp" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "pA" = (
@@ -261,7 +360,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/shuttle/abandoned/medbay)
 "pG" = (
 /obj/machinery/light/directional/north,
@@ -270,45 +372,66 @@
 "pY" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light/directional/east,
+/obj/item/bodypart/leg/right/digitigrade,
+/obj/item/bodypart/leg/left/digitigrade,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
+"qe" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "qs" = (
 /obj/structure/bed{
 	dir = 8
 	},
-/obj/item/bedsheet/cosmos{
+/obj/item/toy/plush/nukeplushie,
+/obj/item/bedsheet/random{
 	dir = 8
 	},
-/obj/item/toy/plush/nukeplushie,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
 "qw" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/silver,
-/obj/item/storage/backpack/chemistry,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "qx" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
+"qB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/curtain/bounty,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned/crew)
+"rb" = (
+/mob/living/simple_animal/hostile/pirate/ranged/space,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "rn" = (
 /obj/effect/decal/cleanable/ants,
+/mob/living/basic/cockroach,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "rJ" = (
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "rU" = (
-/obj/machinery/light/floor,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
 "sh" = (
 /obj/machinery/chem_master,
 /obj/machinery/light/floor,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "sA" = (
@@ -325,21 +448,25 @@
 /obj/effect/turf_decal{
 	dir = 1
 	},
+/obj/structure/table/reinforced,
+/obj/structure/desk_bell,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
+"tL" = (
+/obj/structure/cable,
+/obj/structure/closet/crate/secure/loot,
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/effect/decal/cleanable/greenglow/filled,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/cargo)
 "uj" = (
 /obj/machinery/power/shuttle_engine/large,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
 "uA" = (
-/obj/machinery/vending/cola/sodie,
-/turf/open/floor/iron/smooth,
+/obj/structure/closet/crate/trashcart/laundry,
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/cargo)
-"uY" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/crew)
 "vb" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
@@ -353,12 +480,17 @@
 "wk" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"wt" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "wO" = (
 /obj/machinery/vending/hydronutrients,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
 "wV" = (
 /obj/item/seeds/cannabis,
@@ -366,14 +498,30 @@
 /obj/structure/table/reinforced,
 /obj/item/seeds/cannabis/rainbow,
 /obj/item/reagent_containers/cup/bucket,
-/turf/open/floor/iron/smooth,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/cargo)
+"xi" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/food/plant_smudge,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
 "xr" = (
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
 "xz" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower/directional/north,
+/obj/effect/turf_decal{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"xJ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "xL" = (
 /obj/effect/turf_decal/bot_white,
@@ -405,12 +553,13 @@
 /obj/structure/closet/crate/bin,
 /obj/item/reagent_containers/hypospray/medipen/pumpup,
 /obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"zj" = (
-/obj/structure/window/reinforced/shuttle,
-/turf/open/space/basic,
-/area/shuttle/abandoned/medbay)
+"zg" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/cargo)
 "zw" = (
 /obj/effect/turf_decal{
 	dir = 1
@@ -418,7 +567,8 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/sunglasses/chemical,
 /obj/item/clothing/glasses/sunglasses/chemical,
-/obj/structure/desk_bell,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "zx" = (
@@ -453,6 +603,11 @@
 /obj/item/stack/ore/bluespace_crystal/artificial,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"Aq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "AN" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
@@ -461,6 +616,11 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"AS" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned/crew)
 "Br" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
@@ -470,10 +630,28 @@
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "Ca" = (
 /turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/medbay)
+"Cb" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/stack/ore/bluespace_crystal/artificial,
+/obj/item/food/monkeycube,
+/mob/living/basic/cockroach,
+/obj/item/food/grown/grapes,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/cargo)
+"Cr" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "CC" = (
 /obj/machinery/airalarm/all_access{
@@ -483,7 +661,10 @@
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Di" = (
-/turf/open/floor/iron/smooth,
+/obj/machinery/light/directional/north,
+/obj/effect/spawner/random/clothing/lizardboots,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
 "DA" = (
 /obj/structure/closet/emcloset/anchored,
@@ -497,18 +678,15 @@
 /area/shuttle/abandoned/bar)
 "Es" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/shuttle/abandoned/medbay)
 "EV" = (
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/obj/item/toy/cattoy,
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
 "Fc" = (
-/obj/machinery/shower,
+/obj/item/soap/homemade,
+/obj/machinery/shower/directional/south,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
 "FD" = (
@@ -538,12 +716,26 @@
 /obj/structure/mirror,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/medbay)
+"Hp" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/end,
+/obj/effect/decal/cleanable/food/plant_smudge,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/cargo)
 "Hu" = (
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
+"HK" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/glass/flask,
+/obj/item/reagent_containers/cup/glass/flask,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/medbay)
 "HV" = (
-/obj/structure/window/reinforced/shuttle,
-/turf/open/space/basic,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "Ik" = (
 /obj/structure/table/wood,
@@ -553,8 +745,12 @@
 /area/shuttle/abandoned/cargo)
 "Iw" = (
 /obj/structure/toilet,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
+"Ix" = (
+/turf/open/floor/iron,
+/area/shuttle/abandoned/cargo)
 "Jl" = (
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
@@ -588,11 +784,26 @@
 "La" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/end{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
 "LP" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/cargo)
+"LY" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/gold,
+/obj/item/stack/sheet/mineral/silver,
+/obj/item/storage/backpack/chemistry,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/turf_decal{
+	dir = 10
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "Mi" = (
 /obj/structure/bed{
 	dir = 8
@@ -600,28 +811,45 @@
 /obj/item/bedsheet/random{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/obj/item/food/cheesiehonkers,
+/obj/effect/turf_decal/tile/dark,
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
+"Mp" = (
+/obj/structure/cable,
+/obj/effect/turf_decal{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"MM" = (
+/obj/structure/sign/poster/official/safety_eye_protection,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/medbay)
 "MP" = (
 /mob/living/simple_animal/hostile/pirate/melee/space,
 /obj/effect/turf_decal{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/medbay)
 "Nv" = (
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/food/plant_smudge,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
 "Oe" = (
 /obj/machinery/power/shuttle_engine/propulsion/burst,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
 "Oj" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/clothing/under/misc/pj/blue,
-/turf/open/floor/iron/smooth,
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/cosmos{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
 "Oo" = (
 /turf/template_noop,
@@ -631,15 +859,34 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
+"OC" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/random{
+	dir = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/pumpup,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned/crew)
 "OO" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron/smooth,
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/cargo)
+"OR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
 "Pc" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/end{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/food/plant_smudge,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
 "Pr" = (
 /obj/structure/table/reinforced,
@@ -652,20 +899,23 @@
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "PQ" = (
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = 24
-	},
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/bar)
 "Qo" = (
 /mob/living/simple_animal/hostile/pirate/melee/space,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
+"Rf" = (
+/obj/item/cigbutt/roach,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/crew)
 "Rg" = (
-/obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Rq" = (
@@ -677,8 +927,18 @@
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/tarot,
 /obj/item/storage/box/donkpockets/donkpocketberry,
+/obj/item/toy/cards/deck,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
+"RI" = (
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/item/cigbutt/roach,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/medbay)
 "RJ" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/machinery/plumbing/reaction_chamber/chem,
@@ -687,13 +947,16 @@
 /area/shuttle/abandoned/medbay)
 "Sg" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/shuttle/abandoned/bar)
 "Sh" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"Sk" = (
+/turf/template_noop,
+/area/shuttle/abandoned/cargo)
 "Sm" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sink,
@@ -723,11 +986,18 @@
 /obj/machinery/plumbing/tank,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"Tf" = (
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "TD" = (
 /obj/effect/turf_decal{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/medbay)
 "TF" = (
 /obj/structure/table/reinforced,
@@ -742,29 +1012,41 @@
 /obj/effect/turf_decal{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/medbay)
 "Uo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
 /obj/item/paper/fluff/stations/soap,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "UI" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "UV" = (
 /obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Vl" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
+"Vm" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "Vw" = (
-/obj/structure/window/reinforced/shuttle,
-/turf/open/floor/engine,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/abandoned/medbay)
 "Vx" = (
 /obj/machinery/door/airlock/engineering{
@@ -774,10 +1056,15 @@
 /turf/open/floor/engine,
 /area/shuttle/abandoned/crew)
 "VD" = (
-/obj/machinery/light/floor,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
+"Wb" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "Wq" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -788,7 +1075,7 @@
 /area/shuttle/abandoned/medbay)
 "WR" = (
 /obj/structure/window/reinforced/shuttle,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/plating,
 /area/shuttle/abandoned/bar)
 "WT" = (
 /obj/item/wheelchair,
@@ -800,11 +1087,15 @@
 	pixel_x = -24
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
 "Xw" = (
 /obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/iron/smooth,
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
 "YV" = (
 /obj/structure/table/reinforced,
@@ -819,7 +1110,7 @@
 "Zh" = (
 /obj/machinery/door/airlock/titanium/glass,
 /obj/structure/cable,
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/shuttle/abandoned/medbay)
 "Zn" = (
 /obj/effect/turf_decal{
@@ -832,6 +1123,9 @@
 /obj/structure/sign/warning/chem_diamond{
 	pixel_y = 32
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/fire,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Zy" = (
@@ -843,7 +1137,7 @@
 /area/shuttle/abandoned/cargo)
 "ZB" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
 
 (1,1,1) = {"
@@ -890,10 +1184,10 @@ Oo
 jV
 SG
 La
-La
-KC
+Hp
+aR
 Pc
-La
+bY
 Xg
 Xw
 jV
@@ -917,12 +1211,12 @@ Oo
 jV
 LP
 wO
-Hu
-Hu
-KC
-Hu
-Hu
-Hu
+oD
+Ix
+VD
+nq
+Ix
+Ix
 Xw
 jV
 Oo
@@ -943,12 +1237,12 @@ Oo
 Oo
 jV
 LP
-KC
+tL
 Nv
-Nv
-Nv
+Ix
+OR
 VD
-Hu
+Ix
 OO
 LP
 jV
@@ -971,11 +1265,11 @@ Oo
 jV
 LP
 bF
-KC
-Ga
-Hu
+zg
+OR
+Cb
 kL
-KC
+xi
 wV
 LP
 jV
@@ -1001,9 +1295,9 @@ jr
 MP
 pA
 TD
-sO
+HK
 TZ
-pA
+RI
 gw
 Ca
 Oo
@@ -1026,16 +1320,16 @@ fk
 KJ
 KJ
 KJ
-oW
-Zh
-oW
+Es
+qe
+Es
 KJ
-cC
-fh
+Es
+Vm
 Es
 Ca
 Oe
-xr
+Sk
 Oo
 Oo
 Oo
@@ -1055,7 +1349,7 @@ Ca
 is
 rJ
 rJ
-ct
+iX
 rJ
 Ca
 UV
@@ -1080,14 +1374,14 @@ fk
 DB
 rn
 Ca
-rJ
+Tf
 rJ
 rJ
 Rg
-rJ
+aN
 Ca
-sO
-yw
+jO
+xJ
 Uo
 Ca
 xr
@@ -1108,18 +1402,18 @@ LP
 kp
 jy
 Ca
-PQ
 rJ
 rJ
+aN
 ct
 rJ
 Ca
 sh
-yw
+oe
 qw
 Ca
 Oe
-xr
+Sk
 Oo
 Oo
 Oo
@@ -1142,9 +1436,9 @@ rJ
 ct
 rJ
 Ca
-sO
-yw
-sO
+Cr
+oe
+qw
 Ca
 Oo
 Oo
@@ -1161,16 +1455,16 @@ bL
 zx
 Sg
 vb
-kM
+PQ
 Rr
 Ca
 rJ
 Pw
 rJ
 ct
-rJ
+Aq
 Ca
-cC
+Es
 fh
 Es
 Ca
@@ -1190,16 +1484,16 @@ em
 Sg
 qx
 kM
-UI
+lx
 Ca
 pG
 JK
 YX
 ct
 rJ
-KJ
-sO
-yw
+MM
+LY
+Mp
 xz
 Ca
 mY
@@ -1219,16 +1513,16 @@ Sg
 fk
 Rq
 fk
-zj
+Vw
 rJ
 JK
 rJ
 RJ
-rJ
-oW
+aN
+Es
 zw
 Qo
-sO
+eX
 Ca
 pp
 Hu
@@ -1248,17 +1542,17 @@ gY
 gY
 ym
 Zh
-ct
+ms
 AN
-ct
+ms
 Sh
 ct
 JB
 Zn
 yw
-yw
+Wb
 eN
-VD
+KC
 KC
 if
 mW
@@ -1272,7 +1566,7 @@ ar
 cy
 iQ
 WR
-sA
+lY
 mG
 sA
 Vw
@@ -1281,10 +1575,10 @@ zA
 rJ
 Sh
 rJ
-oW
+Es
 tt
 yw
-sO
+eX
 Ca
 BZ
 Ga
@@ -1301,7 +1595,7 @@ bL
 ey
 WR
 Br
-gY
+gC
 pY
 Vw
 rJ
@@ -1336,9 +1630,9 @@ pG
 Gp
 rJ
 ct
-rJ
+jl
 Ca
-cC
+Es
 fh
 Es
 Ca
@@ -1361,10 +1655,10 @@ ls
 nm
 GQ
 rJ
-rJ
+aN
 rJ
 ct
-rJ
+wt
 Ca
 CC
 wk
@@ -1390,16 +1684,16 @@ yL
 FD
 TF
 rJ
-YX
+rb
 ct
 WI
 Ca
-sO
+gH
 yw
 gT
 Ca
 Oe
-xr
+Sk
 Oo
 Oo
 Oo
@@ -1422,8 +1716,8 @@ rJ
 ct
 Tb
 Ca
-sO
-yw
+kB
+Wb
 aw
 Ca
 xr
@@ -1450,9 +1744,9 @@ rJ
 ct
 xL
 Ca
-sO
-yw
-Hu
+Ca
+Zh
+jV
 Ca
 xr
 xr
@@ -1479,11 +1773,11 @@ Vl
 Jl
 jV
 uA
-VD
-Hu
+AS
+mM
 jV
 Oe
-xr
+Sk
 Oo
 Oo
 Oo
@@ -1506,9 +1800,9 @@ Gf
 Vx
 Gf
 Gf
-Gf
-uY
-Gf
+lM
+ZB
+lM
 Gf
 Oo
 Oo
@@ -1564,8 +1858,8 @@ vS
 Gf
 aE
 rU
-Di
-lY
+OC
+Gf
 ku
 Gf
 Gf
@@ -1591,10 +1885,10 @@ ku
 zU
 Gf
 Di
-ZB
+AS
 nt
-Di
-Di
+qB
+ZB
 Oj
 Gf
 Oo
@@ -1619,9 +1913,9 @@ Gf
 ku
 Gf
 qs
-ZB
+ep
 Mi
-aE
+Rf
 EV
 mD
 Gf

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -5,76 +5,58 @@
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
 "ax" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/abandoned/engine)
+"aE" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"ba" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"bF" = (
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"bL" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/engine)
+"bQ" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/crew)
+"bU" = (
 /obj/machinery/airalarm/all_access{
 	dir = 1;
 	pixel_y = 24
 	},
 /turf/open/floor/wood,
 /area/shuttle/abandoned/engine)
-"aE" = (
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
-"bp" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
-"bA" = (
-/obj/structure/fermenting_barrel,
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"bF" = (
-/obj/machinery/vending/hydroseeds,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"bL" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/engine)
-"bM" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/cell_charger,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"bQ" = (
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
+"ct" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
-"bU" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/royalblack,
-/area/shuttle/abandoned/engine)
-"ct" = (
+/area/shuttle/abandoned/medbay)
+"cy" = (
 /turf/open/floor/wood,
 /area/shuttle/abandoned/engine)
-"cy" = (
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/shuttle/abandoned/bar)
 "cL" = (
 /turf/open/floor/engine,
 /area/shuttle/abandoned/crew)
-"cX" = (
+"dz" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"dJ" = (
 /mob/living/simple_animal/hostile/pirate/melee/space,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
-"dh" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
-"dn" = (
-/obj/machinery/light/floor,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/cargo)
 "dX" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -82,49 +64,55 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
-"ed" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+"ea" = (
+/obj/structure/bed{
+	dir = 8
+	},
+/obj/item/bedsheet/cosmos{
+	dir = 8
+	},
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"ee" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/construction/rcd/loaded,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"ei" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/cell_charger,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "em" = (
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = 24
-	},
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
 "ey" = (
-/obj/structure/cable,
 /obj/machinery/airalarm/all_access{
 	dir = 1;
 	pixel_y = 24
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"eU" = (
-/obj/machinery/vending/cola/sodie,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "fk" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/bar)
-"fI" = (
-/obj/effect/turf_decal{
-	dir = 4
-	},
+"fF" = (
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
+"gu" = (
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "gw" = (
 /obj/machinery/smartfridge/drying_rack,
 /obj/effect/turf_decal{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"gO" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "gY" = (
@@ -136,21 +124,6 @@
 /obj/item/pai_card,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
-"he" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/random{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
-"hq" = (
-/obj/machinery/chem_master,
-/obj/machinery/light/floor,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "hU" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
@@ -190,6 +163,15 @@
 /obj/item/soap/homemade,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
+"jK" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
+"jN" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/crew)
 "jV" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/cargo)
@@ -199,7 +181,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
 "kq" = (
-/obj/structure/cable,
 /obj/machinery/light/floor,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -208,28 +189,27 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
 "kM" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/food/salt,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
-"lq" = (
-/obj/structure/cable,
-/obj/machinery/light/floor,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/cargo)
+"la" = (
+/obj/machinery/rnd/production/protolathe/department/medical,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"lg" = (
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "ls" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"mc" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/storage/belt/utility/full/engi,
-/obj/item/construction/rcd/loaded,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "mD" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /turf/open/floor/iron/smooth,
@@ -238,6 +218,12 @@
 /obj/effect/decal/cleanable/ants,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
+"mJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/item/paper/fluff/stations/soap,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "mW" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -256,59 +242,37 @@
 	width = 33
 	},
 /obj/structure/fans/tiny,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
+"nd" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "nm" = (
 /obj/item/razor,
 /obj/item/knife/combat/survival,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"ok" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/crew)
-"oE" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"oT" = (
-/obj/structure/bed{
-	dir = 8
-	},
-/obj/item/bedsheet/cosmos{
-	dir = 8
-	},
-/obj/item/toy/plush/nukeplushie,
+"nZ" = (
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
 "oW" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"ph" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
+"pf" = (
+/obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "pG" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"pS" = (
-/obj/structure/table/wood,
-/obj/item/storage/medkit,
-/obj/item/ammo_box/magazine/internal/boltaction/pipegun,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "pY" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light/directional/east,
@@ -318,68 +282,35 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"qz" = (
-/obj/effect/turf_decal{
-	dir = 4
-	},
+"qB" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
-"qQ" = (
-/obj/effect/turf_decal/box/white/corners,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"qU" = (
-/obj/machinery/power/smes/engineering{
-	charge = 1e+006
-	},
-/turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
 "rn" = (
-/obj/structure/cable,
-/obj/structure/cable,
 /obj/effect/turf_decal,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
-"rv" = (
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
 "rJ" = (
 /turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"rP" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "sA" = (
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
-"tf" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
-	},
-/obj/structure/cable,
+"tL" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/medbay)
 "uj" = (
 /obj/machinery/power/shuttle_engine/large,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
-"uB" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
-	},
-/obj/structure/cable,
+"uR" = (
+/obj/machinery/light/directional/south,
+/obj/structure/dresser,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"uJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/crew)
 "uY" = (
 /obj/machinery/door/airlock/titanium/glass,
 /obj/structure/cable,
@@ -390,47 +321,61 @@
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"wy" = (
+"ve" = (
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"wK" = (
+/area/shuttle/abandoned/cargo)
+"vi" = (
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = 24
+	},
 /obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"vj" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/under/misc/pj/blue,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"vK" = (
 /obj/effect/turf_decal/bot_white,
-/obj/machinery/plumbing/pill_press,
+/obj/machinery/plumbing/tank,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"vT" = (
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"we" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "wO" = (
 /obj/machinery/vending/hydronutrients,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"wU" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
-"xc" = (
-/obj/item/seeds/cannabis,
-/obj/item/seeds/amanita,
-/obj/structure/table/reinforced,
-/obj/item/seeds/cannabis/rainbow,
-/obj/item/reagent_containers/cup/bucket,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "xr" = (
 /turf/open/floor/plating/airless,
-/area/shuttle/abandoned/cargo)
-"xE" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "xM" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/medbay)
+"xZ" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "ym" = (
 /obj/structure/window/reinforced/shuttle,
 /turf/open/space/basic,
@@ -466,9 +411,13 @@
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/box/white,
+/obj/structure/cable,
 /turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Ah" = (
+/obj/machinery/chem_heater,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Aj" = (
 /obj/item/storage/box/syringes/variety,
@@ -480,24 +429,26 @@
 /obj/item/stack/ore/bluespace_crystal/artificial,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"Al" = (
-/mob/living/simple_animal/pet/cat/space,
+"Ao" = (
+/obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
+/area/shuttle/abandoned/medbay)
+"Aq" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"Ay" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "AN" = (
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"Bh" = (
-/obj/structure/fermenting_barrel,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"Bl" = (
-/obj/machinery/power/shuttle_engine/propulsion/burst,
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned/cargo)
 "Br" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
@@ -506,37 +457,26 @@
 "Ca" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/medbay)
-"Cj" = (
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "CC" = (
-/obj/structure/cable,
 /obj/machinery/airalarm/all_access{
 	dir = 1;
 	pixel_y = 24
 	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
-"CE" = (
-/obj/machinery/rnd/production/protolathe/department/medical,
-/obj/structure/cable,
+"Dl" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/plumbing/pill_press,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Dv" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/gold,
+/obj/item/stack/sheet/mineral/silver,
+/obj/item/storage/backpack/chemistry,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
-"CF" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
-"Dx" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/cargo)
 "DB" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/bar)
@@ -544,9 +484,22 @@
 /obj/machinery/shower,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
+"Fs" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "FD" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/shuttle/abandoned/medbay)
+"FZ" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "Gf" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/crew)
@@ -561,33 +514,18 @@
 /area/shuttle/abandoned/bar)
 "Gp" = (
 /mob/living/simple_animal/hostile/pirate/melee/space,
-/obj/structure/cable,
 /obj/effect/turf_decal{
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
-"Gu" = (
-/obj/structure/cable,
-/obj/effect/turf_decal{
-	dir = 1
+"Gq" = (
+/obj/machinery/power/smes/engineering{
+	charge = 1e+006
 	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/sunglasses/chemical,
-/obj/item/clothing/glasses/sunglasses/chemical,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"Gv" = (
-/obj/structure/table/wood,
-/obj/item/gun/ballistic/rifle/boltaction/pipegun,
-/obj/effect/turf_decal/box/white/corners,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"Gw" = (
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/crew)
 "GQ" = (
 /obj/structure/mirror,
 /turf/closed/wall/mineral/titanium,
@@ -595,18 +533,27 @@
 "Hu" = (
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
+"HJ" = (
+/obj/structure/table/wood,
+/obj/item/storage/medkit,
+/obj/item/ammo_box/magazine/internal/boltaction/pipegun,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "HV" = (
 /obj/structure/window/reinforced/shuttle,
 /turf/open/space/basic,
 /area/shuttle/abandoned/engine)
-"HZ" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "Iw" = (
 /obj/structure/toilet,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
+"IW" = (
+/obj/machinery/vending/cola/sodie,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "Jl" = (
 /obj/machinery/computer/monitor{
 	dir = 8
@@ -617,23 +564,12 @@
 "JD" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/shuttle/abandoned/bar)
-"JI" = (
-/obj/structure/cable,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/crew)
 "JK" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"JS" = (
-/obj/structure/cable,
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "KC" = (
 /obj/structure/cable,
@@ -642,30 +578,20 @@
 "KJ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/medbay)
-"KM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
-/obj/item/paper/fluff/stations/soap,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "La" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"Lf" = (
-/obj/machinery/light/directional/south,
-/obj/structure/dresser,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
-"LH" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/clothing/under/misc/pj/blue,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
 "LP" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/cargo)
+"LR" = (
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "Mi" = (
 /obj/structure/bed{
@@ -674,33 +600,44 @@
 /obj/item/bedsheet/random{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
 "MP" = (
-/obj/structure/cable,
 /obj/effect/turf_decal{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Nv" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"NN" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"NJ" = (
+/obj/machinery/light/floor,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/crew)
-"Og" = (
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = 24
-	},
+"NZ" = (
+/obj/structure/table/wood,
+/obj/item/gun/ballistic/rifle/boltaction/pipegun,
+/obj/effect/turf_decal/box/white/corners,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
+/area/shuttle/abandoned/cargo)
+"Oa" = (
+/obj/item/seeds/cannabis,
+/obj/item/seeds/amanita,
+/obj/structure/table/reinforced,
+/obj/item/seeds/cannabis/rainbow,
+/obj/item/reagent_containers/cup/bucket,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "Oj" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/machinery/plumbing/reaction_chamber/chem,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Oo" = (
@@ -708,13 +645,18 @@
 /area/template_noop)
 "Ov" = (
 /obj/machinery/computer/shuttle,
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
-"OD" = (
-/obj/structure/cable,
+"Ox" = (
+/obj/machinery/chem_master,
 /obj/machinery/light/floor,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/crew)
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"OH" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "Pb" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
@@ -723,9 +665,17 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
+"Pm" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/sunglasses/chemical,
+/obj/item/clothing/glasses/sunglasses/chemical,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "Pr" = (
 /obj/structure/table/reinforced,
 /obj/item/pipe_dispenser,
@@ -736,18 +686,6 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"PL" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"PO" = (
-/obj/machinery/chem_dispenser/fullupgrade,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "PQ" = (
 /obj/machinery/airalarm/all_access{
 	dir = 1;
@@ -755,21 +693,13 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"Qn" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"QF" = (
-/obj/machinery/chem_heater,
-/obj/structure/cable,
+"Ql" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "Rg" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/bot_white/left,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Rq" = (
@@ -786,31 +716,27 @@
 "RJ" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"RT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "Sg" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "Sh" = (
-/obj/effect/turf_decal/bot_white/left,
+/obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/crew)
 "Sm" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sink,
+/obj/structure/cable,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"SB" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/silver,
-/obj/item/storage/backpack/chemistry,
-/turf/open/floor/iron/smooth,
+"Sv" = (
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "SK" = (
 /obj/machinery/door/airlock/titanium,
@@ -825,21 +751,17 @@
 /obj/item/stack/ducts/fifty,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"Uf" = (
+/obj/structure/fermenting_barrel,
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "UI" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"UL" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
-"UW" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "Vl" = (
 /obj/structure/sign/poster/contraband/smoke,
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -852,30 +774,24 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/crew)
-"Vy" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/plumbing/tank,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
 "VD" = (
 /obj/machinery/light/floor,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
-"Wq" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"Wy" = (
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = -24
+"Wb" = (
+/obj/structure/bed{
+	dir = 4
 	},
+/obj/item/bedsheet/random{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"Wq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
@@ -886,9 +802,20 @@
 "WT" = (
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
+"WW" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "Xw" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
+"Yn" = (
+/obj/machinery/power/shuttle_engine/propulsion/burst,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
 "YX" = (
 /mob/living/simple_animal/hostile/pirate/ranged/space,
@@ -900,21 +827,24 @@
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Zn" = (
-/obj/structure/cable,
-/obj/structure/cable,
 /obj/effect/turf_decal{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "Zq" = (
-/obj/structure/cable,
 /obj/structure/sign/warning/chem_diamond{
 	pixel_y = 32
 	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
+"Zy" = (
+/mob/living/simple_animal/pet/cat/space,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
 "ZB" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/crew)
 
@@ -966,7 +896,7 @@ La
 KC
 Pc
 La
-Wy
+ve
 Xw
 jV
 Oo
@@ -992,7 +922,7 @@ wO
 Hu
 Hu
 KC
-Pb
+Hu
 Hu
 Hu
 Xw
@@ -1015,13 +945,13 @@ Oo
 Oo
 jV
 LP
-Hu
-Hu
-Hu
-Hu
-dn
 Pb
-xE
+Hu
+Hu
+Hu
+VD
+Hu
+OH
 LP
 jV
 jV
@@ -1045,10 +975,10 @@ LP
 bF
 Pb
 Wq
-Pb
-Bh
-Dx
-xc
+Hu
+pf
+KC
+Oa
 LP
 jV
 Oo
@@ -1072,10 +1002,10 @@ KJ
 jr
 Gp
 MP
-fI
-wy
-bA
-qz
+lg
+fF
+Uf
+Sv
 gw
 Ca
 Oo
@@ -1102,11 +1032,11 @@ oW
 Zh
 oW
 Ca
-gO
-ph
-bp
+Ql
+ba
+jK
 Ca
-Bl
+Yn
 xr
 Oo
 Oo
@@ -1127,12 +1057,12 @@ Ca
 is
 rJ
 rJ
-RJ
-RJ
+ct
+rJ
 Ca
-QF
+Ah
 kq
-PO
+Ao
 Ca
 xr
 uj
@@ -1156,11 +1086,11 @@ rJ
 rJ
 rJ
 Nv
-RJ
+rJ
 Ca
-HZ
-dh
-KM
+fF
+yw
+mJ
 Ca
 xr
 xr
@@ -1177,20 +1107,20 @@ Oo
 Oo
 fk
 LP
-em
+ey
 jy
 Ca
 PQ
 rJ
 rJ
+ct
 rJ
-RJ
 Ca
-hq
+Ox
 yw
-SB
+Dv
 Ca
-Bl
+Yn
 xr
 Oo
 Oo
@@ -1211,12 +1141,12 @@ xM
 rJ
 zj
 rJ
+ct
 rJ
-RJ
 Ca
-HZ
-dh
-wy
+fF
+yw
+fF
 Ca
 Oo
 Oo
@@ -1239,12 +1169,12 @@ Ca
 rJ
 Pw
 rJ
+ct
 rJ
-RJ
 Ca
-gO
-rP
-bp
+Ql
+ba
+jK
 Ca
 jV
 jV
@@ -1258,7 +1188,7 @@ Oo
 bL
 bL
 bL
-ax
+bU
 Sg
 qx
 gY
@@ -1267,16 +1197,16 @@ Ca
 pG
 JK
 YX
+ct
 rJ
-RJ
 Ca
-HZ
+fF
 yw
-uJ
+tL
 Ca
-oE
+WW
 Hu
-pS
+HJ
 jV
 Oo
 Oo
@@ -1285,7 +1215,7 @@ Oo
 (14,1,1) = {"
 HV
 hd
-yN
+ax
 yN
 Sg
 fk
@@ -1296,15 +1226,15 @@ rJ
 JK
 rJ
 Oj
-RJ
+rJ
 oW
-Gu
-cX
-wy
+Pm
+dJ
+fF
 Ca
-Qn
+Aq
 Hu
-qQ
+gu
 jV
 Oo
 Oo
@@ -1314,22 +1244,22 @@ Oo
 HV
 Ov
 dX
-bU
+ax
 SK
-cy
+em
 kp
 rn
 Zh
-RJ
+ct
 zA
-RJ
+ct
 Rg
-Gw
-PL
+ct
+Ay
 Zn
 yw
 yw
-ed
+dz
 VD
 KC
 if
@@ -1341,7 +1271,7 @@ Oo
 (16,1,1) = {"
 HV
 ar
-yN
+ax
 iQ
 WR
 sA
@@ -1351,16 +1281,16 @@ Vw
 rJ
 zj
 rJ
-Sh
-Gw
+Rg
+rJ
 oW
-JS
+Fs
 yw
-wy
+fF
 Ca
-uB
-RT
-UW
+xZ
+Wq
+we
 jV
 Oo
 Oo
@@ -1370,25 +1300,25 @@ Oo
 bL
 bL
 bL
-ct
+cy
 WR
 Br
-cy
+em
 pY
 Vw
 rJ
 AN
 rJ
-Sh
-RJ
+Rg
+rJ
 Ca
 Zq
-wU
-wy
+nd
+fF
 Ca
-tf
-Cj
-Gv
+FZ
+LR
+NZ
 jV
 Oo
 Oo
@@ -1407,12 +1337,12 @@ FD
 pG
 AN
 rJ
+ct
 rJ
-RJ
 Ca
-gO
-ph
-bp
+Ql
+ba
+jK
 Ca
 jV
 jV
@@ -1435,12 +1365,12 @@ GQ
 rJ
 rJ
 rJ
+ct
 rJ
-RJ
 Ca
 CC
-UL
-bM
+qB
+ei
 Ca
 Oo
 Oo
@@ -1463,14 +1393,14 @@ FD
 TF
 rJ
 YX
-rJ
-Rg
+ct
+vT
 Ca
-HZ
+fF
 yw
-mc
+ee
 Ca
-Bl
+Yn
 xr
 Oo
 Oo
@@ -1491,12 +1421,12 @@ FD
 Pr
 rJ
 rJ
-rJ
-Vy
+ct
+vK
 Ca
-HZ
+fF
 yw
-CE
+la
 Ca
 xr
 uj
@@ -1519,11 +1449,11 @@ FD
 Aj
 rJ
 rJ
-rJ
-wK
+ct
+Dl
 Ca
-HZ
-dh
+fF
+yw
 Hu
 Ca
 xr
@@ -1547,14 +1477,14 @@ LP
 WT
 WT
 WT
+RJ
 WT
-rv
 jV
-eU
-lq
+IW
+VD
 Hu
 jV
-Bl
+Yn
 xr
 Oo
 Oo
@@ -1576,7 +1506,7 @@ LP
 Gf
 Gf
 Vx
-JI
+Gf
 Gf
 Gf
 uY
@@ -1603,12 +1533,12 @@ Oo
 jV
 ku
 cL
+Sh
 cL
-NN
 Gf
-he
-ok
-he
+Wb
+ZB
+Wb
 LP
 Gf
 Oo
@@ -1632,12 +1562,12 @@ Oo
 Gf
 Jl
 bQ
-CF
+jN
 Gf
 aE
-OD
-aE
-Lf
+NJ
+nZ
+uR
 ku
 Gf
 Gf
@@ -1660,13 +1590,13 @@ Oo
 Oo
 Gf
 ku
-qU
+Gq
 Gf
-aE
+nZ
 ZB
-Al
-aE
-LH
+Zy
+nZ
+vj
 Gf
 Gf
 Oo
@@ -1690,11 +1620,11 @@ Oo
 Gf
 ku
 Gf
-oT
+ea
 ZB
 Mi
 aE
-Og
+vi
 mD
 Gf
 Oo

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -12,10 +12,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
-"ba" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+"aG" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/construction/rcd/loaded,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "bF" = (
 /obj/machinery/vending/hydroseeds,
@@ -47,15 +48,24 @@
 "cL" = (
 /turf/open/floor/engine,
 /area/shuttle/abandoned/crew)
-"dz" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
+"di" = (
+/mob/living/simple_animal/pet/cat/space,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
 "dJ" = (
-/mob/living/simple_animal/hostile/pirate/melee/space,
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/sunglasses/chemical,
+/obj/item/clothing/glasses/sunglasses/chemical,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"dO" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/decal/cleanable/blood/footprints,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "dX" = (
 /obj/structure/chair/comfy/shuttle{
@@ -64,28 +74,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
-"ea" = (
-/obj/structure/bed{
-	dir = 8
-	},
-/obj/item/bedsheet/cosmos{
-	dir = 8
-	},
-/obj/item/toy/plush/nukeplushie,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
-"ee" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/storage/belt/utility/full/engi,
-/obj/item/construction/rcd/loaded,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"ei" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/cell_charger,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "em" = (
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
@@ -98,16 +86,24 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
+"eR" = (
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "fk" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/bar)
-"fF" = (
+"ft" = (
+/obj/machinery/power/shuttle_engine/propulsion/burst,
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned/cargo)
+"gg" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
-"gu" = (
-/obj/effect/turf_decal/box/white/corners,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "gw" = (
 /obj/machinery/smartfridge/drying_rack,
 /obj/effect/turf_decal{
@@ -124,6 +120,14 @@
 /obj/item/pai_card,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
+"hg" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/gold,
+/obj/item/stack/sheet/mineral/silver,
+/obj/item/storage/backpack/chemistry,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "hU" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
@@ -136,6 +140,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
+"ik" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/plumbing/tank,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "is" = (
 /obj/item/plunger,
 /obj/item/clothing/glasses/science,
@@ -163,20 +172,21 @@
 /obj/item/soap/homemade,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"jK" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
-"jN" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
+"jT" = (
+/obj/structure/table/wood,
+/obj/item/gun/ballistic/rifle/boltaction/pipegun,
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "jV" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/cargo)
+"kh" = (
+/obj/machinery/vending/cola/sodie,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "kp" = (
-/obj/structure/cable,
+/obj/effect/decal/cleanable/food/salt,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
@@ -189,20 +199,9 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
 "kM" = (
-/obj/effect/decal/cleanable/food/salt,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/decal/cleanable/ants,
+/turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"la" = (
-/obj/machinery/rnd/production/protolathe/department/medical,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"lg" = (
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "ls" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 1
@@ -210,20 +209,28 @@
 /obj/structure/cable,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
+"lR" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "mD" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
 "mG" = (
-/obj/effect/decal/cleanable/ants,
-/turf/open/floor/wood,
+/obj/effect/turf_decal,
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
-"mJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
-/obj/item/paper/fluff/stations/soap,
+"mM" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/cargo)
 "mW" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -244,31 +251,21 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
-"nd" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
 "nm" = (
 /obj/item/razor,
 /obj/item/knife/combat/survival,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"nZ" = (
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
 "oW" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"pf" = (
-/obj/structure/fermenting_barrel,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
+"pE" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "pG" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
@@ -282,35 +279,54 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"qB" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
+"rn" = (
+/obj/structure/window/reinforced/shuttle,
+/turf/open/space/basic,
+/area/shuttle/abandoned/medbay)
+"rG" = (
+/obj/effect/turf_decal{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
-"rn" = (
-/obj/effect/turf_decal,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/shuttle/abandoned/bar)
 "rJ" = (
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
+"rL" = (
+/obj/structure/table/wood,
+/obj/item/storage/medkit,
+/obj/item/ammo_box/magazine/internal/boltaction/pipegun,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "sA" = (
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/bar)
-"tL" = (
-/obj/effect/decal/cleanable/dirt,
+"sL" = (
+/obj/structure/fermenting_barrel,
+/obj/effect/turf_decal{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"tU" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "uj" = (
 /obj/machinery/power/shuttle_engine/large,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
-"uR" = (
-/obj/machinery/light/directional/south,
-/obj/structure/dresser,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
+"uV" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "uY" = (
 /obj/machinery/door/airlock/titanium/glass,
 /obj/structure/cable,
@@ -321,43 +337,15 @@
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
-"ve" = (
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = -24
-	},
+"vC" = (
+/obj/structure/fermenting_barrel,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"vi" = (
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/cable,
+"vE" = (
+/obj/machinery/chem_heater,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
-"vj" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/clothing/under/misc/pj/blue,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
-"vK" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/plumbing/tank,
-/turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"vT" = (
-/obj/effect/turf_decal/bot_white/left,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"we" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "wO" = (
 /obj/machinery/vending/hydronutrients,
 /obj/machinery/light/directional/north,
@@ -366,19 +354,31 @@
 "xr" = (
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
-"xM" = (
-/obj/structure/sign/poster/contraband/lusty_xenomorph,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/medbay)
-"xZ" = (
+"xF" = (
+/obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
+"xM" = (
+/obj/structure/sign/poster/contraband/lusty_xenomorph,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/medbay)
+"yj" = (
+/obj/structure/bed{
+	dir = 8
+	},
+/obj/item/bedsheet/cosmos{
+	dir = 8
+	},
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
 "ym" = (
-/obj/structure/window/reinforced/shuttle,
-/turf/open/space/basic,
+/obj/effect/turf_decal/box/white,
+/obj/machinery/plumbing/synthesizer,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "yw" = (
 /obj/structure/cable,
@@ -399,15 +399,6 @@
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "zj" = (
-/obj/effect/turf_decal/box/white,
-/obj/machinery/plumbing/synthesizer,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"zx" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
-/area/shuttle/abandoned/engine)
-"zA" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
@@ -415,9 +406,24 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"Ah" = (
-/obj/machinery/chem_heater,
+"zx" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/shuttle/abandoned/engine)
+"zA" = (
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"zE" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"zN" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "Aj" = (
 /obj/item/storage/box/syringes/variety,
@@ -429,26 +435,32 @@
 /obj/item/stack/ore/bluespace_crystal/artificial,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"Ao" = (
-/obj/machinery/chem_dispenser/fullupgrade,
+"Ak" = (
+/obj/item/seeds/cannabis,
+/obj/item/seeds/amanita,
+/obj/structure/table/reinforced,
+/obj/item/seeds/cannabis/rainbow,
+/obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"Aq" = (
-/obj/effect/turf_decal/box/white/corners{
+/area/shuttle/abandoned/cargo)
+"AN" = (
+/mob/living/simple_animal/hostile/pirate/melee/space,
+/obj/effect/turf_decal{
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"Ay" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/decal/cleanable/blood/footprints,
+/area/shuttle/abandoned/medbay)
+"AU" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"AX" = (
+/obj/machinery/power/smes/engineering{
+	charge = 1e+006
+	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"AN" = (
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/crew)
 "Br" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
@@ -457,6 +469,11 @@
 "Ca" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/medbay)
+"Cu" = (
+/obj/machinery/light/directional/south,
+/obj/structure/dresser,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
 "CC" = (
 /obj/machinery/airalarm/all_access{
 	dir = 1;
@@ -464,17 +481,9 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
-"Dl" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/plumbing/pill_press,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
-"Dv" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/silver,
-/obj/item/storage/backpack/chemistry,
+"De" = (
+/obj/machinery/chem_master,
+/obj/machinery/light/floor,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "DB" = (
@@ -484,17 +493,16 @@
 /obj/machinery/shower,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"Fs" = (
+"FD" = (
+/turf/closed/wall/mineral/titanium/interior,
+/area/shuttle/abandoned/medbay)
+"FV" = (
 /obj/effect/turf_decal{
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
-"FD" = (
-/turf/closed/wall/mineral/titanium/interior,
-/area/shuttle/abandoned/medbay)
 "FZ" = (
-/obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
 	},
@@ -513,15 +521,8 @@
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
 "Gp" = (
-/mob/living/simple_animal/hostile/pirate/melee/space,
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"Gq" = (
-/obj/machinery/power/smes/engineering{
-	charge = 1e+006
+/obj/machinery/computer/monitor{
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -533,15 +534,14 @@
 "Hu" = (
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"HJ" = (
-/obj/structure/table/wood,
-/obj/item/storage/medkit,
-/obj/item/ammo_box/magazine/internal/boltaction/pipegun,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
+"HL" = (
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = 24
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/crew)
 "HV" = (
 /obj/structure/window/reinforced/shuttle,
 /turf/open/space/basic,
@@ -550,17 +550,18 @@
 /obj/structure/toilet,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"IW" = (
-/obj/machinery/vending/cola/sodie,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
+"IB" = (
+/mob/living/simple_animal/hostile/pirate/melee/space,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "Jl" = (
-/obj/machinery/computer/monitor{
-	dir = 8
+/obj/effect/turf_decal{
+	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "JD" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/shuttle/abandoned/bar)
@@ -570,6 +571,9 @@
 	},
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"JR" = (
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
 "KC" = (
 /obj/structure/cable,
@@ -583,15 +587,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
+"LL" = (
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
 "LP" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/cargo)
-"LR" = (
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
 "Mi" = (
 /obj/structure/bed{
@@ -604,59 +605,55 @@
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
 "MP" = (
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"Nv" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"NJ" = (
-/obj/machinery/light/floor,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/crew)
-"NZ" = (
-/obj/structure/table/wood,
-/obj/item/gun/ballistic/rifle/boltaction/pipegun,
+"Nj" = (
 /obj/effect/turf_decal/box/white/corners,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"Oa" = (
-/obj/item/seeds/cannabis,
-/obj/item/seeds/amanita,
-/obj/structure/table/reinforced,
-/obj/item/seeds/cannabis/rainbow,
-/obj/item/reagent_containers/cup/bucket,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
-"Oj" = (
+"Nv" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/machinery/plumbing/reaction_chamber/chem,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/medbay)
+"Nw" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/under/misc/pj/blue,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"Oj" = (
+/obj/effect/turf_decal/bot_white/left,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Oo" = (
 /turf/template_noop,
 /area/template_noop)
+"Oq" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/cargo)
 "Ov" = (
 /obj/machinery/computer/shuttle,
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/engine)
-"Ox" = (
-/obj/machinery/chem_master,
-/obj/machinery/light/floor,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
-"OH" = (
-/obj/machinery/light/directional/south,
+"ON" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
+"OZ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/item/paper/fluff/stations/soap,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "Pb" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
@@ -667,14 +664,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"Pm" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/sunglasses/chemical,
-/obj/item/clothing/glasses/sunglasses/chemical,
-/turf/open/floor/iron/smooth,
+"Pi" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/plumbing/pill_press,
+/turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
 "Pr" = (
 /obj/structure/table/reinforced,
@@ -693,15 +686,10 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"Ql" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
 "Rg" = (
-/obj/effect/turf_decal/bot_white/left,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/cargo)
 "Rq" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
@@ -716,33 +704,42 @@
 "RJ" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/crew)
+"RO" = (
+/obj/machinery/rnd/production/protolathe/department/medical,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
 "Sg" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "Sh" = (
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/crew)
+/obj/structure/sign/poster/contraband/smoke,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/cargo)
 "Sm" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sink,
 /obj/structure/cable,
 /turf/open/floor/oldshuttle,
 /area/shuttle/abandoned/bar)
-"Sv" = (
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/medbay)
 "SK" = (
 /obj/machinery/door/airlock/titanium,
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/abandoned/bar)
+"Td" = (
+/obj/machinery/chem_dispenser/fullupgrade,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/medbay)
+"To" = (
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned/crew)
+"TE" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/medbay)
 "TF" = (
 /obj/structure/table/reinforced,
 /obj/item/construction/plumbing,
@@ -751,21 +748,27 @@
 /obj/item/stack/ducts/fifty,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/medbay)
-"Uf" = (
-/obj/structure/fermenting_barrel,
-/obj/effect/turf_decal{
-	dir = 4
+"TS" = (
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = -24
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/cargo)
 "UI" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/bar)
 "Vl" = (
-/obj/structure/sign/poster/contraband/smoke,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
+"Vp" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/crew)
 "Vw" = (
 /obj/structure/window/reinforced/shuttle,
 /turf/open/floor/engine,
@@ -782,19 +785,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
-"Wb" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/random{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
 "Wq" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/medbay)
 "WR" = (
 /obj/structure/window/reinforced/shuttle,
 /turf/open/floor/iron/cafeteria,
@@ -802,21 +798,15 @@
 "WT" = (
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
-"WW" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/cargo)
 "Xw" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/cargo)
-"Yn" = (
-/obj/machinery/power/shuttle_engine/propulsion/burst,
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned/cargo)
+"YJ" = (
+/obj/machinery/light/floor,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/crew)
 "YX" = (
 /mob/living/simple_animal/hostile/pirate/ranged/space,
 /turf/open/floor/engine,
@@ -839,13 +829,18 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/medbay)
-"Zy" = (
-/mob/living/simple_animal/pet/cat/space,
-/turf/open/floor/iron/smooth,
-/area/shuttle/abandoned/crew)
 "ZB" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
+/area/shuttle/abandoned/crew)
+"ZI" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/random{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned/crew)
 
 (1,1,1) = {"
@@ -890,13 +885,13 @@ Oo
 Oo
 Oo
 jV
-Vl
+Sh
 La
 La
 KC
 Pc
 La
-ve
+TS
 Xw
 jV
 Oo
@@ -951,7 +946,7 @@ Hu
 Hu
 VD
 Hu
-OH
+Oq
 LP
 jV
 jV
@@ -974,11 +969,11 @@ jV
 LP
 bF
 Pb
-Wq
+Vl
 Hu
-pf
+vC
 KC
-Oa
+Ak
 LP
 jV
 Oo
@@ -1000,12 +995,12 @@ Oo
 Ca
 KJ
 jr
-Gp
-MP
-lg
-fF
-Uf
-Sv
+AN
+Jl
+Wq
+JR
+sL
+rG
 gw
 Ca
 Oo
@@ -1032,11 +1027,11 @@ oW
 Zh
 oW
 Ca
-Ql
-ba
-jK
+AU
+pE
+uV
 Ca
-Yn
+ft
 xr
 Oo
 Oo
@@ -1060,9 +1055,9 @@ rJ
 ct
 rJ
 Ca
-Ah
+vE
 kq
-Ao
+Td
 Ca
 xr
 uj
@@ -1080,17 +1075,17 @@ Oo
 Oo
 fk
 DB
-mG
+kM
 Ca
 rJ
 rJ
 rJ
-Nv
+MP
 rJ
 Ca
-fF
+JR
 yw
-mJ
+OZ
 Ca
 xr
 xr
@@ -1116,11 +1111,11 @@ rJ
 ct
 rJ
 Ca
-Ox
+De
 yw
-Dv
+hg
 Ca
-Yn
+ft
 xr
 Oo
 Oo
@@ -1139,14 +1134,14 @@ ey
 UI
 xM
 rJ
-zj
+ym
 rJ
 ct
 rJ
 Ca
-fF
+JR
 yw
-fF
+JR
 Ca
 Oo
 Oo
@@ -1172,9 +1167,9 @@ rJ
 ct
 rJ
 Ca
-Ql
-ba
-jK
+AU
+pE
+uV
 Ca
 jV
 jV
@@ -1200,13 +1195,13 @@ YX
 ct
 rJ
 Ca
-fF
+JR
 yw
-tL
+gg
 Ca
-WW
+xF
 Hu
-HJ
+rL
 jV
 Oo
 Oo
@@ -1221,20 +1216,20 @@ Sg
 fk
 Rq
 fk
-ym
+rn
 rJ
 JK
 rJ
-Oj
+Nv
 rJ
 oW
-Pm
 dJ
-fF
+IB
+JR
 Ca
-Aq
+FZ
 Hu
-gu
+Nj
 jV
 Oo
 Oo
@@ -1247,19 +1242,19 @@ dX
 ax
 SK
 em
-kp
-rn
+em
+mG
 Zh
 ct
-zA
+zj
 ct
-Rg
+Oj
 ct
-Ay
+dO
 Zn
 yw
 yw
-dz
+TE
 VD
 KC
 if
@@ -1275,22 +1270,22 @@ ax
 iQ
 WR
 sA
-kM
+kp
 sA
 Vw
 rJ
-zj
+ym
 rJ
-Rg
+Oj
 rJ
 oW
-Fs
+FV
 yw
-fF
+JR
 Ca
-xZ
-Wq
-we
+ON
+Vl
+lR
 jV
 Oo
 Oo
@@ -1307,18 +1302,18 @@ em
 pY
 Vw
 rJ
-AN
+zA
 rJ
-Rg
+Oj
 rJ
 Ca
 Zq
-nd
-fF
+tU
+JR
 Ca
-FZ
-LR
-NZ
+mM
+eR
+jT
 jV
 Oo
 Oo
@@ -1335,14 +1330,14 @@ Gi
 JD
 FD
 pG
-AN
+zA
 rJ
 ct
 rJ
 Ca
-Ql
-ba
-jK
+AU
+pE
+uV
 Ca
 jV
 jV
@@ -1369,8 +1364,8 @@ ct
 rJ
 Ca
 CC
-qB
-ei
+zN
+zE
 Ca
 Oo
 Oo
@@ -1394,13 +1389,13 @@ TF
 rJ
 YX
 ct
-vT
+LL
 Ca
-fF
+JR
 yw
-ee
+aG
 Ca
-Yn
+ft
 xr
 Oo
 Oo
@@ -1422,11 +1417,11 @@ Pr
 rJ
 rJ
 ct
-vK
+ik
 Ca
-fF
+JR
 yw
-la
+RO
 Ca
 xr
 uj
@@ -1450,9 +1445,9 @@ Aj
 rJ
 rJ
 ct
-Dl
+Pi
 Ca
-fF
+JR
 yw
 Hu
 Ca
@@ -1477,14 +1472,14 @@ LP
 WT
 WT
 WT
-RJ
+Rg
 WT
 jV
-IW
+kh
 VD
 Hu
 jV
-Yn
+ft
 xr
 Oo
 Oo
@@ -1533,12 +1528,12 @@ Oo
 jV
 ku
 cL
-Sh
+RJ
 cL
 Gf
-Wb
+ZI
 ZB
-Wb
+ZI
 LP
 Gf
 Oo
@@ -1560,14 +1555,14 @@ Oo
 Oo
 Oo
 Gf
-Jl
+Gp
 bQ
-jN
+Vp
 Gf
 aE
-NJ
-nZ
-uR
+YJ
+To
+Cu
 ku
 Gf
 Gf
@@ -1590,13 +1585,13 @@ Oo
 Oo
 Gf
 ku
-Gq
+AX
 Gf
-nZ
+To
 ZB
-Zy
-nZ
-vj
+di
+To
+Nw
 Gf
 Gf
 Oo
@@ -1620,11 +1615,11 @@ Oo
 Gf
 ku
 Gf
-ea
+yj
 ZB
 Mi
 aE
-vi
+HL
 mD
 Gf
 Oo

--- a/_maps/shuttles/whiteship_helio.dmm
+++ b/_maps/shuttles/whiteship_helio.dmm
@@ -297,21 +297,7 @@
 /obj/machinery/door/airlock/shuttle,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fans/tiny,
-/obj/docking_port/mobile{
-	callTime = 250;
-	can_move_docking_ports = 1;
-	dheight = 7;
-	dir = 2;
-	dwidth = 7;
-	height = 17;
-	launch_status = 0;
-	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
-	name = "Mining Shuttle";
-	port_direction = 4;
-	preferred_direction = 8;
-	shuttle_id = "whiteship";
-	width = 13
-	},
+/obj/docking_port/mobile,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
 "mY" = (


### PR DESCRIPTION
## About The Pull Request

A white ship for helio. It's a pirate drug den.  It (now) looks like this:

![image](https://user-images.githubusercontent.com/69338705/209402712-befcf200-0e24-47ef-80ec-e2c04691214c.png)

Now with meth-making hints!

Big thanks to Ruvic for the help with the meth setup!

## Why It's Good For The Game

The /tg/ maps all have their own white ships, so helio should get its own too.

## Changelog
:cl:
add: Added a white ship for helio
/:cl:
