### PR TITLE
Removes the electrified grille/waste spawner in Heliostation engineering maintenace 

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -39640,12 +39640,12 @@
 /area/station/service/kitchen/abandoned)
 "eYR" = (
 /obj/structure/cable,
-/obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "eYW" = (
@@ -53768,6 +53768,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "mPd" = (
@@ -55303,6 +55304,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "nGa" = (
@@ -63965,6 +63967,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "sor" = (
@@ -69083,11 +69086,6 @@
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
-"vdW" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "veg" = (
 /obj/structure/chair/stool/directional/west,
 /obj/structure/cable,
@@ -70220,6 +70218,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "vLx" = (
@@ -95229,7 +95228,7 @@ bSe
 bxJ
 uEk
 fJb
-vdW
+bxJ
 dpb
 bHm
 rGv

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -38717,6 +38717,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"eBs" = (
+/obj/structure/closet/firecloset,
+/turf/closed/wall,
+/area/station/maintenance/department/engine)
 "eBC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/delivery,
@@ -45871,6 +45875,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"iyh" = (
+/obj/structure/closet/firecloset,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "iyr" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Minisat Exterior NW";
@@ -64861,6 +64870,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"sLd" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "sLw" = (
 /obj/structure/lattice,
 /obj/structure/sign/nanotrasen{
@@ -100628,7 +100642,7 @@ vdF
 kYA
 bxJ
 nhF
-eMd
+sLd
 gMG
 bxJ
 fIW
@@ -102175,7 +102189,7 @@ bHm
 meo
 dvx
 gpS
-bTx
+iyh
 bOQ
 rze
 yjX
@@ -102689,7 +102703,7 @@ bxJ
 bxJ
 bxJ
 fGb
-bxJ
+eBs
 bOQ
 vXx
 vXx

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -38717,10 +38717,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
-"eBs" = (
-/obj/structure/closet/firecloset,
-/turf/closed/wall,
-/area/station/maintenance/department/engine)
 "eBC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/delivery,
@@ -45875,11 +45871,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"iyh" = (
-/obj/structure/closet/firecloset,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "iyr" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Minisat Exterior NW";
@@ -64870,11 +64861,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"sLd" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "sLw" = (
 /obj/structure/lattice,
 /obj/structure/sign/nanotrasen{
@@ -100642,7 +100628,7 @@ vdF
 kYA
 bxJ
 nhF
-sLd
+eMd
 gMG
 bxJ
 fIW
@@ -102189,7 +102175,7 @@ bHm
 meo
 dvx
 gpS
-iyh
+bTx
 bOQ
 rze
 yjX
@@ -102703,7 +102689,7 @@ bxJ
 bxJ
 bxJ
 fGb
-eBs
+bxJ
 bOQ
 vXx
 vXx


### PR DESCRIPTION

## About The Pull Request
My brain short-circuited when I was reworking heliostation engineering and decided it was good idea to put 2 electrified grille/waste spawner, thinking it would be funny to troll players.
Turn out I am the only one who is trolled because I mange to walk onto it at least 3 times every single round.
## Why It's Good For The Game
You shouldn't be running into shocked grille when going into straight line in maint such as this:

![image](https://user-images.githubusercontent.com/64306407/228565508-462daa8f-bf4c-43e9-8648-aab19cc35dc1.png)
## Changelog
:cl:
balance: removes the electrified grille/waste spawner in Heliostation engineering maintenace 
/:cl:
