### PR TITLE
Infiltrators now have their own survival box

### DIFF
--- a/fulp_modules/features/antagonists/infiltrators/infiltrator.dm
+++ b/fulp_modules/features/antagonists/infiltrators/infiltrator.dm
@@ -71,7 +71,7 @@
 	ears = /obj/item/radio/headset
 	back = /obj/item/storage/backpack
 	backpack_contents = list(
-		/obj/item/storage/box/survival/syndie = 1,
+		/obj/item/storage/box/survival/infil = 1,
 		/obj/item/knife/combat/survival = 1,
 		/obj/item/infiltrator_radio = 1,
 	)
@@ -146,6 +146,19 @@
 	ears = /obj/item/radio/headset
 	back = /obj/item/storage/backpack
 	backpack_contents = list(
-		/obj/item/storage/box/survival/syndie = 1,
+		/obj/item/storage/box/survival/infil = 1,
 		/obj/item/knife/combat/survival = 1,
 	)
+/obj/item/storage/box/survival/infil 
+	// This is just like /box/survival/syndie, but without the misleading paper about explosive implants.
+	name = "infiltration-ready survival box"
+	desc = "A box with the essentials for your infiltration. This one is labelled to contain an extended-capacity tank."
+	icon_state = "syndiebox"
+	illustration = "extendedtank"
+	mask_type = /obj/item/clothing/mask/gas/syndicate
+	internal_type = /obj/item/tank/internals/emergency_oxygen/engi
+	medipen_type = /obj/item/reagent_containers/hypospray/medipen/atropine
+
+/obj/item/storage/box/survival/infil/PopulateContents()
+	..()
+	new /obj/item/tool_parcel(src)


### PR DESCRIPTION

## About The Pull Request
Gives infiltrator their own survival box instead of re-using the one given to nuclear operatives.
## Why It's Good For The Game
Nukie survival boxes come with a note explaining explosive implants. Infiltrator doesn't get an implant, so this paper can be quite misleading for people playing. Personally I've been duped by this several times (I'm smoothbrained). This PR gives infiltrator their own survival box. I chose to keep the atropine medipen as it's good at healing, but can be swapped out for a regular epi if coders want it.
## Changelog
:cl:
add: Infiltrators now have their own survival box.
/:cl:
