### PR TITLE
Ventrue de-hardcoding and desc fix

### DIFF
--- a/fulp_modules/_defines/bloodsuckers.dm
+++ b/fulp_modules/_defines/bloodsuckers.dm
@@ -21,9 +21,6 @@
 ///Drinks blood from disgusting creatures without Humanity consequences.
 #define BLOODSUCKER_DRINK_INHUMANELY "bloodsucker_drink_imhumanely"
 
-#define BLOODSUCKER_RANK_UP_NORMAL "bloodsucker_rank_up_normal"
-#define BLOODSUCKER_RANK_UP_VASSAL "bloodsucker_rank_up_vassal"
-
 ///If someone passes all checks and can be vassalized
 #define VASSALIZATION_ALLOWED 0
 ///If someone has to accept vassalization
@@ -105,7 +102,7 @@
 #define BLOODSUCKER_RANK_UP "bloodsucker_rank_up"
 
 ///Called when a Bloodsucker attempts to make a Vassal into their Favorite.
-#define BLOODSUCKER_PRE_MAKE_FAVORITE "bloodsucker_pre_make_favorite"
+#define BLOODSUCKER_INTERACT_WITH_VASSAL "bloodsucker_interact_with_vassal"
 ///Called when a Bloodsucker makes a Vassal into their Favorite Vassal: (datum/vassal_datum, mob/master)
 #define BLOODSUCKER_MAKE_FAVORITE "bloodsucker_make_favorite"
 ///Called when a new Vassal is successfully made: (datum/bloodsucker_datum)

--- a/fulp_modules/_defines/bloodsuckers.dm
+++ b/fulp_modules/_defines/bloodsuckers.dm
@@ -1,6 +1,12 @@
 ///Uncomment this to enable testing of Bloodsucker features (such as vassalizing people with a mind instead of a client).
 //#define BLOODSUCKER_TESTING
 
+/// You have special interactions with Bloodsuckers
+#define TRAIT_BLOODSUCKER_HUNTER "bloodsucker_hunter"
+
+/**
+ * Blood-level defines
+ */
 /// Determines Bloodsucker regeneration rate
 #define BS_BLOOD_VOLUME_MAX_REGEN 700
 /// Cost to torture someone halfway, in blood. Called twice for full cost
@@ -11,28 +17,16 @@
 #define FRENZY_THRESHOLD_ENTER 25
 /// Once blood is this high, will exit Frenzy
 #define FRENZY_THRESHOLD_EXIT 250
-/// You have special interactions with Bloodsuckers
-#define TRAIT_BLOODSUCKER_HUNTER "bloodsucker_hunter"
 
-///Drinks blood the normal Bloodsucker way.
-#define BLOODSUCKER_DRINK_NORMAL "bloodsucker_drink_normal"
-///Drinks blood but is snobby, refusing to drink from mindless
-#define BLOODSUCKER_DRINK_SNOBBY "bloodsucker_drink_snobby"
-///Drinks blood from disgusting creatures without Humanity consequences.
-#define BLOODSUCKER_DRINK_INHUMANELY "bloodsucker_drink_imhumanely"
-
+/**
+ * Vassal defines
+ */
 ///If someone passes all checks and can be vassalized
 #define VASSALIZATION_ALLOWED 0
 ///If someone has to accept vassalization
 #define VASSALIZATION_DISLOYAL 1
 ///If someone is not allowed under any circimstances to become a Vassal
 #define VASSALIZATION_BANNED 2
-
-#define DANGER_LEVEL_FIRST_WARNING 1
-#define DANGER_LEVEL_SECOND_WARNING 2
-#define DANGER_LEVEL_THIRD_WARNING 3
-#define DANGER_LEVEL_SOL_ROSE 4
-#define DANGER_LEVEL_SOL_ENDED 5
 
 /**
  * Cooldown defines
@@ -96,30 +90,31 @@
 #define BP_AM_COSTLESS_UNCONSCIOUS (1<<3)
 
 /**
- * Signals
+ * Bloodsucker Signals
  */
 ///Called when a Bloodsucker ranks up: (datum/bloodsucker_datum, mob/owner, mob/target)
 #define BLOODSUCKER_RANK_UP "bloodsucker_rank_up"
-
-///Called when a Bloodsucker attempts to make a Vassal into their Favorite.
+///Called when a Bloodsucker interacts with a Vassal on their persuasion rack.
 #define BLOODSUCKER_INTERACT_WITH_VASSAL "bloodsucker_interact_with_vassal"
 ///Called when a Bloodsucker makes a Vassal into their Favorite Vassal: (datum/vassal_datum, mob/master)
 #define BLOODSUCKER_MAKE_FAVORITE "bloodsucker_make_favorite"
 ///Called when a new Vassal is successfully made: (datum/bloodsucker_datum)
 #define BLOODSUCKER_MADE_VASSAL "bloodsucker_made_vassal"
-
 ///Called when a Bloodsucker exits Torpor.
 #define BLOODSUCKER_EXIT_TORPOR "bloodsucker_exit_torpor"
 ///Called when a Bloodsucker reaches Final Death.
 #define BLOODSUCKER_FINAL_DEATH "bloodsucker_final_death"
-
+	///Whether the Bloodsucker should not be dusted when arriving Final Death
+	#define DONT_DUST (1<<0)
+///Called when a Bloodsucker breaks the Masquerade
 #define COMSIG_BLOODSUCKER_BROKE_MASQUERADE "comsig_bloodsucker_broke_masquerade"
-
-///Whether the Bloodsucker should not be dusted when arriving Final Death
-#define DONT_DUST (1<<0)
+///Called when a Bloodsucker enters Frenzy
+#define BLOODSUCKER_ENTERS_FRENZY "bloodsucker_enters_frenzy"
+///Called when a Bloodsucker exits Frenzy
+#define BLOODSUCKER_EXITS_FRENZY "bloodsucker_exits_frenzy"
 
 /**
- * Sol signals
+ * Sol signals & Defines
  */
 #define COMSIG_SOL_RANKUP_BLOODSUCKERS "comsig_sol_rankup_bloodsuckers"
 #define COMSIG_SOL_RISE_TICK "comsig_sol_rise_tick"
@@ -129,6 +124,24 @@
 #define COMSIG_SOL_WARNING_GIVEN "comsig_sol_warning_given"
 ///Called on a Bloodsucker's Lifetick.
 #define COMSIG_BLOODSUCKER_ON_LIFETICK "comsig_bloodsucker_on_lifetick"
+
+#define DANGER_LEVEL_FIRST_WARNING 1
+#define DANGER_LEVEL_SECOND_WARNING 2
+#define DANGER_LEVEL_THIRD_WARNING 3
+#define DANGER_LEVEL_SOL_ROSE 4
+#define DANGER_LEVEL_SOL_ENDED 5
+
+/**
+ * Clan defines
+ *
+ * This is stuff that is used solely by Clans for clan-related activity.
+ */
+///Drinks blood the normal Bloodsucker way.
+#define BLOODSUCKER_DRINK_NORMAL "bloodsucker_drink_normal"
+///Drinks blood but is snobby, refusing to drink from mindless
+#define BLOODSUCKER_DRINK_SNOBBY "bloodsucker_drink_snobby"
+///Drinks blood from disgusting creatures without Humanity consequences.
+#define BLOODSUCKER_DRINK_INHUMANELY "bloodsucker_drink_imhumanely"
 
 /**
  * Role defines

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
@@ -1,12 +1,16 @@
 /**
- * Gives Bloodsuckers the ability to choose a Clan
- * This will give them their benefits and downsides
- * This is selected through a radial menu over the player's body.
+ * Gives Bloodsuckers the ability to choose a Clan.
+ * If they are already in a Clan, or is in a Frenzy, they will not be able to do so.
+ * The arg is optional and should really only be an Admin setting a Clan for a player.
+ * If set however, it will give them the control of their Clan instead of the Bloodsucker.
+ * This is selected through a radial menu over the player's body, even when an Admin is setting it.
  * Args:
  * person_selecting - Mob override for stuff like Admins selecting someone's clan.
  */
 /datum/antagonist/bloodsucker/proc/assign_clan_and_bane(mob/person_selecting)
 	if(my_clan)
+		return
+	if(owner.current.has_status_effect(/datum/status_effect/frenzy))
 		return
 	if(!person_selecting)
 		person_selecting = owner.current

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
@@ -37,6 +37,9 @@
 	my_clan = new chosen_clan(src)
 
 /datum/antagonist/bloodsucker/proc/remove_clan(mob/admin)
+	if(owner.current.has_status_effect(/datum/status_effect/frenzy))
+		to_chat(admin, span_announce("Removing a Bloodsucker from a Clan while they are in a Frenzy will break stuff, this action has been blocked."))
+		return
 	QDEL_NULL(my_clan)
 	to_chat(owner.current, span_announce("You have been forced out of your clan! You can re-enter one by regular means."))
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
@@ -35,7 +35,7 @@
 	duration = -1
 	tick_interval = 10
 	alert_type = /atom/movable/screen/alert/status_effect/frenzy
-	/// Store whether they were an advancedtooluser, to give the trait back upon exiting.
+	///Boolean on whether they were an AdvancedToolUser, to give the trait back upon exiting.
 	var/was_tooluser = FALSE
 	/// The stored Bloodsucker antag datum
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum
@@ -56,12 +56,7 @@
 	to_chat(owner, span_userdanger("<FONT size = 3>Blood! You need Blood, now! You enter a total Frenzy!"))
 	to_chat(owner, span_announce("* Bloodsucker Tip: While in Frenzy, you instantly Aggresively grab, have stun resistance, cannot speak, hear, or use any powers outside of Feed and Trespass (If you have it)."))
 	owner.balloon_alert(owner, "you enter a frenzy!")
-
-	// Stamina resistances
-	if(bloodsuckerdatum.my_clan.frenzy_stun_immune)
-		ADD_TRAIT(owner, TRAIT_STUNIMMUNE, FRENZY_TRAIT)
-	else
-		user.physiology.stamina_mod *= 0.4
+	SEND_SIGNAL(bloodsuckerdatum, BLOODSUCKER_ENTERS_FRENZY)
 
 	// Give the other Frenzy effects
 	owner.add_traits(list(TRAIT_MUTE, TRAIT_DEAF), FRENZY_TRAIT)
@@ -90,13 +85,7 @@
 	bloodsuckerdatum.frenzygrab.remove(user)
 	owner.remove_client_colour(/datum/client_colour/cursed_heart_blood)
 
-	if(bloodsuckerdatum.my_clan.frenzy_stun_immune)
-		REMOVE_TRAIT(owner, TRAIT_STUNIMMUNE, FRENZY_TRAIT)
-	else
-		owner.set_timed_status_effect(3 SECONDS, /datum/status_effect/dizziness, only_if_higher = TRUE)
-		owner.Paralyze(2 SECONDS)
-		user.physiology.stamina_mod /= 0.4
-
+	SEND_SIGNAL(bloodsuckerdatum, BLOODSUCKER_EXITS_FRENZY)
 	bloodsuckerdatum.frenzied = FALSE
 	return ..()
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
@@ -41,9 +41,13 @@
 /mob/living/simple_animal/hostile/guardian/standard/timestop/Initialize(mapload, theme)
 	//Wizard Holoparasite theme, just to be more visibly stronger than regular ones
 	theme = GUARDIAN_THEME_MAGIC
+	return ..()
+
+/mob/living/simple_animal/hostile/guardian/standard/timestop/set_summoner(mob/living/to_who, different_person = FALSE)
 	. = ..()
 	var/datum/action/cooldown/spell/timestop/guardian/timestop_ability = new()
 	timestop_ability.Grant(src)
+	ADD_TRAIT(to_who, TRAIT_TIME_STOP_IMMUNE, REF(src))
 
 ///Guardian Timestop ability
 /datum/action/cooldown/spell/timestop/guardian
@@ -53,15 +57,3 @@
 	cooldown_time = 60 SECONDS
 	spell_requirements = NONE
 	invocation_type = INVOCATION_NONE
-
-/datum/action/cooldown/spell/timestop/guardian/Grant(mob/grant_to)
-	. = ..()
-	var/mob/living/simple_animal/hostile/guardian/standard/timestop/bloodsucker_guardian = owner
-	if(bloodsucker_guardian && istype(bloodsucker_guardian) && bloodsucker_guardian.summoner)
-		ADD_TRAIT(bloodsucker_guardian.summoner, TRAIT_TIME_STOP_IMMUNE, REF(src))
-
-/datum/action/cooldown/spell/timestop/guardian/Remove(mob/remove_from)
-	var/mob/living/simple_animal/hostile/guardian/standard/timestop/bloodsucker_guardian = owner
-	if(bloodsucker_guardian && istype(bloodsucker_guardian) && bloodsucker_guardian.summoner)
-		REMOVE_TRAIT(bloodsucker_guardian.summoner, TRAIT_TIME_STOP_IMMUNE, REF(src))
-	return ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_procs.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_procs.dm
@@ -60,15 +60,12 @@
 		to_chat(owner.current, span_notice("You have gained a rank. Join a Clan to spend it."))
 		return
 	// Spend Rank Immediately?
-	if(my_clan.rank_up_type == BLOODSUCKER_RANK_UP_NORMAL)
-		if(!istype(owner.current.loc, /obj/structure/closet/crate/coffin))
-			to_chat(owner, span_notice("<EM>You have grown more ancient! Sleep in a coffin that you have claimed to thicken your blood and become more powerful.</EM>"))
-			if(bloodsucker_level_unspent >= 2)
-				to_chat(owner, span_announce("Bloodsucker Tip: If you cannot find or steal a coffin to use, you can build one from wood or metal."))
-			return
-		SpendRank()
-	if(my_clan.rank_up_type == BLOODSUCKER_RANK_UP_VASSAL)
-		to_chat(owner, span_announce("You have recieved a new Rank to level up your Favorite Vassal with!"))
+	if(!istype(owner.current.loc, /obj/structure/closet/crate/coffin))
+		to_chat(owner, span_notice("<EM>You have grown more ancient! Sleep in a coffin (or put your Favorite Vassal on a persuasion rack for Ventrue) that you have claimed to thicken your blood and become more powerful.</EM>"))
+		if(bloodsucker_level_unspent >= 2)
+			to_chat(owner, span_announce("Bloodsucker Tip: If you cannot find or steal a coffin to use, you can build one from wood or metal."))
+		return
+	SpendRank()
 
 /datum/antagonist/bloodsucker/proc/RankDown()
 	bloodsucker_level_unspent--

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/_clan.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/_clan.dm
@@ -25,8 +25,6 @@
 	///Whether the clan can be joined by players. FALSE for flavortext-only clans.
 	var/joinable_clan = TRUE
 
-	///Whether they become entirely stun immune when entering Frenzy.
-	var/frenzy_stun_immune = FALSE
 	///How we will drink blood using Feed.
 	var/blood_drink_type = BLOODSUCKER_DRINK_NORMAL
 
@@ -44,6 +42,9 @@
 	RegisterSignal(bloodsuckerdatum, BLOODSUCKER_EXIT_TORPOR, PROC_REF(on_exit_torpor))
 	RegisterSignal(bloodsuckerdatum, BLOODSUCKER_FINAL_DEATH, PROC_REF(on_final_death))
 
+	RegisterSignal(bloodsuckerdatum, BLOODSUCKER_ENTERS_FRENZY, PROC_REF(on_enter_frenzy))
+	RegisterSignal(bloodsuckerdatum, BLOODSUCKER_EXITS_FRENZY, PROC_REF(on_exit_frenzy))
+
 	give_clan_objective()
 
 /datum/bloodsucker_clan/Destroy(force)
@@ -55,10 +56,28 @@
 		BLOODSUCKER_MADE_VASSAL,
 		BLOODSUCKER_EXIT_TORPOR,
 		BLOODSUCKER_FINAL_DEATH,
+		BLOODSUCKER_ENTERS_FRENZY,
+		BLOODSUCKER_EXITS_FRENZY,
 	))
 	remove_clan_objective()
 	bloodsuckerdatum = null
 	return ..()
+
+/datum/bloodsucker_clan/proc/on_enter_frenzy(datum/antagonist/bloodsucker/source)
+	SIGNAL_HANDLER
+	var/mob/living/carbon/human/human_bloodsucker = bloodsuckerdatum.owner.current
+	if(!istype(human_bloodsucker))
+		return
+	human_bloodsucker.physiology.stamina_mod *= 0.4
+
+/datum/bloodsucker_clan/proc/on_exit_frenzy(datum/antagonist/bloodsucker/source)
+	SIGNAL_HANDLER
+	var/mob/living/carbon/human/human_bloodsucker = bloodsuckerdatum.owner.current
+	if(!istype(human_bloodsucker))
+		return
+	human_bloodsucker.set_timed_status_effect(3 SECONDS, /datum/status_effect/dizziness, only_if_higher = TRUE)
+	human_bloodsucker.Paralyze(2 SECONDS)
+	human_bloodsucker.physiology.stamina_mod /= 0.4
 
 /datum/bloodsucker_clan/proc/give_clan_objective()
 	if(isnull(clan_objective))

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/_clan.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/_clan.dm
@@ -25,8 +25,6 @@
 	///Whether the clan can be joined by players. FALSE for flavortext-only clans.
 	var/joinable_clan = TRUE
 
-	///How the Bloodsucker ranks up, if they do.
-	var/rank_up_type = BLOODSUCKER_RANK_UP_NORMAL
 	///Whether they become entirely stun immune when entering Frenzy.
 	var/frenzy_stun_immune = FALSE
 	///How we will drink blood using Feed.
@@ -39,7 +37,7 @@
 	RegisterSignal(bloodsuckerdatum, COMSIG_BLOODSUCKER_ON_LIFETICK, PROC_REF(handle_clan_life))
 	RegisterSignal(bloodsuckerdatum, BLOODSUCKER_RANK_UP, PROC_REF(on_spend_rank))
 
-	RegisterSignal(bloodsuckerdatum, BLOODSUCKER_PRE_MAKE_FAVORITE, PROC_REF(on_offer_favorite))
+	RegisterSignal(bloodsuckerdatum, BLOODSUCKER_INTERACT_WITH_VASSAL, PROC_REF(on_interact_with_vassal))
 	RegisterSignal(bloodsuckerdatum, BLOODSUCKER_MAKE_FAVORITE, PROC_REF(on_favorite_vassal))
 
 	RegisterSignal(bloodsuckerdatum, BLOODSUCKER_MADE_VASSAL, PROC_REF(on_vassal_made))
@@ -52,7 +50,7 @@
 	UnregisterSignal(bloodsuckerdatum, list(
 		COMSIG_BLOODSUCKER_ON_LIFETICK,
 		BLOODSUCKER_RANK_UP,
-		BLOODSUCKER_PRE_MAKE_FAVORITE,
+		BLOODSUCKER_INTERACT_WITH_VASSAL,
 		BLOODSUCKER_MAKE_FAVORITE,
 		BLOODSUCKER_MADE_VASSAL,
 		BLOODSUCKER_EXIT_TORPOR,
@@ -200,12 +198,12 @@
  * bloodsuckerdatum - the antagonist datum of the Bloodsucker performing this.
  * vassaldatum - the antagonist datum of the Vassal being offered up.
  */
-/datum/bloodsucker_clan/proc/on_offer_favorite(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/vassaldatum)
+/datum/bloodsucker_clan/proc/on_interact_with_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/vassaldatum)
 	SIGNAL_HANDLER
 
-	INVOKE_ASYNC(src, PROC_REF(offer_favorite), bloodsuckerdatum, vassaldatum)
+	INVOKE_ASYNC(src, PROC_REF(interact_with_vassal), bloodsuckerdatum, vassaldatum)
 
-/datum/bloodsucker_clan/proc/offer_favorite(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/vassaldatum)
+/datum/bloodsucker_clan/proc/interact_with_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/vassaldatum)
 	if(vassaldatum.special_type)
 		to_chat(bloodsuckerdatum.owner.current, span_notice("This Vassal was already assigned a special position."))
 		return FALSE
@@ -237,6 +235,7 @@
 		return FALSE
 	vassaldatum.make_special(vassal_response)
 	bloodsuckerdatum.bloodsucker_blood_volume -= 150
+	return TRUE
 
 /**
  * Called when we are successfully turn a Vassal into a Favorite Vassal

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_flavortext.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_flavortext.dm
@@ -5,8 +5,13 @@
 		Full Moons do not seem to have an effect, despite common-told stories. \n\
 		The Favorite Vassal turns into a Werewolf whenever their Master does."
 	joinable_clan = FALSE
-	frenzy_stun_immune = TRUE
 	blood_drink_type = BLOODSUCKER_DRINK_INHUMANELY
+
+/datum/bloodsucker_clan/gangrel/on_enter_frenzy(datum/antagonist/bloodsucker/source)
+	ADD_TRAIT(bloodsuckerdatum.owner.current, TRAIT_STUNIMMUNE, FRENZY_TRAIT)
+
+/datum/bloodsucker_clan/gangrel/on_exit_frenzy(datum/antagonist/bloodsucker/source)
+	REMOVE_TRAIT(bloodsuckerdatum.owner.current, TRAIT_STUNIMMUNE, FRENZY_TRAIT)
 
 /datum/bloodsucker_clan/gangrel/handle_clan_life(datum/antagonist/bloodsucker/source)
 	. = ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_malkavian.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_malkavian.dm
@@ -5,8 +5,13 @@
 	join_icon_state = "malkavian"
 	join_description = "Completely insane. You gain constant hallucinations, become a prophet with unintelligable rambling, \
 		and become the enforcer of the Masquerade code."
-	frenzy_stun_immune = TRUE
 	blood_drink_type = BLOODSUCKER_DRINK_INHUMANELY
+
+/datum/bloodsucker_clan/malkavian/on_enter_frenzy(datum/antagonist/bloodsucker/source)
+	ADD_TRAIT(bloodsuckerdatum.owner.current, TRAIT_STUNIMMUNE, FRENZY_TRAIT)
+
+/datum/bloodsucker_clan/malkavian/on_exit_frenzy(datum/antagonist/bloodsucker/source)
+	REMOVE_TRAIT(bloodsuckerdatum.owner.current, TRAIT_STUNIMMUNE, FRENZY_TRAIT)
 
 /datum/bloodsucker_clan/malkavian/New(datum/antagonist/bloodsucker/owner_datum)
 	. = ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
@@ -1,8 +1,8 @@
 /datum/bloodsucker_clan/ventrue
 	name = CLAN_VENTRUE
 	description = "The Ventrue Clan is extremely snobby with their meals, and refuse to drink blood from people without a mind. \n\
-		There is additionally no way to rank themselves up, instead will have to rank their Favorite Vassal through a Persuasion Rack. \n\
-		The Favorite Vassal will slowly turn into a Bloodsucker this way, until they finally lose their last bits of Humanity."
+		You may only level yourself up to Level 3, anything further will be ranks to spend on their Favorite Vassal through a Persuasion Rack. \n\
+		The Favorite Vassal will slowly turn more Vampiric this way, until they finally lose their last bits of Humanity."
 	clan_objective = /datum/objective/bloodsucker/embrace
 	join_icon_state = "ventrue"
 	join_description = "Lose the ability to drink from mindless mobs, can't level up or gain new powers, \

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_coffin.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_coffin.dm
@@ -219,7 +219,7 @@
 		//Level up if possible.
 		if(!bloodsuckerdatum.my_clan)
 			to_chat(user, span_notice("You must enter a Clan to rank up."))
-		else if(bloodsuckerdatum.my_clan.rank_up_type == BLOODSUCKER_RANK_UP_NORMAL || (bloodsuckerdatum.my_clan.rank_up_type == BLOODSUCKER_RANK_UP_VASSAL && bloodsuckerdatum.bloodsucker_level < 4))
+		else
 			bloodsuckerdatum.SpendRank()
 		// You're in a Coffin, everything else is done, you're likely here to heal. Let's offer them the oppertunity to do so.
 		bloodsuckerdatum.check_begin_torpor()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -1,6 +1,3 @@
-///How much it costs for a Ventrue to rank up without a spare rank to spend.
-#define BLOODSUCKER_BLOOD_RANKUP_COST (550)
-
 /obj/structure/bloodsucker
 	///Who owns this structure?
 	var/mob/living/owner
@@ -81,8 +78,8 @@
 		balloon_alert(user, "unbolt [src]?")
 		var/static/list/unclaim_options = list(
 			"Yes" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_yes"),
-			"No" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_no")
-			)
+			"No" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_no"),
+		)
 		var/unclaim_response = show_radial_menu(user, src, unclaim_options, radius = 36, require_near = TRUE)
 		switch(unclaim_response)
 			if("Yes")
@@ -254,9 +251,9 @@
 		return
 
 	var/datum/antagonist/vassal/vassaldatum = IS_VASSAL(buckled_carbons)
-	// Are they our Vassal, or Dead?
+	// Are they our Vassal?
 	if(vassaldatum && (vassaldatum in bloodsuckerdatum.vassals))
-		SEND_SIGNAL(bloodsuckerdatum, BLOODSUCKER_PRE_MAKE_FAVORITE, vassaldatum)
+		SEND_SIGNAL(bloodsuckerdatum, BLOODSUCKER_INTERACT_WITH_VASSAL, vassaldatum)
 		return
 
 	// Not our Vassal, but Alive & We're a Bloodsucker, good to torture!
@@ -441,16 +438,6 @@
 	icon_state = "candelabrum[lit ? "_lit" : ""]"
 	return ..()
 
-/obj/structure/bloodsucker/candelabrum/examine(mob/user)
-	. = ..()
-	var/datum/antagonist/bloodsucker/bloodsuckerdatum = user.mind.has_antag_datum(/datum/antagonist/bloodsucker)
-	if(!bloodsuckerdatum || !bloodsuckerdatum.my_clan)
-		return
-	if(bloodsuckerdatum.my_clan.rank_up_type == BLOODSUCKER_RANK_UP_VASSAL)
-		. += span_cult("As part of the Ventrue Clan, you can Rank Up your Favorite Vassal.\n\
-		Drag your Vassal's sprite onto the Candelabrum to secure them in place. From there, Clicking will Rank them up, while Right-click will unbuckle, as long as you are in reach.\n\
-		Ranking up a Vassal will rank up what powers you currently have, and will allow you to choose what Power your Favorite Vassal will recieve.")
-
 /obj/structure/bloodsucker/candelabrum/bolt()
 	. = ..()
 	set_anchored(TRUE)
@@ -461,16 +448,13 @@
 	set_anchored(FALSE)
 	density = FALSE
 
-/obj/structure/bloodsucker/candelabrum/attack_hand_secondary(mob/user, modifiers)
+/obj/structure/bloodsucker/candelabrum/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
-	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+	if(!.)
 		return
-
-	if(!has_buckled_mobs() || !isliving(user))
-		return
-	var/mob/living/carbon/target = pick(buckled_mobs)
-	if(target)
-		unbuckle_mob(target, user)
+	if(anchored && (IS_VASSAL(user) || IS_BLOODSUCKER(user)))
+		toggle()
+	return ..()
 
 /obj/structure/bloodsucker/candelabrum/proc/toggle(mob/user)
 	lit = !lit
@@ -493,102 +477,6 @@
 			continue
 		nearly_people.adjust_hallucinations(5 SECONDS)
 		nearly_people.add_mood_event("vampcandle", /datum/mood_event/vampcandle)
-
-/*
- *	# Candelabrum Ventrue Stuff
- *
- *	Ventrue Bloodsuckers can buckle Vassals onto the Candelabrum to "Upgrade" them.
- *	This is limited to a Single vassal, called 'My Favorite Vassal'.
- *
- *	Most of this is just copied over from Persuasion Rack.
- */
-/obj/structure/bloodsucker/candelabrum/attack_hand(mob/living/user, list/modifiers)
-	. = ..()
-	if(!.)
-		return
-	if(!anchored)
-		return
-
-	if(IS_VASSAL(user))
-		toggle()
-		return
-
-	var/datum/antagonist/bloodsucker/bloodsuckerdatum = user.mind.has_antag_datum(/datum/antagonist/bloodsucker)
-	// Checks: We're Ventrue, they're Buckled & Alive.
-	if(!bloodsuckerdatum || !bloodsuckerdatum.my_clan)
-		return ..()
-
-	if(!has_buckled_mobs())
-		toggle()
-		return
-
-	if(bloodsuckerdatum.my_clan.rank_up_type != BLOODSUCKER_RANK_UP_VASSAL)
-		return
-	var/mob/living/carbon/target = pick(buckled_mobs)
-	if(target.stat >= HARD_CRIT)
-		unbuckle_mob(target)
-		return
-	// Are we spending a Rank?
-	if(!bloodsuckerdatum.bloodsucker_level_unspent <= 0)
-		bloodsuckerdatum.SpendRank(target)
-	else if(bloodsuckerdatum.bloodsucker_blood_volume >= BLOODSUCKER_BLOOD_RANKUP_COST)
-		// We don't have any ranks to spare? Let them upgrade... with enough Blood.
-		to_chat(user, span_warning("Do you wish to spend [BLOODSUCKER_BLOOD_RANKUP_COST] Blood to Rank [target] up?"))
-		var/static/list/rank_options = list(
-			"Yes" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_yes"),
-			"No" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_no"),
-		)
-		var/rank_response = show_radial_menu(user, target, rank_options, radius = 36, require_near = TRUE)
-		switch(rank_response)
-			if("Yes")
-				bloodsuckerdatum.SpendRank(target, cost_rank = FALSE, blood_cost = BLOODSUCKER_BLOOD_RANKUP_COST)
-				return
-	else
-		// Neither? Shame. Goodbye!
-		to_chat(user, span_danger("You don't have any levels or enough Blood to Rank [target] up with."))
-
-/// Buckling someone in
-/obj/structure/bloodsucker/candelabrum/MouseDrop_T(mob/living/target, mob/user)
-	if(!anchored && IS_BLOODSUCKER(user))
-		to_chat(user, span_danger("Until the candelabrum is secured in place, it cannot serve its purpose."))
-		return
-	/// Default checks
-	if(!target.Adjacent(src) || target == user || !isliving(user) || has_buckled_mobs() || user.incapacitated() || target.buckled)
-		return
-	var/datum/antagonist/bloodsucker/bloodsuckerdatum = IS_BLOODSUCKER(user)
-	var/datum/antagonist/vassal/favorite_vassaldatum = IS_FAVORITE_VASSAL(target)
-	/// Are you even a Bloodsucker?
-	if(!bloodsuckerdatum || !favorite_vassaldatum || !bloodsuckerdatum.my_clan)
-		return
-	/// Are you part of Ventrue? No? Then go away.
-	if(bloodsuckerdatum.my_clan.rank_up_type != BLOODSUCKER_RANK_UP_VASSAL)
-		return
-	/// They are a Favorite vassal, but are they OUR Vassal?
-	if(!favorite_vassaldatum.master == bloodsuckerdatum)
-		return
-
-	/// Good to go - Buckle them!
-	if(do_after(user, 5 SECONDS, target))
-		attach_mob(target, user)
-
-/obj/structure/bloodsucker/candelabrum/proc/attach_mob(mob/living/target, mob/living/user)
-	user.visible_message(
-		span_notice("[user] lifts and buckles [target] onto the candelabrum."),
-		span_boldnotice("You buckle [target] onto the candelabrum."),
-	)
-
-	playsound(src.loc, 'sound/effects/pop_expl.ogg', 25, 1)
-	target.forceMove(get_turf(src))
-
-	if(!buckle_mob(target))
-		return
-	update_icon()
-
-/// Attempt Unbuckle
-/obj/structure/bloodsucker/candelabrum/unbuckle_mob(mob/living/buckled_mob, force = FALSE, can_fall = TRUE)
-	. = ..()
-	src.visible_message(span_danger("[buckled_mob][buckled_mob.stat==DEAD?"'s corpse":""] slides off of the candelabrum."))
-	update_icon()
 
 /// Blood Throne - Allows Bloodsuckers to remotely speak with their Vassals. - Code (Mostly) stolen from comfy chairs (armrests) and chairs (layers)
 /obj/structure/bloodsucker/bloodthrone
@@ -702,5 +590,3 @@
 		to_chat(dead_mob, "[link] [rendered]")
 
 	speech_args[SPEECH_MESSAGE] = ""
-
-#undef BLOODSUCKER_BLOOD_RANKUP_COST

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_objects.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_objects.dm
@@ -19,7 +19,7 @@
 		playsound(victim.loc, 'sound/items/drink.ogg', 30, 1)
 		return TRUE
 
-	while(do_after(victim, 1 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE, extra_checks = CALLBACK(src, PROC_REF(can_drink))))
+	while(do_after(victim, 1 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE, extra_checks = CALLBACK(src, PROC_REF(can_drink), attacker, victim)))
 		victim.visible_message(
 			span_notice("[victim] puts the [src] up to their mouth."),
 			span_notice("You take a sip from the [src]."),


### PR DESCRIPTION
## About The Pull Request

Fixes the Ventrue fix and makes how many levels they can upgrade to a define, so we can always keep track of it and can easily change it in the future without breaking it again.

I also moved Favorite Vassal upgrading to the Persuasion rack, because the candelabrum:
1. Is all copy paste code
2. Is an annoyance more than something you're working for
3. Does nothing good for any other Clan
4. Is hard to click on when someone is buckled to it.

Because of this, I was able to de-hardcode Ventrue some more, removing the ``rank_up_type`` var from Clans, which never should have been added and was really just an indication of my laziness to not want to make clans (which are intended to be modular and easily swapped if an admin wishes) use signals like God intended.

I also removed ``frenzy_stun_immune`` var from Clans, replacing that with a signal as well. To ensure this won't break shit, Bloodsuckers can no longer enter a Clan while they're in a Frenzy. I would hope they aren't doing that in-game anyway...

Lastly, I just organized the Bloodsucker defines folder, so I know exactly what's next to remove in the future.

## Why It's Good For The Game



## Changelog

:cl:
fix: Ventrue's description now properly says what level they can upgrade to.
/:cl:

