### PR TITLE
Removes punch holopara type

### DIFF
--- a/code/modules/unit_tests/simple_animal_freeze.dm
+++ b/code/modules/unit_tests/simple_animal_freeze.dm
@@ -340,8 +340,7 @@
 		// READ THE COMMENT ABOVE
 		// Fulp TGEdit here to add in some of the mobs that are affected by this test
 		// so that it ignores these mobs before we start to refactor them else TGU will never be completed
-		/mob/living/simple_animal/hostile/guardian/punch/timestop,
-		/mob/living/simple_animal/hostile/guardian/punch,
+		/mob/living/simple_animal/hostile/guardian/standard/timestop,
 		/mob/living/simple_animal/hostile/gorilla/albino,
 		/mob/living/simple_animal/hostile/devil/arch_devil,
 		/mob/living/simple_animal/hostile/devil,

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
@@ -57,7 +57,7 @@
 /datum/action/cooldown/spell/timestop/guardian/Grant(mob/grant_to)
 	. = ..()
 	var/mob/living/simple_animal/hostile/guardian/standard/timestop/bloodsucker_guardian = owner
-	if(bloodsucker_guardian && istype(bloodsucker_guardian))
+	if(bloodsucker_guardian && istype(bloodsucker_guardian) && bloodsucker_guardian.summoner)
 		ADD_TRAIT(bloodsucker_guardian.summoner, TRAIT_TIME_STOP_IMMUNE, REF(src))
 
 /datum/action/cooldown/spell/timestop/guardian/Remove(mob/remove_from)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
@@ -62,6 +62,6 @@
 
 /datum/action/cooldown/spell/timestop/guardian/Remove(mob/remove_from)
 	var/mob/living/simple_animal/hostile/guardian/standard/timestop/bloodsucker_guardian = owner
-	if(bloodsucker_guardian && istype(bloodsucker_guardian))
+	if(bloodsucker_guardian && istype(bloodsucker_guardian) && bloodsucker_guardian.summoner)
 		REMOVE_TRAIT(bloodsucker_guardian.summoner, TRAIT_TIME_STOP_IMMUNE, REF(src))
 	return ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
@@ -6,7 +6,7 @@
 		used = FALSE
 		return
 	if(IS_BLOODSUCKER(user))
-		var/mob/living/simple_animal/hostile/guardian/standard/timestop/bloodsucker_guardian = new bloodsucker_guardian(user, theme)
+		var/mob/living/simple_animal/hostile/guardian/standard/timestop/bloodsucker_guardian = new(user, GUARDIAN_THEME_MAGIC)
 		bloodsucker_guardian.name = mob_name
 		bloodsucker_guardian.summoner = user
 		bloodsucker_guardian.key = candidate.key

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
@@ -7,19 +7,14 @@
 		return
 	if(IS_BLOODSUCKER(user))
 		var/mob/living/simple_animal/hostile/guardian/standard/timestop/bloodsucker_guardian = new(user, GUARDIAN_THEME_MAGIC)
-		bloodsucker_guardian.name = mob_name
-		bloodsucker_guardian.summoner = user
+
+		bloodsucker_guardian.set_summoner(user, different_person = TRUE)
 		bloodsucker_guardian.key = candidate.key
-		bloodsucker_guardian.mind.enslave_mind_to_creator(user)
-		log_game("[key_name(user)] has summoned [key_name(bloodsucker_guardian)], a Timestop holoparasite.")
-		add_verb(user, list(
-			/mob/living/proc/guardian_comm,
-			/mob/living/proc/guardian_recall,
-			/mob/living/proc/guardian_reset,
-		))
-		to_chat(user, "[bloodsucker_guardian.magic_fluff_string]")
-		to_chat(user, span_holoparasite("<b>[bloodsucker_guardian.real_name]</b> has been summoned!"))
-		bloodsucker_guardian?.client.init_verbs()
+		user.log_message("has summoned [key_name(bloodsucker_guardian)], a [bloodsucker_guardian.creator_name] holoparasite.", LOG_GAME)
+		bloodsucker_guardian.log_message("was summoned as a [bloodsucker_guardian.creator_name] holoparasite.", LOG_GAME)
+		to_chat(user, bloodsucker_guardian.magic_fluff_string)
+		to_chat(user, replacetext(success_message, "%GUARDIAN", mob_name))
+		bloodsucker_guardian.client?.init_verbs()
 		return
 
 	// Call parent to deal with everyone else

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
@@ -33,7 +33,7 @@
 
 	//None of these shouldn't appear in game outside of admin intervention
 	playstyle_string = span_holoparasite("As a <b>time manipulation</b> type you can stop time and you have a damage multiplier instead of armor as-well as powerful melee attacks capable of smashing through walls.")
-	magic_fluff_string = span_holoparasite("...And draw... The World, through sheer luck or perhaps destiny, maybe even your own physiology. Manipulator of time, a guardian powerful enough to control THE WORLD!.")
+	magic_fluff_string = span_holoparasite("...And draw... The World, through sheer luck or perhaps destiny, maybe even your own physiology. Manipulator of time, a guardian powerful enough to control THE WORLD!")
 	tech_fluff_string = span_holoparasite("ERROR... T$M3 M4N!PULA%I0N modules loaded. Holoparasite swarm online.")
 	carp_fluff_string = span_holoparasite("CARP CARP CARP! You caught one! It's imbued with the power of Carp'Sie herself. Time to rule THE WORLD!.")
 	miner_fluff_string = span_holoparasite("You encounter... The World, the controller of time and space.")


### PR DESCRIPTION
## About The Pull Request

The punch holoparasite was repathed to standard, it was there the whole time what the HELL

## Why It's Good For The Game

We should try to gut our simple animals to remove a TG edit 👍 

## Changelog

:cl:
fix: Bloodsucker holoparasites should now have their old punching abilities back & won't break the Guardian radial menu anymore.
/:cl: