### PR TITLE
AFK mentors are no longer hidden from MentorWho

### DIFF
--- a/fulp_modules/features/mentors/mentorwho.dm
+++ b/fulp_modules/features/mentors/mentorwho.dm
@@ -28,8 +28,6 @@
 	//Regular version
 	else
 		for(var/client/mentor_clients in GLOB.mentors)
-			if(mentor_clients.is_afk())
-				continue
 			if(GLOB.deadmins[mentor_clients.ckey])
 				continue
 


### PR DESCRIPTION

## About The Pull Request

What it says on the tin.
## Why It's Good For The Game

Avoids situations where Mentors might have the game on the background waiting for the sound cue and thus appear AFK, discouraging people from Mhelping if they see no mentors online.
## Changelog
:cl:
qol: AFK mentors are no longer hidden from MentorWho
/:cl:
