### PR TITLE
Allows beefcyto to actually spawn

### DIFF
--- a/fulp_modules/mapping/ruins/icemoon/beef_cytology.dmm
+++ b/fulp_modules/mapping/ruins/icemoon/beef_cytology.dmm
@@ -398,7 +398,7 @@
 /turf/open/misc/asteroid/snow/atmosphere,
 /area/icemoon/underground/explored)
 "sZ" = (
-/mob/living/simple_animal/hostile/netherworld/migo,
+/mob/living/basic/migo,
 /obj/machinery/light/floor,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered/beefcyto)
@@ -458,8 +458,8 @@
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
 "uZ" = (
-/mob/living/simple_animal/hostile/carp,
 /obj/machinery/light/floor,
+/mob/living/simple_animal/slime,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered/beefcyto)
 "ve" = (
@@ -586,6 +586,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
+/obj/item/kirbyplants/fern,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "zQ" = (
@@ -620,12 +621,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/powered/beefcyto)
-"BJ" = (
-/obj/structure/closet/crate/bin,
-/obj/item/food/breadslice/moldy/bacteria,
-/obj/item/food/pizzaslice/moldy/bacteria,
-/turf/open/floor/wood,
-/area/space)
 "BL" = (
 /obj/machinery/light{
 	dir = 8
@@ -2253,7 +2248,7 @@ Mc
 Mc
 Mc
 Mc
-BJ
+Sh
 pv
 yD
 yD


### PR DESCRIPTION
## About The Pull Request

Bro its been like half a year since carps arent simple animals whats up with that

## Why It's Good For The Game

I replaced the carp in the cell with a slime because carps are bitch to deal with nowadays and will just teleport outside the moated ruin + their cells can be gotten from moisture traps anyway
I also added a guaranteed fern plant because everything fun is locked behind them which says a lot because cyto isnt actually fun