### PR TITLE
Fixes some pubby issues

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -13795,8 +13795,8 @@
 "bcc" = (
 /obj/machinery/biogenerator,
 /obj/machinery/door/window/right/directional/south{
-	req_one_access = list("hydroponics", "kitchen");
-	name = "biogenerator access"
+	req_one_access = list("hydroponics","kitchen");
+	name = "Biogenerator Access"
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -645,6 +645,19 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"adm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "adn" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -3203,15 +3216,17 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "amb" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/rack,
+/obj/item/shovel{
+	pixel_x = -5
+	},
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "amc" = (
@@ -4167,7 +4182,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "apm" = (
@@ -4182,7 +4198,8 @@
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "apo" = (
@@ -5362,7 +5379,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/command/captain,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "atM" = (
@@ -6074,7 +6091,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/command/captain,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "avN" = (
@@ -6106,7 +6123,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "avR" = (
@@ -13766,30 +13783,31 @@
 /area/station/service/hydroponics)
 "bcb" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/west{
-	base_state = "left";
-	dir = 1;
-	icon_state = "left";
-	name = "Hydroponics Desk";
-	req_access = list("hydroponics")
-	},
 /obj/item/reagent_containers/cup/bucket,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/window/right/directional/north{
+	name = "Hydroponics Desk";
+	req_one_access = list("hydroponics")
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "bcc" = (
 /obj/machinery/biogenerator,
+/obj/machinery/door/window/right/directional/south{
+	req_one_access = list("hydroponics", "kitchen");
+	name = "biogenerator access"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "bcd" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/west{
-	dir = 1;
-	name = "Hydroponics Desk";
-	req_access = list("hydroponics")
-	},
-/obj/item/food/monkeycube,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/window/right/directional/north{
+	name = "Hydroponics Desk";
+	req_one_access = list("hydroponics")
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "bce" = (
@@ -13876,6 +13894,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/computer/order_console/mining,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcC" = (
@@ -13884,18 +13903,23 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
-"bcE" = (
-/obj/structure/closet/wardrobe/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"bcF" = (
+"bcE" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
 /obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
+"bcF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/computer/shuttle/mining,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcG" = (
@@ -14347,25 +14371,6 @@
 "beI" = (
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
-"beO" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen,
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
-"beP" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "beS" = (
 /obj/structure/sign/warning,
 /turf/open/floor/plating,
@@ -14499,15 +14504,18 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "bfB" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
-/obj/item/pickaxe{
-	pixel_x = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/item/shovel{
-	pixel_x = -5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -14997,34 +15005,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/robotics,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
-"bhr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
-"bhs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "bhu" = (
 /obj/machinery/light/directional/south,
 /obj/structure/closet/secure_closet/miner,
@@ -15259,29 +15239,7 @@
 /obj/effect/decal/cleanable/robot_debris{
 	icon_state = "gib3"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
-"biC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/item/shard{
-	icon_state = "small"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "biD" = (
@@ -16801,10 +16759,15 @@
 /area/station/science/server)
 "bqo" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/photocopier,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/rack,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/book/manual/wiki/experimentor,
+/obj/item/multitool,
+/obj/item/multitool,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "bqp" = (
@@ -17220,14 +17183,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "brG" = (
-/obj/machinery/fax{
-	fax_name = "Research Division";
-	name = "Research Division Fax Machine"
-	},
-/obj/structure/table,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "brJ" = (
@@ -17574,13 +17533,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "btg" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/crowbar,
-/obj/item/book/manual/wiki/experimentor,
-/obj/item/multitool,
-/obj/item/multitool,
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
@@ -17807,23 +17759,10 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "buw" = (
-/obj/item/kirbyplants/photosynthetic{
-	pixel_y = 10
-	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/lab)
-"buy" = (
-/obj/item/kirbyplants/photosynthetic{
-	pixel_y = 10
-	},
-/obj/structure/sign/departments/rndserver/directional/north,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
@@ -18095,13 +18034,6 @@
 "bvO" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/lab)
-"bvP" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
@@ -19550,6 +19482,7 @@
 "bBO" = (
 /obj/machinery/computer/atmos_control/ordnancemix,
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bBP" = (
@@ -20138,6 +20071,7 @@
 "bEd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/tank_dispenser,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bEf" = (
@@ -25329,24 +25263,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"cdg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Mining";
-	name = "Mining Bay Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "cdm" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -30109,6 +30025,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "dAG" = (
@@ -31035,6 +30952,14 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"ese" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/photocopier,
+/turf/open/floor/iron/dark,
+/area/station/science/lab)
 "esz" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 4
@@ -32100,7 +32025,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "fjs" = (
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 8
 	},
@@ -32128,7 +32052,6 @@
 /obj/item/multitool/circuit{
 	pixel_x = 7
 	},
-/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "flq" = (
@@ -32351,12 +32274,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "fwe" = (
-/obj/machinery/firealarm/directional/west,
-/obj/structure/chair/office{
-	dir = 1
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/fax{
+	fax_name = "Research Division";
+	name = "Research Division Fax Machine"
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/server)
+/area/station/science/lab)
 "fwg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -32531,6 +32458,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fFF" = (
@@ -32803,24 +32731,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
-"fQD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "fQH" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
@@ -32982,6 +32892,24 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
+"gap" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/requests_console/directional/south{
+	department = "Mining";
+	name = "Mining Bay Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "gbi" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /mob/living/basic/butterfly,
@@ -33986,6 +33914,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"gUY" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "gVc" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
@@ -34751,20 +34686,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"hIi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "hID" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -36096,9 +36017,6 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "jaJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -36106,8 +36024,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "jaS" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 1
@@ -37203,6 +37122,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/engine,
 /area/station/science/ordnance)
 "ket" = (
@@ -38062,7 +37982,14 @@
 /area/station/command/heads_quarters/hos)
 "kOp" = (
 /obj/structure/disposalpipe/segment,
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "kPM" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -38391,9 +38318,15 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Cargo Mining Dock"
 	},
-/obj/machinery/computer/order_console/mining,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/shovel{
+	pixel_x = -5
+	},
+/obj/item/pickaxe{
+	pixel_x = 5
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -38828,10 +38761,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
-"ltJ" = (
-/obj/structure/statue/petrified,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "lug" = (
 /obj/effect/decal/cleanable/ash,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40818,6 +40747,7 @@
 	pixel_x = 7;
 	pixel_y = 2
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "noR" = (
@@ -40838,6 +40768,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"npZ" = (
+/obj/item/shard{
+	icon_state = "small"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "nqa" = (
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
@@ -41194,6 +41130,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"nIB" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/lab)
 "nIU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -42299,6 +42241,16 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
+/area/station/science/lab)
+"oEv" = (
+/obj/structure/sign/departments/rndserver/directional/north,
+/obj/item/kirbyplants/photosynthetic{
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/lab)
 "oEA" = (
 /turf/closed/wall,
@@ -43675,6 +43627,7 @@
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 5
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "pJU" = (
@@ -47036,6 +46989,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/execution)
+"szl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "szG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -48907,6 +48866,10 @@
 /obj/structure/reflector/box/anchored,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"tYX" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "tZU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -49296,6 +49259,16 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"ule" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/lab)
 "ulq" = (
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -49425,6 +49398,11 @@
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
+"uqG" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/closet/wardrobe/miner,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "urG" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
 	dir = 8
@@ -50272,15 +50250,20 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "uZx" = (
-/obj/structure/rack,
-/obj/item/pickaxe{
-	pixel_x = 5
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Maintenance"
 	},
-/obj/item/shovel{
-	pixel_x = -5
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "uZJ" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -53805,6 +53788,13 @@
 /obj/item/pen/blue,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"xJR" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "xJU" = (
 /obj/structure/table/wood,
 /obj/item/food/grown/harebell,
@@ -77439,8 +77429,8 @@ omu
 qUe
 bjK
 czJ
-txm
 csl
+txm
 iFm
 kUw
 wqC
@@ -92599,13 +92589,13 @@ bgI
 bhn
 bgI
 bfz
-iSi
-iSi
-iSi
-bkt
-bkt
-bkt
-bkt
+beI
+bkx
+bkx
+bkx
+bkx
+bkx
+bkx
 bkt
 bkt
 bkt
@@ -92856,15 +92846,15 @@ bgJ
 bhn
 bhV
 vyn
-iSi
-ltJ
-iSi
+beI
 vDT
 bnT
 fGa
 bql
-fwe
+tYX
 bkx
+fwe
+ese
 buw
 bvM
 sTi
@@ -93114,14 +93104,14 @@ bhp
 iSi
 iSi
 iSi
-gvM
-iSi
 bmT
 bnU
 eUU
 bpb
 pdv
 btf
+ule
+ule
 uVN
 uVN
 sTi
@@ -93368,10 +93358,8 @@ khX
 khX
 khX
 fGd
-aam
-bix
 yet
-fgl
+bix
 iSi
 bmU
 eNq
@@ -93379,8 +93367,10 @@ bpc
 bqn
 pSd
 bkx
-buy
+oEv
 bvO
+bwa
+bwa
 sTi
 byW
 bHw
@@ -93624,20 +93614,20 @@ gvM
 gvM
 gvM
 gvM
-hIi
-gvM
 aam
+yet
+yet
 iSi
-iSi
-iSi
-eSL
-eSL
-eSL
+bkx
+bkx
+bkx
+bkx
+bkx
+bkx
 cCl
-cCl
-cCl
-bod
-bvP
+nIB
+bFf
+bvO
 sTi
 byX
 bHw
@@ -94136,10 +94126,10 @@ bbI
 bcB
 hgV
 hgV
-hgV
-hgV
-cdg
+adm
 gvM
+fgl
+yet
 pBg
 iSi
 bkz
@@ -94393,10 +94383,10 @@ bbI
 bcC
 qfZ
 hgV
-hgV
-hgV
-fQD
+gap
 gvM
+gvM
+yet
 pBg
 iSi
 bkA
@@ -94650,10 +94640,10 @@ qXb
 udR
 dma
 lGJ
-lGJ
-lGJ
-bhr
+adm
+gUY
 gvM
+yet
 pBg
 iSi
 vYH
@@ -94904,13 +94894,13 @@ sql
 aZr
 baD
 jbo
-xkk
-xkk
-xkk
+uqG
 xkk
 kif
-bhs
+szl
+bhu
 gvM
+yet
 pBg
 iSi
 iSi
@@ -95164,11 +95154,11 @@ bbI
 bcE
 hgV
 hgV
-hgV
 pXH
 bhv
 gvM
-biC
+npZ
+qhH
 dSK
 iSi
 aak
@@ -95420,10 +95410,10 @@ baF
 bbK
 bcF
 hgV
-beO
 hgV
 pXH
 bhu
+gvM
 gvM
 yet
 pBg
@@ -95677,12 +95667,12 @@ ale
 bbK
 bcG
 bdM
-beP
 hgV
 pXH
-bhv
+xJR
 gvM
-gvM
+dKH
+yet
 pBg
 iSi
 aaw
@@ -95937,9 +95927,9 @@ bbI
 bdI
 bfI
 bdI
-bbI
 gvM
-dKH
+gvM
+yet
 pBg
 aat
 aay

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2139,7 +2139,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "aiH" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -2581,7 +2581,7 @@
 /area/station/security/office)
 "ajX" = (
 /turf/closed/wall,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "ajY" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
@@ -3044,7 +3044,7 @@
 "alp" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "alq" = (
 /obj/item/storage/box/bodybags,
 /obj/machinery/light/directional/west,
@@ -7625,7 +7625,7 @@
 "aBH" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "aBK" = (
 /obj/structure/table,
 /obj/machinery/light/directional/east,
@@ -13094,7 +13094,7 @@
 	icon_state = "plant-05"
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "aYZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13102,7 +13102,7 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/restaurant_portal/bar,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "aZb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13125,7 +13125,7 @@
 	},
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "aZf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -13144,7 +13144,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "aZi" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -13320,18 +13320,18 @@
 /obj/structure/chair/wood,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bap" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/carpet/lone,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "baq" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/lone,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bar" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -13582,26 +13582,26 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bbp" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bbr" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bbs" = (
 /obj/item/cane,
 /obj/item/clothing/head/hats/tophat,
 /obj/structure/table/wood/fancy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bbt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
@@ -13609,25 +13609,25 @@
 /obj/item/clothing/under/suit/waiter,
 /obj/item/clothing/under/dress/tango,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bbu" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bbv" = (
 /obj/item/trash/can,
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/carpet/lone,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bbw" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/carpet/lone,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bbx" = (
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/carpet/lone,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bbA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -13835,7 +13835,7 @@
 "bcm" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bcn" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -13852,24 +13852,24 @@
 	pixel_y = 5
 	},
 /turf/open/floor/carpet,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bcq" = (
 /obj/item/clothing/glasses/monocle,
 /obj/item/instrument/recorder,
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bcr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bcs" = (
 /obj/item/clothing/shoes/sandal,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bcB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14058,7 +14058,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bdG" = (
 /obj/structure/sign/warning/deathsposal,
 /turf/closed/wall,
@@ -14274,18 +14274,18 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bey" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bez" = (
 /obj/structure/table/wood,
 /obj/item/instrument/trombone,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "beA" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -14297,7 +14297,7 @@
 	req_access = list("bar")
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "beB" = (
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -14312,19 +14312,19 @@
 	req_access = list("bar")
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "beD" = (
 /obj/structure/table/wood,
 /obj/item/food/chocolatebar,
 /obj/item/kitchen/fork,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "beE" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "beG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14336,14 +14336,14 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "beH" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "beI" = (
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
@@ -14451,7 +14451,7 @@
 "bfr" = (
 /obj/machinery/barsign,
 /turf/closed/wall,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bfs" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
@@ -14459,7 +14459,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bft" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -14739,7 +14739,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bgu" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
@@ -14751,7 +14751,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bgv" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-14"
@@ -16208,7 +16208,7 @@
 "bnb" = (
 /obj/machinery/restaurant_portal/restaurant,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bnd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -16894,7 +16894,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bqA" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment,
@@ -17594,7 +17594,7 @@
 /area/station/science/lab)
 "btt" = (
 /obj/machinery/door/airlock/research{
-	name = "Xenobiology Lab"
+	name = "Xenobiology/Genetics"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -18121,11 +18121,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
-"bvU" = (
-/obj/machinery/recharger,
-/obj/structure/table,
-/turf/open/floor/iron/dark,
-/area/station/science/lab)
 "bvV" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
@@ -18266,7 +18261,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "bwO" = (
 /obj/structure/table,
 /obj/item/stack/medical/gauze,
@@ -18728,7 +18723,6 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
@@ -19716,8 +19710,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bCn" = (
@@ -19954,11 +19950,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/table/glass,
 /obj/machinery/fax{
 	fax_name = "Chief Medical Officer's Office";
 	name = "Chief Medical Officer's Fax Machine"
 	},
-/obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bDy" = (
@@ -20196,7 +20192,17 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/pdapainter/medbay,
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	layer = 3.1
+	},
+/obj/item/folder/blue{
+	pixel_x = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bEF" = (
@@ -20206,11 +20212,13 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/computer_disk/medical,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bEI" = (
@@ -20524,7 +20532,6 @@
 /area/station/science/lab)
 "bGk" = (
 /obj/machinery/light/directional/south,
-/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "bGl" = (
@@ -27338,7 +27345,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "cpk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -27350,7 +27357,7 @@
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/bar,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "cpl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -27376,7 +27383,7 @@
 "cpo" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "cpq" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -27391,7 +27398,7 @@
 "cpt" = (
 /obj/item/beacon,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "cpu" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/table,
@@ -27459,7 +27466,7 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "cpH" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
@@ -30190,7 +30197,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "dFn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -30970,15 +30977,6 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "epJ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/science/ordnance/burnchamber)
-"epJ" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/carpet,
 /area/station/service/abandoned_gambling_den)
@@ -31285,7 +31283,6 @@
 	network = list("ss13","medbay");
 	pixel_y = -22
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -31299,11 +31296,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "eFW" = (
@@ -31885,7 +31878,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "fby" = (
-/obj/structure/sign/poster/official/no_erp/directional/east,
 /obj/structure/chair/office{
 	dir = 1
 	},
@@ -31893,6 +31885,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/sign/poster/official/no_erp/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/abandoned)
 "fcK" = (
@@ -34022,9 +34015,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -34155,7 +34145,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "hfX" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/cable,
@@ -34196,11 +34186,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "hhN" = (
-/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -34211,6 +34199,7 @@
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/pdapainter/medbay,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "hiw" = (
@@ -34578,6 +34567,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/stamp/head/cmo{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "hBT" = (
@@ -34741,7 +34733,7 @@
 "hHG" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "hHJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -35686,7 +35678,7 @@
 /obj/machinery/computer/slot_machine,
 /obj/machinery/bluespace_vendor/directional/north,
 /turf/open/floor/carpet/lone,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "iEx" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/captain/private)
@@ -36167,7 +36159,7 @@
 "jdA" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "jdL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
@@ -36362,7 +36354,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "joE" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -36716,7 +36708,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "jIM" = (
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
@@ -37590,6 +37582,9 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science/xenobiology)
+"krD" = (
+/turf/closed/wall,
+/area/station/medical/abandoned)
 "krI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38524,7 +38519,7 @@
 /area/station/medical/surgery/theatre)
 "liQ" = (
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "liR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -38794,6 +38789,7 @@
 	name = "CMO Shutter Control";
 	req_access = list("cmo")
 	},
+/obj/item/computer_disk/medical,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "lsy" = (
@@ -39031,7 +39027,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "lGv" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance"
@@ -39262,7 +39258,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "lTq" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
@@ -41721,7 +41717,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "ogX" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/camera/directional/south{
@@ -42767,6 +42763,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"oUO" = (
+/turf/closed/wall,
+/area/station/medical/cryo)
 "oWw" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44333,7 +44332,7 @@
 	},
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "qmK" = (
 /obj/machinery/meter,
 /obj/structure/cable,
@@ -46743,7 +46742,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "snT" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/directional/north,
@@ -48831,7 +48830,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "tWc" = (
 /obj/structure/sign/directions/science{
 	dir = 4;
@@ -48999,6 +48998,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "udb" = (
@@ -49017,7 +49017,7 @@
 "udo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "udr" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -49813,9 +49813,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
@@ -51617,7 +51614,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "wfs" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/latex{
@@ -52592,7 +52589,7 @@
 	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "wSC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -52841,7 +52838,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -53098,6 +53094,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "xhB" = (
@@ -53250,29 +53247,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
-"xlo" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	layer = 3.1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/stamp/head/cmo{
-	pixel_y = 8
-	},
-/obj/item/folder/blue{
-	pixel_x = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "xlA" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
@@ -53433,7 +53407,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "xsO" = (
 /obj/item/ectoplasm,
 /turf/open/floor/plating{
@@ -53693,13 +53667,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"xCF" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "xDl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -54175,7 +54142,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/lounge)
+/area/station/service/bar/atrium)
 "xXi" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Access"
@@ -77987,7 +77954,7 @@ jzF
 tbS
 uhi
 tqH
-xCF
+tqH
 iIS
 vgk
 bqV
@@ -78507,8 +78474,8 @@ bpy
 biv
 bsr
 imE
-tqC
-tqC
+oUO
+oUO
 bwx
 bye
 bzG
@@ -78765,7 +78732,7 @@ bCd
 bvL
 htK
 pjB
-tqC
+oUO
 gDX
 shv
 bzI
@@ -79022,7 +78989,7 @@ srf
 bFJ
 ovL
 fdR
-tqC
+oUO
 ezx
 urO
 eZM
@@ -81593,7 +81560,7 @@ uFc
 buc
 bvk
 tEE
-xlo
+uEY
 dZb
 uEY
 bEE
@@ -85965,7 +85932,7 @@ dRj
 hEC
 hEC
 hEC
-lRN
+hEC
 lRN
 lRN
 lRN
@@ -86479,7 +86446,7 @@ lRN
 hEC
 cIe
 fby
-oJj
+krD
 eMp
 oXV
 oJj
@@ -86733,10 +86700,10 @@ oPH
 oPH
 eMp
 oPH
-oJj
-oJj
-oJj
-oJj
+krD
+krD
+krD
+krD
 hop
 oJj
 oJj
@@ -86986,8 +86953,8 @@ xPQ
 xPQ
 bJN
 mOt
-gVk
-gVk
+mOt
+mOt
 gVk
 gVk
 gVk
@@ -93160,7 +93127,7 @@ uVN
 sTi
 byV
 bHw
-bBG
+bCR
 bCR
 qnQ
 qnQ
@@ -93418,7 +93385,7 @@ sTi
 byW
 bHw
 bBG
-bCR
+bBG
 qqZ
 tct
 bGi
@@ -94955,7 +94922,7 @@ jJQ
 cCt
 vfp
 djD
-bvU
+bwa
 bxD
 bzc
 bAF


### PR DESCRIPTION
## About The Pull Request

I feel like I've been in this place before

- Fixes cryo APC being a double of med storage APC
- Connects med storage APC to the net
- Removes cables in sci maints leading to nothing
- Renames Xenobio lab door to Xenobio/Genetics
- Shuffles around CMO office to put the trimmer next to the ID management console
- Renames Bar/Kitchen eating area to the Atrium rather than being a commons area.
- Fixes some decals sitting over the ground
- Command can now leave to space through the left side of the Bridge
- Made mining bay more compact & moved the R&D servers up, giving more space to maints and science
- Added lights to ordnance

## Why It's Good For The Game

Admins don't want to remove pubby but they also don't want to maintain it

## Changelog

:cl:
add: Pubbystation
/:cl: