### PR TITLE
[Heliostation] Officers no longer have med access & fixes engineering external access

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -13166,6 +13166,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Post - Medbay"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "blS" = (
@@ -26472,9 +26473,9 @@
 /area/station/security/checkpoint/engineering)
 "cYv" = (
 /obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "cYA" = (
@@ -44222,11 +44223,11 @@
 /area/station/engineering/break_room)
 "kCU" = (
 /obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "kCX" = (


### PR DESCRIPTION
## About The Pull Request

There is one single airlock in Engineering/Atmos that leads to space, and it is behind External access. Engineering is supposed to be exempt from the rule of doors leading to space requiring external access because of the SM's external loop.
Also fixes the airlock in the security medical post, requiring medical access on top of security, to enter Medbay through it.

## Why It's Good For The Game

No more free access!!!!

## Changelog

:cl:
fix: [Heliostation] The security medical outpost no longer gives security full access to Medbay, even if they aren't assigned there.
fix: [Heliostation] Engineering's airlocks leading to space are now behind Engineering access.
/:cl:
