### PR TITLE
Fixes the position of the grav gens on fulp maps

### DIFF
--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -170,7 +170,8 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 /obj/machinery/gravity_generator/main/proc/setup_parts()
 	var/turf/our_turf = get_turf(src)
 	// 9x9 block obtained from the bottom middle of the block
-	var/list/spawn_turfs = CORNER_BLOCK(our_turf, 3, 3)
+	//var/list/spawn_turfs = CORNER_BLOCK(our_turf, 3, 3) // bandaid-fix tg edit
+	var/list/spawn_turfs = CORNER_BLOCK_OFFSET(our_turf, 3, 3, -1, 0) //  overwrite the fuck out of it during TGU
 	var/count = 10
 	for(var/turf/T in spawn_turfs)
 		count--


### PR DESCRIPTION

## About The Pull Request

They were offset one tile to the right due to our second-to-last TGU. This PR fixes that.
## Changelog
:cl:
fix: fixed the position of grav generators on Heliostation, Selenestation and Pubbystation
/:cl:
