### PR TITLE
Limits Bloodsucker vassals amount to 3

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
@@ -39,7 +39,7 @@
 		return TRUE
 	var/vassals_amount = bloodsuckerdatum.vassals.len
 	if(vassals_amount >= limit)
-		to_chat(owner.current, span_danger("too many, dumbass!"))
+		to_chat(owner.current, span_danger("Your are unable to bring more than 3 vassals under your control!"))
 		return FALSE
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = master.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	if(bloodsuckerdatum && bloodsuckerdatum.broke_masquerade)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
@@ -40,7 +40,7 @@
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = master.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	var/vassals_amount = bloodsuckerdatum.vassals.len
 	if(vassals_amount >= limit)
-		to_chat(owner.current, span_danger("You'ree unable to bring more than [vassal_limit] vassals under your control!"))
+		to_chat(owner.current, span_danger("You're unable to bring more than [vassal_limit] vassals under your control!"))
 		return FALSE
 	if(bloodsuckerdatum && bloodsuckerdatum.broke_masquerade)
 		//vassal stealing

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
@@ -40,7 +40,7 @@
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = master.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	var/vassals_amount = bloodsuckerdatum.vassals.len
 	if(vassals_amount >= limit)
-		to_chat(owner.current, span_danger("Your are unable to bring more than 3 vassals under your control!"))
+		to_chat(owner.current, span_danger("You'ree unable to bring more than [vassal_limit] vassals under your control!"))
 		return FALSE
 	if(bloodsuckerdatum && bloodsuckerdatum.broke_masquerade)
 		//vassal stealing

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
@@ -37,11 +37,11 @@
 	var/mob/living/master = conversion_target.mind.enslaved_to?.resolve()
 	if(!master || (master == owner.current))
 		return TRUE
+	var/datum/antagonist/bloodsucker/bloodsuckerdatum = master.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	var/vassals_amount = bloodsuckerdatum.vassals.len
 	if(vassals_amount >= limit)
 		to_chat(owner.current, span_danger("Your are unable to bring more than 3 vassals under your control!"))
 		return FALSE
-	var/datum/antagonist/bloodsucker/bloodsuckerdatum = master.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	if(bloodsuckerdatum && bloodsuckerdatum.broke_masquerade)
 		//vassal stealing
 		return TRUE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
@@ -37,6 +37,10 @@
 	var/mob/living/master = conversion_target.mind.enslaved_to?.resolve()
 	if(!master || (master == owner.current))
 		return TRUE
+	var/vassals_amount = bloodsuckerdatum.vassals.len
+	if(vassals_amount >= limit)
+		to_chat(owner.current, span_danger("too many, dumbass!"))
+		return FALSE
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = master.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	if(bloodsuckerdatum && bloodsuckerdatum.broke_masquerade)
 		//vassal stealing

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
@@ -39,7 +39,7 @@
 		return TRUE
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = master.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	var/vassals_amount = bloodsuckerdatum.vassals.len
-	if(vassals_amount >= limit)
+	if(vassals_amount >= vassal_limit)
 		to_chat(owner.current, span_danger("You're unable to bring more than [vassal_limit] vassals under your control!"))
 		return FALSE
 	if(bloodsuckerdatum && bloodsuckerdatum.broke_masquerade)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -55,6 +55,8 @@
 	///Frenzy Grab Martial art given to Bloodsuckers in a Frenzy
 	var/datum/martial_art/frenzygrab/frenzygrab = new
 
+	///The limit to how many vassals bloodsucker can own
+	var/limit = 3
 	///Vassals under my control. Periodically remove the dead ones.
 	var/list/datum/antagonist/vassal/vassals = list()
 	///Special vassals I own, to not have double of the same type.

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -56,7 +56,7 @@
 	var/datum/martial_art/frenzygrab/frenzygrab = new
 
 	///The limit to how many vassals bloodsucker can own
-	var/limit = 3
+	var/vassal_limit = 3
 	///Vassals under my control. Periodically remove the dead ones.
 	var/list/datum/antagonist/vassal/vassals = list()
 	///Special vassals I own, to not have double of the same type.


### PR DESCRIPTION

## About The Pull Request
Limits Bloodsucker vassals amount to 3
## Why It's Good For The Game
Bloodsucker itself can already be extreme powerful, with many abilities available to be used; a high level bloodsucker's abilities can potentially compete against ling. In spite of this, bloodsucker, which is supposed to be a lone antag, has the ability to convert limitless vassals, with the vassals being able to function as completely normal as before without any debuff, sometimes even with special ability if it is favorite bloodsucker. If we look into another lone antag, flesh heretic, that also has ability to convert human player into minion; the minions are either limited or suffer from strong debuff- Ghouls, despite limitless, is easy to be spotted because of husk and only has 25hp without any special ability; voiceless death, limit of 2, muted and only has 50hp without any speical ability.
## Changelog
:cl:
balance: limits Bloodsucker vassals amount to 3
/:cl:
