### PR TITLE
Removes one of Pubby's viro disposals

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -42188,12 +42188,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
-"ohH" = (
-/obj/machinery/disposal/bin{
-	name = "Disposal To Space"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
@@ -76643,7 +76637,7 @@ dIj
 dIj
 pEI
 qIl
-ohH
+sEN
 jJN
 iaj
 ksP


### PR DESCRIPTION
There were two disposals chutes in viro, one clearly placed on accident, and this removes it.
## About The Pull Request

Fixes issue #868 , where Pubby's virology office had two disposal chutes. One chute led to absolutely nowhere, while the other was correctly placed, so all I did was remove the extra.

Before:
![image](https://user-images.githubusercontent.com/107831677/209659355-3257ffb0-71ee-46b7-8e9e-ac107b2e59f7.png)

After:
![image](https://user-images.githubusercontent.com/107831677/209659343-f3e2cc57-388d-46c3-97e8-83d1f0fe365f.png)
## Why It's Good For The Game

The extra disposals chute blocked the pandemic machine, resulting in virologists being unable to do their job. This makes virologists who happen to play on pubby not be station deadweights.
## Changelog
:cl:
fix: Removed the accidental second disposals to space chute from Virology.
/:cl:
