### PR TITLE
Fixes medical storage door names on helio

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -67054,12 +67054,12 @@
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "tiN" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medical Storage"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Coroner Office"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "tje" = (

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -31848,7 +31848,7 @@
 /area/station/maintenance/department/security/upper)
 "flj" = (
 /obj/machinery/door/airlock/medical/glass{
-	name = "Coroner Office"
+	name = "Medical Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/structure/cable,
@@ -35524,7 +35524,7 @@
 "gNH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/medical/glass{
-	name = "Coroner Office"
+	name = "Medical Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/firedoor,
@@ -67055,7 +67055,7 @@
 /area/station/engineering/break_room)
 "tiN" = (
 /obj/machinery/door/airlock/medical/glass{
-	name = "Coroner Office"
+	name = "Medical Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,


### PR DESCRIPTION

## About The Pull Request

The doors for medical storage were named "Coroner office", which is wrong. This fixes that

## Why It's Good For The Game
Self-explanatory
## Changelog
:cl:
spellcheck: Fixed the names of the medical storage doors on Heliostation
/:cl:
