### PR TITLE
Fixes pubby's shuttle

### DIFF
--- a/_maps/shuttles/escape_pod_pubby.dmm
+++ b/_maps/shuttles/escape_pod_pubby.dmm
@@ -1,0 +1,111 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"h" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/item/storage/pod/directional/west,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"r" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"u" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/pod_1)
+"A" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"B" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/pod_1)
+"C" = (
+/obj/machinery/computer/shuttle/monastery_shuttle,
+/obj/machinery/light/directional/north,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"H" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"J" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"L" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"M" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"O" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Shuttle Airlock"
+	},
+/obj/docking_port/mobile/monastery,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"W" = (
+/turf/template_noop,
+/area/template_noop)
+"Z" = (
+/obj/machinery/power/shuttle_engine/propulsion/burst,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/pod_1)
+
+(1,1,1) = {"
+W
+B
+B
+u
+B
+Z
+"}
+(2,1,1) = {"
+B
+B
+J
+L
+h
+Z
+"}
+(3,1,1) = {"
+u
+C
+r
+r
+r
+O
+"}
+(4,1,1) = {"
+B
+B
+M
+H
+A
+Z
+"}
+(5,1,1) = {"
+W
+B
+B
+u
+B
+Z
+"}

--- a/code/modules/shuttle/monastery.dm
+++ b/code/modules/shuttle/monastery.dm
@@ -2,6 +2,6 @@
 	name = "monastery shuttle console"
 	desc = "Used to control the monastery shuttle."
 	circuit = /obj/item/circuitboard/computer/monastery_shuttle
-	shuttleId = "pod"
+	shuttleId = "mining_common"
 	possible_destinations = "monastery_shuttle_asteroid;monastery_shuttle_station;lavaland_common_away;landing_zone_dock;mining_public"
 	no_destination_swap = TRUE

--- a/fulp_modules/mapping/shuttles/docking_port.dm
+++ b/fulp_modules/mapping/shuttles/docking_port.dm
@@ -1,0 +1,9 @@
+/obj/docking_port/mobile/monastery
+	name = "monastery pod"
+	shuttle_id = "mining_common" //set so mining can call it down
+	launch_status = UNLAUNCHED //required for it to launch as a pod.
+
+/obj/docking_port/mobile/monastery/on_emergency_dock()
+	if(launch_status == ENDGAME_LAUNCHED)
+		initiate_docking(SSshuttle.getDock("pod_away")) //docks our shuttle as any pod would
+		mode = SHUTTLE_ENDGAME

--- a/fulp_modules/mapping/shuttles/map_templates.dm
+++ b/fulp_modules/mapping/shuttles/map_templates.dm
@@ -64,3 +64,11 @@
 
 /obj/docking_port/stationary/laborcamp_home/helio
 	roundstart_template = /datum/map_template/shuttle/labour/helio
+
+/**
+ * PODS
+ */
+/datum/map_template/shuttle/escape_pod/pubby
+	suffix = "pubby"
+	name = "escape pod (Pubby)"
+	description = "The Pubbystation monastery shuttle, but functions on Pubbystation."

--- a/fulp_modules/tg_edits.md
+++ b/fulp_modules/tg_edits.md
@@ -40,6 +40,7 @@
 - _maps/selenestation.json
 - _maps/map_files/PubbyStation.dmm
 - _maps/pubbystation.json
+- _maps/shuttles/escape_pod_pubby.dmm
 
 ### TGUI
 - tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/bloodsucker.ts

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5256,6 +5256,7 @@
 #include "fulp_modules\mapping\ruins\code.dm"
 #include "fulp_modules\mapping\ruins\icemoon\beefman_cytology\beefcyto_spawner.dm"
 #include "fulp_modules\mapping\ruins\space\beefman_station\beefman_station.dm"
+#include "fulp_modules\mapping\shuttles\docking_port.dm"
 #include "fulp_modules\mapping\shuttles\map_templates.dm"
 #include "fulp_modules\mapping\station_objects\decals.dm"
 #include "fulp_modules\mapping\station_objects\fluff.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes the pubby monastery console
Closes https://github.com/fulpstation/fulpstation/issues/869

The shuttle can now be called from lavaland
The shuttle now properly works as an emergency pod

I had to make a new .dmm file to avoid tg edits, however the only change between them is the docking port being pathed to ``/obj/docking_port/mobile/monastery``.

## Why It's Good For The Game

Fulpstation.com can't make up their mind whether to fix the map or remove it
Closes a 4 month old gamebreaking issue.

## Changelog

:cl:
fix: the Pubbystation monastery shuttle now flies, can be called from Lavaland, and works as an emergency pod. Again.
/:cl: