### PR TITLE
You no longer get antag tips if you're an antag who doesn't have

### DIFF
--- a/fulp_modules/features/antagonists/antag_tips/antag_tip_integration.dm
+++ b/fulp_modules/features/antagonists/antag_tips/antag_tip_integration.dm
@@ -8,7 +8,7 @@
 
 /datum/antagonist/on_gain()
 	. = ..()
-	if(silent || isnull(antag_tips))
+	if(silent || !antag_tips.len)
 		return
 	tips = new(name, tip_theme, antag_tips)
 	add_verb(owner.current, /mob/living/proc/open_tips)


### PR DESCRIPTION
## About The Pull Request

No more of this
![image](https://user-images.githubusercontent.com/53777086/209724656-62209d6c-7d15-471c-8346-1c8093086277.png)

## Why It's Good For The Game

No more of this
![image](https://user-images.githubusercontent.com/53777086/209724656-62209d6c-7d15-471c-8346-1c8093086277.png)

## Changelog

:cl:
fix: Antagonists who don't have any antag tips will no longer get an empty UI about mhelping.
/:cl: