### PR TITLE
Adds HoochMaster Pubbystation's Bar

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -12411,10 +12411,7 @@
 	name = "Bar Lockdown";
 	req_access = list("bar")
 	},
-/obj/machinery/firealarm/directional/north{
-	dir = 4;
-	pixel_x = -4
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "aVk" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2022,7 +2022,7 @@
 /turf/open/floor/plastic,
 /area/station/security/lockers)
 "ahP" = (
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "ahR" = (
@@ -11661,6 +11661,11 @@
 /obj/item/coin/silver,
 /obj/item/stack/spacecash/c10,
 /obj/item/stack/spacecash/c100,
+/obj/machinery/requests_console/directional/west{
+	department = "Bar";
+	name = "Bar Requests console";
+	supplies_requestable = 1
+	},
 /turf/open/floor/wood,
 /area/station/service/bar)
 "aRR" = (
@@ -12325,7 +12330,11 @@
 "aVg" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table,
-/obj/machinery/newscaster/directional/north,
+/obj/machinery/requests_console/directional/north{
+	name = "Bar Requests console";
+	supplies_requestable = 1;
+	department = "Bar"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "aVh" = (
@@ -12350,7 +12359,9 @@
 /obj/item/holosign_creator/robot_seat/bar{
 	pixel_y = -10
 	},
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "aVi" = (
@@ -12399,6 +12410,10 @@
 	id = "barshutters";
 	name = "Bar Lockdown";
 	req_access = list("bar")
+	},
+/obj/machinery/firealarm/directional/north{
+	dir = 4;
+	pixel_x = -4
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -12655,6 +12670,10 @@
 "aWm" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/storage/box/drinkingglasses,
+/obj/item/radio/intercom/directional/east{
+	pixel_x = 29;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "aWo" = (
@@ -14162,10 +14181,10 @@
 /area/station/service/kitchen)
 "bck" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/requests_console/directional/east{
-	department = "Bar";
-	name = "Bar Requests console";
-	supplies_requestable = 1
+/obj/machinery/chem_master/condimaster{
+	desc = "For Cocktails, Chemistry, and Catastrophe. - The HoochMaster Deluxe.";
+	name = "HoochMaster Deluxe";
+	pixel_x = -1
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -28270,7 +28289,6 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Bar Drinks"
 	},
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "cpf" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -12411,7 +12411,10 @@
 	name = "Bar Lockdown";
 	req_access = list("bar")
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 4;
+	pixel_x = -4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "aVk" = (

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -13,13 +13,8 @@ Format:
 	votable (is this map votable)
 endmap
 
-map pubbystation
-	#default
-	minplayers 0
-	votable
-endmap
-
 map metastation
+	#default
 	minplayers 25
 	#voteweight 0.5
 	votable

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -13,8 +13,13 @@ Format:
 	votable (is this map votable)
 endmap
 
-map metastation
+map pubbystation
 	#default
+	minplayers 0
+	votable
+endmap
+
+map metastation
 	minplayers 25
 	#voteweight 0.5
 	votable


### PR DESCRIPTION

## About The Pull Request

**Adds a HoochMaster Deluxe** (Bar variant of CondiMaster/ChemMaster) **to the Pubbystation Bar**, adds a 2nd Bar Requests Console in Bar Storage (Next to the double-barreled shotgun), moves around most of the wall-mounted stuff in the Bar (Newscaster, Request Console, Intercom, Fire Alarm), and adjusts the Light switch's X/Y position a little. No changes to the Lounge.

## Why It's Good For The Game

This tweaks the layout of the wall-mounted objects in a mildly more appealing manner, as well as adding a HoochMaster Deluxe, which Pubby's bar **doesn't have**. This forces the Bartender(s) to take or build a ChemMaster or equivalent machine if they want to make cocktails of any complexity. I also believe the storage room could use an additional request console. If nothing else, it's a little extra clutter.

## Changelog

:cl:
add: Adds a HoochMaster Deluxe (Bar variant of CondiMaster/ChemMaster) to the Pubbystation Bar!
add: Adds 2nd Bar Requests Console in Bar Storage (Next to the double-barreled shotgun)
qol: Moves the Newscaster, Request Console, Fire Alarm, and Intercom to new positions on the Bar's walls
/:cl: