### PR TITLE
Sect Buffs and Mapping Consistency

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -593,8 +593,8 @@
 "agn" = (
 /obj/structure/bed/dogbed/renault,
 /obj/machinery/newscaster/directional/south,
-/mob/living/simple_animal/pet/fox/renault,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/pet/fox/renault,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "ago" = (
@@ -9077,6 +9077,7 @@
 "cgH" = (
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/cup/glass/bottle/holywater,
+/obj/item/nullrod,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "cgJ" = (
@@ -14375,8 +14376,8 @@
 "dxl" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/structure/filingcabinet/chestdrawer,
-/mob/living/simple_animal/parrot/poly,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "dxo" = (
@@ -21138,8 +21139,8 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "fiu" = (
-/mob/living/basic/cockroach,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/cockroach,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "fiB" = (
@@ -40718,7 +40719,7 @@
 /obj/effect/spawner/random/structure/table_fancy,
 /obj/item/reagent_containers/cup/glass/bottle/beer{
 	desc = "Whatever it is, it reeks of foul, putrid froth.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing=15);
+	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing = 15);
 	name = "Delta-Down";
 	pixel_x = 5;
 	pixel_y = 5
@@ -42708,10 +42709,10 @@
 "kDv" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/item/radio/intercom/directional/south,
-/mob/living/simple_animal/pet/cat/runtime,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/mob/living/simple_animal/pet/cat/runtime,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/cmo)
 "kDA" = (
@@ -47482,8 +47483,8 @@
 /area/station/commons/vacant_room/office)
 "lNN" = (
 /obj/structure/bed/dogbed/mcgriff,
-/mob/living/basic/pet/dog/pug/mcgriff,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/mob/living/basic/pet/dog/pug/mcgriff,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "lNR" = (
@@ -49175,8 +49176,8 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/mob/living/basic/cockroach,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/cockroach,
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
 "mmM" = (
@@ -49242,7 +49243,7 @@
 "mnK" = (
 /obj/structure/table/wood/fancy,
 /obj/item/book/granter/action/spell/smoke/lesser,
-/obj/item/nullrod,
+/obj/item/soulstone/anybody/chaplain,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "mnN" = (
@@ -51418,8 +51419,8 @@
 /obj/effect/turf_decal/trimline/white/warning{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "mOp" = (
@@ -54959,8 +54960,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/mob/living/simple_animal/bot/secbot/beepsky/officer,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/bot/secbot/beepsky/officer,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nJK" = (
@@ -95301,8 +95302,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/mob/living/simple_animal/sloth/citrus,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/sloth/citrus,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "xPo" = (
@@ -95378,8 +95379,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/basic/cockroach,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/cockroach,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "xQr" = (

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -10194,7 +10194,10 @@
 /area/station/maintenance/starboard/fore)
 "aZP" = (
 /obj/structure/table/wood,
-/obj/item/toy/figure/chaplain,
+/obj/item/book/granter/action/spell/smoke/lesser{
+	name = "mysterious old book of cloud-chasing"
+	},
+/obj/item/soulstone/anybody/chaplain,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "aZQ" = (
@@ -19816,7 +19819,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/beer{
 	desc = "Whatever it is, it reeks of foul, putrid froth.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing=15);
+	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing = 15);
 	name = "Delta-Down";
 	pixel_x = 3;
 	pixel_y = 8
@@ -35341,8 +35344,8 @@
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "fVC" = (
-/mob/living/carbon/human/species/monkey,
 /obj/structure/flora/grass/jungle/a/style_2,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "fVF" = (
@@ -46762,7 +46765,7 @@
 	Uses = 0
 	},
 /obj/item/reagent_containers/dropper{
-	list_reagents = list(/datum/reagent/toxin/plasma=4);
+	list_reagents = list(/datum/reagent/toxin/plasma = 4);
 	pixel_x = -5;
 	pixel_y = -8
 	},
@@ -56237,8 +56240,8 @@
 /area/station/science/robotics/mechbay)
 "phZ" = (
 /obj/structure/bed/dogbed/ian,
-/mob/living/basic/pet/dog/corgi/ian,
 /obj/structure/extinguisher_cabinet/directional/east,
+/mob/living/basic/pet/dog/corgi/ian,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "pia" = (
@@ -63202,13 +63205,13 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/prison)
 "snr" = (
-/mob/living/simple_animal/hostile/retaliate/goat{
-	name = "Pete"
-	},
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/mob/living/simple_animal/hostile/retaliate/goat{
+	name = "Pete"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "snA" = (
@@ -63796,9 +63799,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "sBs" = (
-/mob/living/carbon/human/species/monkey/punpun,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "sBt" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3909,10 +3909,10 @@
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
-/mob/living/basic/giant_spider/sgt_araneus,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/mob/living/basic/giant_spider/sgt_araneus,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "anT" = (
@@ -4008,13 +4008,13 @@
 /area/station/security/brig)
 "aop" = (
 /obj/structure/bed/dogbed/mcgriff,
-/mob/living/basic/pet/dog/pug/mcgriff,
 /obj/machinery/requests_console/directional/west{
 	department = "Security";
 	name = "Warden's Office Requests Console";
 	assistance_requestable = 1;
 	anon_tips_receiver = 1
 	},
+/mob/living/basic/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "aoq" = (
@@ -7857,8 +7857,8 @@
 /area/station/command/heads_quarters/hop)
 "aBF" = (
 /obj/structure/bed/dogbed/ian,
-/mob/living/basic/pet/dog/corgi/ian,
 /obj/machinery/status_display/evac/directional/north,
+/mob/living/basic/pet/dog/corgi/ian,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "aBG" = (
@@ -12293,10 +12293,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "aUZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "aVa" = (
@@ -12639,12 +12639,12 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
-/mob/living/carbon/human/species/monkey/punpun,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "aWf" = (
@@ -24785,7 +24785,6 @@
 /obj/item/folder/yellow,
 /obj/item/paper/monitorkey,
 /obj/item/pen,
-/mob/living/simple_animal/parrot/poly,
 /obj/machinery/button/door/directional/west{
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
@@ -24806,6 +24805,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "bVG" = (
@@ -28855,7 +28855,10 @@
 /area/station/service/chapel/office)
 "cso" = (
 /obj/structure/table/wood,
-/obj/item/nullrod,
+/obj/item/book/granter/action/spell/smoke/lesser{
+	name = "mysterious old book of cloud-chasing"
+	},
+/obj/item/soulstone/anybody/chaplain,
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
 "csp" = (
@@ -28901,6 +28904,7 @@
 	pixel_x = -2;
 	pixel_y = 2
 	},
+/obj/item/nullrod,
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
 "csE" = (
@@ -38940,10 +38944,10 @@
 /area/station/hallway/primary/central/aft)
 "lfI" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/mob/living/simple_animal/butterfly,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "lfS" = (
@@ -42548,10 +42552,10 @@
 /area/station/hallway/primary/central/fore)
 "oAk" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "oAw" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -4617,8 +4617,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bAt" = (
-/mob/living/simple_animal/bot/medbot,
 /obj/effect/turf_decal/tile/medical/opposingcorners,
+/mob/living/simple_animal/bot/medbot,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bAu" = (
@@ -5779,12 +5779,12 @@
 	location = "QM #2"
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #2";
 	suffix = "#2"
-	},
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -6316,10 +6316,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/mob/living/simple_animal/bot/cleanbot/medbay,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 1
 	},
+/mob/living/simple_animal/bot/cleanbot/medbay,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "cbe" = (
@@ -8775,8 +8775,8 @@
 	dir = 4
 	},
 /obj/structure/bed/dogbed/lia,
-/mob/living/basic/carp/pet/lia,
 /obj/effect/turf_decal/tile/security/half,
+/mob/living/basic/carp/pet/lia,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "cSW" = (
@@ -9256,10 +9256,10 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/storage)
 "cZf" = (
-/mob/living/carbon/human/species/monkey,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "cZr" = (
@@ -15016,10 +15016,10 @@
 /obj/structure/sink/kitchen/directional/south{
 	name = "utility sink"
 	},
-/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
+/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "fac" = (
@@ -15971,13 +15971,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "fpl" = (
+/obj/effect/turf_decal/siding/wideplating/dark/end,
 /mob/living/basic/cockroach{
 	desc = "The pet of the Mime and Clown. Get too close and he'll hiss at you.";
 	name = "Tiger";
 	real_name = "Tiger";
 	resize = 1.1
 	},
-/obj/effect/turf_decal/siding/wideplating/dark/end,
 /turf/open/floor/grass,
 /area/station/service/theater)
 "fpn" = (
@@ -20737,10 +20737,10 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "gTn" = (
-/mob/living/carbon/human/species/monkey,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "gTw" = (
@@ -25747,10 +25747,10 @@
 /obj/structure/bed/dogbed{
 	name = "Tom's bed"
 	},
-/mob/living/basic/mouse/brown/tom,
 /obj/effect/turf_decal/tile/prison/anticorner{
 	dir = 8
 	},
+/mob/living/basic/mouse/brown/tom,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "iFq" = (
@@ -39772,6 +39772,7 @@
 "ndK" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/book/granter/action/spell/smoke/lesser,
+/obj/item/soulstone/anybody/chaplain,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "ndM" = (
@@ -53132,10 +53133,10 @@
 "rJm" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/structure/cable,
-/mob/living/simple_animal/pet/cat/runtime,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 1
 	},
+/mob/living/simple_animal/pet/cat/runtime,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "rJv" = (
@@ -54524,10 +54525,10 @@
 /area/station/commons/dorms)
 "shG" = (
 /obj/structure/filingcabinet,
-/mob/living/simple_animal/parrot/poly,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "shT" = (
@@ -56244,11 +56245,11 @@
 	location = "QM #1"
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #1";
 	suffix = "#1"
 	},
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "sKQ" = (

--- a/code/modules/religion/burdened/burdened_trauma.dm
+++ b/code/modules/religion/burdened/burdened_trauma.dm
@@ -6,7 +6,7 @@
 	gain_text = span_notice("You feel burdened!")
 	lose_text = span_warning("You no longer feel the need to burden yourself!")
 	random_gain = FALSE
-	/// goes from 0 to 9 (but can be beyond 9, just does nothing) and gives rewards. increased by disabling yourself with debuffs
+	/// goes from 0 to 6 (but can be beyond 6, just does nothing) and gives rewards. increased by disabling yourself with debuffs
 	var/burden_level = 0
 
 /datum/brain_trauma/special/burdened/on_gain()
@@ -63,55 +63,38 @@
 			to_chat(owner, span_warning("You feel no weight on your shoulders. You are not feeling [GLOB.deity]'s suffering."))
 		if(1)
 			if(increase)
-				to_chat(owner, span_notice("You begin to feel the scars on [GLOB.deity]. You must continue to burden yourself."))
-			else
-				to_chat(owner, span_warning("The weight on your shoulders feels lighter. You are barely feeling [GLOB.deity]'s suffering."))
-		if(2)
-			if(increase)
 				to_chat(owner, span_notice("You have done well to understand [GLOB.deity]. You are almost at a breakthrough."))
 			else
 				to_chat(owner, span_warning("The weight on your shoulders feels lighter. You have lost some universal truths."))
 				dna.remove_mutation(/datum/mutation/human/telepathy)
-				dna.remove_mutation(/datum/mutation/human/unintelligible)
 				owner.remove_filter("burden_outline")
-		if(3)
+		if(2)
 			if(increase)
 				to_chat(owner, span_notice("Your suffering is only a fraction of [GLOB.deity]'s, and yet the universal truths are coming to you."))
 				dna.add_mutation(/datum/mutation/human/telepathy)
-				dna.add_mutation(/datum/mutation/human/unintelligible)
 				owner.add_filter("burden_outline", 9, list("type" = "outline", "color" = "#6c6eff"))
 			else
 				to_chat(owner, span_warning("The weight on your shoulders feels lighter. You feel like you're about to forget."))
-		if(4)
-			if(increase)
-				to_chat(owner, span_notice("It hurts, each ounce of pain a lesson told. How does [GLOB.deity] bear this weight?"))
-			else
-				to_chat(owner, span_warning("The weight on your shoulders feels lighter. You're growing further from your goal."))
-		if(5)
+		if(3)
 			if(increase)
 				to_chat(owner, span_notice("Your body is a canvas of loss. You are almost at a breakthrough."))
 			else
 				to_chat(owner, span_warning("The weight on your shoulders feels lighter. You have lost some universal truths."))
 				dna.remove_mutation(/datum/mutation/human/telekinesis)
 				dna.remove_mutation(/datum/mutation/human/mindreader)
-		if(6)
+		if(4)
 			if(increase)
 				to_chat(owner, span_notice("Your suffering is respectful, your scars immaculate. More universal truths are clear, but you do not fully understand yet."))
 				dna.add_mutation(/datum/mutation/human/telekinesis)
 				dna.add_mutation(/datum/mutation/human/mindreader)
 			else
 				to_chat(owner, span_warning("The weight on your shoulders feels lighter. You feel like you're about to forget."))
-		if(7)
+		if(5)
 			if(increase)
-				to_chat(owner, span_notice("The weight on your shoulders is immense. [GLOB.deity] is shattered across the cosmos."))
-			else
-				to_chat(owner, span_warning("The weight on your shoulders feels lighter. You're growing further from your goal."))
-		if(8)
-			if(increase)
-				to_chat(owner, span_notice("You're on the cusp of another breakthrough. [GLOB.deity] lost everything."))
+				to_chat(owner, span_notice("You're on the cusp of another breakthrough. [GLOB.deity] is shattered across the cosmos. [GLOB.deity] lost everything."))
 			else
 				to_chat(owner, span_warning("The weight on your shoulders feels lighter. You have lost some universal truths."))
-		if(9)
+		if(6)
 			if(increase)
 				to_chat(owner, span_notice("You have finally broken yourself enough to understand [GLOB.deity]. It's all so clear to you."))
 				var/mob/living/carbon/human/knower = owner

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -113,7 +113,7 @@
 		return FALSE
 	var/mob/living/carbon/human/human_user = user
 	var/datum/brain_trauma/special/burdened/burden = human_user.has_trauma_type(/datum/brain_trauma/special/burdened)
-	if(!burden || burden.burden_level < 9)
+	if(!burden || burden.burden_level < 6)
 		to_chat(human_user, span_warning("You aren't burdened enough."))
 		return FALSE
 	for(var/obj/item/nullrod/null_rod in get_turf(religious_tool))
@@ -145,7 +145,7 @@
 	obj_flags = UNIQUE_RENAME
 	custom_materials = null
 	actions_types = list(/datum/action/item_action/pray_refill)
-	/// Needs burden level nine to refill.
+	/// Needs burden level six to refill.
 	var/needs_burden = TRUE
 	/// List of all possible names and descriptions.
 	var/static/list/possible_names = list(
@@ -201,7 +201,7 @@
 	if(DOING_INTERACTION_WITH_TARGET(user, src) || !istype(user))
 		return
 	var/datum/brain_trauma/special/burdened/burden = user.has_trauma_type(/datum/brain_trauma/special/burdened)
-	if(needs_burden && (!burden || burden.burden_level < 9))
+	if(needs_burden && (!burden || burden.burden_level < 6))
 		to_chat(user, span_warning("You aren't burdened enough."))
 		return
 	user.manual_emote("presses [user.p_their()] palms together...")

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -223,7 +223,7 @@
 	qdel(offering)
 	return TRUE
 
-#define GREEDY_HEAL_COST 50
+#define GREEDY_HEAL_COST 40
 
 /datum/religion_sect/greed
 	name = "Greedy God"
@@ -292,7 +292,7 @@
 		return FALSE
 	var/datum/brain_trauma/special/burdened/burden = burdened.has_trauma_type(/datum/brain_trauma/special/burdened)
 	if(burden)
-		return "You are at burden level [burden.burden_level]/9."
+		return "You are at burden level [burden.burden_level]/6."
 	return "You are not burdened."
 
 

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -75,7 +75,7 @@
 						"... We call upon you, in the face of adversity ...",
 						"... to complete us, removing that which is undesirable ...")
 	invoke_msg = "... Arise, our champion! Become that which your soul craves, live in the world as your true form!!"
-	favor_cost = 1000
+	favor_cost = 750
 
 /datum/religion_rites/synthconversion/perform_rite(mob/living/user, atom/religious_tool)
 	if(!ismovable(religious_tool))
@@ -123,7 +123,7 @@
 	ritual_invocations =list( "Let your will power our forges.",
 							"...Help us in our great conquest!")
 	invoke_msg = "The end of flesh is near!"
-	favor_cost = 2000
+	favor_cost = 1500
 
 /datum/religion_rites/machine_blessing/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	..()


### PR DESCRIPTION
## Why It's Good For The Game

Mapping consistency is a good thing. Punished Sect sucks, Mechanical God favor cost has been too high, and the Greed God's drawback of paying for bible heals is too high to be worth it when bible heals would otherwise be free. Just making these sects more favorable so that the chaplain doesn't spend 50+ minutes for a handicap (Punished Sect) or boon they can't really make use of since it is too late into the round (Mechanical God).

## Changelog
:cl:
add: Added chaplain's cloud chasing book and old shard to every mainline map for consistency
balance: Mechanical God favor costs reduced to be more reasonable
balance: Greedy God bible heal money cost reduced by 20% (50 credits -> 40 credits)
balance: Punished Sect now needs a solid 6 burdens instead of 9
/:cl:
