### PR TITLE
Removes discord verification button

### DIFF
--- a/fulp_modules/fulp_world/fulp_client.dm
+++ b/fulp_modules/fulp_world/fulp_client.dm
@@ -1,0 +1,3 @@
+/client/New()
+	. = ..()
+	remove_verb(src, /client/verb/verify_in_discord)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5247,6 +5247,7 @@
 #include "fulp_modules\features\spells\fulp_spellbook.dm"
 #include "fulp_modules\features\toys\code\plushies.dm"
 #include "fulp_modules\fulp_world\_global_vars.dm"
+#include "fulp_modules\fulp_world\fulp_client.dm"
 #include "fulp_modules\fulp_world\fulp_config.dm"
 #include "fulp_modules\fulp_world\fulp_preferences.dm"
 #include "fulp_modules\fulp_world\fulp_world.dm"


### PR DESCRIPTION
## About The Pull Request

Removes the discord verification button

## Why It's Good For The Game

We don't have a verification bot. If we get one, then we can remove this, but currently it serves nothing but to confuse people trying to verify in the discord.

Helpful PR for new players 👍 