### PR TITLE
Transfer honeycomb from bags into the all-in-one grinder

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -174,7 +174,6 @@
 	//Fill machine with a bag!
 	if(istype(I, /obj/item/storage/bag))
 		var/list/inserted = list()
-		//This code causes the grinder to prioritise taking food items before honeycombs, requires revision of atom_storage.remove_type func to process in parallel
 		if(I.atom_storage.remove_type(/obj/item/food/grown, src, limit - length(holdingitems), TRUE, FALSE, user, inserted))
 			for(var/i in inserted)
 				holdingitems[i] = TRUE

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -174,7 +174,11 @@
 	//Fill machine with a bag!
 	if(istype(I, /obj/item/storage/bag))
 		var/list/inserted = list()
+		//This code causes the grinder to prioritise taking food items before honeycombs, requires revision of atom_storage.remove_type func to process in parallel
 		if(I.atom_storage.remove_type(/obj/item/food/grown, src, limit - length(holdingitems), TRUE, FALSE, user, inserted))
+			for(var/i in inserted)
+				holdingitems[i] = TRUE
+		if(I.atom_storage.remove_type(/obj/item/reagent_containers/honeycomb, src, limit - length(holdingitems), TRUE, FALSE, user, inserted))
 			for(var/i in inserted)
 				holdingitems[i] = TRUE
 			if(!I.contents.len)


### PR DESCRIPTION
## About The Pull Request

Added an additional function call to the logic for dumping items from bags into the all-in-one grinder, this call checks to see if the bag contains any honeycombs and tries to fill the container with them.

## Why It's Good For The Game

This is a very simple quality of life change, being able to fill plant bags with honeycomb is already an interesting choice since they are not a plant, and having to take them out one by one to put into the reagent grinder is an unnecessary step.

## Changelog

:cl:
qol: dump honeycomb from bags into the all-in-one grinder
/:cl:
