### PR TITLE
Malf AIs can only buy doomsday if they have valid objective

### DIFF
--- a/fulp_modules/Z_edits/malf_edit.dm
+++ b/fulp_modules/Z_edits/malf_edit.dm
@@ -1,0 +1,12 @@
+/**
+ * Prevents the AI from purchasing the nuclear device ability if they
+ * don't have a valid objective to do so.
+ */
+/datum/module_picker/purchase_module(mob/living/silicon/ai/AI, datum/ai_module/purchasing_module)
+	if(!istype(purchasing_module, /datum/ai_module/destructive/nuke_station))
+		return ..()
+	var/datum/antagonist/malf_ai/malf_datum = AI.mind.has_antag_datum(/datum/antagonist/malf_ai)
+	if(!(locate(/datum/objective/purge) in malf_datum.objectives) && !(locate(/datum/objective/block) in malf_datum.objectives))
+		to_chat(AI, span_warning("Unable to purchase, user lacks reasoning (No hijack or nuclear objective)."))
+		return FALSE
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5226,6 +5226,7 @@
 #include "fulp_modules\Z_edits\felinid_edit.dm"
 #include "fulp_modules\Z_edits\fulp_bans.dm"
 #include "fulp_modules\Z_edits\job_edits.dm"
+#include "fulp_modules\Z_edits\malf_edit.dm"
 #include "fulp_modules\Z_edits\nightmare_edit.dm"
 #include "fulp_modules\Z_edits\upstream_bot.dm"
 #include "fulp_modules\Z_edits\antag_edits\changeling_spiders.dm"


### PR DESCRIPTION
## About The Pull Request

Malf AIs can now only doomsday if they have one of the two malf AI murderbone objectives.

## Why It's Good For The Game

I was told this was an admin request? I was never aware of this.

## Changelog

:cl:
balance: Malf AIs who don't have a murderbone objective can no longer purchase the doomsday device.
/:cl: