### PR TITLE
Adds an operating computer to Selene's morgue

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -55739,12 +55739,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "sww" = (
-/obj/structure/table,
-/obj/item/scalpel{
-	pixel_y = 12
-	},
-/obj/item/clothing/suit/apron/surgical,
 /obj/effect/turf_decal/tile/medical/anticorner,
+/obj/structure/table/optable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "swF" = (
@@ -69905,10 +69901,12 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "xnz" = (
-/obj/structure/table/optable,
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 8
+	},
+/obj/machinery/computer/operating{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)


### PR DESCRIPTION
Selene's morgue did not have a computer to do any advanced surgeries or surgeries that required a computer. This should now allow doctors to do surgeries such as dissections roundstart in the morgue.
## About The Pull Request

Out of all the maps Fulpstation offers, the morgue routinely offers a surgical table and operating computer for doctors to perform surgeries with. However, Selene was the only map to only feature a table, and no computer, resulting in doctors having to assemble their own or drag corpses out of the morgue for surgeries that required a computer, such as dissections. 

Before:
![image](https://user-images.githubusercontent.com/107831677/230270099-898036ee-5e17-48bb-8ac2-709103f17c01.png)


After:
![image](https://user-images.githubusercontent.com/107831677/230270117-0015268b-d2d6-4c29-a2e8-bd9ee13813aa.png)


## Why It's Good For The Game

Allows doctors to actually operate in the morgue and perform surgeries that require the operating computer to perform. Mostly good for round-start dissection surgeries. Also removes the unnecessary table with a random scalpel + surgical apron that used to be there.

## Changelog
:cl:
add: adds a surgical computer to Selene's morgue
/:cl:
