### PR TITLE
Boring Bloodsucker Rebalance

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
@@ -51,8 +51,6 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(!bloodsuckerdatum_power.coffin)
-		return FALSE
 
 	switch(teleporting_stage)
 		if(GOHOME_START)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/haste.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/haste.dm
@@ -84,7 +84,7 @@
 	for(var/mob/living/hit_living in dview(1, get_turf(owner)) - owner)
 		if(hit.Find(hit_living))
 			continue
-		hit += all_targets
-		playsound(all_targets, "sound/weapons/punch[rand(1,4)].ogg", 15, 1, -1)
-		all_targets.Knockdown(10 + level_current * 4)
-		all_targets.spin(10, 1)
+		hit += hit_living
+		playsound(hit_living, "sound/weapons/punch[rand(1,4)].ogg", 15, 1, -1)
+		hit_living.Knockdown(10 + level_current * 4)
+		hit_living.spin(10, 1)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/haste.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/haste.dm
@@ -20,7 +20,7 @@
 	target_range = 15
 	power_activates_immediately = TRUE
 	///List of all people hit by our power, so we don't hit them again.
-	var/list/hit
+	var/list/hit = list()
 
 /datum/action/bloodsucker/targeted/haste/CheckCanUse(mob/living/carbon/user, trigger_flags)
 	. = ..()
@@ -48,7 +48,6 @@
 /// This is a non-async proc to make sure the power is "locked" until this finishes.
 /datum/action/bloodsucker/targeted/haste/FireTargetedPower(atom/target_atom)
 	. = ..()
-	hit = list()
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	var/mob/living/user = owner
 	var/turf/targeted_turf = isturf(target_atom) ? target_atom : get_turf(target_atom)
@@ -78,7 +77,7 @@
 /datum/action/bloodsucker/targeted/haste/PowerActivatedSuccessfully()
 	. = ..()
 	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
-	hit = null
+	hit.Cut()
 
 /datum/action/bloodsucker/targeted/haste/proc/on_move()
 	for(var/mob/living/hit_living in dview(1, get_turf(owner)) - owner)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/mesmerize.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/mesmerize.dm
@@ -5,7 +5,6 @@
  * 	Level 2: Additionally mutes
  * 	Level 3: Can be used through face protection
  * 	Level 5: Doesn't need to be facing you anymore
- * 	Level 6: Causes the target to fall asleep
  */
 
 /datum/action/bloodsucker/targeted/mesmerize
@@ -20,7 +19,6 @@
 		At level 2, your target will additionally be muted.\n\
 		At level 3, you will be able to use the power through items covering your face.\n\
 		At level 5, you will be able to mesmerize regardless of your target's direction.\n\
-		At level 6, you will cause your target to fall asleep.\n\
 		Higher levels will increase the time of the mesmerize's freeze."
 	power_flags = NONE
 	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_IN_FRENZY|BP_CANT_USE_WHILE_INCAPACITATED|BP_CANT_USE_WHILE_UNCONSCIOUS
@@ -119,8 +117,6 @@
 		return
 	if(iscarbon(mesmerized_target))
 		owner.balloon_alert(owner, "successfully mesmerized [mesmerized_target].")
-		if(level_current >= 6)
-			ADD_TRAIT(mesmerized_target, TRAIT_KNOCKEDOUT, BLOODSUCKER_TRAIT)
 		else if(level_current >= 2)
 			ADD_TRAIT(mesmerized_target, TRAIT_MUTE, BLOODSUCKER_TRAIT)
 		mesmerized_target.Immobilize(power_time)
@@ -137,7 +133,6 @@
 
 /datum/action/bloodsucker/targeted/mesmerize/proc/end_mesmerize(mob/living/user, mob/living/target)
 	target.notransform = FALSE
-	REMOVE_TRAIT(target, TRAIT_KNOCKEDOUT, BLOODSUCKER_TRAIT)
 	REMOVE_TRAIT(target, TRAIT_MUTE, BLOODSUCKER_TRAIT)
 	// They Woke Up! (Notice if within view)
 	if(istype(user) && target.stat == CONSCIOUS && (target in view(6, get_turf(user))))

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/mesmerize.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/mesmerize.dm
@@ -117,7 +117,7 @@
 		return
 	if(iscarbon(mesmerized_target))
 		owner.balloon_alert(owner, "successfully mesmerized [mesmerized_target].")
-		else if(level_current >= 2)
+		if(level_current >= 2)
 			ADD_TRAIT(mesmerized_target, TRAIT_MUTE, BLOODSUCKER_TRAIT)
 		mesmerized_target.Immobilize(power_time)
 		mesmerized_target.adjust_silence(power_time)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/vassal_fold.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/vassal_fold.dm
@@ -1,9 +1,11 @@
 /datum/action/bloodsucker/vassal_blood
 	name = "Help Vassal"
-	desc = "Bring an ex-Vassal back into the fold. RMB: Check Vassal status."
+	desc = "Bring an ex-Vassal back into the fold, or create blood using a bag. RMB: Check Vassal status."
 	button_icon_state = "power_torpor"
 	power_explanation = "Help Vassal:\n\
 		Use this power while you have an ex-Vassal grabbed to bring them back into the fold. \
+		Use this power with a bloodbag in your hand to instead fill it with Vampiric Blood which \
+		can be used to reset ex-vassal deconversion timers. \
 		Right-Click will show the status of all Vassals."
 	power_flags = NONE
 	check_flags = NONE


### PR DESCRIPTION
## About The Pull Request

Removes Mesmerize putting people to sleep because it would sell Bloodsuckers out more than it helped.
Adds better explanation of the Fold ability
Removes unused Monsterhunter exception from Haste, removes Paralyze, and removes using the ability while resting.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/53777086/227848764-4da543b9-cec1-474e-9ad6-ebecd4323ca4.png)

## Changelog

:cl:
balance: Mesmerize can no longer put to sleep.
balance: Haste no longer paralyzes people
balance: Haste now increases the knockdown by 0.4 seconds per level instead of 0.5, so at level 5 you'll be knocking your target down for 3 whole seconds instead of 3.5
/:cl: