### PR TITLE
Selene Medbay QOL Attempt 2

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -9256,6 +9256,11 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Medical - Viro Monkey Pen";
+	dir = 10;
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "cZr" = (
@@ -41451,10 +41456,6 @@
 /area/station/security/checkpoint/science)
 "nHl" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/obj/machinery/camera{
-	c_tag = "Public - Arrivals N";
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "nHm" = (
@@ -50966,7 +50967,7 @@
 /obj/item/storage/box/bodybags,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /obj/machinery/button/door/directional/south{
-	id = Virology Breach;
+	id = VirologyBreach;
 	name = "Virology Breach Prevention"
 	},
 /turf/open/floor/iron/white,

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -36349,10 +36349,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Virology Breach";
-	name = "Virology Breach Prevention"
-	},
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "mah" = (
@@ -43582,14 +43578,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"ouk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Virology Breach";
-	name = "Virology Breach Prevention"
-	},
-/turf/open/floor/plating,
-/area/station/medical/virology)
 "oum" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment{
@@ -50966,10 +50954,6 @@
 /obj/item/storage/box/masks,
 /obj/item/storage/box/bodybags,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/obj/machinery/button/door/directional/south{
-	id = VirologyBreach;
-	name = "Virology Breach Prevention"
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "qZe" = (
@@ -121725,7 +121709,7 @@ uCZ
 mpH
 tsD
 aio
-ouk
+fiV
 iQW
 iQW
 yju
@@ -122233,7 +122217,7 @@ iQW
 iQW
 iQW
 iQW
-ouk
+fiV
 fOh
 ygZ
 vEF
@@ -123001,7 +122985,7 @@ iQW
 vmD
 iQW
 iQW
-ouk
+fiV
 aOT
 tpi
 jhI
@@ -123013,7 +122997,7 @@ jNf
 rdg
 rdg
 ubw
-ouk
+fiV
 iQW
 iQW
 vmD
@@ -123258,7 +123242,7 @@ iQW
 yju
 iQW
 iQW
-ouk
+fiV
 lrF
 uJD
 gOP
@@ -123270,7 +123254,7 @@ iVl
 oWL
 qNs
 ubw
-ouk
+fiV
 iQW
 iQW
 xBY
@@ -125319,9 +125303,9 @@ iQW
 iQW
 iQW
 nit
-ouk
+fiV
 mab
-ouk
+fiV
 nit
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -10681,14 +10681,15 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dAC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "dAU" = (
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = -2;
@@ -18906,8 +18907,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "goE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -22504,14 +22515,6 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
-"hCz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Virology Breach";
-	name = "Virology Breach Prevention"
-	},
-/turf/open/floor/plating,
-/area/station/medical/virology)
 "hCG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -26783,13 +26786,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "iYy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "iYz" = (
@@ -27935,9 +27932,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "jte" = (
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -31510,9 +31509,10 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "kyO" = (
-/obj/structure/window/reinforced,
-/obj/item/plunger,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kyT" = (
 /obj/structure/sign/directions/supply{
@@ -34984,15 +34984,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "lFT" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Chemlab Maintenance"
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -35950,10 +35946,8 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "lUO" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -37184,9 +37178,10 @@
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "mmB" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/obj/machinery/chem_heater/withbuffer,
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine,
+/area/station/medical/chemistry)
 "mmE" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -38883,18 +38878,15 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "mQR" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Chemlab Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/medical/opposingcorners{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -40945,12 +40937,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "nxC" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "nxF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -43592,6 +43581,14 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"ouk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Virology Breach";
+	name = "Virology Breach Prevention"
+	},
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "oum" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment{
@@ -50970,7 +50967,6 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /obj/machinery/button/door/directional/south{
 	id = Virology Breach;
-	req_access = list("virology");
 	name = "Virology Breach Prevention"
 	},
 /turf/open/floor/iron/white,
@@ -52102,9 +52098,11 @@
 /turf/open/floor/carpet/lone/star,
 /area/station/service/chapel)
 "rqV" = (
-/obj/machinery/chem_heater/withbuffer,
-/obj/machinery/light/directional/north,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "rrg" = (
 /obj/machinery/porta_turret/ai,
@@ -55142,8 +55140,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "srC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -55325,20 +55326,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "stZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
+/obj/structure/window/reinforced,
+/obj/item/plunger,
+/turf/open/floor/engine,
 /area/station/medical/chemistry)
 "sux" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -56668,9 +56658,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "sTN" = (
-/obj/effect/spawner/random/decoration/glowstick,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "sTT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -63313,11 +63308,18 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "vgr" = (
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -63770,15 +63772,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
-"vpa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "vpA" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -66400,11 +66393,10 @@
 /turf/open/floor/carpet/orange,
 /area/station/commons/dorms)
 "wmI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -69192,6 +69184,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
+"xjk" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/medical{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "xjw" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -72432,8 +72431,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
+/obj/effect/turf_decal/tile/medical/opposingcorners{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -112491,14 +112490,14 @@ wzS
 wzS
 jCH
 ptu
-srC
+kyO
 pYu
 oOO
 oOO
 oOO
 oOO
 oOO
-nxC
+xjk
 dMp
 tEc
 xaG
@@ -112748,7 +112747,7 @@ pAF
 kGK
 qZE
 ptu
-srC
+kyO
 jCH
 ptu
 ptu
@@ -113005,7 +113004,7 @@ lkG
 eKF
 fqm
 rEP
-srC
+kyO
 jCH
 ptu
 ptu
@@ -113262,7 +113261,7 @@ hVO
 ijY
 rlq
 jCH
-srC
+kyO
 jCH
 ptu
 ptu
@@ -113773,10 +113772,10 @@ enn
 xaG
 xaG
 hVO
-rqV
-kyO
+mmB
+stZ
 jCH
-srC
+kyO
 jCH
 ptu
 ptu
@@ -114032,16 +114031,16 @@ hfS
 hVO
 hVO
 hVO
-mQR
-vpa
+goE
+lFT
 coA
+srC
+srC
+srC
+srC
+srC
 yjZ
-yjZ
-yjZ
-yjZ
-yjZ
-dAC
-wmI
+sTN
 pOG
 xaG
 ksz
@@ -114287,10 +114286,10 @@ rFc
 rTC
 rTC
 rTC
-iYy
-lFT
-stZ
-jte
+dAC
+mQR
+vgr
+rqV
 ptu
 ptu
 ptu
@@ -114298,7 +114297,7 @@ ptu
 ptu
 ptu
 ptu
-goE
+lUO
 tEc
 xaG
 hSZ
@@ -114546,8 +114545,8 @@ xaG
 xeH
 oRs
 hVO
-lUO
-vgr
+wmI
+jte
 rEP
 ptu
 ptu
@@ -116601,7 +116600,7 @@ rRL
 aWP
 xaG
 wpj
-sTN
+iYy
 ajJ
 xBU
 xBU
@@ -117114,7 +117113,7 @@ xgZ
 cbF
 mrA
 fSi
-mmB
+nxC
 wpj
 ajJ
 igb
@@ -121725,7 +121724,7 @@ uCZ
 mpH
 tsD
 aio
-hCz
+ouk
 iQW
 iQW
 yju
@@ -122233,7 +122232,7 @@ iQW
 iQW
 iQW
 iQW
-hCz
+ouk
 fOh
 ygZ
 vEF
@@ -123001,7 +123000,7 @@ iQW
 vmD
 iQW
 iQW
-hCz
+ouk
 aOT
 tpi
 jhI
@@ -123013,7 +123012,7 @@ jNf
 rdg
 rdg
 ubw
-hCz
+ouk
 iQW
 iQW
 vmD
@@ -123258,7 +123257,7 @@ iQW
 yju
 iQW
 iQW
-hCz
+ouk
 lrF
 uJD
 gOP
@@ -123270,7 +123269,7 @@ iVl
 oWL
 qNs
 ubw
-hCz
+ouk
 iQW
 iQW
 xBY
@@ -125319,9 +125318,9 @@ iQW
 iQW
 iQW
 nit
-hCz
+ouk
 mab
-hCz
+ouk
 nit
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -7031,9 +7031,13 @@
 /turf/open/space/basic,
 /area/space)
 "coA" = (
-/obj/machinery/chem_dispenser,
-/obj/structure/sign/departments/chemistry/directional/north,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "coL" = (
 /obj/structure/table/glass,
@@ -10677,9 +10681,13 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dAC" = (
-/obj/machinery/chem_heater/withbuffer,
-/obj/machinery/light/directional/north,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/medical/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "dAU" = (
 /obj/item/reagent_containers/condiment/saltshaker{
@@ -14943,7 +14951,6 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/item/storage/box/gloves,
-/obj/item/blood_filter,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "faa" = (
@@ -18899,14 +18906,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "goE" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "goW" = (
@@ -22503,12 +22505,13 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "hCz" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Virology Breach";
+	name = "Virology Breach Prevention"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "hCG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -26780,12 +26783,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "iYy" = (
-/obj/effect/turf_decal/tile/medical{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "iYz" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -27388,13 +27394,9 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "jlb" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/chem_dispenser,
+/obj/structure/sign/departments/chemistry/directional/north,
+/turf/open/floor/engine,
 /area/station/medical/chemistry)
 "jlh" = (
 /obj/structure/chair{
@@ -27933,12 +27935,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "jte" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "jtt" = (
@@ -30340,6 +30340,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kgr" = (
@@ -31509,13 +31510,9 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "kyO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/structure/window/reinforced,
+/obj/item/plunger,
+/turf/open/floor/engine,
 /area/station/medical/chemistry)
 "kyT" = (
 /obj/structure/sign/directions/supply{
@@ -34988,17 +34985,14 @@
 /area/station/hallway/primary/fore)
 "lFT" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/door/airlock/maintenance{
+	name = "Chemlab Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/medical/opposingcorners{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -35956,8 +35950,7 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "lUO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
@@ -38890,6 +38883,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "mQR" = (
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -40951,13 +40945,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "nxC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Virology Breach";
-	name = "Virology Breach Prevention"
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/medical{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/medical/virology)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "nxF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -42758,7 +42751,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "oen" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "oet" = (
@@ -43597,15 +43592,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"ouk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "oum" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment{
@@ -52116,10 +52102,9 @@
 /turf/open/floor/carpet/lone/star,
 /area/station/service/chapel)
 "rqV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/chem_heater/withbuffer,
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine,
 /area/station/medical/chemistry)
 "rrg" = (
 /obj/machinery/porta_turret/ai,
@@ -53450,6 +53435,7 @@
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 8
 	},
+/obj/item/blood_filter,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "rQu" = (
@@ -54183,12 +54169,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"scS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "scY" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor/border_only{
@@ -55162,11 +55142,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "srC" = (
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -55349,14 +55326,20 @@
 /area/station/security/checkpoint/engineering)
 "stZ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "sux" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -56685,10 +56668,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "sTN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/effect/spawner/random/decoration/glowstick,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "sTT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -58579,15 +58561,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
-"tBj" = (
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "tBI" = (
 /obj/effect/turf_decal/tile/engineering,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
@@ -58647,12 +58620,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"tCK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "tDa" = (
 /obj/machinery/air_sensor/oxygen_tank,
 /turf/open/floor/engine/o2,
@@ -58733,14 +58700,6 @@
 "tEi" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"tEN" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "tEO" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -61784,11 +61743,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"uFe" = (
-/obj/structure/window/reinforced,
-/obj/item/plunger,
-/turf/open/floor/engine,
-/area/station/medical/chemistry)
 "uFf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -63359,15 +63313,11 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "vgr" = (
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Chemlab Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -63821,7 +63771,12 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "vpa" = (
-/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "vpA" = (
@@ -66125,12 +66080,6 @@
 /area/station/engineering/atmos)
 "wfR" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "wga" = (
@@ -66451,9 +66400,14 @@
 /turf/open/floor/carpet/orange,
 /area/station/commons/dorms)
 "wmI" = (
-/obj/effect/spawner/random/decoration/glowstick,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "wnb" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/machinery/light/directional/east,
@@ -69238,13 +69192,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
-"xjk" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "xjw" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -72482,18 +72429,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "yjZ" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -112294,15 +112234,15 @@ pAg
 wzS
 jCH
 ptu
-ptu
+oen
 oSy
 ptu
 ptu
-pYu
-oOO
-oOO
-xEW
 ptu
+ptu
+ptu
+ptu
+qFr
 pOG
 hVO
 jBM
@@ -112551,15 +112491,15 @@ wzS
 wzS
 jCH
 ptu
-scS
-vpa
-ptu
-ptu
-jCH
-ptu
-qFr
-pOG
-ptu
+srC
+pYu
+oOO
+oOO
+oOO
+oOO
+oOO
+nxC
+dMp
 tEc
 xaG
 fYH
@@ -112808,15 +112748,15 @@ pAF
 kGK
 qZE
 ptu
-kgq
 srC
-hCz
+jCH
+ptu
 ptu
 wfR
 ptu
-dMp
-pOG
 ptu
+pOG
+dMp
 pOG
 xaG
 hSZ
@@ -113065,15 +113005,15 @@ lkG
 eKF
 fqm
 rEP
-kgq
-tBj
-iYy
-ptu
+srC
 jCH
 ptu
-dMp
-pOG
 ptu
+ptu
+ptu
+ptu
+pOG
+dMp
 pOG
 xaG
 gzg
@@ -113322,15 +113262,15 @@ hVO
 ijY
 rlq
 jCH
-kgq
-tBj
-iYy
-ptu
+srC
 jCH
 ptu
-dMp
-pOG
 ptu
+ptu
+ptu
+ptu
+pOG
+dMp
 pOG
 xaG
 hnE
@@ -113576,18 +113516,18 @@ sGj
 etD
 iNH
 hVO
-coA
+jlb
 iiY
 jCH
 kgq
-tBj
-iYy
-ptu
 jCH
 ptu
-dMp
-pOG
 ptu
+ptu
+ptu
+ptu
+pOG
+dMp
 iOA
 xaG
 hSZ
@@ -113833,18 +113773,18 @@ enn
 xaG
 xaG
 hVO
-dAC
-uFe
-mQR
+rqV
 kyO
-lUO
-jte
-sTN
-goE
-sTN
-ouk
-pOG
+jCH
+srC
+jCH
 ptu
+ptu
+ptu
+ptu
+ptu
+pOG
+dMp
 pOG
 xaG
 bAs
@@ -114092,16 +114032,16 @@ hfS
 hVO
 hVO
 hVO
+mQR
+vpa
+coA
 yjZ
-tCK
-ptu
-ptu
-ptu
-jCH
-ptu
-rqV
-pOG
-ptu
+yjZ
+yjZ
+yjZ
+yjZ
+dAC
+wmI
 pOG
 xaG
 ksz
@@ -114347,18 +114287,18 @@ rFc
 rTC
 rTC
 rTC
-stZ
-vgr
+iYy
 lFT
-oen
+stZ
+jte
 ptu
 ptu
 ptu
-xXq
-tAW
-tAW
-xjk
 ptu
+ptu
+ptu
+ptu
+goE
 tEc
 xaG
 hSZ
@@ -114606,8 +114546,8 @@ xaG
 xeH
 oRs
 hVO
-tEN
-jlb
+lUO
+vgr
 rEP
 ptu
 ptu
@@ -116661,7 +116601,7 @@ rRL
 aWP
 xaG
 wpj
-wmI
+sTN
 ajJ
 xBU
 xBU
@@ -121785,7 +121725,7 @@ uCZ
 mpH
 tsD
 aio
-nxC
+hCz
 iQW
 iQW
 yju
@@ -122293,7 +122233,7 @@ iQW
 iQW
 iQW
 iQW
-nxC
+hCz
 fOh
 ygZ
 vEF
@@ -123061,7 +123001,7 @@ iQW
 vmD
 iQW
 iQW
-nxC
+hCz
 aOT
 tpi
 jhI
@@ -123073,7 +123013,7 @@ jNf
 rdg
 rdg
 ubw
-nxC
+hCz
 iQW
 iQW
 vmD
@@ -123318,7 +123258,7 @@ iQW
 yju
 iQW
 iQW
-nxC
+hCz
 lrF
 uJD
 gOP
@@ -123330,7 +123270,7 @@ iVl
 oWL
 qNs
 ubw
-nxC
+hCz
 iQW
 iQW
 xBY
@@ -125379,9 +125319,9 @@ iQW
 iQW
 iQW
 nit
-nxC
+hCz
 mab
-nxC
+hCz
 nit
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -36349,6 +36349,10 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "viro_breach";
+	name = "Virology Breach Prevention"
+	},
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "mah" = (
@@ -43578,6 +43582,14 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"ouk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "viro_breach";
+	name = "Virology Breach Prevention"
+	},
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "oum" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment{
@@ -50954,6 +50966,10 @@
 /obj/item/storage/box/masks,
 /obj/item/storage/box/bodybags,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/machinery/button/door/directional/south{
+	id = "viro_breach";
+	name = "Virology Breach Prevention"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "qZe" = (
@@ -121709,7 +121725,7 @@ uCZ
 mpH
 tsD
 aio
-fiV
+ouk
 iQW
 iQW
 yju
@@ -122217,7 +122233,7 @@ iQW
 iQW
 iQW
 iQW
-fiV
+ouk
 fOh
 ygZ
 vEF
@@ -122985,7 +123001,7 @@ iQW
 vmD
 iQW
 iQW
-fiV
+ouk
 aOT
 tpi
 jhI
@@ -122997,7 +123013,7 @@ jNf
 rdg
 rdg
 ubw
-fiV
+ouk
 iQW
 iQW
 vmD
@@ -123242,7 +123258,7 @@ iQW
 yju
 iQW
 iQW
-fiV
+ouk
 lrF
 uJD
 gOP
@@ -123254,7 +123270,7 @@ iVl
 oWL
 qNs
 ubw
-fiV
+ouk
 iQW
 iQW
 xBY
@@ -125303,9 +125319,9 @@ iQW
 iQW
 iQW
 nit
-fiV
+ouk
 mab
-fiV
+ouk
 nit
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1716,6 +1716,10 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/rack,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/crowbar,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aCk" = (
@@ -2892,6 +2896,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/medical/opposingcorners,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aXd" = (
@@ -5412,6 +5417,16 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/medical/half,
+/obj/structure/table/glass,
+/obj/item/clothing/shoes/sneakers/white,
+/obj/item/clothing/shoes/sneakers/white,
+/obj/item/clothing/under/misc/pj/red{
+	pixel_y = 1
+	},
+/obj/item/clothing/under/misc/pj/blue{
+	pixel_x = 3
+	},
+/obj/item/toy/figure/md,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bNk" = (
@@ -7027,11 +7042,21 @@
 /area/station/medical/chemistry)
 "coL" = (
 /obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/obj/item/toy/figure/cmo,
+/obj/item/paper_bin{
+	pixel_x = -6
+	},
+/obj/item/pen/fountain{
+	pixel_x = -6
+	},
 /obj/effect/turf_decal/trimline/blue/end{
 	color = "#FFD700"
+	},
+/obj/item/stamp/denied{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/stamp/cmo{
+	pixel_x = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
@@ -14924,14 +14949,12 @@
 /obj/structure/table/glass,
 /obj/machinery/light_switch/directional/west,
 /obj/structure/cable,
-/obj/item/clothing/under/misc/pj/blue,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/storage/box,
-/obj/item/blood_filter,
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/item/storage/box/gloves,
+/obj/item/blood_filter,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "faa" = (
@@ -16065,7 +16088,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "frD" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -16089,6 +16112,10 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 4
+	},
+/obj/item/toy/figure/cmo{
+	pixel_y = 9;
+	pixel_x = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
@@ -21711,11 +21738,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "hmE" = (
-/obj/structure/table/glass,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/firealarm/directional/south,
-/obj/item/defibrillator,
 /obj/effect/turf_decal/tile/medical/anticorner,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "hmK" = (
@@ -24302,7 +24331,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "iiw" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 4
@@ -29338,6 +29367,19 @@
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 1
 	},
+/obj/structure/table/glass,
+/obj/item/clothing/suit/jacket/straight_jacket{
+	pixel_x = -6
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -6
+	},
+/obj/item/clothing/glasses/blindfold{
+	pixel_x = -6
+	},
+/obj/item/healthanalyzer/wound{
+	pixel_x = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "jQK" = (
@@ -29592,9 +29634,7 @@
 /obj/structure/cable,
 /obj/item/book/manual/wiki/medicine,
 /obj/effect/turf_decal/tile/medical/half,
-/obj/item/toy/plush/lizard_plushie,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/healthanalyzer,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jUQ" = (
@@ -30064,10 +30104,10 @@
 "kdu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/duct,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "kdw" = (
@@ -36318,6 +36358,10 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Virology Breach";
+	name = "Virology Breach Prevention"
+	},
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "mah" = (
@@ -41419,12 +41463,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "nHl" = (
-/obj/machinery/camera{
-	c_tag = "Medical - Viro Monkey Pen";
-	dir = 10;
-	network = list("ss13","medbay")
-	},
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/machinery/camera{
+	c_tag = "Public - Arrivals N";
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "nHm" = (
@@ -42055,6 +42098,7 @@
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "nSI" = (
@@ -50937,6 +50981,11 @@
 /obj/item/storage/box/masks,
 /obj/item/storage/box/bodybags,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/machinery/button/door/directional/south{
+	id = Virology Breach;
+	req_access = list("virology");
+	name = "Virology Breach Prevention"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "qZe" = (
@@ -51108,11 +51157,12 @@
 /area/station/security/prison/work)
 "rbk" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/masks,
 /obj/item/storage/box/gloves,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer/wound,
 /obj/effect/turf_decal/tile/medical/half,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/toy/plush/lizard_plushie,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rbr" = (
@@ -51720,6 +51770,9 @@
 /area/station/service/hydroponics/garden)
 "rld" = (
 /obj/effect/turf_decal/tile/medical/half,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rlq" = (
@@ -53391,7 +53444,7 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard)
 "rQt" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/machinery/airalarm/directional/west,
 /obj/item/book/manual/wiki/surgery,
 /obj/effect/turf_decal/tile/medical/half{
@@ -56393,9 +56446,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "sOX" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 1
+	},
+/obj/machinery/defibrillator_mount{
+	pixel_y = 28
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
@@ -58619,6 +58675,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"tDz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Virology Breach";
+	name = "Virology Breach Prevention"
+	},
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "tDD" = (
 /obj/structure/table,
 /obj/effect/spawner/random/clothing/gloves,
@@ -65595,7 +65659,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "vXl" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 4
@@ -68910,9 +68974,12 @@
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "xee" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 4
+	},
+/obj/machinery/defibrillator_mount{
+	pixel_y = 28
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
@@ -70494,6 +70561,9 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/medical/half,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xEi" = (
@@ -121709,7 +121779,7 @@ uCZ
 mpH
 tsD
 aio
-fiV
+tDz
 iQW
 iQW
 yju
@@ -122217,7 +122287,7 @@ iQW
 iQW
 iQW
 iQW
-fiV
+tDz
 fOh
 ygZ
 vEF
@@ -122985,7 +123055,7 @@ iQW
 vmD
 iQW
 iQW
-fiV
+tDz
 aOT
 tpi
 jhI
@@ -122997,7 +123067,7 @@ jNf
 rdg
 rdg
 ubw
-fiV
+tDz
 iQW
 iQW
 vmD
@@ -123242,7 +123312,7 @@ iQW
 yju
 iQW
 iQW
-fiV
+tDz
 lrF
 uJD
 gOP
@@ -123254,7 +123324,7 @@ iVl
 oWL
 qNs
 ubw
-fiV
+tDz
 iQW
 iQW
 xBY
@@ -125303,9 +125373,9 @@ iQW
 iQW
 iQW
 nit
-fiV
+tDz
 mab
-fiV
+tDz
 nit
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -7031,14 +7031,9 @@
 /turf/open/space/basic,
 /area/space)
 "coA" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/chem_dispenser,
+/obj/structure/sign/departments/chemistry/directional/north,
+/turf/open/floor/engine,
 /area/station/medical/chemistry)
 "coL" = (
 /obj/structure/table/glass,
@@ -10682,13 +10677,9 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dAC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/chem_heater/withbuffer,
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine,
 /area/station/medical/chemistry)
 "dAU" = (
 /obj/item/reagent_containers/condiment/saltshaker{
@@ -12386,8 +12377,8 @@
 /turf/open/floor/iron/white,
 /area/station/service/theater)
 "edD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
 "edR" = (
@@ -12987,6 +12978,7 @@
 /obj/effect/turf_decal/tile/medical/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "eov" = (
@@ -14078,19 +14070,16 @@
 /turf/open/floor/plating,
 /area/station/commons/fitness)
 "eKF" = (
-/obj/structure/rack,
-/obj/item/book/manual/wiki/grenades,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/book/manual/wiki/plumbing,
-/obj/item/construction/plumbing,
-/obj/item/construction/plumbing,
-/obj/structure/sign/departments/chemistry/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -15992,11 +15981,16 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "fqm" = (
-/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
+/obj/structure/rack,
+/obj/item/book/manual/wiki/grenades,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/book/manual/wiki/plumbing,
+/obj/item/construction/plumbing,
+/obj/item/construction/plumbing,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "fqD" = (
@@ -17400,13 +17394,13 @@
 /area/station/service/janitor)
 "fMz" = (
 /obj/structure/cable,
-/obj/structure/closet/l3closet,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/closet/athletic_mixed,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "fME" = (
@@ -18905,10 +18899,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "goE" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "goW" = (
@@ -22505,12 +22503,9 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "hCz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/medical{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -24425,11 +24420,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/rec)
 "ijX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -26785,17 +26780,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "iYy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/effect/turf_decal/tile/medical{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "iYz" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "iYD" = (
@@ -27395,7 +27388,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "jlb" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -27937,16 +27933,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "jte" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/medical/opposingcorners{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/spawner/random/decoration/glowstick,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "jtt" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -29306,9 +29300,6 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/starboard/fore)
 "jPB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
@@ -30346,8 +30337,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "kgq" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kgr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
@@ -31516,8 +31509,13 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "kyO" = (
-/obj/machinery/chem_heater/withbuffer,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kyT" = (
 /obj/structure/sign/directions/supply{
@@ -32141,15 +32139,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "kGK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/medical/opposingcorners{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -32432,7 +32429,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "kLZ" = (
-/obj/machinery/atmospherics/components/binary/valve/digital,
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2,
 /obj/machinery/airalarm/all_access{
 	dir = 4;
 	name = "Grenade Testing Scrubber Control";
@@ -34990,15 +34987,21 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "lFT" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+	dir = 9
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lGe" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -35792,10 +35795,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "lSA" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Medical - Chemistry Lab W";
 	network = list("ss13","medbay")
@@ -35957,13 +35956,13 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "lUO" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
 	},
-/obj/item/plunger,
-/turf/open/floor/engine,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "lUR" = (
 /obj/structure/table/glass,
@@ -37192,9 +37191,9 @@
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "mmB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "mmE" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -38400,6 +38399,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/sign/poster/contraband/syndicate_pistol{
+	pixel_x = -32
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "mHf" = (
@@ -38888,16 +38890,20 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "mQR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/structure/cable,
-/obj/structure/closet/athletic_mixed,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "mQX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -39361,7 +39367,7 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "mYo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -40156,7 +40162,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "nlz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "nlB" = (
@@ -40945,14 +40951,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "nxC" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Virology Breach";
+	name = "Virology Breach Prevention"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "nxF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -42753,11 +42758,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "oen" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "oet" = (
@@ -43597,11 +43598,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ouk" = (
-/obj/structure/sign/poster/contraband/syndicate_pistol{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "oum" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment{
@@ -44803,7 +44807,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "oRm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /turf/open/floor/engine,
@@ -46846,10 +46850,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/navigate_destination/chemfactory,
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
@@ -48128,7 +48129,7 @@
 /turf/closed/wall,
 /area/station/hallway/primary/central)
 "pYW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
@@ -52115,10 +52116,9 @@
 /turf/open/floor/carpet/lone/star,
 /area/station/service/chapel)
 "rqV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "rrg" = (
@@ -54183,6 +54183,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"scS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "scY" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor/border_only{
@@ -55156,9 +55162,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "srC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/medical/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "srH" = (
@@ -55339,14 +55348,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "stZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "sux" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -58557,7 +58567,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "tBd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -58570,11 +58580,11 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "tBj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/medical{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -58641,10 +58651,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "tDa" = (
@@ -58675,14 +58681,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"tDz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Virology Breach";
-	name = "Virology Breach Prevention"
-	},
-/turf/open/floor/plating,
-/area/station/medical/virology)
 "tDD" = (
 /obj/structure/table,
 /obj/effect/spawner/random/clothing/gloves,
@@ -58735,6 +58733,14 @@
 "tEi" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"tEN" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/medical{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "tEO" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -61778,6 +61784,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"uFe" = (
+/obj/structure/window/reinforced,
+/obj/item/plunger,
+/turf/open/floor/engine,
+/area/station/medical/chemistry)
 "uFf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -63348,11 +63359,14 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "vgr" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Chemlab Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/medical/opposingcorners{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -66110,8 +66124,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "wfR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -66439,15 +66451,9 @@
 /turf/open/floor/carpet/orange,
 /area/station/commons/dorms)
 "wmI" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/effect/spawner/random/decoration/glowstick,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "wnb" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/machinery/light/directional/east,
@@ -66487,13 +66493,7 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
 "wnX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "woa" = (
@@ -67380,7 +67380,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "wEn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -68217,7 +68217,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
 /turf/open/floor/engine,
@@ -72482,11 +72482,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "yjZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/medical{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -112033,7 +112039,7 @@ eof
 eKT
 qZE
 ptu
-jlb
+ptu
 ptu
 ptu
 ptu
@@ -112289,8 +112295,8 @@ wzS
 jCH
 ptu
 ptu
+oSy
 ptu
-jlb
 ptu
 pYu
 oOO
@@ -112544,14 +112550,14 @@ ybQ
 wzS
 wzS
 jCH
-oSy
 ptu
+scS
 vpa
-dAC
-qFr
+ptu
+ptu
 jCH
 ptu
-ptu
+qFr
 pOG
 ptu
 tEc
@@ -112800,15 +112806,15 @@ ijX
 jPB
 pAF
 kGK
-vgr
-goE
-srC
+qZE
+ptu
+kgq
 srC
 hCz
-rqV
+ptu
 wfR
-sTN
-iYy
+ptu
+dMp
 pOG
 ptu
 pOG
@@ -113058,14 +113064,14 @@ hfm
 lkG
 eKF
 fqm
-nxC
-tAW
-tAW
 rEP
+kgq
+tBj
+iYy
 ptu
 jCH
 ptu
-stZ
+dMp
 pOG
 ptu
 pOG
@@ -113313,19 +113319,19 @@ cmr
 cUe
 gbD
 hVO
-hVO
-hVO
-hVO
 ijY
 rlq
 jCH
+kgq
+tBj
+iYy
 ptu
 jCH
 ptu
-tBj
-oen
-mmB
-yjZ
+dMp
+pOG
+ptu
+pOG
 xaG
 hnE
 xaG
@@ -113570,12 +113576,12 @@ sGj
 etD
 iNH
 hVO
-yju
-yju
-hVO
-kgq
+coA
 iiY
 jCH
+kgq
+tBj
+iYy
 ptu
 jCH
 ptu
@@ -113826,17 +113832,17 @@ xaG
 enn
 xaG
 xaG
-xaG
-xBU
-yju
 hVO
+dAC
+uFe
+mQR
 kyO
 lUO
-jCH
-ptu
-jCH
-ptu
-dMp
+jte
+sTN
+goE
+sTN
+ouk
 pOG
 ptu
 pOG
@@ -114081,19 +114087,19 @@ pXI
 qrj
 qrj
 fFV
-wpj
+bJy
 hfS
-xeH
-xBU
-yju
 hVO
 hVO
-coA
-qZE
+hVO
+yjZ
+tCK
+ptu
+ptu
 ptu
 jCH
 ptu
-dMp
+rqV
 pOG
 ptu
 pOG
@@ -114340,17 +114346,17 @@ wpj
 rFc
 rTC
 rTC
+rTC
+stZ
+vgr
 lFT
-xBU
-xBU
-yju
-hVO
-wmI
+oen
+ptu
 ptu
 ptu
 xXq
 tAW
-tCK
+tAW
 xjk
 ptu
 tEc
@@ -114597,12 +114603,12 @@ xaG
 xOX
 xaG
 xaG
-ajJ
-ouk
-xBU
-yju
+xeH
+oRs
 hVO
-jCH
+tEN
+jlb
+rEP
 ptu
 ptu
 ptu
@@ -114855,9 +114861,9 @@ eHl
 kLj
 xaG
 wnX
-lFT
-xBU
-yju
+ajJ
+hVO
+hVO
 hVO
 jCH
 ani
@@ -115626,7 +115632,7 @@ sch
 vrV
 ucb
 xaG
-jte
+ajJ
 xBU
 yju
 yju
@@ -116655,8 +116661,8 @@ rRL
 aWP
 xaG
 wpj
-wpj
-mQR
+wmI
+ajJ
 xBU
 xBU
 xBU
@@ -116911,8 +116917,8 @@ mrA
 mrA
 mrA
 xaG
-xBU
 bGV
+wpj
 ind
 kyU
 slm
@@ -117167,8 +117173,8 @@ duU
 xgZ
 cbF
 mrA
-yju
-xBU
+fSi
+mmB
 wpj
 ajJ
 igb
@@ -121779,7 +121785,7 @@ uCZ
 mpH
 tsD
 aio
-tDz
+nxC
 iQW
 iQW
 yju
@@ -122287,7 +122293,7 @@ iQW
 iQW
 iQW
 iQW
-tDz
+nxC
 fOh
 ygZ
 vEF
@@ -123055,7 +123061,7 @@ iQW
 vmD
 iQW
 iQW
-tDz
+nxC
 aOT
 tpi
 jhI
@@ -123067,7 +123073,7 @@ jNf
 rdg
 rdg
 ubw
-tDz
+nxC
 iQW
 iQW
 vmD
@@ -123312,7 +123318,7 @@ iQW
 yju
 iQW
 iQW
-tDz
+nxC
 lrF
 uJD
 gOP
@@ -123324,7 +123330,7 @@ iVl
 oWL
 qNs
 ubw
-tDz
+nxC
 iQW
 iQW
 xBY
@@ -125373,9 +125379,9 @@ iQW
 iQW
 iQW
 nit
-tDz
+nxC
 mab
-tDz
+nxC
 nit
 iQW
 iQW


### PR DESCRIPTION

## About The Pull Request

This renovates Selene Station's medbay a bit to hopefully remedy some issues I've noticed.
- A disposal bin was added to medbay central.
- Surgery rooms have been fitted with defibrillator mounts and the glass tables have been reinforced.
- The exam room now has tables with a straight jacket, earmuffs, blindfold, and various other items.
- Stamps have been added to CMO's office.
- The chemistry lab has been slightly expanded. There is now an airlock leading directly into maintenance, the disposal bin has been moved a bit more out of the way, and the scrubber pipes coming from the smoke room have been moved to the correct layer.
- Virology has been with fitted breach prevention doors. Virologists will also be provided with handcuffs for their test subjects as most stations do.

## Changlelog
🆑
qol: disposal bin in central
qol: defibrillator mount in surgery
balance: reinforced glass tables in surgery
add: straight jacket, earmuffs, blindfold, pajamas to exam room
fix: stamp to cmo office
fix: smoke room scrubber pipes on 2nd layer instead of 3rd
balance: chemlab beeger
qol: chemlab maintenance access
balance: virology blast doors
qol: virology has handcuffs now
fix: missing action figure added to the exam room C:
balance: blood filter removed from central and added to surgery
fix: a camera in virology was floating off a wall
/🆑