### PR TITLE
Removes mayhem in a bottle as a bubblegum drop

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -124,7 +124,6 @@
 
 /obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
 	new /obj/item/clothing/suit/hooded/hostile_environment(src)
-	var/loot = rand(1,2)
 	new /obj/item/soulscythe(src)
 
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -125,11 +125,8 @@
 /obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
 	new /obj/item/clothing/suit/hooded/hostile_environment(src)
 	var/loot = rand(1,2)
-	switch(loot)
-		if(1)
-			new /obj/item/mayhem(src)
-		if(2)
-			new /obj/item/soulscythe(src)
+	new /obj/item/soulscythe(src)
+
 
 /obj/structure/closet/crate/necropolis/bubblegum/crusher
 	name = "bloody bubblegum chest"


### PR DESCRIPTION
## About The Pull Request
This pr removes mayhem in a bottle as a bubblegum drop
## Why It's Good For The Game
Under the current fulp rules, this item is nearly impossible to use. Considering that its a drop from "arguably" the hardest lavaland boss, I don't believe that you should have to hope to get the 50 50 on getting a useful item. Even for people with final, you will never see them going for bubblegum since the risk is just too high. (I tried to get this through on tg, but since mayhem is usable there it didnt go through)
## Changelog
:cl:
del: removes mayhem in a bottle as a bubblegum drop
/:cl:
