### PR TITLE
Fixes some href exploits and adds a new MH uplink UI

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -331,6 +331,8 @@
 
 	switch(action)
 		if("join_clan")
+			if(my_clan)
+				return
 			assign_clan_and_bane()
 			ui.send_full_update(force = TRUE)
 			return

--- a/fulp_modules/features/antagonists/infiltrators/infil_corpmarket.dm
+++ b/fulp_modules/features/antagonists/infiltrators/infil_corpmarket.dm
@@ -120,7 +120,7 @@
 	///current category we viewing on the ui
 	var/datum/corp_category/viewing_category
 	/// What item is the current uplink attempting to buy?
-	var/selected_item
+	var/datum/infil_corpitem/selected_item
 	///are we currently buying somth
 	var/buying
 	///the market we's connected to
@@ -132,7 +132,6 @@
 	///the area we need to be in to connect to HQ
 	var/area/connecting_zone
 
-
 /obj/item/infil_uplink/proc/set_connecting_zone()
 	for(var/sanity in 1 to 100)
 		var/area/selected_area = pick(get_sorted_areas())
@@ -141,8 +140,6 @@
 		connecting_zone = selected_area
 		break
 
-
-
 /obj/item/infil_uplink/Initialize(mapload)
 	. = ..()
 	set_connecting_zone()
@@ -150,9 +147,7 @@
 	market = new /datum/infil_corpmarket
 	viewing_category = market.category[1]
 
-
 /obj/item/infil_uplink/ui_interact(mob/living/user, datum/tgui/ui)
-
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		add_overlay("uplink_on")
@@ -179,11 +174,11 @@
 	if(viewing_category)
 		for(var/datum/infil_corpitem/contraband in viewing_category.item)
 			data["items"] += list(list(
-			"id" = contraband.type,
-			"name" = contraband.name,
-			"desc" = contraband.desc,
-			"cost" = contraband.cost,
-				))
+				"id" = contraband.type,
+				"name" = contraband.name,
+				"desc" = contraband.desc,
+				"cost" = contraband.cost,
+			))
 	return data
 
 /obj/item/infil_uplink/ui_act(action, params)
@@ -205,7 +200,9 @@
 		if("select")
 			if(isnull(params["item"]))
 				return
-			var/item = text2path(params["item"])
+			var/datum/infil_corpitem/item = text2path(params["item"])
+			if(!ispath(item))
+				return
 			selected_item = item
 			buying = TRUE
 			. = TRUE

--- a/fulp_modules/features/antagonists/infiltrators/infil_items.dm
+++ b/fulp_modules/features/antagonists/infiltrators/infil_items.dm
@@ -362,9 +362,7 @@
 		return
 	switch(action)
 		if("launch_missiles")
-			if(!disk)
-				return
-			if(used)
+			if(!disk || used)
 				return
 			used = TRUE
 			var/datum/round_event_control/missilegalore/missiles = new
@@ -376,8 +374,6 @@
 			if(!terrorism)
 				return
 			terrorism.completed = TRUE
-
-	return
 
 /obj/item/missilephone/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
@@ -75,7 +75,7 @@
 			. = TRUE
 			purchase(selected_item, usr)
 		if("claim_reward")
-			if(!objectives_completed || !length(owner.rabbits) || used_up)
+			if(!objectives_completed || length(owner.rabbits) || used_up)
 				return
 			if(!is_station_level(loc.z))
 				to_chat(usr, span_warning("The pull of the ice moon isn't strong enough here...."))

--- a/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
@@ -9,10 +9,13 @@
 	///the datum containing all weapons
 	var/list/datum/hunter_weapons/weapons = list()
 	///the weapon that we have purchased
-	var/selected_item
+	var/datum/hunter_weapons/selected_item
 	///the owner of this contract
 	var/datum/antagonist/monsterhunter/owner
-	///is the contract used up?
+
+	///Boolean on whether all objectives have been completed.
+	var/objectives_completed = FALSE
+	///Boolean on whether the contract has given it's final objective.
 	var/used_up = FALSE
 
 /obj/item/hunting_contract/Initialize(mapload, datum/antagonist/monsterhunter/hunter)
@@ -39,23 +42,22 @@
 	if(weapons.len)
 		for(var/datum/hunter_weapons/contraband as anything in weapons)
 			data["items"] += list(list(
-			"id" = contraband.type,
-			"name" = contraband.name,
-			"desc" = contraband.desc,
+				"id" = contraband.type,
+				"name" = contraband.name,
+				"desc" = contraband.desc,
 			))
-	var/check_completed = TRUE  ///determines if all objectives have been completed
 	if(owner)
-		for(var/datum/objective/obj as anything in owner.objectives)
-			data["objectives"] += list(list(
-			"explanation" = obj.explanation_text,
-			"completed" = (obj.check_completion()),
-			))
-			if(!(obj.check_completion()))
-				check_completed = FALSE
-		data["all_completed"] = check_completed
-		data["number_of_rabbits"] = owner.rabbits_spotted
 		data["rabbits_found"] = !(owner.rabbits.len)
 		data["used_up"] = used_up
+		var/objective_unfinished = FALSE
+		for(var/datum/objective/existing_objective as anything in owner.objectives)
+			var/completed = existing_objective.check_completion()
+			if(completed)
+				continue
+			data["objectives"] += list(list("explanation" = existing_objective.explanation_text))
+			objective_unfinished = TRUE
+		objectives_completed = !objective_unfinished
+		data["all_completed"] = objectives_completed
 	return data
 
 /obj/item/hunting_contract/ui_act(action, params)
@@ -66,13 +68,17 @@
 		if("select")
 			if(isnull(params["item"]))
 				return
-			var/item = text2path(params["item"])
+			var/datum/hunter_weapons/item = text2path(params["item"])
+			if(!ispath(item))
+				return
 			selected_item = item
 			. = TRUE
 			purchase(selected_item, usr)
 		if("claim_reward")
+			if(!objectives_completed || !length(owner.rabbits) || used_up)
+				return
 			if(!is_station_level(loc.z))
-				to_chat(usr,span_warning("The pull of the ice moon isn't strong enough here...."))
+				to_chat(usr, span_warning("The pull of the ice moon isn't strong enough here...."))
 				return
 			SEND_SIGNAL(owner, COMSIG_BEASTIFY)
 			used_up = TRUE

--- a/fulp_modules/features/antagonists/monster_hunter/monsterhunter_datum.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/monsterhunter_datum.dm
@@ -5,14 +5,6 @@
 	job_rank = ROLE_MONSTERHUNTER
 	antag_hud_name = "obsessed"
 	preview_outfit = /datum/outfit/monsterhunter
-	var/list/datum/action/powers = list()
-	var/give_objectives = TRUE
-	///how many rabbits have we found
-	var/rabbits_spotted = 0
-	///the list of white rabbits
-	var/list/obj/effect/client_image_holder/white_rabbit/rabbits = list()
-	///the red card tied to this trauma if any
-	var/obj/item/rabbit_locator/locator
 	tip_theme = "spookyconsole"
 	antag_tips = list(
 		"You are the Monster Hunter, hired to rid this station of several troublesome creatures.",
@@ -22,6 +14,13 @@
 		"You can upgrade your weapon in Wonderland by placing it on the weapon forge table and using a rabbit's eye on the table!",
 		"Only when all the rabbits are found and the monsters are terminated can we unleash the apocalypse."
 	)
+
+	///how many rabbits have we found
+	var/rabbits_spotted = 0
+	///the list of white rabbits
+	var/list/obj/effect/client_image_holder/white_rabbit/rabbits = list()
+	///the red card tied to this trauma if any
+	var/obj/item/rabbit_locator/locator
 	///a list of our prey
 	var/list/datum/mind/prey = list()
 
@@ -39,8 +38,7 @@
 
 /datum/antagonist/monsterhunter/on_gain()
 	//Give Hunter Objective
-	if(give_objectives)
-		find_monster_targets()
+	find_monster_targets()
 	var/datum/map_template/wonderland/wonder = new()
 	if(!wonder.load_new_z())
 		message_admins("The wonderland failed to load.")
@@ -51,7 +49,7 @@
 	owner.teach_crafting_recipe(/datum/crafting_recipe/silver_stake)
 	var/mob/living/carbon/criminal = owner.current
 	var/obj/item/rabbit_locator/card = new(get_turf(criminal), src)
-	var/list/slots = list ("backpack" = ITEM_SLOT_BACKPACK, "left pocket" = ITEM_SLOT_LPOCKET, "right pocket" = ITEM_SLOT_RPOCKET)
+	var/list/slots = list("backpack" = ITEM_SLOT_BACKPACK, "left pocket" = ITEM_SLOT_LPOCKET, "right pocket" = ITEM_SLOT_RPOCKET)
 	if(!criminal.equip_in_one_of_slots(card, slots))
 		var/obj/item/rabbit_locator/droppod_card = new()
 		grant_drop_ability(droppod_card)
@@ -61,7 +59,7 @@
 		grant_drop_ability(droppod_contract)
 	RegisterSignal(src, COMSIG_GAIN_INSIGHT, PROC_REF(insight_gained))
 	RegisterSignal(src, COMSIG_BEASTIFY, PROC_REF(turn_beast))
-	for(var/i in 1 to 5 )
+	for(var/i in 1 to 5)
 		var/turf/rabbit_hole = get_safe_random_station_turf()
 		var/obj/effect/client_image_holder/white_rabbit/cretin =  new(rabbit_hole, owner.current)
 		cretin.hunter = src
@@ -72,7 +70,6 @@
 	gun_holder.drop_gun = TRUE
 	var/datum/action/cooldown/spell/track_monster/track = new
 	track.Grant(owner.current)
-
 	return ..()
 
 /datum/antagonist/monsterhunter/proc/grant_drop_ability(obj/item/tool)
@@ -85,7 +82,6 @@
 		contract.owner = src
 	summon_contract.Grant(owner.current)
 
-
 /datum/antagonist/monsterhunter/on_removal()
 	UnregisterSignal(src, COMSIG_GAIN_INSIGHT)
 	UnregisterSignal(src, COMSIG_BEASTIFY)
@@ -95,15 +91,8 @@
 	if(locator)
 		locator.hunter = null
 	locator = null
-	to_chat(owner.current, span_userdanger("Your hunt has ended: You enter retirement once again, and are no longer a Monster Hunter."))
+	to_chat(owner.current, span_userdanger("Your hunt has ended: You enter retirement once again, and are no longer \a [name]."))
 	return ..()
-
-
-/datum/antagonist/monsterhunter/on_body_transfer(mob/living/old_body, mob/living/new_body)
-	. = ..()
-	for(var/datum/action/all_powers as anything in powers)
-		all_powers.Remove(old_body)
-		all_powers.Grant(new_body)
 
 /datum/antagonist/monsterhunter/get_preview_icon()
 	var/mob/living/carbon/human/dummy/consistent/hunter = new
@@ -175,7 +164,7 @@
 	to_chat(owner.current, span_announce("While we can kill anyone in our way to destroy the monsters lurking around, <b>causing property damage is unacceptable</b>."))
 	to_chat(owner.current, span_announce("However, security WILL detain us if they discover our mission."))
 	to_chat(owner.current, span_announce("In exchange for our services, it shouldn't matter if a few items are gone missing for our... personal collection."))
-	owner.current.playsound_local(null, 'fulp_modules/features/antagonists/monster_hunter/sounds/monsterhunterintro.ogg', 100, FALSE, pressure_affected = FALSE)
+	owner.current.playsound_local(null, 'fulp_modules/features/antagonists/monster_hunter/sounds/monsterhunterintro.ogg', 75, FALSE, pressure_affected = FALSE)
 	owner.announce_objectives()
 
 /datum/antagonist/monsterhunter/proc/insight_gained()
@@ -275,7 +264,7 @@
 		"target" = get_turf(owner),
 		"style" = STYLE_SYNDICATE,
 		"spawn" = item_path,
-		))
+	))
 	qdel(src)
 	return TRUE
 

--- a/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
@@ -144,7 +144,6 @@
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 
-
 /obj/item/melee/trick_weapon/threaded_cane/Initialize(mapload)
 	. = ..()
 	force = base_force
@@ -153,18 +152,17 @@
 		throwforce_on = 10, \
 		throw_speed_on = throw_speed, \
 		sharpness_on = SHARP_EDGED, \
-		w_class_on = WEIGHT_CLASS_BULKY)
+		w_class_on = WEIGHT_CLASS_BULKY, \
+	)
 	RegisterSignal(src, COMSIG_TRANSFORMING_ON_TRANSFORM, PROC_REF(on_transform))
 	RegisterSignal(src,WEAPON_UPGRADE, PROC_REF(upgrade_weapon))
-
-
 
 /obj/item/melee/trick_weapon/threaded_cane/proc/on_transform(obj/item/source, mob/user, active)
 	SIGNAL_HANDLER
 	balloon_alert(user, active ? "extended" : "collapsed")
 	inhand_icon_state = active ? "chain" : "threaded_cane"
 	if(active)
-		playsound(src,'sound/magic/clockwork/fellowship_armory.ogg',50)
+		playsound(src, 'sound/magic/clockwork/fellowship_armory.ogg',50)
 	reach = active ? 2 : 1
 	enabled = active
 	force = active ? upgraded_val(on_force, upgrade_level) : upgraded_val(base_force, upgrade_level)

--- a/fulp_modules/features/mentors/mentor_manager.dm
+++ b/fulp_modules/features/mentors/mentor_manager.dm
@@ -41,10 +41,12 @@ GLOBAL_DATUM_INIT(mentor_requests, /datum/request_manager/mentor, new)
 
 	// Get the request this relates to
 	var/id = params["id"] != null ? text2num(params["id"]) : null
-	if (!id)
+	if (!id || isnum(id))
 		to_chat(usr, "Failed to find a request ID in your action, please report this", confidential = TRUE)
 		CRASH("Received an action without a request ID, this shouldn't happen!")
 	var/datum/request/request = !id ? null : requests_by_id[id]
+	if(isnull(request))
+		return
 
 	switch(action)
 		if ("reply")

--- a/fulp_modules/features/mentors/mentor_manager.dm
+++ b/fulp_modules/features/mentors/mentor_manager.dm
@@ -41,7 +41,7 @@ GLOBAL_DATUM_INIT(mentor_requests, /datum/request_manager/mentor, new)
 
 	// Get the request this relates to
 	var/id = params["id"] != null ? text2num(params["id"]) : null
-	if (!id || isnum(id))
+	if (!id)
 		to_chat(usr, "Failed to find a request ID in your action, please report this", confidential = TRUE)
 		CRASH("Received an action without a request ID, this shouldn't happen!")
 	var/datum/request/request = !id ? null : requests_by_id[id]

--- a/tgui/packages/fulpui-patches/HunterContract.js
+++ b/tgui/packages/fulpui-patches/HunterContract.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../tgui/backend';
-import { Box, Button, Section, Stack, Icon } from '../tgui/components';
+import { Box, Button, Dropdown, Stack } from '../tgui/components';
 import { Window } from '../tgui/layouts';
 
 const HunterObjectives = (props, context) => {
@@ -7,34 +7,29 @@ const HunterObjectives = (props, context) => {
   const { objectives = [], all_completed, rabbits_found, used_up } = data;
   return (
     <Stack vertical fill>
-      <Stack.Item grow>
-        <Section fill title="Objectives">
-          {objectives.map((objective) => (
-            <Box key={objective.explanation}>
-              <Stack align="baseline">
-                <Stack.Item grow bold>
-                  {objective.explanation}
-                </Stack.Item>
-              </Stack>
-              <Icon
-                name={objective.completed ? 'check' : 'times'}
-                color={objective.completed ? 'good' : 'bad'}
-              />
-            </Box>
-          ))}
-          <Box>
-            <Button
-              fluid
-              textAlign="center"
-              align="center"
-              width={50}
-              content={'Commence Apocalypse'}
-              fontSize="200%"
-              disabled={!all_completed || !rabbits_found || used_up}
-              onClick={() => act('claim_reward')}
-            />
-          </Box>
-        </Section>
+      <Stack.Item>
+        <Dropdown
+          over
+          width="100%"
+          options={objectives.map((objective) => objective.explanation)}
+          displayText={'Incomplete Objectives'}
+        />
+      </Stack.Item>
+      <Stack.Item>
+        <Box>
+          <Button
+            fluid
+            textAlign="center"
+            align="center"
+            content={'Commence Apocalypse'}
+            fontSize="200%"
+            disabled={!all_completed || !rabbits_found || used_up}
+            onClick={() => act('claim_reward')}
+            tooltip={
+              'Only unlocked once all objectives are completed and rabbits are found, this will allow you to start your Final Reckoning.'
+            }
+          />
+        </Box>
       </Stack.Item>
     </Stack>
   );
@@ -42,17 +37,26 @@ const HunterObjectives = (props, context) => {
 
 export const HunterContract = (props, context) => {
   const { act, data } = useBackend(context);
-  const { items = [], bought, number_of_rabbits } = data;
+  const { items = [], bought } = data;
   return (
-    <Window width={670} height={400} theme="spookyconsole">
+    <Window
+      width={500}
+      height={365}
+      theme="spookyconsole"
+      title="Hunter's Contract">
       <Window.Content scrollable>
-        <Section title="Hunter's Contract" />
         {
           <Stack vertical fill>
-            <Stack.Item fontSize="20px" textAlign="center">
-              Pick your Hunter tool
-            </Stack.Item>
-            <Stack.Item grow>
+            <Button
+              icon="question"
+              fontSize="20px"
+              textAlign="center"
+              tooltip={
+                'Select one item to be your Hunting tool. You may only choose one, so pick wisely!'
+              }>
+              Uplink Items
+            </Button>
+            <Stack.Item>
               {items.map((item) => (
                 <Box key={item.name} className="candystripe" p={1} pb={2}>
                   <Stack align="baseline">
@@ -74,28 +78,6 @@ export const HunterContract = (props, context) => {
                   {item.desc}
                 </Box>
               ))}
-            </Stack.Item>
-            <Stack.Item>
-              <Section fill title="Hunter's Guide">
-                <Stack vertical fill>
-                  <Stack.Item>
-                    <span>
-                      Look for the white rabbits! Use their eyes to upgrade your
-                      hunter&#39;s weapon, the red queen&#39;s card will guide
-                      you!{' '}
-                      <span className={'color-red'}>
-                        {' '}
-                        YOU HAVE FOUND {number_of_rabbits}{' '}
-                        {number_of_rabbits === 1 ? 'RABBIT' : 'RABBITS'}{' '}
-                      </span>
-                      Only once the contract is fullfilled and the rabbits are
-                      found will you be able to bring upon the
-                      <span className={'color-red'}> APOCALYPSE </span>!
-                    </span>
-                    <br />
-                  </Stack.Item>
-                </Stack>
-              </Section>
             </Stack.Item>
             <Stack.Item>
               <Box>


### PR DESCRIPTION
## About The Pull Request

I've seen discussion around href exploits and decided to go through potential ones in fulp-specific code.
This should get them all, but while looking around I saw that Infil and MH UIs weren't that great.
I didn't touch infiltrator because it's not too bad, but I overhauled the Monster Hunter one to be more compact and hopefully fit better as a "paper", making it more vertical and less horizontal.

![image](https://github.com/fulpstation/fulpstation/assets/53777086/27877c0e-dcf4-4bc3-b435-53f2bda1e594)

## Why It's Good For The Game

No href exploits
Better MH UI

## Changelog

:cl:
qol: Added a better Monster Hunter UI
fix: Removed potential href exploit locations from a few fulp-unique UIs.
/:cl: