### PR TITLE
Fixes and balances Bloodsuckers, adds admin testing support

### DIFF
--- a/fulp_modules/_defines/bloodsuckers.dm
+++ b/fulp_modules/_defines/bloodsuckers.dm
@@ -1,4 +1,4 @@
-///Uncomment this to enable testing of Bloodsucker features. (such as vassalizing people with a mind instead of a client).
+///Uncomment this to enable testing of Bloodsucker features (such as vassalizing people with a mind instead of a client).
 //#define BLOODSUCKER_TESTING
 
 /// Determines Bloodsucker regeneration rate

--- a/fulp_modules/_defines/bloodsuckers.dm
+++ b/fulp_modules/_defines/bloodsuckers.dm
@@ -1,6 +1,6 @@
-/**
- * Bloodsucker defines
- */
+///Uncomment this to enable testing of Bloodsucker features.
+//#define BLOODSUCKER_TESTING
+
 /// Determines Bloodsucker regeneration rate
 #define BS_BLOOD_VOLUME_MAX_REGEN 700
 /// Cost to torture someone halfway, in blood. Called twice for full cost

--- a/fulp_modules/_defines/bloodsuckers.dm
+++ b/fulp_modules/_defines/bloodsuckers.dm
@@ -1,4 +1,4 @@
-///Uncomment this to enable testing of Bloodsucker features.
+///Uncomment this to enable testing of Bloodsucker features. (such as vassalizing people with a mind instead of a client).
 //#define BLOODSUCKER_TESTING
 
 /// Determines Bloodsucker regeneration rate

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
@@ -31,7 +31,7 @@
 	if(!conversion_target.mind)
 		to_chat(owner.current, span_danger("[conversion_target] isn't self-aware enough to be made into a Vassal."))
 		return FALSE
-	if(!AmValidAntag(conversion_target))
+	if(AmValidAntag(conversion_target))
 		to_chat(owner.current, span_danger("[conversion_target] resists the power of your blood to dominate their mind!"))
 		return FALSE
 	var/mob/living/master = conversion_target.mind.enslaved_to?.resolve()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -133,6 +133,11 @@
 		on_hud_created()
 	else
 		RegisterSignal(current_mob, COMSIG_MOB_HUD_CREATED, PROC_REF(on_hud_created))
+#ifdef BLOODSUCKER_TESTING
+	var/turf/user_loc = get_turf(current_mob)
+	new /obj/structure/closet/crate/coffin(user_loc)
+	new /obj/structure/bloodsucker/vassalrack(user_loc)
+#endif
 
 /**
  * Remove innate effects is everything given to the mob

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_hud.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_hud.dm
@@ -27,6 +27,13 @@
 	name = "Solar Flare Timer"
 	icon_state = "sunlight"
 	screen_loc = UI_SUNLIGHT_DISPLAY
+#ifdef BLOODSUCKER_TESTING
+	var/datum/controller/subsystem/sunlight/sunlight_subsystem
+
+/atom/movable/screen/bloodsucker/sunlight_counter/New(loc, ...)
+	. = ..()
+	sunlight_subsystem = SSsunlight
+#endif
 
 /// Update Blood Counter + Rank Counter
 /datum/antagonist/bloodsucker/proc/update_hud()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -395,13 +395,11 @@
 /obj/structure/bloodsucker/vassalrack/proc/RequireDisloyalty(mob/living/user, mob/living/target)
 #ifdef BLOODSUCKER_TESTING
 	if(!target || !target.mind)
-		balloon_alert(user, "target has no mind!")
-		return VASSALIZATION_BANNED
 #else
 	if(!target || !target.client)
+#endif
 		balloon_alert(user, "target has no mind!")
 		return VASSALIZATION_BANNED
-#endif
 
 	if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 		return VASSALIZATION_DISLOYAL

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -325,58 +325,50 @@
 		SEND_SIGNAL(bloodsuckerdatum.my_clan, BLOODSUCKER_MADE_VASSAL, user, target)
 
 /obj/structure/bloodsucker/vassalrack/proc/do_torture(mob/living/user, mob/living/carbon/target, mult = 1)
-	/// Fifteen seconds if you aren't using anything. Shorter with weapons and such.
+	// Fifteen seconds if you aren't using anything. Shorter with weapons and such.
 	var/torture_time = 15
 	var/torture_dmg_brute = 2
 	var/torture_dmg_burn = 0
-	/// Get Bodypart
-	var/target_string = ""
-	var/obj/item/bodypart/selected_bodypart = null
-	selected_bodypart = pick(target.bodyparts)
-	if(selected_bodypart)
-		target_string += selected_bodypart.name
-	/// Get Weapon
-	var/obj/item/held_item = user.get_active_held_item()
-	if(!istype(held_item))
-		held_item = user.get_inactive_held_item()
+	var/obj/item/bodypart/selected_bodypart = pick(target.bodyparts)
+	// Get Weapon
+	var/obj/item/held_item = user.get_inactive_held_item()
 	/// Weapon Bonus
 	if(held_item)
 		torture_time -= held_item.force / 4
-		torture_dmg_brute += held_item.force / 4
-		//torture_dmg_burn += I.
-		if(held_item.sharpness == SHARP_EDGED)
-			torture_time -= 2
-		else if(held_item.sharpness == SHARP_POINTY)
-			torture_time -= 3
-		/// This will hurt your eyes.
-		else if(held_item.tool_behaviour == TOOL_WELDER)
-			if(held_item.use_tool(src, user, 0, volume = 5))
-				torture_time -= 6
-				torture_dmg_burn += 5
-		held_item.play_tool_sound(target)
-	/// Minimum 5 seconds.
-	torture_time = max(50, torture_time * 10)
-	/// Now run process.
-	if(!do_after(user, torture_time * mult, target))
+		if(!held_item.use_tool(src, user, 0, volume = 5))
+			return
+		switch(held_item.damtype)
+			if(BRUTE)
+				torture_dmg_brute = held_item.force / 4
+				torture_dmg_burn = 0
+			if(BURN)
+				torture_dmg_brute = 0
+				torture_dmg_burn = held_item.force / 4
+		switch(held_item.sharpness)
+			if(SHARP_EDGED)
+				torture_time -= 2
+			if(SHARP_POINTY)
+				torture_time -= 3
+
+	// Minimum 5 seconds.
+	torture_time = max(5 SECONDS, torture_time * 10)
+	// Now run process.
+	if(!do_after(user, (torture_time * mult), target))
 		return FALSE
-	/// Success?
+
 	if(held_item)
-		playsound(loc, held_item.hitsound, 30, 1, -1)
 		held_item.play_tool_sound(target)
 	target.visible_message(
-		span_danger("[user] performs a ritual, spilling some of [target]'s blood from their [target_string] and shaking them up!"),
-		span_userdanger("[user] performs a ritual, spilling some blood from your [target_string], shaking you up!"),
-	)
+		span_danger("[user] performs a ritual, spilling some of [target]'s blood from their [selected_bodypart.name] and shaking them up!"),
+		span_userdanger("[user] performs a ritual, spilling some blood from your [selected_bodypart.name], shaking you up!"))
+
 	INVOKE_ASYNC(target, TYPE_PROC_REF(/mob, emote), "scream")
 	target.set_timed_status_effect(5 SECONDS, /datum/status_effect/jitter, only_if_higher = TRUE)
-	target.apply_damages(brute = torture_dmg_brute, burn = torture_dmg_burn, def_zone = (selected_bodypart ? selected_bodypart.body_zone : null)) // take_overall_damage(6,0)
+	target.apply_damages(brute = torture_dmg_brute, burn = torture_dmg_burn, def_zone = selected_bodypart.body_zone)
 	return TRUE
 
 /// Offer them the oppertunity to join now.
 /obj/structure/bloodsucker/vassalrack/proc/do_disloyalty(mob/living/user, mob/living/target)
-	if(!target || !target.client)
-		balloon_alert(user, "target has no mind!")
-		return FALSE
 	if(disloyalty_offered)
 		return FALSE
 
@@ -395,12 +387,22 @@
 		if("Accept")
 			disloyalty_confirm = TRUE
 		else
-			to_chat(target, span_notice("You refuse to give in! You <i>will not</i> break!"))
+			target.balloon_alert_to_viewers("stares defiantly", "refused vassalization!")
 	disloyalty_offered = FALSE
 
 	return TRUE
 
 /obj/structure/bloodsucker/vassalrack/proc/RequireDisloyalty(mob/living/user, mob/living/target)
+#ifdef BLOODSUCKER_TESTING
+	if(!target || !target.mind)
+		balloon_alert(user, "target has no mind!")
+		return VASSALIZATION_BANNED
+#else
+	if(!target || !target.client)
+		balloon_alert(user, "target has no mind!")
+		return VASSALIZATION_BANNED
+#endif
+
 	if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 		return VASSALIZATION_DISLOYAL
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = IS_BLOODSUCKER(user)


### PR DESCRIPTION
## About The Pull Request

I added a define for bloodsucker testing.
When you make someone a bloodsucker with it, it'll automatically spawn a coffin and vassal rack.
Also removes the need for a client to vassalize, making it possible to test vassal things locally using fake minds.

Also fixes not being able to vassalize non-mindshielded people.

Finally, I rebalanced the vassalization timers.
Welders no longer deal brute damage.
All items that deal burn now properly help with speed.
Welders now take into account their force when lowering timer, instead of being flat.

## Why It's Good For The Game

Fix, and easier to test Bloodsuckers.
Also balances Bloodsuckers to make more sense I find, burn weapons shouldnt deal brute, and welders should use the same system everyone else uses.

## Changelog

:cl:
fix: Bloodsuckers can now vassalize non-mindshielded people again.
balance: Welders now speed up vassalization process with their force, instead of a flat speed increase.
balance: Welders no longer deal brute to people being vassalized.
/:cl: