### PR TITLE
Fixes midround bloodsuckers

### DIFF
--- a/fulp_modules/features/antagonists/rulesets/bloodsucker_rulesets.dm
+++ b/fulp_modules/features/antagonists/rulesets/bloodsucker_rulesets.dm
@@ -72,6 +72,7 @@
 	repeatable = FALSE
 
 /datum/dynamic_ruleset/midround/bloodsucker/trim_candidates()
+	. = ..()
 	candidates = living_players
 	for(var/mob/living/player in candidates)
 		if(!is_station_level(player.z))
@@ -80,7 +81,7 @@
 			candidates.Remove(player)
 
 /datum/dynamic_ruleset/midround/bloodsucker/execute()
-	var/mob/selected_mobs = pick(living_players)
+	var/mob/selected_mobs = pick(candidates)
 	assigned += selected_mobs.mind
 	living_players -= selected_mobs
 	var/datum/mind/candidate_mind = selected_mobs.mind


### PR DESCRIPTION
## About The Pull Request

Borbop reported from Monkestation that Bloodsucker's midround doesn't work and said exactly what was causing it to go wrong, so this is thanks to them.
This fixes midround bloodsuckers' ruleset to properly role and to take into account the restrictions.

## Why It's Good For The Game


## Changelog

:cl:
fix: Midround Bloodsucker awakening should now work.
/:cl: