### PR TITLE
Fixes some Bloodsucker issues

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
@@ -31,7 +31,7 @@
 	if(!conversion_target.mind)
 		to_chat(owner.current, span_danger("[conversion_target] isn't self-aware enough to be made into a Vassal."))
 		return FALSE
-	if(AmValidAntag(conversion_target))
+	if(AmValidAntag(conversion_target) == VASSALIZATION_BANNED)
 		to_chat(owner.current, span_danger("[conversion_target] resists the power of your blood to dominate their mind!"))
 		return FALSE
 	var/mob/living/master = conversion_target.mind.enslaved_to?.resolve()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_procs.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_procs.dm
@@ -9,9 +9,13 @@
 
 ///Called when a Bloodsucker buys a power: (power)
 /datum/antagonist/bloodsucker/proc/BuyPower(datum/action/bloodsucker/power)
+	for(var/datum/action/bloodsucker/current_powers as anything in powers)
+		if(current_powers.type == power.type)
+			return FALSE
 	powers += power
 	power.Grant(owner.current)
 	log_uplink("[key_name(owner.current)] purchased [power].")
+	return TRUE
 
 ///Called when a Bloodsucker loses a power: (power)
 /datum/antagonist/bloodsucker/proc/RemovePower(datum/action/bloodsucker/power)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
@@ -6,16 +6,17 @@
 
 /// Start Sol, called when someone is assigned Bloodsucker
 /datum/antagonist/bloodsucker/proc/check_start_sunlight()
-	if(length(get_antag_minds(/datum/antagonist/bloodsucker)))
+	var/list/existing_suckers = get_antag_minds(/datum/antagonist/bloodsucker) - src
+	if(!length(existing_suckers))
 		message_admins("New Sol has been created due to Bloodsucker assignment.")
 		SSsunlight.can_fire = TRUE
 
 /// End Sol, if you're the last Bloodsucker
 /datum/antagonist/bloodsucker/proc/check_cancel_sunlight()
-	if(!length(get_antag_minds(/datum/antagonist/bloodsucker)))
+	var/list/existing_suckers = get_antag_minds(/datum/antagonist/bloodsucker) - src
+	if(!length(existing_suckers))
 		message_admins("Sol has been deleted due to the lack of Bloodsuckers")
 		SSsunlight.can_fire = FALSE
-
 
 ///Ranks the Bloodsucker up, called by Sol.
 /datum/antagonist/bloodsucker/proc/sol_rank_up(atom/source)
@@ -129,16 +130,17 @@
 	var/total_brute = user.getBruteLoss_nonProsthetic()
 	var/total_burn = user.getFireLoss_nonProsthetic()
 	var/total_damage = total_brute + total_burn
+	if(total_burn >= 199)
+		return
+	if(SSsunlight.sunlight_active)
+		return
 	// You are in a Coffin, so instead we'll check TOTAL damage, here.
 	if(istype(user.loc, /obj/structure/closet/crate/coffin))
-		if(!SSsunlight.sunlight_active && total_damage <= 10)
+		if(total_damage <= 10)
 			torpor_end()
-	// You're not in a Coffin? We won't check for low Burn damage
-	else if(!SSsunlight.sunlight_active && total_brute <= 10)
-		// You're under 10 brute, but over 200 Burn damage? Don't exit Torpor, to prevent spam revival/death. Only way out is healing that Burn.
-		if(total_burn >= 199)
-			return
-		torpor_end()
+	else
+		if(total_brute <= 10)
+			torpor_end()
 
 /datum/antagonist/bloodsucker/proc/torpor_begin()
 	to_chat(owner.current, span_notice("You enter the horrible slumber of deathless Torpor. You will heal until you are renewed."))

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
@@ -6,7 +6,7 @@
 
 /// Start Sol, called when someone is assigned Bloodsucker
 /datum/antagonist/bloodsucker/proc/check_start_sunlight()
-	var/list/existing_suckers = get_antag_minds(/datum/antagonist/bloodsucker) - src
+	var/list/existing_suckers = get_antag_minds(/datum/antagonist/bloodsucker) - owner
 	if(!length(existing_suckers))
 		message_admins("New Sol has been created due to Bloodsucker assignment.")
 		SSsunlight.can_fire = TRUE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
@@ -13,7 +13,7 @@
 
 /// End Sol, if you're the last Bloodsucker
 /datum/antagonist/bloodsucker/proc/check_cancel_sunlight()
-	var/list/existing_suckers = get_antag_minds(/datum/antagonist/bloodsucker) - src
+	var/list/existing_suckers = get_antag_minds(/datum/antagonist/bloodsucker) - owner
 	if(!length(existing_suckers))
 		message_admins("Sol has been deleted due to the lack of Bloodsuckers")
 		SSsunlight.can_fire = FALSE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
@@ -45,7 +45,6 @@
 		target.balloon_alert(target, "learned [choice]!")
 		to_chat(target, span_notice("Your master taught you how to use [choice]!"))
 
-	vassaldatum.LevelUpPowers()
 	vassaldatum.vassal_level++
 	switch(vassaldatum.vassal_level)
 		if(2)
@@ -76,6 +75,7 @@
 			vassaldatum.set_vassal_level(target)
 
 	finalize_spend_rank(bloodsuckerdatum, cost_rank, blood_cost)
+	vassaldatum.LevelUpPowers()
 
 /datum/bloodsucker_clan/ventrue/on_favorite_vassal(datum/source, datum/antagonist/vassal/vassaldatum, mob/living/bloodsucker)
 	to_chat(bloodsucker, span_announce("* Bloodsucker Tip: You can now upgrade your Favorite Vassal by buckling them onto a Candelabrum!"))

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
@@ -118,13 +118,9 @@
 	/// TELEPORT: Move to Coffin & Close it!
 	user.set_resting(TRUE, TRUE, FALSE)
 	do_teleport(owner, bloodsuckerdatum_power.coffin, no_effects = TRUE, forced = TRUE, channel = TELEPORT_CHANNEL_QUANTUM)
-	user.Stun(3 SECONDS, TRUE)
-
-	// Puts me inside.
-	if(!bloodsuckerdatum_power.coffin.insert(owner))
-		// CLOSE LID: If fail, force me in.
-		bloodsuckerdatum_power.coffin.close(owner)
-		playsound(bloodsuckerdatum_power.coffin.loc, bloodsuckerdatum_power.coffin.close_sound, 15, 1, -3)
+	bloodsuckerdatum_power.coffin.close(owner)
+	bloodsuckerdatum_power.coffin.take_contents()
+	playsound(bloodsuckerdatum_power.coffin.loc, bloodsuckerdatum_power.coffin.close_sound, 15, 1, -3)
 
 	DeactivatePower()
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -275,19 +275,19 @@
 		var/datum/antagonist/vassal/vassaldatum = target.mind.has_antag_datum(/datum/antagonist/vassal)
 		if(!vassaldatum.master.broke_masquerade)
 			balloon_alert(user, "someone else's vassal!")
-			return
+			return FALSE
 
 	var/disloyalty_requires = RequireDisloyalty(user, target)
 	if(disloyalty_requires == VASSALIZATION_BANNED)
-		return
+		balloon_alert(user, "can't be vassalized!")
+		return FALSE
 
 	// Conversion Process
 	if(convert_progress)
 		balloon_alert(user, "spilling blood...")
 		bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_HALF_COST)
 		if(!do_torture(user, target))
-			balloon_alert(user, "interrupted!")
-			return
+			return FALSE
 		bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_HALF_COST)
 		// Prevent them from unbuckling themselves as long as we're torturing.
 		target.Paralyze(1 SECONDS)
@@ -307,7 +307,7 @@
 	if(!disloyalty_confirm && disloyalty_requires)
 		if(!do_disloyalty(user, target))
 			return
-		else if(!disloyalty_confirm)
+		if(!disloyalty_confirm)
 			balloon_alert(user, "refused persuasion!")
 		else
 			balloon_alert(user, "ready for communion!")
@@ -317,7 +317,7 @@
 	if(!do_after(user, 5 SECONDS, target))
 		balloon_alert(user, "interrupted!")
 		return
-	/// Convert to Vassal!
+	// Convert to Vassal!
 	bloodsuckerdatum.AddBloodVolume(-TORTURE_CONVERSION_COST)
 	if(bloodsuckerdatum.make_vassal(target))
 		remove_loyalties(target)
@@ -388,7 +388,6 @@
 		else
 			target.balloon_alert_to_viewers("stares defiantly", "refused vassalization!")
 	disloyalty_offered = FALSE
-
 	return TRUE
 
 /obj/structure/bloodsucker/vassalrack/proc/RequireDisloyalty(mob/living/user, mob/living/target)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/vassal/types/revenge_vassal.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/vassal/types/revenge_vassal.dm
@@ -81,26 +81,3 @@
 	var/datum/action/antag_info/info_button = new(src)
 	info_button.Grant(owner.current)
 	info_button_ref = WEAKREF(info_button)
-
-/datum/antagonist/vassal/admin_add(datum/mind/new_owner, mob/admin)
-	var/list/datum/mind/possible_vampires = list()
-	for(var/datum/antagonist/bloodsucker/bloodsuckerdatums in GLOB.antagonists)
-		var/datum/mind/vamp = bloodsuckerdatums.owner
-		if(!vamp)
-			continue
-		if(!vamp.current)
-			continue
-		if(vamp.current.stat == DEAD)
-			continue
-		possible_vampires += vamp
-	if(!length(possible_vampires))
-		message_admins("[key_name_admin(usr)] tried vassalizing [key_name_admin(new_owner)], but there were no bloodsuckers!")
-		return
-	var/datum/mind/choice = input("Which bloodsucker should this vassal belong to?", "Bloodsucker") in possible_vampires
-	if(!choice)
-		return
-	log_admin("[key_name_admin(usr)] turned [key_name_admin(new_owner)] into a vassal of [key_name_admin(choice)]!")
-	var/datum/antagonist/bloodsucker/vampire = choice.has_antag_datum(/datum/antagonist/bloodsucker)
-	master = vampire
-	new_owner.add_antag_datum(src)
-	to_chat(choice, span_notice("Through divine intervention, you've gained a new vassal!"))

--- a/fulp_modules/features/antagonists/bloodsuckers/code/vassal/vassal_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/vassal/vassal_datum.dm
@@ -158,3 +158,26 @@
 	if(master && master.owner)
 		to_chat(master.owner, span_cultbold("You feel the bond with your vassal [owner.current] has somehow been broken!"))
 
+/datum/antagonist/vassal/admin_add(datum/mind/new_owner, mob/admin)
+	var/list/datum/mind/possible_vampires = list()
+	for(var/datum/antagonist/bloodsucker/bloodsuckerdatums in GLOB.antagonists)
+		var/datum/mind/vamp = bloodsuckerdatums.owner
+		if(!vamp)
+			continue
+		if(!vamp.current)
+			continue
+		if(vamp.current.stat == DEAD)
+			continue
+		possible_vampires += vamp
+	if(!length(possible_vampires))
+		message_admins("[key_name_admin(usr)] tried vassalizing [key_name_admin(new_owner)], but there were no bloodsuckers!")
+		return
+	var/datum/mind/choice = input("Which bloodsucker should this vassal belong to?", "Bloodsucker") in possible_vampires
+	if(!choice)
+		return
+	log_admin("[key_name_admin(usr)] turned [key_name_admin(new_owner)] into a vassal of [key_name_admin(choice)]!")
+	var/datum/antagonist/bloodsucker/vampire = choice.has_antag_datum(/datum/antagonist/bloodsucker)
+	master = vampire
+	new_owner.add_antag_datum(src)
+	to_chat(choice, span_notice("Through divine intervention, you've gained a new vassal!"))
+


### PR DESCRIPTION
## About The Pull Request

Bloodsucker's Vanishing Act should now let them re-exit Sol after
Antags should be vassalizable again
Bloodsuckers can no longer have two of the exact same power (Ventrue Favorite Vassals)
Sunlight properly starts and ends now
Ventrue Favorite Vassals now automatically start with their new powers at a power level of 1, meaning they can use Feed from the start.

## Why It's Good For The Game

