### PR TITLE
Changes devil to basic animal (+ gives them dancefloor)

### DIFF
--- a/code/modules/unit_tests/simple_animal_freeze.dm
+++ b/code/modules/unit_tests/simple_animal_freeze.dm
@@ -343,8 +343,6 @@
 		/mob/living/simple_animal/hostile/guardian/punch/timestop,
 		/mob/living/simple_animal/hostile/guardian/punch,
 		/mob/living/simple_animal/hostile/gorilla/albino,
-		/mob/living/simple_animal/hostile/devil/arch_devil,
-		/mob/living/simple_animal/hostile/devil,
 		/mob/living/simple_animal/hostile/red_rabbit,
 		/mob/living/simple_animal/hostile/killer_rabbit,
 	)

--- a/fulp_modules/features/mobs/devil.dm
+++ b/fulp_modules/features/mobs/devil.dm
@@ -1,4 +1,4 @@
-/mob/living/simple_animal/hostile/devil
+/mob/living/basic/devil
 	name = "True Devil"
 	desc = "A pile of infernal energy, taking a vaguely humanoid form."
 	icon = 'fulp_modules/features/mobs/32x64.dmi'
@@ -6,7 +6,6 @@
 	gender = NEUTER
 	health = 200
 	maxHealth = 200
-	obj_damage = 60
 	melee_damage_lower = 25
 	melee_damage_upper = 25
 	attack_verb_continuous = "slashes"
@@ -15,9 +14,9 @@
 	combat_mode = TRUE
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_CLAW
-	del_on_death = TRUE
+	basic_mob_flags = DEL_ON_DEATH
 
-/mob/living/simple_animal/hostile/devil/arch_devil
+/mob/living/basic/devil/arch_devil
 	name = "Arch Devil"
 	desc = "A pile of infernal energy, taking a goatlike form."
 	icon_state = "arch_devil"

--- a/fulp_modules/features/mobs/devil.dm
+++ b/fulp_modules/features/mobs/devil.dm
@@ -16,6 +16,15 @@
 	attack_vis_effect = ATTACK_EFFECT_CLAW
 	basic_mob_flags = DEL_ON_DEATH
 
+	///The dancefloor ability we give to the devil.
+	var/datum/action/cooldown/spell/summon_dancefloor/dancefloor_ability
+
+/mob/living/basic/devil/Initialize()
+	. = ..()
+	grant_all_languages()
+	dancefloor_ability = new()
+	dancefloor_ability.Grant(src)
+
 /mob/living/basic/devil/arch_devil
 	name = "Arch Devil"
 	desc = "A pile of infernal energy, taking a goatlike form."


### PR DESCRIPTION
## About The Pull Request

Our devils already do nothing, there's no difference between simple animal and basic animal.

Also, gives them their danceflood ability that they were meant to have from the start. They were meant to have 4 powers, but 3 of them didn't get in because we ended up making them a mob that had no hands, then the one that did get in was never given to them.

## Why It's Good For The Game

This is a small change that will remove 2 TG edit lines, which would be useful to removing our TG edit in simple animal freeze.

## Changelog

:cl:
balance: Devils can now make dance floors.
refactor: Devils are now basic animals.
/:cl: