### PR TITLE
Fixes Selene and Pubby ordnance freezer chamber

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -40518,7 +40518,9 @@
 	name = "Ordnance Lab"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/freezerchamber)
 "nku" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -13611,7 +13611,9 @@
 	name = "Freeze Chamber Access"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2{
+	dir = 1
+	},
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/science)


### PR DESCRIPTION
## About The Pull Request

The freezer chamber HE pipes don't actually connect because there isn't a HE junction there, just a normal pipe. This PR fixes that on both Selen and Pubby

## Why It's Good For The Game
Fixes #937, and the same issue on Pubby
## Changelog
:cl:
fix: Fixes the freezer chamber in Selene's ordnance lab
fix: Fixes the freezer chamber in Pubby's ordnance lab
/:cl:
