### PR TITLE
Rewiring Heliostation for a circular design

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -731,6 +731,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/sign/warning/electric_shock/directional/east,
 /turf/open/floor/iron,
 /area/station/security/office)
 "adC" = (
@@ -1065,7 +1066,7 @@
 	c_tag = "Security - Office";
 	network = list("ss13","security")
 	},
-/obj/machinery/firealarm/directional/east,
+/obj/structure/sign/departments/maint/directional/east,
 /turf/open/floor/iron,
 /area/station/security/office)
 "afh" = (
@@ -4264,6 +4265,7 @@
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ayH" = (
@@ -4799,6 +4801,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk,
+/obj/structure/sign/warning/electric_shock/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "aDw" = (
@@ -5948,9 +5951,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aIT" = (
-/obj/structure/sign/map/fulp/helio/left,
-/turf/closed/wall,
-/area/station/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "aJa" = (
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -6703,6 +6711,7 @@
 	name = "Medbay Camera";
 	network = list("ss13","medbay")
 	},
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},
@@ -10255,6 +10264,7 @@
 	},
 /obj/structure/closet/secure_closet/medical2,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/sign/departments/maint/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/medical/surgery/theatre)
 "aZS" = (
@@ -10269,6 +10279,7 @@
 	name = "Surgery Camera";
 	network = list("ss13","medbay")
 	},
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aZT" = (
@@ -12879,6 +12890,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/sign/departments/maint/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bkJ" = (
@@ -14948,9 +14960,10 @@
 /turf/open/space/basic,
 /area/space)
 "brT" = (
-/obj/structure/sign/map/fulp/helio/right,
-/turf/closed/wall,
-/area/station/construction/mining/aux_base)
+/obj/structure/cable,
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "brU" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "aux_base_shutters";
@@ -15160,6 +15173,7 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
+/obj/structure/sign/departments/maint/alt/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bsF" = (
@@ -15846,6 +15860,7 @@
 	dir = 9
 	},
 /obj/machinery/light/directional/south,
+/obj/structure/sign/departments/maint/alt/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bvK" = (
@@ -23050,6 +23065,8 @@
 /area/station/engineering/supermatter)
 "cEq" = (
 /obj/structure/closet/firecloset,
+/obj/structure/sign/warning/electric_shock/directional/south,
+/obj/structure/sign/departments/maint/alt/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cEr" = (
@@ -32106,6 +32123,7 @@
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 1
 	},
+/obj/structure/sign/warning/electric_shock/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "ful" = (
@@ -33470,6 +33488,13 @@
 /obj/structure/flora/grass/jungle/a/style_2,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"fVE" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/departments/maint/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "fVF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -35028,6 +35053,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 1
 	},
+/obj/structure/sign/departments/maint/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "gHF" = (
@@ -37740,8 +37766,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/cable,
+/obj/structure/sign/warning/electric_shock/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "hEi" = (
@@ -47364,6 +47390,7 @@
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 1
 	},
+/obj/structure/sign/warning/electric_shock/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "lAe" = (
@@ -48509,6 +48536,7 @@
 /obj/structure/sign/directions/command/directional/south{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "lYs" = (
@@ -50425,6 +50453,7 @@
 	network = list("ss13","security")
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/departments/maint/alt/directional/west,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "mLf" = (
@@ -57503,6 +57532,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"pwO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/sign/departments/maint/alt/directional/west,
+/turf/open/floor/iron/textured_half,
+/area/station/cargo/warehouse)
 "pwV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/stripes/line,
@@ -57694,6 +57730,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"pCs" = (
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/obj/structure/sign/departments/maint/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "pCz" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall,
@@ -58384,6 +58426,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/departments/maint/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "pQK" = (
@@ -59349,6 +59392,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"qlK" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "qlL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
@@ -60236,6 +60284,8 @@
 /area/station/science/auxlab/firing_range)
 "qCZ" = (
 /obj/machinery/vending/cigarette,
+/obj/structure/sign/warning/electric_shock/directional/west,
+/obj/structure/sign/departments/maint/alt/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/science/research)
 "qDa" = (
@@ -62049,6 +62099,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 10
 	},
+/obj/structure/sign/warning/electric_shock/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "rmD" = (
@@ -62395,6 +62446,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"rsI" = (
+/obj/structure/sign/map/fulp/helio/right,
+/turf/closed/wall,
+/area/station/commons/vacant_room/office)
 "rsR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -63062,6 +63117,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
+"rHM" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "rHP" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
@@ -63424,8 +63483,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "rPj" = (
-/obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "rPA" = (
@@ -65220,8 +65279,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/north,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "sFE" = (
@@ -65489,6 +65548,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/structure/sign/departments/maint/alt/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "sJQ" = (
@@ -65568,7 +65628,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/south,
+/obj/structure/sign/warning/electric_shock/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "sLw" = (
@@ -66083,6 +66143,7 @@
 	network = list("ss13","cargo")
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/electric_shock/directional/east,
 /turf/open/floor/iron/textured_half,
 /area/station/cargo/warehouse)
 "sVZ" = (
@@ -66202,6 +66263,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"sXJ" = (
+/obj/structure/sign/map/fulp/helio/left,
+/turf/closed/wall,
+/area/station/commons/vacant_room/office)
 "sXN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -71286,12 +71351,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "vcS" = (
-/obj/structure/sign/warning/electric_shock/directional/north,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
+/obj/structure/sign/warning/electric_shock/directional/west,
+/turf/open/floor/iron/white/textured,
+/area/station/science/xenobiology)
 "vcU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -73907,11 +73969,11 @@
 /turf/open/floor/stone,
 /area/station/service/kitchen/abandoned)
 "weM" = (
-/obj/structure/sign/departments/maint/directional/north,
 /obj/machinery/light/dim/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "weO" = (
@@ -74980,6 +75042,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/south,
+/obj/structure/sign/departments/maint/alt/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "wEy" = (
@@ -75424,6 +75487,7 @@
 /area/station/hallway/secondary/command)
 "wNe" = (
 /obj/structure/closet/emcloset,
+/obj/structure/sign/departments/maint/alt/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "wNj" = (
@@ -96433,8 +96497,8 @@ azQ
 azQ
 azQ
 azQ
-aIT
-buh
+azQ
+brT
 bsI
 xTF
 tKH
@@ -96690,7 +96754,7 @@ bmr
 bnK
 bpj
 bqr
-brT
+aZp
 bsE
 btO
 but
@@ -96952,7 +97016,7 @@ pHZ
 btP
 xTF
 bsI
-bsI
+rHM
 bwM
 vGW
 qZI
@@ -98238,7 +98302,7 @@ btP
 xTF
 bsI
 bsI
-bwM
+sXJ
 jmX
 oPG
 hya
@@ -98495,7 +98559,7 @@ btP
 xTF
 bsI
 bsI
-bwM
+rsI
 bwM
 tEm
 bwM
@@ -113605,7 +113669,7 @@ abM
 nYD
 oBM
 aax
-nYE
+fVE
 cOl
 eTY
 azV
@@ -114119,7 +114183,7 @@ abM
 abM
 abM
 aax
-vcS
+nYE
 cOl
 eTY
 iEF
@@ -116509,7 +116573,7 @@ gXS
 jJX
 mEJ
 kpu
-xxk
+pwO
 cgV
 cig
 cjY
@@ -121402,7 +121466,7 @@ chn
 ske
 sJH
 jhd
-xIW
+vcS
 eqc
 cnz
 cSC
@@ -126503,7 +126567,7 @@ boJ
 fyz
 brF
 bhK
-btm
+qlK
 buR
 mnK
 buR
@@ -126992,7 +127056,7 @@ aEd
 aEd
 aEd
 aEd
-bkF
+aIT
 aQZ
 bhI
 aTU
@@ -127788,7 +127852,7 @@ aEd
 aEd
 aEd
 aEd
-brN
+pCs
 buR
 buX
 buR

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -394,6 +394,7 @@
 "acb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/suit_storage_unit/hos,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
 "acc" = (
@@ -734,6 +735,7 @@
 /area/station/security/office)
 "adC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
 "adD" = (
@@ -974,6 +976,7 @@
 /area/station/security/office)
 "aeI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
 "aeN" = (
@@ -9740,6 +9743,7 @@
 /obj/effect/landmark/blobstart,
 /obj/machinery/light/small/directional/north,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "aYd" = (
@@ -19293,9 +19297,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bTE" = (
-/obj/machinery/computer/monitor{
-	name = "backup power monitoring console"
-	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bTG" = (
@@ -19391,14 +19392,14 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bVk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair/office{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/structure/chair/office,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bVm" = (
@@ -19468,6 +19469,7 @@
 "bVJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bVK" = (
@@ -19478,6 +19480,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bVL" = (
@@ -19595,6 +19598,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/computer/monitor{
+	name = "backup power monitoring console";
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bWD" = (
@@ -97899,7 +97907,7 @@ auh
 akK
 avw
 ajP
-ajP
+bks
 ajP
 ajP
 aDC
@@ -116250,7 +116258,7 @@ bJp
 bRm
 bSK
 bVv
-cem
+uwK
 jJX
 qja
 oFO
@@ -116507,7 +116515,7 @@ bJp
 bJp
 bJp
 lsM
-cem
+uwK
 jJX
 bXB
 tKt
@@ -116764,7 +116772,7 @@ bJp
 bRP
 bSK
 bVv
-cem
+uwK
 jJX
 bXC
 niG

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -19804,8 +19804,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 9
 	},
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /obj/structure/cable/layer1,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored{
+	cable_layer = 1
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "bYY" = (
@@ -20807,8 +20809,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 5
 	},
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /obj/structure/cable/layer1,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored{
+	cable_layer = 1
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "cjk" = (
@@ -31048,8 +31052,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
 	},
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /obj/structure/cable/layer1,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored{
+	cable_layer = 1
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "eSX" = (
@@ -31825,8 +31831,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 4
 	},
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /obj/structure/cable/layer1,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored{
+	cable_layer = 1
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "fmY" = (
@@ -31915,8 +31923,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
 	},
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /obj/structure/cable/layer1,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored{
+	cable_layer = 1
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "fpd" = (
@@ -49252,6 +49262,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"mlW" = (
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "mma" = (
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
@@ -74185,8 +74199,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 4
 	},
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /obj/structure/cable/layer1,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored{
+	cable_layer = 1
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "wgY" = (
@@ -107496,7 +107512,7 @@ cCZ
 hou
 uzx
 jTx
-czV
+mlW
 vFD
 qmk
 czV

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -57986,6 +57986,15 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"pHa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "pHf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -77199,15 +77208,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"xxS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "xxW" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 8
@@ -115246,7 +115246,7 @@ ugK
 cam
 hxC
 bJp
-xxS
+pHa
 iAN
 cnv
 cGK

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -6071,8 +6071,9 @@
 "aJA" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/camera/directional/west,
-/obj/structure/closet/radiation,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "aJB" = (
@@ -29702,7 +29703,6 @@
 	pixel_x = -4;
 	pixel_y = 8
 	},
-/obj/machinery/camera/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "esY" = (
@@ -29870,6 +29870,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"ewk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "ewp" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/button/ignition{
@@ -31583,6 +31589,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"fgT" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "fgW" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -34222,7 +34237,6 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "gnO" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
 /obj/structure/cable,
@@ -42974,6 +42988,7 @@
 /area/station/medical/storage)
 "jHw" = (
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jHD" = (
@@ -49268,8 +49283,10 @@
 "mlW" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/closet/radiation,
 /obj/machinery/light/dim/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "mma" = (
@@ -55603,6 +55620,7 @@
 "oKB" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/camera/directional/south,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -63093,10 +63111,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "rEh" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rEs" = (
@@ -67740,7 +67761,7 @@
 /area/station/security/prison/safe/exterior)
 "tzV" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -70846,6 +70867,12 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "uPa" = (
@@ -105196,7 +105223,7 @@ lfJ
 llO
 jce
 gnO
-iDa
+fgT
 uOY
 rEh
 aIu
@@ -105452,7 +105479,7 @@ gMZ
 cNJ
 jHw
 hXO
-vYC
+ewk
 mlW
 qmj
 tpJ

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -40743,11 +40743,6 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "iQf" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 10;
-	name = "security red"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -111,17 +111,19 @@
 /turf/closed/wall,
 /area/station/maintenance/department/security/upper)
 "aaB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/security/prison/visit)
+/area/station/maintenance/department/medical)
 "aaD" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /mob/living/simple_animal/bot/secbot/beepsky/officer,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "aaE" = (
@@ -209,8 +211,10 @@
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "abd" = (
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison)
+/area/station/hallway/secondary/entry)
 "abh" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -223,11 +227,11 @@
 /area/station/command/heads_quarters/hos)
 "abl" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "hoslock";
 	name = "HoS Space Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
 "abp" = (
@@ -237,6 +241,7 @@
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/breakroom)
 "abv" = (
@@ -307,6 +312,7 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "abG" = (
@@ -335,11 +341,11 @@
 /area/station/maintenance/department/security/upper)
 "abK" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "hoslock";
 	name = "HoS Office Lockdown Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/office)
 "abL" = (
@@ -383,8 +389,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "acb" = (
@@ -407,9 +413,9 @@
 /turf/open/floor/iron/smooth_edge,
 /area/station/security/office)
 "acf" = (
-/obj/structure/cable,
 /obj/machinery/computer/department_orders/security,
 /obj/effect/turf_decal/tile/brown/half,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_edge,
 /area/station/security/office)
 "acg" = (
@@ -441,10 +447,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "acn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "acu" = (
@@ -500,7 +508,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "acI" = (
@@ -510,7 +517,6 @@
 /area/station/security/prison/mess)
 "acJ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "hoslock";
 	name = "HoS Office Lockdown Door"
@@ -520,12 +526,14 @@
 	id = "hosdorm";
 	name = "Privacy Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
 "acK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "acL" = (
@@ -534,6 +542,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "acM" = (
@@ -541,18 +550,20 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/random/contraband/prison,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "acP" = (
 /obj/machinery/pdapainter/security,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "acS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "acT" = (
@@ -597,10 +608,10 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "acZ" = (
-/obj/structure/cable,
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/office)
 "ada" = (
@@ -622,9 +633,9 @@
 "adn" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "adp" = (
@@ -638,7 +649,6 @@
 /area/station/security/prison/mess)
 "adr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -681,11 +691,9 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "adx" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -694,7 +702,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "ady" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -709,7 +716,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "adA" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -729,7 +735,6 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "adC" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
@@ -747,17 +752,16 @@
 /turf/open/misc/asteroid/airless,
 /area/lavaland/surface)
 "adG" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "adI" = (
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "adJ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "adM" = (
@@ -796,7 +800,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -810,10 +813,10 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "adV" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "adW" = (
@@ -837,6 +840,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "adZ" = (
@@ -846,23 +850,22 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "aea" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "aed" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "aeh" = (
@@ -883,6 +886,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "aeq" = (
@@ -913,10 +917,10 @@
 "aev" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "aex" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -925,6 +929,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "aey" = (
@@ -941,8 +946,8 @@
 "aez" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/machinery/photocopier,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "aeA" = (
@@ -966,12 +971,11 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "aeE" = (
+/obj/structure/lattice,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/security/office)
+/turf/open/space/basic,
+/area/space/nearstation)
 "aeI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
@@ -993,16 +997,15 @@
 /area/station/service/bar/backroom)
 "aeU" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
 	id = "visitation";
 	name = "Visitation Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/visit)
 "aeV" = (
-/obj/structure/cable,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/large,
 /area/station/security/prison/visit)
@@ -1065,40 +1068,36 @@
 /turf/closed/wall/r_wall,
 /area/station/security/office)
 "afi" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
+/area/station/command/heads_quarters/captain)
 "afj" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Quarters"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/hos,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "afl" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "afm" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "hosprivacy";
 	name = "Privacy Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
 "aft" = (
@@ -1137,12 +1136,12 @@
 /area/station/security/medical)
 "afE" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "afH" = (
@@ -1156,6 +1155,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "afJ" = (
@@ -1174,6 +1174,7 @@
 	pixel_x = -2;
 	pixel_y = -2
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "afM" = (
@@ -1205,6 +1206,7 @@
 	name = "Interrogation Intercom"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/interrogation)
 "afU" = (
@@ -1231,7 +1233,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "afX" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -1259,19 +1260,20 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "agl" = (
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison/garden)
+/area/station/hallway/primary/starboard)
 "ago" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
 	name = "Prison Lockdown Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison)
 "agp" = (
-/obj/structure/cable,
 /obj/machinery/button/flasher{
 	id = "visitorflash";
 	pixel_x = -24;
@@ -1286,11 +1288,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/visit)
 "agr" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "agt" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth,
@@ -1299,18 +1304,17 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "agv" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "agx" = (
@@ -1326,7 +1330,6 @@
 /area/station/security/medical)
 "agy" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/medical)
 "agz" = (
@@ -1354,6 +1357,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "agE" = (
@@ -1371,7 +1375,6 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "agG" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/security_officer,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 2
@@ -1413,6 +1416,7 @@
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/interrogation)
 "agL" = (
@@ -1420,7 +1424,6 @@
 /turf/open/misc/asteroid,
 /area/station/security/prison/rec)
 "agM" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "agO" = (
@@ -1450,9 +1453,9 @@
 /area/station/command/heads_quarters/hos)
 "agX" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "agY" = (
@@ -1471,15 +1474,14 @@
 /area/station/security/prison/visit)
 "ahf" = (
 /obj/structure/chair/stool/directional/west,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/prison/visit)
 "ahg" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1492,6 +1494,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light_switch/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "ahm" = (
@@ -1515,7 +1518,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ahp" = (
-/obj/structure/cable,
 /obj/item/wirecutters,
 /obj/item/screwdriver{
 	pixel_y = 7
@@ -1523,17 +1525,20 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "ahq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/syndicatebomb/training,
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "ahr" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "ahs" = (
@@ -1590,16 +1595,16 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Permabrig Visitation"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/prison/visit)
 "ahC" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/interrogation)
 "ahG" = (
@@ -1637,20 +1642,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/medical)
 "ahS" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "ahT" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1660,14 +1663,12 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/office)
 "ahW" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/airlock/security{
 	name = "Interrogation"
@@ -1677,7 +1678,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "ahX" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -1693,9 +1693,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "aic" = (
@@ -1735,7 +1735,6 @@
 "ail" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
@@ -1751,7 +1750,6 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/item/clothing/suit/jacket/straight_jacket,
 /turf/open/floor/iron/freezer,
 /area/station/security/medical)
@@ -1776,14 +1774,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ait" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/office)
 "aiu" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1821,7 +1817,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "aiz" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -1880,6 +1875,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/visit)
 "aiQ" = (
@@ -1924,7 +1920,6 @@
 /area/station/security/prison/visit)
 "aiV" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
 	name = "Prison Lockdown Door"
@@ -1949,9 +1944,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "ajd" = (
@@ -1960,7 +1955,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -1968,17 +1962,11 @@
 /turf/closed/wall,
 /area/station/security/office)
 "ajh" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "ajj" = (
 /turf/closed/wall,
 /area/station/security/interrogation)
@@ -1993,12 +1981,12 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "ajp" = (
@@ -2018,7 +2006,6 @@
 /area/station/security/prison/visit)
 "ajt" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/hos,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/command{
@@ -2028,16 +2015,17 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "aju" = (
 /turf/closed/wall/r_wall,
 /area/station/security/brig)
 "ajw" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "ajB" = (
@@ -2061,15 +2049,10 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "ajG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "ajI" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
@@ -2081,7 +2064,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "ajK" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -2094,23 +2076,23 @@
 /turf/open/misc/asteroid,
 /area/station/security/prison/rec)
 "ajR" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "ajS" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "ajT" = (
@@ -2120,16 +2102,17 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "ajU" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "ajV" = (
@@ -2137,6 +2120,7 @@
 	dir = 9
 	},
 /obj/item/kirbyplants/random,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "ajW" = (
@@ -2179,7 +2163,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "akq" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -2191,7 +2174,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -2210,7 +2192,6 @@
 /turf/closed/mineral/random/labormineral,
 /area/station/security/prison/rec)
 "akL" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -2247,10 +2228,11 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "alb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/fore)
+/area/station/hallway/primary/central)
 "alc" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -2263,6 +2245,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "alq" = (
@@ -2298,7 +2281,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "alx" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -2307,6 +2289,7 @@
 	dir = 2
 	},
 /obj/effect/mapping_helpers/mail_sorting/security/hos_office,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "alz" = (
@@ -2326,8 +2309,8 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/brig/hallway)
 "alF" = (
@@ -2353,6 +2336,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "amb" = (
@@ -2362,6 +2346,7 @@
 "ame" = (
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "amf" = (
@@ -2378,7 +2363,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/security/lockers)
 "aml" = (
@@ -2415,26 +2399,26 @@
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/security/lockers)
 "amu" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "amv" = (
 /turf/closed/wall,
 /area/station/security/prison/safe/exterior)
 "amw" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark/textured_edge,
-/area/station/security/lockers)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/visit)
 "amx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2508,6 +2492,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/lockers)
 "amT" = (
@@ -2524,24 +2509,24 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/lockers)
 "amY" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/lockers)
 "amZ" = (
@@ -2550,16 +2535,15 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "ana" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
@@ -2568,26 +2552,24 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "anc" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/brig/hallway)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "and" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "ane" = (
@@ -2633,7 +2615,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "anv" = (
@@ -2649,12 +2630,12 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/lockers)
 "anE" = (
@@ -2675,6 +2656,7 @@
 "anH" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "anI" = (
@@ -2739,7 +2721,6 @@
 /turf/open/misc/asteroid/airless,
 /area/lavaland/surface)
 "anY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
 /obj/machinery/door/window/brigdoor{
 	name = "Justice Chamber";
@@ -2758,10 +2739,10 @@
 	id = "justiceshutter";
 	name = "Justice Shutter"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/execution/education)
 "aoa" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -2773,7 +2754,6 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "aoe" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
@@ -2844,13 +2824,13 @@
 /area/station/security/brig/hallway)
 "aop" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/warning/electric_shock/directional/east,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "justiceshutter";
 	name = "Justice Shutter"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "aoq" = (
@@ -2898,12 +2878,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "aoH" = (
-/obj/structure/cable,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
 "aoK" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "aoM" = (
@@ -3000,13 +2980,13 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "apf" = (
@@ -3020,7 +3000,6 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/storage/eva)
 "apn" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 5
 	},
@@ -3034,6 +3013,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "apt" = (
@@ -3041,10 +3021,10 @@
 /obj/machinery/door/airlock{
 	name = "Prison Garden"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "apu" = (
@@ -3093,7 +3073,6 @@
 "apI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -3101,6 +3080,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "apJ" = (
@@ -3150,6 +3130,7 @@
 	},
 /obj/item/inspector,
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "aqy" = (
@@ -3161,7 +3142,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "aqz" = (
@@ -3182,14 +3162,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "aqD" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/office)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "aqE" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
@@ -3223,9 +3199,9 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
 "aqL" = (
@@ -3259,17 +3235,17 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
 "aqR" = (
 /obj/effect/turf_decal/trimline/red,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
 "aqS" = (
@@ -3304,7 +3280,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
@@ -3378,7 +3353,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "arU" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -3404,11 +3378,10 @@
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
 "arY" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "asa" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
@@ -3424,15 +3397,16 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/medical)
 "ass" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "asD" = (
@@ -3507,8 +3481,8 @@
 /area/station/ai_monitored/security/armory)
 "asV" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "asX" = (
@@ -3533,7 +3507,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "atf" = (
@@ -3548,7 +3521,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "atj" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -3568,9 +3540,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "atI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "atJ" = (
@@ -3610,7 +3582,6 @@
 /turf/open/misc/asteroid,
 /area/station/security/prison/rec)
 "auc" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
@@ -3665,7 +3636,6 @@
 /area/station/security/medical)
 "aum" = (
 /obj/structure/chair/office,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -3717,7 +3687,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "auy" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
@@ -3745,7 +3714,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "auN" = (
@@ -3793,11 +3761,9 @@
 /obj/effect/landmark/start/captain,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "avn" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
@@ -3849,14 +3815,10 @@
 /turf/open/floor/plating,
 /area/station/security/prison/rec)
 "avz" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/office)
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "avA" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -3916,7 +3878,6 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -3981,7 +3942,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "awl" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
@@ -3997,6 +3957,7 @@
 /area/station/security/prison/rec)
 "awq" = (
 /obj/effect/spawner/random/contraband/permabrig_weapon,
+/obj/structure/cable,
 /turf/open/misc/asteroid,
 /area/station/security/prison/rec)
 "awr" = (
@@ -4005,12 +3966,14 @@
 	pixel_y = 13
 	},
 /obj/effect/decal/cleanable/blood/drip,
+/obj/structure/cable,
 /turf/open/misc/asteroid,
 /area/station/security/prison/rec)
 "aws" = (
 /obj/structure/fence/door/opened{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/misc/asteroid,
 /area/station/security/prison/rec)
 "awt" = (
@@ -4022,6 +3985,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
 /turf/open/misc/asteroid,
 /area/station/security/prison/rec)
 "awu" = (
@@ -4032,6 +3996,7 @@
 "awv" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "aww" = (
@@ -4042,13 +4007,11 @@
 /turf/open/misc/asteroid,
 /area/station/security/prison/rec)
 "awx" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "awy" = (
 /obj/effect/decal/cleanable/blood/bubblegum,
-/obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
@@ -4066,7 +4029,6 @@
 /area/station/security/prison/rec)
 "awC" = (
 /obj/item/kirbyplants/random,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
@@ -4077,12 +4039,12 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "awD" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "awE" = (
@@ -4151,9 +4113,9 @@
 "awM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "awN" = (
@@ -4199,7 +4161,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "awS" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4326,10 +4287,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/warden)
 "ayK" = (
@@ -4350,13 +4311,12 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "ayM" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
@@ -4367,7 +4327,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "ayR" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -4375,6 +4334,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "ayW" = (
@@ -4399,14 +4359,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/science/robotics/lab)
 "azn" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "azt" = (
-/obj/structure/cable,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=red";
 	location = "command2";
@@ -4417,7 +4375,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "azv" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "azQ" = (
@@ -4430,7 +4387,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -4502,7 +4458,6 @@
 	},
 /obj/item/radio,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/security/lockers)
 "aAo" = (
@@ -4517,7 +4472,6 @@
 /area/station/security/checkpoint/customs/fore)
 "aAr" = (
 /obj/structure/chair,
-/obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
@@ -4614,10 +4568,10 @@
 	pixel_y = -3;
 	req_access = list("security")
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "aBa" = (
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "aBc" = (
@@ -4634,11 +4588,21 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/warden)
 "aBi" = (
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "aBl" = (
 /obj/structure/table/reinforced/rglass,
 /obj/machinery/computer/records/medical/laptop,
@@ -4652,7 +4616,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/freezer,
 /area/station/security/warden)
@@ -4699,19 +4662,19 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "aBJ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "aBL" = (
@@ -4773,11 +4736,11 @@
 "aCv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "aCw" = (
@@ -4877,7 +4840,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "aDA" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -4885,6 +4847,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "aDB" = (
@@ -5040,10 +5003,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aEo" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aEp" = (
@@ -5071,7 +5034,6 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "aEt" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -5080,10 +5042,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "aEu" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -5092,26 +5054,27 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "aEv" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "aEw" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Legal Processing"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "aEx" = (
@@ -5156,10 +5119,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "aEE" = (
@@ -5185,13 +5148,11 @@
 /turf/open/floor/carpet/red,
 /area/station/security/courtroom)
 "aEO" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "aFc" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/green,
@@ -5230,7 +5191,6 @@
 "aFg" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance/external/glass{
 	name = "Prison Yard"
 	},
@@ -5271,10 +5231,10 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "aFr" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "aFs" = (
@@ -5327,6 +5287,7 @@
 /area/station/security/courtroom)
 "aFQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aFR" = (
@@ -5352,7 +5313,6 @@
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5392,7 +5352,6 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing Access"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -5416,7 +5375,6 @@
 /area/station/medical/virology)
 "aGh" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/port/fore)
 "aGj" = (
@@ -5425,7 +5383,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aGk" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
@@ -5434,6 +5391,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aGl" = (
@@ -5442,6 +5400,7 @@
 /obj/machinery/door/airlock/maintenance/external/glass{
 	name = "Prison Yard"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "aGm" = (
@@ -5486,10 +5445,10 @@
 "aGu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "aGB" = (
@@ -5587,13 +5546,13 @@
 /area/station/security/courtroom)
 "aGY" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/court,
 /obj/machinery/door/airlock/security{
 	name = "Legal Processing"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "aHa" = (
@@ -5604,7 +5563,6 @@
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "aHe" = (
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5624,10 +5582,10 @@
 "aHh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "aHi" = (
@@ -5638,7 +5596,6 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "aHj" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -5688,8 +5645,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "aHw" = (
@@ -5704,7 +5661,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aHy" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Gravity Generator"
 	},
@@ -5712,6 +5668,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/engineering/gravity_generator)
 "aHD" = (
@@ -5827,6 +5784,7 @@
 	dir = 6
 	},
 /obj/machinery/light/dim/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "aHW" = (
@@ -5868,7 +5826,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aIr" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -5888,10 +5845,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aIu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/atmos)
 "aIv" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -5990,10 +5953,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aIT" = (
@@ -6046,6 +6009,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "aJm" = (
@@ -6055,7 +6019,6 @@
 "aJn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "aJo" = (
@@ -6093,6 +6056,7 @@
 "aJv" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "aJy" = (
@@ -6107,6 +6071,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aJA" = (
@@ -6205,12 +6170,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
-"aJM" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"aJM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "aJN" = (
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -6247,6 +6214,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aJT" = (
@@ -6264,6 +6232,7 @@
 /area/station/hallway/primary/fore)
 "aJV" = (
 /obj/structure/lattice/catwalk,
+/obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/port/fore)
 "aJW" = (
@@ -6298,7 +6267,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aKc" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
@@ -6337,7 +6305,6 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "aKm" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
@@ -6390,10 +6357,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aKB" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
+/turf/open/floor/engine,
+/area/station/engineering/supermatter)
 "aKF" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
@@ -6456,7 +6422,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aKS" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6545,7 +6510,6 @@
 /turf/closed/wall,
 /area/station/maintenance/department/medical)
 "aLx" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/virology{
@@ -6559,6 +6523,7 @@
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aLy" = (
@@ -6668,11 +6633,15 @@
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "aLU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "aLV" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/structure/table/wood,
@@ -6717,8 +6686,8 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/break_room)
 "aMj" = (
@@ -6727,6 +6696,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/break_room)
 "aMl" = (
@@ -6753,6 +6723,7 @@
 "aMm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/medical/medbay/central)
 "aMn" = (
@@ -6770,7 +6741,6 @@
 	},
 /area/station/medical/medbay/central)
 "aMr" = (
-/obj/structure/cable,
 /obj/machinery/door_buttons/access_button{
 	idDoor = "virology_airlock_interior";
 	idSelf = "virology_airlock_control";
@@ -6783,6 +6753,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aMs" = (
@@ -6841,10 +6812,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/maintenance/port/fore)
 "aMC" = (
@@ -6897,18 +6868,18 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "aMH" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aMI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aMK" = (
@@ -6921,7 +6892,6 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
@@ -6994,7 +6964,6 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/textured,
@@ -7003,10 +6972,10 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/break_room)
 "aMY" = (
@@ -7054,19 +7023,19 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aNc" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNd" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aNf" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -7074,6 +7043,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aNh" = (
@@ -7244,7 +7214,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "aNF" = (
@@ -7311,10 +7280,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/break_room)
 "aNS" = (
@@ -7366,7 +7335,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aNY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -7389,6 +7357,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aNZ" = (
@@ -7425,9 +7394,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aOd" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aOe" = (
 /obj/item/stack/cable_coil/five,
 /obj/structure/closet/toolcloset,
@@ -7480,10 +7454,10 @@
 /area/station/command/heads_quarters/cmo)
 "aOw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "aOz" = (
@@ -7502,13 +7476,13 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass{
 	name = "Break Room"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/break_room)
 "aOB" = (
@@ -7526,10 +7500,10 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Coldroom Storage"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/medical/medbay/central)
 "aOF" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -7541,6 +7515,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aOG" = (
@@ -7615,10 +7590,10 @@
 /area/station/service/lawoffice)
 "aOU" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/pdapainter/medbay,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "aOW" = (
@@ -7681,11 +7656,11 @@
 /area/station/service/lawoffice)
 "aPr" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "detprivacy";
 	name = "Privacy Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
 "aPs" = (
@@ -7724,10 +7699,10 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "aPv" = (
@@ -7735,6 +7710,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aPw" = (
@@ -7751,16 +7727,18 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aPB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "aPC" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Medbay - Northeast Hall";
@@ -7784,7 +7762,6 @@
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "aPH" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -7796,7 +7773,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aPL" = (
-/obj/structure/cable,
 /obj/machinery/chem_heater/withbuffer,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
@@ -7805,8 +7781,8 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
 "aPM" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
 "aPN" = (
@@ -7839,7 +7815,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "aPQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
@@ -7877,7 +7852,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aPZ" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
 	},
@@ -7894,6 +7868,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aQa" = (
@@ -7909,7 +7884,6 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/port/fore)
 "aQd" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -7917,6 +7891,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/mail_sorting/medbay/virology,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aQe" = (
@@ -7974,7 +7949,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -8000,8 +7974,10 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "aQq" = (
-/turf/open/floor/wood,
-/area/station/service/lawoffice)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "aQs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8102,10 +8078,10 @@
 	name = "Medbay Camera";
 	network = list("ss13","medbay")
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aQT" = (
@@ -8130,6 +8106,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aQZ" = (
@@ -8139,6 +8116,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aRd" = (
@@ -8164,13 +8142,13 @@
 "aRe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
 "aRf" = (
@@ -8192,7 +8170,6 @@
 	id = "foreport";
 	name = "Fore Port Solars Control"
 	},
-/obj/structure/cable,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 30
 	},
@@ -8204,7 +8181,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aRj" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
@@ -8214,6 +8190,7 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aRl" = (
@@ -8224,12 +8201,12 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aRn" = (
@@ -8306,8 +8283,8 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /obj/structure/closet/emcloset,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aRA" = (
@@ -8339,7 +8316,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "aRJ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -8429,11 +8405,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aSg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/command/bridge)
 "aSi" = (
 /obj/machinery/jukebox/disco,
 /turf/open/floor/eighties,
@@ -8493,7 +8468,6 @@
 /area/station/service/lawoffice)
 "aSr" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -8575,7 +8549,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/navigate_destination/lawyer,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "aSI" = (
@@ -8619,14 +8592,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aSX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aSZ" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
@@ -8647,11 +8615,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aTd" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aTe" = (
@@ -8743,13 +8711,13 @@
 /area/station/service/lawoffice)
 "aTq" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aTr" = (
@@ -8800,13 +8768,13 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "aTy" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 6;
 	name = "engineering yellow"
 	},
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aTz" = (
@@ -8848,8 +8816,8 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "aTN" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aTP" = (
@@ -8958,6 +8926,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "aUn" = (
@@ -8966,11 +8935,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "aUo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
 "aUp" = (
@@ -8980,6 +8951,7 @@
 /obj/effect/landmark/start/lawyer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
 "aUq" = (
@@ -8987,6 +8959,7 @@
 /obj/item/storage/briefcase/lawyer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
 "aUr" = (
@@ -8995,29 +8968,29 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
 "aUt" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/law_office,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aUu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "aUv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "aUw" = (
@@ -9026,6 +8999,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aUx" = (
@@ -9054,6 +9028,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "aUC" = (
@@ -9106,7 +9081,6 @@
 	},
 /area/station/ai_monitored/turret_protected/ai)
 "aUY" = (
-/obj/structure/cable,
 /obj/machinery/camera/directional/east{
 	c_tag = "Medbay - Treatment Center Left Access";
 	name = "Medbay Camera";
@@ -9177,19 +9151,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aVj" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aVk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/area/station/hallway/secondary/construction)
 "aVl" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -9220,7 +9196,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aVp" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9282,10 +9257,10 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "aVA" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aVD" = (
@@ -9314,10 +9289,10 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Surgery Maintenance"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aVT" = (
@@ -9446,29 +9421,29 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "aWl" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aWm" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aWq" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aWs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aWt" = (
@@ -9479,7 +9454,6 @@
 "aWu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "aWw" = (
@@ -9496,11 +9470,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "aWH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aWI" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
@@ -9514,17 +9487,17 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "aWS" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "aWU" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aWY" = (
@@ -9577,10 +9550,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aXi" = (
@@ -9606,16 +9579,14 @@
 /turf/closed/wall,
 /area/station/commons/dorms)
 "aXn" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aXo" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aXp" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9628,16 +9599,20 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "aXu" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "aXy" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "aXz" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -9645,10 +9620,10 @@
 /obj/effect/landmark/start/virologist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aXB" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -9659,6 +9634,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aXH" = (
@@ -9772,7 +9748,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aYc" = (
-/obj/structure/cable,
 /obj/effect/landmark/blobstart,
 /obj/machinery/light/small/directional/north,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -9930,8 +9905,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aYz" = (
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "aYA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -9986,14 +9964,12 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "aYI" = (
-/obj/structure/cable,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aYJ" = (
-/obj/structure/cable,
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10040,7 +10016,6 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms)
 "aYX" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -10121,7 +10096,6 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "aZn" = (
@@ -10135,16 +10109,16 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Office Maintenance"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "aZs" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "aZv" = (
@@ -10154,6 +10128,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "aZx" = (
@@ -10162,6 +10137,7 @@
 /obj/item/storage/crayons,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "aZy" = (
@@ -10170,6 +10146,7 @@
 /obj/item/nullrod,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "aZz" = (
@@ -10178,8 +10155,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "aZB" = (
@@ -10346,7 +10323,6 @@
 /area/station/engineering/atmos)
 "baa" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -10354,13 +10330,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bab" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/mob/living/simple_animal/slime,
+/obj/effect/turf_decal/box,
+/obj/structure/cable,
+/turf/open/floor/iron/large,
+/area/station/science/xenobiology)
 "bac" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -10381,12 +10355,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bai" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bak" = (
@@ -10402,6 +10376,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bal" = (
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/ce)
 "bam" = (
@@ -10418,14 +10393,13 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "bap" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -10476,12 +10450,12 @@
 /obj/effect/landmark/start/chaplain,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bax" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/structure/chair/office/light{
 	dir = 4
 	},
@@ -10489,6 +10463,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/chemist,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
 "bay" = (
@@ -10622,16 +10597,17 @@
 /area/station/command/bridge)
 "baT" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
 "baV" = (
 /obj/structure/sign/departments/holy{
 	pixel_x = -29
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "baW" = (
@@ -10758,6 +10734,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bbH" = (
@@ -10863,11 +10840,11 @@
 /area/station/commons/dorms)
 "bcb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bcc" = (
@@ -10999,6 +10976,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "bcI" = (
@@ -11008,7 +10986,6 @@
 "bcJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "bcK" = (
@@ -11020,11 +10997,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "bcO" = (
@@ -11078,14 +11055,12 @@
 /turf/open/floor/iron/white,
 /area/station/commons/dorms)
 "bda" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/line,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "bdd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "bdm" = (
@@ -11278,6 +11253,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/lone,
 /area/station/service/chapel)
 "beb" = (
@@ -11404,6 +11380,7 @@
 /area/station/commons/dorms)
 "bet" = (
 /obj/structure/chair/stool/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "beu" = (
@@ -11535,7 +11512,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bfo" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
 	},
@@ -11550,6 +11526,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "bfp" = (
@@ -11637,6 +11614,7 @@
 	icon_state = "small"
 	},
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bfM" = (
@@ -11806,6 +11784,7 @@
 "bgn" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bgo" = (
@@ -11816,11 +11795,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bgr" = (
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/medical/medbay/central)
 "bgs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bgt" = (
@@ -11834,7 +11815,6 @@
 /area/station/medical/medbay/central)
 "bgv" = (
 /obj/structure/sign/poster/official/random/directional/south,
-/obj/structure/cable,
 /obj/structure/sign/departments/chemistry/pharmacy{
 	pixel_y = -30
 	},
@@ -11845,7 +11825,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "bgx" = (
@@ -11873,8 +11852,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bgD" = (
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "bgE" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/camera/directional/north{
@@ -11924,16 +11907,17 @@
 /obj/structure/altar_of_gods,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "bgN" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bgO" = (
@@ -12006,6 +11990,7 @@
 /obj/structure/table,
 /obj/item/pai_card,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bgY" = (
@@ -12015,6 +12000,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bgZ" = (
@@ -12136,10 +12122,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bhI" = (
+/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bhJ" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock"
@@ -12187,6 +12173,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "bhV" = (
@@ -12204,11 +12191,11 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/medbay/lobby)
 "bhX" = (
-/obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bhY" = (
@@ -12257,13 +12244,17 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
 "big" = (
-/turf/open/floor/carpet,
-/area/station/service/chapel)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_half,
+/area/station/science/xenobiology)
 "bih" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "bii" = (
@@ -12273,6 +12264,7 @@
 /obj/structure/table,
 /obj/item/storage/crayons,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bik" = (
@@ -12302,6 +12294,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bip" = (
@@ -12383,19 +12376,18 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "biN" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "biO" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -12451,7 +12443,6 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Pharmacy"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -12465,6 +12456,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "biZ" = (
@@ -12590,13 +12582,13 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/chair/comfy/brown{
 	color = "#4169e1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "bjw" = (
@@ -12698,6 +12690,7 @@
 	dir = 4;
 	pixel_x = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bjL" = (
@@ -12732,7 +12725,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bjR" = (
@@ -12759,6 +12751,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bjW" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bjX" = (
@@ -12777,8 +12770,8 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bjY" = (
@@ -12786,8 +12779,10 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bjZ" = (
+/obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/area/station/hallway/primary/central)
 "bka" = (
 /obj/structure/toilet,
 /obj/item/beacon,
@@ -12851,9 +12846,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bks" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/structure/cable,
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/station/engineering/atmos)
 "bku" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -12877,7 +12880,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "bkx" = (
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/paper_bin,
@@ -12905,7 +12907,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/pharmacy)
 "bkF" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -13107,6 +13108,7 @@
 /area/station/commons/toilet)
 "blq" = (
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "blr" = (
@@ -13239,11 +13241,9 @@
 /area/station/commons/lounge)
 "blP" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
 "blQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -13253,6 +13253,7 @@
 	name = "Security Post - Medbay"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "blS" = (
@@ -13284,10 +13285,10 @@
 "bmb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bmc" = (
@@ -13295,6 +13296,7 @@
 	dir = 4
 	},
 /obj/machinery/space_heater,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bmd" = (
@@ -13303,6 +13305,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bme" = (
@@ -13311,6 +13314,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bmh" = (
@@ -13320,7 +13324,6 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
@@ -13356,6 +13359,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bmm" = (
@@ -13437,6 +13441,7 @@
 	},
 /obj/structure/chair/stool/directional/south,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bmy" = (
@@ -13479,12 +13484,14 @@
 /area/station/commons/toilet)
 "bmD" = (
 /obj/machinery/nuclearbomb/selfdestruct,
+/obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
 "bmE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "bmF" = (
@@ -13522,19 +13529,17 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bmK" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/area/station/security/brig/hallway)
 "bmL" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13542,6 +13547,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bmM" = (
@@ -13561,24 +13567,20 @@
 /area/station/service/chapel)
 "bmS" = (
 /obj/effect/landmark/start/assistant,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bmT" = (
 /obj/machinery/holopad,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bmU" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bmV" = (
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
 "bmZ" = (
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13600,7 +13602,6 @@
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bnf" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/west,
@@ -13608,6 +13609,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "bng" = (
@@ -13685,7 +13687,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bnv" = (
@@ -13738,10 +13739,10 @@
 /area/station/security/checkpoint/escape)
 "bnF" = (
 /obj/structure/chair,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "bnI" = (
@@ -13852,6 +13853,7 @@
 "bnW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "bnX" = (
@@ -13900,16 +13902,17 @@
 "bof" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/siding/thinplating/light,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bog" = (
 /obj/effect/turf_decal/siding/thinplating/light,
 /obj/machinery/light/small/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "boh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "boi" = (
@@ -13936,7 +13939,6 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bon" = (
@@ -13978,7 +13980,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/break_room)
 "boB" = (
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13987,10 +13988,10 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "boD" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
@@ -14011,7 +14012,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "boH" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/depsec/medical,
 /obj/effect/turf_decal/tile/blue/anticorner,
@@ -14034,7 +14034,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "boJ" = (
@@ -14044,6 +14043,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "boK" = (
@@ -14167,10 +14167,10 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/break_room)
 "bpi" = (
@@ -14265,7 +14265,6 @@
 /area/station/commons/toilet)
 "bpw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bpx" = (
@@ -14315,7 +14314,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bpE" = (
@@ -14340,11 +14338,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bpK" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -14422,11 +14418,11 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "bqa" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "bqc" = (
@@ -14441,12 +14437,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "bqg" = (
@@ -14461,10 +14457,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bqj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "bqk" = (
@@ -14524,6 +14520,7 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "bqq" = (
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bqr" = (
@@ -14647,7 +14644,6 @@
 "bqB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/thinplating/light,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bqC" = (
@@ -14703,11 +14699,10 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bqM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "bqN" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/machinery/light/directional/south,
@@ -14735,7 +14730,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bqS" = (
@@ -14811,6 +14805,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "brj" = (
@@ -14842,12 +14837,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "brs" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/landmark/start/depsec/medical,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "bru" = (
@@ -14875,10 +14870,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "brx" = (
@@ -14945,9 +14940,9 @@
 /area/station/security/checkpoint/customs)
 "brJ" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "brL" = (
@@ -14957,14 +14952,13 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "brN" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "brO" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -14976,8 +14970,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "brQ" = (
@@ -15042,8 +15036,8 @@
 	name = "Auxiliary Construction Zone"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "bsb" = (
@@ -15058,28 +15052,16 @@
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bse" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Primary Tool Storage"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
+/obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/security/prison)
 "bsf" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -15096,7 +15078,6 @@
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bsh" = (
@@ -15104,7 +15085,6 @@
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
 "bsi" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/stool/directional/south,
@@ -15115,10 +15095,10 @@
 /obj/machinery/door/airlock/command{
 	name = "Customs"
 	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "bsl" = (
@@ -15133,11 +15113,12 @@
 /turf/closed/wall/r_wall,
 /area/station/security/checkpoint/escape)
 "bsr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/security/prison/visit)
 "bss" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -15148,16 +15129,19 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bst" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bsw" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "bsy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "bsz" = (
@@ -15199,6 +15183,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bsF" = (
@@ -15227,9 +15212,11 @@
 	c_tag = "Port Primary Hallway - Restrooms";
 	name = "Hallway Camera"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bsI" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bsJ" = (
@@ -15381,6 +15368,7 @@
 "bts" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "btt" = (
@@ -15420,11 +15408,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "btD" = (
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
 	name = "Prison Lockdown Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "btE" = (
@@ -15470,18 +15458,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "btP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "btQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "btR" = (
@@ -15495,11 +15482,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "btT" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -15531,7 +15516,6 @@
 /area/station/hallway/primary/port)
 "btY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "btZ" = (
@@ -15580,7 +15564,6 @@
 	location = "customs";
 	name = "Patrol Beacon"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bum" = (
@@ -15610,28 +15593,24 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "but" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "buu" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "buB" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "buC" = (
@@ -15639,7 +15618,6 @@
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "buG" = (
@@ -15674,21 +15652,21 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "buT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "buU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination/dockarrival,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "buW" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -15697,7 +15675,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "buX" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -15712,7 +15689,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bvb" = (
@@ -15800,7 +15776,6 @@
 /obj/structure/plaque/static_plaque/golden/commission/helio{
 	pixel_y = 32
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bvt" = (
@@ -15810,8 +15785,8 @@
 	name = "Patrol Beacon"
 	},
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bvu" = (
@@ -15845,9 +15820,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bvz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/security/prison)
 "bvA" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -15879,11 +15859,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bvH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/green,
+/area/station/service/library)
 "bvI" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=evac";
@@ -15906,11 +15885,10 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
 "bvL" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/maintenance/aft/lesser)
 "bvN" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
@@ -15978,7 +15956,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bwd" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -16009,7 +15986,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bwl" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bwp" = (
@@ -16056,7 +16032,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/upper)
 "bwC" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16116,7 +16091,6 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/office)
@@ -16152,7 +16126,6 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bwV" = (
-/obj/structure/cable,
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16172,7 +16145,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bwZ" = (
@@ -16278,7 +16250,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
@@ -16320,7 +16291,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "byc" = (
@@ -16387,9 +16357,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "byn" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "byp" = (
@@ -16498,7 +16468,6 @@
 	location = "brown";
 	name = "Patrol Beacon"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "byF" = (
@@ -16619,7 +16588,6 @@
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "byY" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "byZ" = (
@@ -16658,10 +16626,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bzm" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
@@ -16697,9 +16665,9 @@
 "bzv" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/landmark/generic_maintenance_landmark,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden/abandoned)
 "bzB" = (
@@ -16753,7 +16721,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bzQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -16793,8 +16760,14 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "bAc" = (
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/hallway/secondary/command)
 "bAe" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/siding/green{
@@ -16887,12 +16860,12 @@
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "bAu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "bAv" = (
@@ -16914,7 +16887,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "bAz" = (
@@ -16989,7 +16961,6 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
 "bBn" = (
@@ -17114,26 +17085,26 @@
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "bBT" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "bBU" = (
 /obj/machinery/airalarm/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "bBV" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "bBW" = (
@@ -17220,7 +17191,6 @@
 /area/station/service/library)
 "bCw" = (
 /obj/item/trash/energybar,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bCB" = (
@@ -17402,7 +17372,6 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "bDP" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bDQ" = (
@@ -17712,7 +17681,6 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/solars)
 "bGn" = (
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "bGo" = (
@@ -17753,9 +17721,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bGx" = (
+/obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
+/turf/open/floor/plating,
+/area/station/security/prison/rec)
 "bGz" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -17839,7 +17808,6 @@
 /area/station/service/library)
 "bHf" = (
 /obj/effect/landmark/start/hangover,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bHi" = (
@@ -17920,7 +17888,6 @@
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "bHP" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/gravity_generator)
@@ -17941,11 +17908,13 @@
 /area/station/service/library)
 "bHX" = (
 /obj/structure/displaycase/trophy,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bHY" = (
 /obj/structure/displaycase/trophy,
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bHZ" = (
@@ -17979,7 +17948,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bIn" = (
@@ -18004,7 +17972,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bIw" = (
-/obj/structure/cable,
 /obj/structure/closet/firecloset,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18012,7 +17979,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bIy" = (
-/obj/structure/cable,
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/four,
 /obj/structure/disposalpipe/segment{
@@ -18021,12 +17987,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bIz" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bIB" = (
@@ -18042,7 +18008,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bIL" = (
@@ -18081,10 +18046,10 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bIQ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18143,13 +18108,14 @@
 /area/station/service/bar)
 "bJd" = (
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bJe" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bJf" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -18209,6 +18175,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "bJw" = (
@@ -18221,11 +18188,11 @@
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "bJB" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bJI" = (
 /obj/structure/chair/stool/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bJT" = (
@@ -18326,10 +18293,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "bKG" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bKH" = (
@@ -18340,13 +18307,12 @@
 /turf/closed/wall,
 /area/station/maintenance/starboard)
 "bKJ" = (
-/obj/structure/cable,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bKM" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bLf" = (
@@ -18363,7 +18329,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bLB" = (
@@ -18410,6 +18375,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bLU" = (
@@ -18418,7 +18384,6 @@
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "bLV" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -18456,6 +18421,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bMj" = (
@@ -18517,6 +18483,7 @@
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "bMA" = (
@@ -18580,7 +18547,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bNM" = (
@@ -18589,8 +18555,10 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "bNP" = (
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/station/service/kitchen/coldroom)
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "bNR" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/directional/west,
@@ -18668,10 +18636,10 @@
 "bOo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bOA" = (
@@ -18704,9 +18672,9 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bOP" = (
@@ -18782,22 +18750,22 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "bPF" = (
 /obj/item/stack/sheet/pizza,
 /obj/machinery/space_heater,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bPG" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bPH" = (
-/obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -18826,12 +18794,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bQb" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bQc" = (
@@ -18855,6 +18823,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/bridge)
 "bQL" = (
@@ -18931,11 +18900,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bRh" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/turf/open/floor/iron,
+/area/station/security/brig/hallway)
 "bRk" = (
 /obj/machinery/icecream_vat,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -19027,6 +18995,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bRv" = (
@@ -19036,16 +19005,15 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bRw" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Emergency Oxygen Supply"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bRF" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
 	},
@@ -19056,6 +19024,7 @@
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "bRO" = (
@@ -19087,9 +19056,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/lockers)
 "bSr" = (
@@ -19152,8 +19121,8 @@
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bSJ" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "bSK" = (
@@ -19188,6 +19157,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/maintenance/department/cargo)
 "bSP" = (
@@ -19210,17 +19180,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "bTb" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "bTe" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
@@ -19228,7 +19197,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/central)
 "bTf" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -19236,11 +19204,10 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bTj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/area/station/maintenance/department/security/upper)
 "bTk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -19255,7 +19222,6 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bTo" = (
@@ -19286,10 +19252,10 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "bTs" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "bTt" = (
@@ -19340,7 +19306,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bTD" = (
-/obj/structure/cable,
 /obj/machinery/power/smes,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
@@ -19349,7 +19314,6 @@
 /obj/machinery/computer/monitor{
 	name = "backup power monitoring console"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bTG" = (
@@ -19360,10 +19324,13 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bUa" = (
-/obj/machinery/firealarm/directional/east,
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "bUe" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -19379,18 +19346,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bUu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bUM" = (
@@ -19441,7 +19408,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bVj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/terminal{
 	dir = 1
@@ -19449,7 +19415,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bVk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/office{
@@ -19458,17 +19423,22 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bVm" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
-"bVo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
+"bVo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bVp" = (
@@ -19482,10 +19452,10 @@
 /obj/structure/table,
 /obj/item/folder,
 /obj/item/crowbar,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bVr" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -19498,7 +19468,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bVx" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -19512,7 +19481,6 @@
 	alpha = 255;
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bVD" = (
@@ -19529,13 +19497,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bVJ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bVK" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/engineering{
@@ -19549,15 +19515,9 @@
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/freezerchamber)
 "bVM" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/hallway/secondary/entry)
 "bVN" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
@@ -19593,7 +19553,6 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bWh" = (
@@ -19612,21 +19571,19 @@
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bWl" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bWo" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bWt" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -19674,11 +19631,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bWE" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "bWG" = (
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bWK" = (
@@ -19724,6 +19682,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "bXq" = (
@@ -19737,11 +19696,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/captain,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bXv" = (
@@ -19786,11 +19745,11 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/item/storage/toolbox/electrical,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/machinery/camera/directional/north{
 	c_tag = "Cargo - Abandoned Warehouse";
 	network = list("ss13","cargo")
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "bXD" = (
@@ -19863,11 +19822,11 @@
 /area/station/medical/treatment_center)
 "bYW" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 9
 	},
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "bYY" = (
@@ -19889,6 +19848,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bZa" = (
@@ -19918,6 +19878,7 @@
 /obj/item/book/random,
 /obj/item/pen,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bZg" = (
@@ -19944,7 +19905,6 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bZC" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 1
 	},
@@ -20002,7 +19962,6 @@
 /area/station/commons/vacant_room/commissary)
 "cai" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "cal" = (
@@ -20028,6 +19987,7 @@
 /obj/structure/rack,
 /obj/item/tape,
 /obj/item/flashlight/lamp/green,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cap" = (
@@ -20055,15 +20015,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "caE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/service/chapel/monastery)
-"caF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/area/station/security/office)
+"caF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_half,
+/area/station/science/xenobiology)
 "caI" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
@@ -20080,13 +20040,15 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "caP" = (
-/obj/effect/landmark/start/hangover,
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/security/prison/mess)
 "caS" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 8
@@ -20094,10 +20056,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "caT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "caU" = (
@@ -20106,6 +20068,7 @@
 "caX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "cbe" = (
@@ -20136,7 +20099,6 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "cbm" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -20149,6 +20111,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cbJ" = (
@@ -20205,7 +20168,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "ccf" = (
@@ -20233,8 +20195,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "ccu" = (
@@ -20270,10 +20232,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ccX" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "ccY" = (
@@ -20292,9 +20254,9 @@
 	},
 /area/station/science/ordnance)
 "cda" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "cdc" = (
@@ -20307,8 +20269,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 1
 	},
@@ -20350,7 +20312,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -20360,19 +20321,19 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cdZ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cec" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20390,13 +20351,12 @@
 /area/station/maintenance/department/cargo)
 "cek" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/escape)
 "cem" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cep" = (
@@ -20427,7 +20387,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ceB" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance{
@@ -20436,6 +20395,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "ceR" = (
@@ -20508,7 +20468,6 @@
 	alpha = 255;
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cfy" = (
@@ -20549,7 +20508,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cfN" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20561,12 +20519,16 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "cfW" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/science/robotics/lab)
 "cgc" = (
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -20605,7 +20567,6 @@
 /area/station/science/ordnance/bomb)
 "cgj" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/port/aft)
 "cgk" = (
@@ -20670,7 +20631,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "chm" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
@@ -20748,6 +20708,7 @@
 "cih" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cii" = (
@@ -20860,7 +20821,6 @@
 /area/station/science/ordnance/bomb)
 "cja" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/structure/cable,
 /obj/machinery/camera/directional/south{
 	c_tag = "Engineering - Engine Chamber";
 	network = list("ss13","engineering","engine")
@@ -20869,6 +20829,7 @@
 	dir = 5
 	},
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "cjk" = (
@@ -20927,6 +20888,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/reagent_dispensers/watertank,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "cjT" = (
@@ -20938,11 +20900,11 @@
 "cjW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cjX" = (
@@ -20955,23 +20917,21 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cjZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "ckj" = (
 /turf/closed/wall,
 /area/station/maintenance/department/science/xenobiology)
 "ckk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ckm" = (
@@ -21115,11 +21075,11 @@
 "cld" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cln" = (
@@ -21198,9 +21158,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/landmark/start/depsec/supply,
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/supply)
 "cmi" = (
@@ -21266,7 +21226,6 @@
 /obj/item/storage/box/lights/mixed,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
@@ -21276,9 +21235,9 @@
 /turf/open/floor/iron/textured,
 /area/station/maintenance/department/science/xenobiology)
 "cmO" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/station/solars/port/aft)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "cmR" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -21348,18 +21307,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "cob" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "coh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/camera/directional/north{
 	c_tag = "Cargo - Lobby N";
 	network = list("ss13","cargo");
@@ -21372,8 +21330,8 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/item/kirbyplants/random,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "cok" = (
@@ -21383,6 +21341,7 @@
 "col" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/cargo_technician,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "coq" = (
@@ -21417,9 +21376,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "cpi" = (
@@ -21440,14 +21399,12 @@
 "cpk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cpm" = (
 /obj/effect/turf_decal/tile/brown/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
 	},
@@ -21457,13 +21414,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "cpn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/girder,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/commons/dorms)
+/area/station/maintenance/department/medical)
 "cpx" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine,
@@ -21480,16 +21435,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cpG" = (
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/aft)
 "cpH" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -21503,13 +21453,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "cpR" = (
-/obj/structure/cable,
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -21526,15 +21475,14 @@
 "cqd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/start/shaft_miner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "cqi" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -21561,10 +21509,10 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenobiology Maintenance"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/science/xenobiology)
 "cqW" = (
@@ -21573,6 +21521,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/bot/cleanbot,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
@@ -21657,11 +21606,10 @@
 /turf/open/space/basic,
 /area/space)
 "crm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/atmos)
 "cry" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -21744,7 +21692,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "cse" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -21755,6 +21702,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "csf" = (
@@ -21812,9 +21760,9 @@
 	name = "Service Hall"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "csF" = (
@@ -21836,7 +21784,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "csN" = (
@@ -21861,10 +21808,10 @@
 "csU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "csW" = (
@@ -21896,6 +21843,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ctK" = (
@@ -21922,13 +21870,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "cug" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/rnd_all,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "cun" = (
@@ -22016,12 +21964,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cuY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cvg" = (
@@ -22050,12 +21998,13 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "cvA" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "cvB" = (
@@ -22072,14 +22021,13 @@
 /turf/closed/wall,
 /area/station/science/auxlab/firing_range)
 "cvM" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cvN" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22092,6 +22040,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cvP" = (
@@ -22121,8 +22070,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "cwt" = (
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "cww" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/structure/table,
@@ -22180,7 +22135,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "cxa" = (
@@ -22239,17 +22193,17 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/ordnance/testlab)
 "cxi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /obj/structure/cable,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/turf/open/floor/iron,
+/area/station/security/prison)
 "cxm" = (
 /obj/structure/table/wood,
 /obj/structure/showcase/machinery/tv{
 	dir = 1;
 	pixel_y = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
 "cxo" = (
@@ -22259,7 +22213,6 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/qm)
 "cxv" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -22267,6 +22220,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "cxz" = (
@@ -22283,6 +22237,7 @@
 	c_tag = "Engineering - Storage";
 	network = list("ss13","engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -22335,7 +22290,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cyl" = (
-/obj/structure/cable,
 /obj/structure/closet/crate/engineering/electrical,
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
@@ -22363,6 +22317,7 @@
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/solars/starboard/aft)
 "cyo" = (
@@ -22429,10 +22384,10 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/solars)
 "cyT" = (
-/obj/structure/cable,
 /obj/machinery/power/smes,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "cyV" = (
@@ -22505,26 +22460,23 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "czq" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/space_heater,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "czw" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "czy" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
+/turf/open/floor/carpet/royalblack,
+/area/station/command/bridge)
 "czC" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -22575,7 +22527,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "czV" = (
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cAe" = (
@@ -22597,12 +22548,12 @@
 	name = "Solars Camera";
 	network = list("ss13","engineering")
 	},
-/obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "cAt" = (
@@ -22611,7 +22562,6 @@
 /area/station/maintenance/department/science/xenobiology)
 "cAu" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
 "cAv" = (
@@ -22675,6 +22625,7 @@
 	name = "Mining Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "cAI" = (
@@ -22684,7 +22635,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cAO" = (
-/obj/structure/cable,
 /obj/machinery/power/solar_control{
 	dir = 1;
 	id = "aftstarboard";
@@ -22705,8 +22655,10 @@
 /turf/open/space,
 /area/space/nearstation)
 "cAW" = (
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/structure/chair,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "cBg" = (
 /obj/effect/gibspawner/human/bodypartless,
 /obj/effect/decal/cleanable/dirt,
@@ -22725,6 +22677,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cBp" = (
@@ -22752,6 +22705,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "cBw" = (
@@ -22760,12 +22714,12 @@
 /area/station/medical/psychology)
 "cBz" = (
 /obj/structure/sign/warning/vacuum/external/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "cBG" = (
@@ -22852,7 +22806,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "cCe" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
 	},
@@ -22861,6 +22814,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/starboard/aft)
 "cCf" = (
@@ -22870,16 +22824,13 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cCg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "cCh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cCi" = (
@@ -22891,8 +22842,9 @@
 /area/space/nearstation)
 "cCj" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/area/station/security/warden)
 "cCl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22915,7 +22867,6 @@
 "cCy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -22954,7 +22905,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cDf" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22972,7 +22922,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22980,6 +22929,7 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "cDj" = (
@@ -23009,9 +22959,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cDq" = (
@@ -23031,14 +22981,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "cDw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "cDx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -23059,11 +23016,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cDB" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cDD" = (
@@ -23098,18 +23055,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cEf" = (
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/girder,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "cEp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -23119,8 +23068,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cEr" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cEs" = (
@@ -23149,17 +23098,17 @@
 /area/station/cargo/lobby)
 "cEw" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cEx" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 8
-	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/area/station/engineering/atmos)
 "cEz" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 4;
@@ -23198,7 +23147,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cEJ" = (
@@ -23248,8 +23196,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
 "cEX" = (
-/turf/open/floor/engine,
-/area/station/engineering/supermatter)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "cFa" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -23279,23 +23230,19 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cFk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/solars/starboard/aft)
 "cFl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/space/basic,
+/area/station/solars/port/aft)
 "cFo" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -23339,7 +23286,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
@@ -23347,7 +23293,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
@@ -23355,7 +23300,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
@@ -23458,7 +23402,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "cGg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -23484,11 +23427,11 @@
 /turf/open/floor/wood/large,
 /area/station/maintenance/department/science/central)
 "cGC" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/decoration/glowstick,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cGF" = (
@@ -23499,20 +23442,22 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cGG" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "cGH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cGI" = (
@@ -23553,7 +23498,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cGR" = (
-/obj/structure/cable,
 /mob/living/simple_animal/slime,
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/large,
@@ -23566,13 +23510,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cGW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cGY" = (
@@ -23580,6 +23524,7 @@
 /obj/effect/turf_decal/siding/thinplating/light/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "cHe" = (
@@ -23638,14 +23583,17 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/science/xenobiology)
 "cIh" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "cIi" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cIk" = (
@@ -23658,7 +23606,6 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cIq" = (
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "cIr" = (
@@ -23666,10 +23613,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "cIs" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cIw" = (
@@ -23703,11 +23650,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/mail_sorting/service/janitor_closet,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "cIQ" = (
@@ -23719,10 +23666,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "cIU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/engineering/storage)
 "cIV" = (
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 4
@@ -23742,7 +23693,6 @@
 	},
 /area/station/cargo/miningoffice)
 "cJa" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
@@ -23753,6 +23703,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "cJc" = (
@@ -23783,9 +23734,11 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cJf" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/cable,
+/turf/open/floor/iron/half{
+	dir = 8
+	},
+/area/station/science/xenobiology)
 "cJg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -23794,12 +23747,10 @@
 /area/space/nearstation)
 "cJh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cJi" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
@@ -23832,9 +23783,9 @@
 /area/station/hallway/primary/starboard)
 "cJI" = (
 /obj/effect/turf_decal/siding/dark_blue,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "cJJ" = (
@@ -23871,7 +23822,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "cJR" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
@@ -23881,26 +23831,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "cJU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cJV" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cJW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating,
@@ -23930,9 +23878,9 @@
 /area/station/engineering/atmos)
 "cKk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "cKp" = (
@@ -23950,12 +23898,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cKu" = (
@@ -23980,12 +23926,11 @@
 /obj/item/stack/package_wrap,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/machinery/light_switch/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/prison/work)
 "cKy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -24013,7 +23958,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cKJ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -24034,13 +23978,13 @@
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "cKU" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "cKV" = (
@@ -24081,9 +24025,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "cLt" = (
@@ -24092,7 +24036,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cLv" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -24197,7 +24140,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/department/science/central)
 "cMa" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -24205,6 +24147,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "cMb" = (
@@ -24215,7 +24158,6 @@
 /area/space/nearstation)
 "cMc" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cMd" = (
@@ -24260,6 +24202,7 @@
 /area/station/security/prison/shower)
 "cMJ" = (
 /obj/effect/turf_decal/siding/thinplating/light,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "cML" = (
@@ -24292,7 +24235,6 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
 "cNa" = (
@@ -24315,7 +24257,6 @@
 "cNm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -24352,6 +24293,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "cNr" = (
@@ -24437,30 +24379,20 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cOi" = (
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/structure/barricade/wooden,
 /obj/structure/cable,
-/obj/machinery/door/airlock/wood{
-	name = "Maintenance Access"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom)
 "cOk" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/hfr_room)
 "cOl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "cOn" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -24470,7 +24402,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cOo" = (
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/disposalpipe/segment,
@@ -24517,35 +24448,39 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/science/xenobiology)
 "cOy" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/department/science/xenobiology)
-"cOA" = (
+/obj/effect/spawner/structure/window,
 /obj/structure/cable,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
+"cOA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cOD" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cOE" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cOH" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/power/terminal,
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable,
 /obj/machinery/light/small/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/solars/starboard/fore)
 "cOM" = (
@@ -24568,11 +24503,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/command/captain,
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
 "cOS" = (
@@ -24605,7 +24540,6 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cOW" = (
@@ -24615,7 +24549,6 @@
 /obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/department/science/xenobiology)
 "cPc" = (
@@ -24625,7 +24558,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -24670,7 +24602,6 @@
 /area/station/maintenance/disposal)
 "cPs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/science/xenobiology)
 "cPt" = (
@@ -24708,7 +24639,8 @@
 "cPy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/space/basic,
 /area/station/maintenance/department/science/central)
 "cPA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24755,11 +24687,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/eva/abandoned)
 "cPO" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/central)
 "cPP" = (
@@ -24769,6 +24701,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cPQ" = (
@@ -24790,6 +24723,7 @@
 	},
 /obj/structure/sign/poster/contraband/random/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/central)
 "cPT" = (
@@ -24841,6 +24775,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cQe" = (
@@ -24851,11 +24786,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/central)
 "cQf" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/machinery/processor/slime,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cQh" = (
@@ -24887,20 +24822,20 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/eva/abandoned)
 "cQr" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/machinery/smartfridge/extract/preloaded,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cQs" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cQt" = (
@@ -24911,7 +24846,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "cQw" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
@@ -25041,7 +24975,6 @@
 /obj/structure/transit_tube/station/dispenser/reverse/flipped{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/transit_tube)
 "cQQ" = (
@@ -25055,7 +24988,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "cQR" = (
@@ -25063,7 +24995,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/window/brigdoor/right/directional/west{
 	name = "MiniSat Access";
@@ -25078,9 +25009,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "cQT" = (
@@ -25110,6 +25041,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Science - MiniSat Access"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "cQW" = (
@@ -25129,6 +25061,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "cRb" = (
@@ -25136,6 +25069,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "cRd" = (
@@ -25146,6 +25080,7 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/official/state_laws/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "cRh" = (
@@ -25162,7 +25097,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/transit_tube)
 "cRj" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
@@ -25187,7 +25121,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "cRn" = (
@@ -25230,11 +25163,11 @@
 	id = "rdxeno";
 	name = "Xenobiology Containment Door"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/xenobiology)
 "cRw" = (
@@ -25255,15 +25188,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/xenobiology)
 "cRy" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "cRz" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/transit_tube,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/transit_tube)
 "cRA" = (
@@ -25272,10 +25204,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cRC" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cRD" = (
@@ -25288,10 +25220,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cRF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "cRG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25333,12 +25270,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cRN" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cRO" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -25352,16 +25287,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cRR" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cRS" = (
@@ -25392,7 +25328,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cSb" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -25402,16 +25337,17 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "cSe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cSf" = (
@@ -25425,7 +25361,6 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cSi" = (
@@ -25447,9 +25382,9 @@
 "cSj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cSk" = (
@@ -25459,13 +25394,14 @@
 	name = "Engineering External Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cSl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cSm" = (
@@ -25481,11 +25417,11 @@
 "cSn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/central)
 "cSp" = (
@@ -25493,7 +25429,6 @@
 /turf/open/space/basic,
 /area/station/solars/ai)
 "cSr" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -25555,7 +25490,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/central)
 "cSC" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
@@ -25563,7 +25497,6 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/science/xenobiology)
 "cSD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
@@ -25572,14 +25505,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cSG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/xenobiology)
 "cSI" = (
@@ -25650,14 +25582,13 @@
 /area/station/maintenance/department/science/central)
 "cSW" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/ai)
 "cSX" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cSY" = (
@@ -25666,9 +25597,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cSZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/science/central)
 "cTa" = (
@@ -25747,9 +25678,9 @@
 /area/station/science/xenobiology)
 "cTq" = (
 /obj/effect/turf_decal/trimline/purple,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/xenobiology)
 "cTr" = (
@@ -25774,7 +25705,6 @@
 	},
 /area/station/science/xenobiology)
 "cTx" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -25783,6 +25713,7 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "cTz" = (
@@ -25795,8 +25726,8 @@
 "cTA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating/rust,
 /area/station/maintenance/department/science/xenobiology)
 "cTB" = (
@@ -25812,11 +25743,11 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/science/central)
 "cTD" = (
@@ -25879,9 +25810,9 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/science/central)
 "cTT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/science/central)
 "cTW" = (
@@ -25903,8 +25834,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/department/science/central)
 "cTY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/science/central)
 "cUb" = (
@@ -25950,6 +25881,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cUh" = (
@@ -25962,9 +25894,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cUl" = (
@@ -25977,10 +25909,10 @@
 "cUs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/broken_flooring/corner/directional/west,
 /obj/effect/spawner/random/trash/graffiti,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cUu" = (
@@ -26081,8 +26013,8 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/science/central)
 "cUP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/science/central)
 "cUV" = (
@@ -26095,11 +26027,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cVa" = (
-/mob/living/simple_animal/slime,
 /obj/structure/cable,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/large,
-/area/station/science/xenobiology)
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "cVc" = (
 /obj/machinery/door/window/left/directional/north{
 	dir = 4;
@@ -26112,7 +26042,6 @@
 	name = "Containment Pen #1";
 	req_access = list("xenobiology")
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 8
 	},
@@ -26122,7 +26051,6 @@
 /area/station/science/xenobiology)
 "cVe" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cVf" = (
@@ -26130,9 +26058,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cVh" = (
@@ -26147,10 +26075,10 @@
 	name = "Containment Pen #2";
 	req_access = list("xenobiology")
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -26174,11 +26102,11 @@
 	id = "rdxeno";
 	name = "Xenobiology Containment Door"
 	},
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdxenowindows";
 	name = "Xenobiology Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "cVu" = (
@@ -26218,14 +26146,15 @@
 /area/station/science/xenobiology)
 "cVB" = (
 /obj/effect/turf_decal/trimline/purple/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cVE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cVF" = (
@@ -26283,12 +26212,10 @@
 /area/station/maintenance/department/science/central)
 "cVV" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/lobby)
 "cVX" = (
 /obj/effect/turf_decal/siding/dark_blue,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -26355,7 +26282,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cWw" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26419,10 +26345,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cXm" = (
@@ -26587,7 +26513,6 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "cXK" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/blobstart,
@@ -26628,7 +26553,6 @@
 	},
 /area/station/ai_monitored/turret_protected/ai)
 "cXU" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
 	},
@@ -26637,6 +26561,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/starboard/aft)
 "cXV" = (
@@ -26660,17 +26585,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cXY" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -26679,6 +26603,7 @@
 	name = "Engineering External Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cYb" = (
@@ -26708,11 +26633,11 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/depsec/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "cYv" = (
 /obj/machinery/door/airlock/external,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
@@ -26722,11 +26647,11 @@
 	name = "Ordnance Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 1
 	},
@@ -26761,7 +26686,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "cZm" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
@@ -26780,6 +26704,7 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/breakroom)
 "cZG" = (
@@ -26795,12 +26720,12 @@
 /area/station/security/detectives_office)
 "daf" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	id = "detprivacy";
 	name = "Privacy Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
 "dap" = (
@@ -26845,7 +26770,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/maintenance/aft/lesser)
 "dbi" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
@@ -26886,7 +26810,6 @@
 	dir = 4;
 	name = "Gas to Mix"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/box,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -26912,10 +26835,10 @@
 /area/station/maintenance/department/science)
 "dbU" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "dca" = (
@@ -26949,6 +26872,7 @@
 /obj/structure/rack,
 /obj/item/book/random,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "ddo" = (
@@ -27078,15 +27002,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "dgp" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "dgy" = (
@@ -27133,6 +27056,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dhj" = (
@@ -27213,7 +27137,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
 "din" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -27229,21 +27152,19 @@
 "div" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "diw" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "diS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -27383,7 +27304,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
 "dnx" = (
@@ -27400,13 +27320,13 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "dnD" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -27478,6 +27398,7 @@
 	dir = 1
 	},
 /obj/structure/closet/emcloset,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "doY" = (
@@ -27575,6 +27496,7 @@
 /area/station/maintenance/port/greater)
 "dqK" = (
 /obj/effect/spawner/random/structure/girder,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "dqL" = (
@@ -27648,7 +27570,6 @@
 /area/station/maintenance/department/medical/plasmaman)
 "drN" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -27660,17 +27581,17 @@
 /area/station/medical/morgue)
 "dsm" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "dst" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "dsw" = (
@@ -27701,7 +27622,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "dsN" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
@@ -27711,7 +27631,6 @@
 "dsP" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/fueltank/large,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "dsY" = (
@@ -27787,7 +27706,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
 "duS" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/mess,
@@ -27824,13 +27742,13 @@
 "dvp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "dvq" = (
@@ -27889,8 +27807,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "dya" = (
@@ -27972,7 +27890,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -27981,8 +27898,8 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "dzB" = (
@@ -27990,7 +27907,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "dAg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -28051,12 +27967,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "dBL" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "dBU" = (
@@ -28094,12 +28010,12 @@
 	id = "AI Chamber entrance shutters";
 	name = "AI Chamber Entrance Shutters"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/ai_monitored/turret_protected/ai)
 "dCn" = (
@@ -28115,7 +28031,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
 "dCB" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -28217,6 +28132,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "dEi" = (
@@ -28262,11 +28178,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "dFA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "dFB" = (
@@ -28278,6 +28194,7 @@
 	dir = 1;
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -28292,10 +28209,10 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "dFX" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
@@ -28310,7 +28227,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/structure/disposalpipe/segment,
@@ -28417,20 +28333,20 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/command{
 	name = "Emergency Escape"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/captain,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/bridge)
 "dJx" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "dJz" = (
@@ -28462,7 +28378,6 @@
 	id = "aftport";
 	name = "Aft Port Solars Control"
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
@@ -28481,7 +28396,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "dLz" = (
@@ -28489,14 +28403,15 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "dLD" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "dLX" = (
@@ -28505,6 +28420,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "dMG" = (
@@ -28543,12 +28459,12 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/ordnance/storage)
 "dNP" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "dNU" = (
@@ -28558,7 +28474,6 @@
 /turf/open/floor/wood/large,
 /area/station/maintenance/department/science/central)
 "dOc" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -28568,9 +28483,9 @@
 /area/station/hallway/secondary/service)
 "dOs" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "dOI" = (
@@ -28593,15 +28508,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "dPM" = (
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/station/hallway/secondary/construction)
 "dPP" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination/tcomms,
@@ -28611,6 +28524,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "dQr" = (
@@ -28624,6 +28538,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "dQt" = (
@@ -28637,7 +28552,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "dQw" = (
@@ -28712,7 +28626,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "dRQ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
@@ -28722,20 +28635,18 @@
 /obj/machinery/power/shieldwallgen/xenobiologyaccess,
 /obj/effect/turf_decal/box,
 /obj/structure/sign/warning/xeno_mining/directional/south,
-/obj/structure/cable,
 /turf/open/floor/plating/rust,
 /area/station/science/xenobiology)
 "dSu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "dSA" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
@@ -28744,6 +28655,7 @@
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "dSB" = (
@@ -28756,7 +28668,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "dTj" = (
@@ -28794,6 +28705,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "dTV" = (
@@ -28825,7 +28737,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/warden)
 "dUO" = (
@@ -28905,7 +28816,6 @@
 	},
 /obj/effect/landmark/start/geneticist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "dXh" = (
@@ -28914,7 +28824,6 @@
 /area/station/engineering/break_room)
 "dXk" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28945,16 +28854,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "dYV" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/green,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "dZq" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "dZu" = (
@@ -28964,9 +28872,9 @@
 /area/station/ai_monitored/turret_protected/aisat/solars)
 "dZE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "dZT" = (
@@ -29031,11 +28939,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/auxlab/firing_range)
 "ebz" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/upper)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "ebB" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -29051,7 +28962,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ecw" = (
@@ -29104,8 +29014,8 @@
 "edR" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/effect/landmark/navigate_destination/det,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "edW" = (
@@ -29160,6 +29070,7 @@
 "eeF" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "eeG" = (
@@ -29202,7 +29113,6 @@
 /area/station/command/bridge)
 "efw" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
@@ -29216,7 +29126,6 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/command)
 "efC" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -29251,6 +29160,7 @@
 /obj/machinery/computer/rdconsole,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/rd)
 "egh" = (
@@ -29285,12 +29195,11 @@
 /turf/open/floor/iron,
 /area/station/science/auxlab/firing_range)
 "ehP" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "ehT" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -29298,7 +29207,6 @@
 /area/station/hallway/primary/aft)
 "ehX" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -29308,6 +29216,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "eib" = (
@@ -29347,7 +29256,6 @@
 /area/station/command/heads_quarters/cmo)
 "eid" = (
 /obj/structure/chair/stool/bar/directional/north,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -29361,7 +29269,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "eiR" = (
@@ -29374,8 +29281,8 @@
 "eiS" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "eja" = (
@@ -29391,8 +29298,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/structure/sign/poster/official/random/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "ejD" = (
@@ -29461,9 +29368,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "elM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical)
 "elY" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/duct,
@@ -29486,7 +29399,6 @@
 /area/station/engineering/atmos)
 "emQ" = (
 /obj/effect/turf_decal/stripes/full,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
@@ -29494,7 +29406,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "ena" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -29510,7 +29421,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "ent" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "enY" = (
@@ -29548,6 +29458,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "epe" = (
@@ -29614,7 +29525,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "epO" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -29670,12 +29580,12 @@
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "eqr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "eqx" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29714,7 +29624,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "erB" = (
@@ -29739,10 +29648,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "est" = (
@@ -29831,7 +29740,6 @@
 /area/station/engineering/atmos)
 "etU" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -29902,20 +29810,23 @@
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/office)
 "evm" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube/crossing,
-/turf/open/space/basic,
-/area/space/nearstation)
-"evs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/turf/open/floor/iron/white,
+/area/station/science/lab)
+"evs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "evx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -29947,7 +29858,6 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29964,7 +29874,6 @@
 /area/station/science/research)
 "ewp" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
 /obj/machinery/button/ignition{
 	id = "executionburn";
 	name = "Justice Ignition Switch";
@@ -29992,18 +29901,19 @@
 	pixel_y = -36;
 	req_access = list("armory")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "ewx" = (
 /obj/structure/sign/departments/psychology/directional/east,
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "ewz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "ewF" = (
@@ -30142,18 +30052,19 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/checkpoint/science/research)
 "eyz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "eyH" = (
@@ -30186,7 +30097,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
@@ -30201,7 +30111,6 @@
 /area/station/engineering/supermatter/room)
 "ezQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -30347,6 +30256,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "eCL" = (
@@ -30393,12 +30303,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "eDY" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Auxiliary Power"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -30409,7 +30319,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "eEh" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
@@ -30419,6 +30328,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "eEo" = (
@@ -30572,7 +30482,6 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/ce)
 "eGY" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -30591,6 +30500,8 @@
 	req_access = list("ai_upload")
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/ai)
 "eHf" = (
@@ -30603,6 +30514,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "eHp" = (
@@ -30613,6 +30525,7 @@
 	alpha = 255;
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "eHD" = (
@@ -30662,15 +30575,16 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "eIP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/crate_abandoned,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "eJc" = (
@@ -30701,12 +30615,14 @@
 /obj/effect/turf_decal/siding/thinplating/light/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "eJQ" = (
+/obj/structure/closet/firecloset,
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "eJR" = (
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 4
@@ -30714,6 +30630,7 @@
 /obj/effect/turf_decal/siding/thinplating/light/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "eJT" = (
@@ -30746,6 +30663,7 @@
 /area/station/engineering/lobby)
 "eJY" = (
 /obj/structure/displaycase/labcage,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/command/heads_quarters/rd)
 "eKp" = (
@@ -30776,7 +30694,6 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/plasmaman)
 "eKN" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/girder,
@@ -30835,14 +30752,10 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "eLL" = (
-/obj/effect/turf_decal/tile/green/half{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/station/security/prison/garden)
+/turf/open/floor/plating,
+/area/station/security/checkpoint/escape)
 "eLT" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -30879,8 +30792,8 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "eMY" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "eNc" = (
@@ -30914,9 +30827,9 @@
 /area/station/science/research)
 "eNE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/abandoned_gambling_den)
 "eNI" = (
@@ -30928,9 +30841,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/item/kirbyplants/random,
 /obj/machinery/newscaster/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "eOn" = (
@@ -30939,8 +30852,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "eOp" = (
@@ -30993,7 +30906,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ePo" = (
@@ -31024,17 +30936,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "ePH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "eQe" = (
@@ -31057,6 +30969,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "eQW" = (
@@ -31098,10 +31011,10 @@
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "eRP" = (
@@ -31140,11 +31053,11 @@
 /area/station/maintenance/disposal/incinerator)
 "eSS" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
 	},
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "eSX" = (
@@ -31173,6 +31086,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "eTY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "eUa" = (
@@ -31191,11 +31105,11 @@
 /area/station/maintenance/port/greater)
 "eUC" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
 	name = "Prison Lockdown Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/work)
 "eUG" = (
@@ -31235,8 +31149,8 @@
 	dir = 6
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "eVC" = (
@@ -31259,8 +31173,8 @@
 /obj/effect/turf_decal/box,
 /obj/structure/closet/emcloset,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /obj/machinery/light_switch/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/solars/starboard/fore)
 "eWd" = (
@@ -31281,7 +31195,6 @@
 /obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
 	dir = 1
 	},
@@ -31308,6 +31221,7 @@
 "eWA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/structure/sign/warning/no_smoking/directional/west,
+/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security/upper)
@@ -31336,11 +31250,15 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/teleporter)
 "eXy" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/wood/tile,
-/area/station/command/bridge)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/office)
 "eXE" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
@@ -31355,7 +31273,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "eYv" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/machinery/door/airlock/glass_large{
 	name = "Xenobiology Lab"
@@ -31414,12 +31331,12 @@
 /area/station/science/ordnance/testlab)
 "eZR" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "rdoffice";
 	name = "Research Director's Office Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
 "fag" = (
@@ -31435,7 +31352,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/warden)
 "faq" = (
@@ -31542,14 +31458,13 @@
 	pixel_y = -1
 	},
 /obj/item/stamp/head/hos,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "fde" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "fdm" = (
 /obj/effect/turf_decal/tile/security/fourcorners,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -31565,6 +31480,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/shipping,
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "fdw" = (
@@ -31613,7 +31529,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "ffb" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -31621,6 +31536,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/prison/visit)
 "ffu" = (
@@ -31639,14 +31555,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
 "ffy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "fgg" = (
@@ -31659,10 +31573,10 @@
 /obj/effect/spawner/random/trash/garbage,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "fgW" = (
@@ -31695,8 +31609,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "fib" = (
@@ -31769,7 +31683,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "fkb" = (
@@ -31793,7 +31706,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fkA" = (
@@ -31842,8 +31754,8 @@
 /area/station/science/lobby)
 "flh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "flj" = (
@@ -31851,12 +31763,12 @@
 	name = "Medical Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "flk" = (
@@ -31915,11 +31827,11 @@
 /area/station/medical/chemistry)
 "fmN" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 4
 	},
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "fmY" = (
@@ -31934,35 +31846,32 @@
 /area/station/medical/pharmacy)
 "fnc" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "fnt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
-"fny" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/turf/open/floor/engine,
+/area/station/command/heads_quarters/rd)
+"fny" = (
+/obj/item/kirbyplants/random,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison/visit)
+/area/station/commons/lounge)
 "fnU" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fnV" = (
 /obj/item/melee/baseball_bat,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
@@ -32003,18 +31912,17 @@
 /area/station/security/prison/mess)
 "foW" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
 	},
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "fpd" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "fpu" = (
@@ -32058,7 +31966,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/plasmaman)
 "fqs" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -32079,7 +31986,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "fqV" = (
@@ -32088,12 +31994,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/breakroom)
 "fra" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "frv" = (
@@ -32108,7 +32016,6 @@
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
@@ -32131,7 +32038,6 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "fss" = (
@@ -32146,6 +32052,7 @@
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fsF" = (
@@ -32176,7 +32083,6 @@
 "ftp" = (
 /obj/item/stack/ore/glass,
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
 /obj/machinery/camera/directional/north{
 	c_tag = "Security - Prison - Exterior";
 	network = list("ss13","security","prison")
@@ -32187,7 +32093,6 @@
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
@@ -32229,17 +32134,17 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "fuy" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "fuD" = (
@@ -32252,7 +32157,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "fva" = (
@@ -32266,6 +32170,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "fvf" = (
@@ -32297,12 +32202,12 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "fvO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -32310,14 +32215,15 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "fvV" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/science/research)
 "fwk" = (
@@ -32382,8 +32288,8 @@
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "fxb" = (
@@ -32428,25 +32334,26 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "fxK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "fxZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "fyd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "fye" = (
@@ -32467,13 +32374,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/plasmaman)
 "fyj" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/girder,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "fym" = (
@@ -32489,6 +32396,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/chemical,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fyO" = (
@@ -32501,13 +32409,15 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "fzn" = (
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/bridge)
 "fzX" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/line{
@@ -32535,7 +32445,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "fAL" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -32587,7 +32496,6 @@
 /turf/open/floor/wood,
 /area/station/maintenance/aft/lesser)
 "fBx" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/large,
 /area/station/science/xenobiology)
@@ -32606,12 +32514,12 @@
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "fBX" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "fCo" = (
@@ -32630,25 +32538,24 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fCC" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fCD" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/toolcloset,
 /obj/item/wrench,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "fCF" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
 	},
@@ -32687,7 +32594,6 @@
 	name = "Containment Pen #3";
 	req_access = list("xenobiology")
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 8
 	},
@@ -32757,12 +32663,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "fGv" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/turf/open/misc/asteroid,
+/area/station/security/prison/rec)
 "fGG" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/box/white{
@@ -32799,8 +32702,8 @@
 /turf/open/floor/iron/textured_half,
 /area/station/maintenance/port)
 "fGU" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "fHa" = (
@@ -32839,6 +32742,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "fIs" = (
@@ -32850,7 +32754,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "fIu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32905,33 +32808,31 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fJU" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "fJX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/command{
 	name = "E.V.A. Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /obj/effect/landmark/navigate_destination,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
 "fKe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -32954,10 +32855,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/half{
 	dir = 8
 	},
@@ -32982,20 +32883,20 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/navigate_destination/gateway,
 /obj/machinery/door/airlock/command/glass{
 	name = "Gateway Chamber"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/gateway,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "fLA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "fLB" = (
@@ -33007,17 +32908,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fLL" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "fLX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -33025,6 +32923,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "fMa" = (
@@ -33033,7 +32932,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "fMm" = (
@@ -33051,7 +32949,6 @@
 /area/station/command/gateway)
 "fMv" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -33127,8 +33024,8 @@
 /area/station/service/abandoned_gambling_den)
 "fOi" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "fOl" = (
@@ -33159,18 +33056,18 @@
 	name = "Containment Pen #4";
 	req_access = list("xenobiology")
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
 /area/station/science/xenobiology)
 "fOF" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "fOM" = (
@@ -33215,14 +33112,15 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "fPv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/command/bridge)
+/turf/open/floor/iron/white,
+/area/station/commons/toilet)
 "fPA" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron{
@@ -33234,7 +33132,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
@@ -33258,6 +33155,7 @@
 	name = "Bridge"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "fQq" = (
@@ -33269,7 +33167,6 @@
 /obj/machinery/power/shieldwallgen/xenobiologyaccess,
 /obj/effect/turf_decal/box,
 /obj/structure/sign/warning/xeno_mining/directional/south,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "fQI" = (
@@ -33315,13 +33212,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "fRm" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /obj/effect/landmark/start/depsec/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "fRs" = (
@@ -33364,7 +33261,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "fRW" = (
@@ -33403,6 +33299,7 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "fSx" = (
@@ -33441,10 +33338,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "fSO" = (
@@ -33456,16 +33353,15 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fSP" = (
 /obj/effect/turf_decal/box,
-/obj/structure/cable,
 /obj/machinery/power/tracker{
 	id = "aisolar"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/ai)
 "fTq" = (
@@ -33489,7 +33385,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "fTH" = (
@@ -33531,10 +33426,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "fUs" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "fUu" = (
@@ -33582,11 +33477,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "fVC" = (
@@ -33658,7 +33553,6 @@
 "fWw" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "fXh" = (
@@ -33682,9 +33576,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/eva/abandoned)
 "fXO" = (
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/station/security/prison/safe/exterior)
+/obj/structure/cable,
+/turf/closed/wall,
+/area/station/maintenance/port/greater)
 "fXR" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/o2,
@@ -33914,6 +33808,7 @@
 	pixel_x = 3
 	},
 /obj/effect/spawner/random/medical/minor_healing,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "gdA" = (
@@ -33932,8 +33827,8 @@
 /obj/effect/spawner/random/maintenance/two,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "gdR" = (
@@ -33953,6 +33848,7 @@
 "gei" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "gel" = (
@@ -33989,7 +33885,6 @@
 /obj/structure/sign/warning/secure_area/directional/north,
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/oil,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
@@ -34000,6 +33895,7 @@
 "ggh" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "ggv" = (
@@ -34020,9 +33916,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "ggJ" = (
@@ -34037,15 +33933,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "ght" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/dim/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "ghB" = (
@@ -34057,6 +33954,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plastic,
 /area/station/maintenance/department/medical)
+"gii" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/engineering/atmos)
 "gim" = (
 /obj/structure/sink/directional/west,
 /obj/structure/sign/poster/official/cleanliness/directional/east,
@@ -34099,6 +34005,7 @@
 "giK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "giN" = (
@@ -34110,9 +34017,9 @@
 /turf/open/floor/wood,
 /area/station/security/prison)
 "giY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "gje" = (
@@ -34164,7 +34071,6 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/geneticist,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "gkr" = (
@@ -34208,10 +34114,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "glu" = (
@@ -34229,13 +34135,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "glO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "glS" = (
@@ -34246,10 +34153,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/stack/cable_coil/five,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "gmd" = (
@@ -34282,12 +34189,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "gnv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "gnC" = (
@@ -34317,6 +34222,7 @@
 "goa" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "gog" = (
@@ -34355,10 +34261,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/cafeteria)
 "goM" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gpk" = (
@@ -34412,10 +34318,10 @@
 /area/station/maintenance/disposal/incinerator)
 "gqB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/ce)
 "gqT" = (
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/item/mod/module/plasma_stabilizer,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -34424,7 +34330,6 @@
 /area/station/security/office)
 "gqY" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -34511,17 +34416,16 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "gtn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/maintenance/port/greater)
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "gtu" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gtD" = (
@@ -34529,12 +34433,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "gtK" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "guv" = (
@@ -34574,7 +34478,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "gvc" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
@@ -34619,10 +34522,10 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Psychology Maintenance"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "gwe" = (
@@ -34694,8 +34597,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "gxz" = (
@@ -34705,11 +34608,11 @@
 /area/station/security/brig/hallway)
 "gxD" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "corporatelounge";
 	name = "Corporate Lounge Window Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "gxE" = (
@@ -34785,7 +34688,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -34797,12 +34699,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "gzE" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "gzF" = (
@@ -34813,7 +34715,6 @@
 /area/station/security/checkpoint)
 "gzG" = (
 /obj/structure/table,
-/obj/structure/cable,
 /obj/machinery/recharger,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
@@ -34824,6 +34725,7 @@
 "gzN" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "gzW" = (
@@ -34854,6 +34756,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "gBh" = (
@@ -34869,6 +34772,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/port)
+"gCl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/tcommsat/computer)
 "gCt" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -34884,7 +34793,6 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "gCF" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
@@ -34920,16 +34828,15 @@
 /area/station/commons/vacant_room/office)
 "gCV" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "gDb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -35041,8 +34948,8 @@
 	pixel_y = -1
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "gEV" = (
@@ -35057,10 +34964,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "gFc" = (
@@ -35139,6 +35046,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
 "gHB" = (
@@ -35170,8 +35078,8 @@
 /area/station/science/ordnance/freezerchamber)
 "gHM" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "gHS" = (
@@ -35185,11 +35093,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "gIm" = (
@@ -35204,6 +35112,7 @@
 /area/station/maintenance/department/medical)
 "gIt" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "gIw" = (
@@ -35219,6 +35128,7 @@
 	dir = 4
 	},
 /obj/machinery/light/dim/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gIW" = (
@@ -35273,7 +35183,6 @@
 "gKb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "gKk" = (
@@ -35300,8 +35209,8 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/structure/sign/warning/electric_shock/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "gKD" = (
@@ -35354,6 +35263,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"gLu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "gLD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35389,7 +35303,6 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "gMs" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
 	},
@@ -35397,6 +35310,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/port/aft)
 "gMt" = (
@@ -35406,7 +35320,6 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "gMu" = (
@@ -35423,10 +35336,10 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/maintenance/department/security/upper)
 "gMP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "gMT" = (
@@ -35435,7 +35348,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "gMZ" = (
@@ -35463,11 +35375,11 @@
 /area/station/security/prison)
 "gNi" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /obj/machinery/camera/directional/west{
 	c_tag = "Cargo - Vault";
 	network = list("ss13","vault")
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "gNl" = (
@@ -35511,6 +35423,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/warden)
 "gNF" = (
@@ -35620,7 +35533,6 @@
 /area/station/hallway/secondary/command)
 "gPq" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/camera/directional/south{
 	c_tag = "Engineering - External Engine Control";
 	name = "Engine Camera";
@@ -35657,7 +35569,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "gQz" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35668,6 +35579,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/solars)
 "gQG" = (
@@ -35679,7 +35591,6 @@
 /area/station/engineering/supermatter/room)
 "gRu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
@@ -35764,7 +35675,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/camera/directional/south{
 	c_tag = "Engineering - Secondary Storage";
 	network = list("ss13","engineering")
@@ -35803,7 +35713,6 @@
 "gTf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -35814,12 +35723,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "gTG" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gTK" = (
@@ -35837,7 +35747,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "gUf" = (
@@ -35883,6 +35792,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "gVf" = (
@@ -35906,7 +35816,6 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "gWa" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/brown,
@@ -35920,10 +35829,10 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "gWo" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/engineering/gravity_generator)
 "gWF" = (
@@ -35960,7 +35869,6 @@
 	color = "#990099";
 	name = "Science purple corner"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "gXd" = (
@@ -35994,6 +35902,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "gXS" = (
@@ -36024,6 +35933,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "gYz" = (
@@ -36042,8 +35952,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "gYJ" = (
@@ -36067,22 +35977,21 @@
 /obj/item/kitchen/spoon{
 	pixel_x = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "gZa" = (
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/upper)
 "gZd" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/rust,
 /area/station/maintenance/department/science/xenobiology)
 "gZi" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -36092,6 +36001,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "gZu" = (
@@ -36139,15 +36049,14 @@
 "har" = (
 /obj/machinery/computer/station_alert,
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "hax" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "haH" = (
@@ -36215,12 +36124,12 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "hbI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "hbK" = (
@@ -36240,6 +36149,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
@@ -36282,7 +36192,6 @@
 /area/station/command/bridge)
 "hcT" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
 "hcW" = (
@@ -36291,14 +36200,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "hdb" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -36331,7 +36238,6 @@
 /area/station/maintenance/fore)
 "hdR" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -36353,7 +36259,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/bridge)
 "heg" = (
@@ -36363,9 +36268,9 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "hes" = (
@@ -36397,7 +36302,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "heJ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
 	},
@@ -36406,6 +36310,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "heL" = (
@@ -36422,6 +36327,7 @@
 /area/station/engineering/atmos/hfr_room)
 "hfo" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "hfu" = (
@@ -36440,10 +36346,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "hfI" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "hfK" = (
@@ -36462,7 +36368,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge Access"
 	},
@@ -36470,6 +36375,7 @@
 	cycle_id = "bridge-left"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/bridge)
 "hfS" = (
@@ -36515,6 +36421,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "hgQ" = (
@@ -36603,7 +36510,6 @@
 /area/station/security/checkpoint/customs/fore)
 "hjj" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance{
@@ -36611,13 +36517,14 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "hjp" = (
 /obj/machinery/light/dim/directional/north,
-/obj/structure/cable,
 /obj/structure/table,
 /obj/effect/spawner/round_default_module,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "hka" = (
@@ -36672,6 +36579,7 @@
 	c_tag = "Command - Bridge N";
 	network = list("ss13","command")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "hks" = (
@@ -36693,19 +36601,22 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "hky" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "hkC" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitory"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison/visit)
+/area/station/commons/dorms)
 "hkI" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
 	name = "Burn Chamber Interior Airlock"
@@ -36746,7 +36657,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
@@ -36798,11 +36708,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "hls" = (
@@ -36842,7 +36752,6 @@
 /area/station/engineering/storage/tech)
 "hlv" = (
 /obj/structure/chair/stool/bar/directional/north,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -36883,24 +36792,24 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hmV" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "hne" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "hnr" = (
@@ -36972,7 +36881,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "hnV" = (
-/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "hos" = (
@@ -37021,6 +36929,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "hpH" = (
@@ -37056,6 +36965,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "hqw" = (
+/obj/structure/cable,
 /turf/open/floor/glass/reinforced,
 /area/station/engineering/storage_shared)
 "hqI" = (
@@ -37091,7 +37001,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "hqW" = (
-/obj/structure/cable,
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
@@ -37199,7 +37108,6 @@
 "htH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/insectguts,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/plastic,
 /area/station/commons/toilet/auxiliary)
@@ -37241,6 +37149,7 @@
 	pixel_x = -4;
 	pixel_y = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "huR" = (
@@ -37261,11 +37170,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "hvw" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_red/filled,
 /obj/effect/landmark/start/depsec/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "hvz" = (
@@ -37316,13 +37225,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "hws" = (
@@ -37331,8 +37240,8 @@
 	dir = 4;
 	name = "engineering yellow"
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "hwR" = (
@@ -37451,7 +37360,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/upper)
 "hyu" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -37461,6 +37369,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "hyx" = (
@@ -37580,6 +37489,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "hzS" = (
@@ -37587,7 +37497,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -37612,13 +37521,13 @@
 /area/station/medical/treatment_center)
 "hAn" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/mail_sorting/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "hAo" = (
@@ -37635,27 +37544,19 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "hAy" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/storage/gas)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "hAG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "hAI" = (
@@ -37673,8 +37574,8 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "hBb" = (
@@ -37731,15 +37632,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "hBG" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "hBH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/meter,
+/obj/structure/cable,
 /turf/open/floor/iron/half{
 	dir = 8
 	},
@@ -37776,18 +37676,18 @@
 	},
 /area/station/science/ordnance/testlab)
 "hCL" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/prison)
 "hCO" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "hCP" = (
@@ -37825,7 +37725,6 @@
 /area/station/maintenance/department/science/xenobiology)
 "hDr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -37861,8 +37760,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "hEg" = (
@@ -37870,10 +37769,12 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "hEi" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
+/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security/upper)
@@ -37906,7 +37807,6 @@
 /obj/effect/turf_decal/tile/green/half{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/edge{
 	dir = 4
@@ -37917,19 +37817,18 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/item/kirbyplants/random,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "hFE" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "hFH" = (
-/obj/structure/cable,
 /turf/open/misc/asteroid,
 /area/station/security/prison/safe/exterior)
 "hGb" = (
@@ -37990,8 +37889,8 @@
 /obj/structure/disposalpipe/sorting/mail,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/mail_sorting/supply/disposals,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "hHR" = (
@@ -38031,7 +37930,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "hIy" = (
@@ -38094,10 +37992,10 @@
 "hJu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "hJS" = (
@@ -38137,10 +38035,10 @@
 /area/station/security/prison)
 "hKu" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "hKX" = (
@@ -38225,11 +38123,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "hMM" = (
@@ -38260,7 +38158,6 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "hNH" = (
@@ -38341,15 +38238,16 @@
 	dir = 4
 	},
 /obj/structure/cable/layer3,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "hQe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "hQk" = (
@@ -38362,7 +38260,6 @@
 "hQs" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -38370,10 +38267,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "hQu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hQC" = (
@@ -38382,7 +38279,6 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "hQF" = (
@@ -38417,7 +38313,6 @@
 /area/station/maintenance/disposal)
 "hQY" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "hRk" = (
@@ -38488,7 +38383,6 @@
 	},
 /area/station/cargo/sorting)
 "hSW" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
@@ -38520,7 +38414,6 @@
 	color = "#52B4E9"
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/machinery/button/door/directional/east{
 	id = "surgerya";
 	name = "Surgery Privacy Button";
@@ -38531,6 +38424,7 @@
 	name = "Surgery A Camera";
 	network = list("ss13","medbay")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "hTQ" = (
@@ -38540,8 +38434,6 @@
 	pixel_x = 3;
 	pixel_y = -23
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/door/window/brigdoor/left/directional/west{
 	name = "Primary AI Core Access";
 	req_access = list("ai_upload")
@@ -38574,11 +38466,11 @@
 /turf/open/floor/iron/smooth_edge,
 /area/station/science/robotics/lab)
 "hUM" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/starboard/aft)
 "hUO" = (
@@ -38669,11 +38561,11 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "hXO" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/freezer,
-/area/station/security/warden)
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage)
 "hXQ" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -38692,8 +38584,8 @@
 /obj/structure/sign/warning/electric_shock/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "hYy" = (
@@ -38762,6 +38654,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "hZQ" = (
@@ -38775,7 +38668,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "ial" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
@@ -38784,6 +38676,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ian" = (
@@ -38795,10 +38688,10 @@
 "iar" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "iau" = (
@@ -38849,7 +38742,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "iaR" = (
@@ -38927,28 +38819,27 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "icP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/prison)
 "icU" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/command_all,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/storage/tech)
 "idi" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Xenobiology Secure Chamber"
 	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/science/xenobiology)
 "idQ" = (
@@ -38969,7 +38860,6 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
@@ -39018,7 +38908,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "igg" = (
@@ -39031,17 +38920,18 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "igl" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/command{
 	name = "MiniSat Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/engineering/transit_tube)
 "igm" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "igx" = (
@@ -39081,8 +38971,8 @@
 	name = "Psychologist's Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "ihs" = (
@@ -39110,9 +39000,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/eva/abandoned)
 "ihY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/lobby)
 "iik" = (
@@ -39123,7 +39013,6 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "iil" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -39168,7 +39057,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "iiX" = (
@@ -39214,7 +39102,6 @@
 	dir = 4
 	},
 /obj/structure/sign/warning/secure_area/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "ijS" = (
@@ -39224,7 +39111,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
@@ -39262,7 +39148,6 @@
 /area/station/engineering/break_room)
 "ikF" = (
 /obj/effect/spawner/random/trash/mess,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -39295,13 +39180,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "ilI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /obj/machinery/meter,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "ilJ" = (
@@ -39348,17 +39232,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "imr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"imM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"imM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -39433,13 +39316,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "inu" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "inX" = (
@@ -39507,7 +39390,6 @@
 "ipl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -39521,7 +39403,6 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "ips" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/brown,
@@ -39542,8 +39423,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ipJ" = (
@@ -39560,6 +39441,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "ipP" = (
@@ -39641,13 +39523,13 @@
 /area/station/maintenance/department/eva/abandoned)
 "iqn" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/door/airlock/security{
 	name = "Firing Range"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/range)
 "iqq" = (
@@ -39665,9 +39547,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "iqv" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "iqA" = (
@@ -39689,7 +39571,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "iqG" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -39728,13 +39609,13 @@
 /turf/open/floor/wood/large,
 /area/station/maintenance/department/science/xenobiology)
 "irD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "irR" = (
@@ -39868,6 +39749,7 @@
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ivf" = (
@@ -39875,23 +39757,20 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "ivj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "ivt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "ivO" = (
@@ -39942,7 +39821,6 @@
 "ixm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/smes,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ixn" = (
@@ -39970,7 +39848,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "ixL" = (
@@ -39982,7 +39859,6 @@
 /area/station/engineering/atmos)
 "ixP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -39996,6 +39872,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "iye" = (
@@ -40013,10 +39890,10 @@
 /area/station/maintenance/department/science/xenobiology)
 "iyx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "iyD" = (
@@ -40048,6 +39925,7 @@
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "iyZ" = (
@@ -40069,14 +39947,13 @@
 /turf/open/floor/plating/rust,
 /area/station/maintenance/department/science/xenobiology)
 "izo" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "izr" = (
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/reagent_containers/cup/glass/mug/britcup,
@@ -40155,7 +40032,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/upper)
 "iBu" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -40163,10 +40039,12 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "iBI" = (
 /obj/effect/spawner/random/engineering/tank,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "iBJ" = (
@@ -40186,8 +40064,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "iBO" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "iBR" = (
@@ -40198,12 +40076,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "iBV" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "iCb" = (
@@ -40225,7 +40103,6 @@
 	req_access = list("command")
 	},
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
 "iCf" = (
@@ -40254,7 +40131,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "iCl" = (
@@ -40352,7 +40228,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -40386,10 +40261,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "iEF" = (
@@ -40411,9 +40286,9 @@
 /area/station/maintenance/department/science/xenobiology)
 "iES" = (
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /obj/structure/sign/poster/random/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "iET" = (
@@ -40482,12 +40357,12 @@
 /area/station/engineering/supermatter/room)
 "iGI" = (
 /obj/item/kirbyplants/random,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "iGY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "iHe" = (
@@ -40544,12 +40419,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/department/security/upper)
 "iHM" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Tech Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
@@ -40576,7 +40451,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "iIM" = (
@@ -40593,10 +40467,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/central)
 "iJu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/warning/xeno_mining/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "iJC" = (
@@ -40612,23 +40486,26 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "iJH" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "iJQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "iKp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -40756,7 +40633,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
 "iNQ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40767,6 +40643,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "iNU" = (
@@ -40778,7 +40655,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "iOy" = (
@@ -40823,6 +40699,7 @@
 "iOM" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "iOT" = (
@@ -40844,12 +40721,12 @@
 	c_tag = "Atmospherics - North East";
 	network = list("ss13","engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "iPA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40868,7 +40745,6 @@
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/captain)
 "iPW" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -40929,6 +40805,7 @@
 /obj/machinery/recharge_station,
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "iRA" = (
@@ -40948,13 +40825,13 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "iRS" = (
@@ -40976,6 +40853,7 @@
 "iSn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "iSw" = (
@@ -40985,7 +40863,6 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
 	},
@@ -40993,6 +40870,7 @@
 	c_tag = "Atmospherics - Equipment";
 	network = list("ss13","engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "iSE" = (
@@ -41015,6 +40893,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/box,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "iSZ" = (
@@ -41051,6 +40930,7 @@
 	name = "Gateway Chamber"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/gateway,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "iTy" = (
@@ -41154,7 +41034,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/lab)
 "iVa" = (
@@ -41166,7 +41045,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -41177,7 +41055,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -41189,6 +41066,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "engi-entrance"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "iVE" = (
@@ -41202,6 +41080,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "iVJ" = (
@@ -41212,7 +41091,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
@@ -41222,6 +41100,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -41292,7 +41171,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "iXp" = (
@@ -41398,10 +41276,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "iYN" = (
@@ -41449,8 +41327,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "iZy" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "iZK" = (
@@ -41458,12 +41336,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "iZV" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/wood/large,
-/area/station/command/heads_quarters/hop)
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "jaa" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
 "jab" = (
@@ -41473,7 +41354,6 @@
 /area/station/maintenance/port)
 "jaf" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -41503,6 +41383,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "jbs" = (
@@ -41529,13 +41410,13 @@
 "jbX" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/structure/grille,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "jce" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -41543,6 +41424,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jcl" = (
@@ -41554,9 +41436,9 @@
 /obj/effect/turf_decal/siding/red,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/machinery/computer/mecha,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/checkpoint/science/research)
 "jcz" = (
@@ -41577,7 +41459,6 @@
 /area/station/security/prison/visit)
 "jcW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/mail_sorting/medbay/general,
@@ -41665,7 +41546,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "jfH" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jfW" = (
@@ -41748,12 +41628,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
 "jhd" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "jhn" = (
@@ -41808,11 +41688,11 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "jhG" = (
@@ -41841,9 +41721,10 @@
 "jhZ" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/incident_display/delam/directional/north,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "jiy" = (
@@ -41868,6 +41749,7 @@
 "jiT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "jjd" = (
@@ -41902,10 +41784,10 @@
 "jjD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "jjH" = (
@@ -41936,7 +41818,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -41948,7 +41829,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
 "jkr" = (
@@ -41985,7 +41865,6 @@
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -42022,6 +41901,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "jlu" = (
@@ -42029,6 +41909,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "jlw" = (
@@ -42045,8 +41926,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "jlS" = (
@@ -42055,7 +41936,6 @@
 /area/station/science/ordnance)
 "jmd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -42081,7 +41961,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/freezer,
 /area/station/security/warden)
@@ -42093,7 +41972,6 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/burnchamber)
 "jmW" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
@@ -42108,8 +41986,8 @@
 "jnp" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/radiation,
-/obj/structure/cable,
 /obj/machinery/light_switch/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "jnr" = (
@@ -42122,10 +42000,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "jnz" = (
@@ -42174,8 +42052,8 @@
 /area/station/science/lobby)
 "jpf" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
 "jpg" = (
@@ -42183,11 +42061,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "jpA" = (
@@ -42197,6 +42075,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "jpF" = (
@@ -42297,9 +42176,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/lockers)
 "jrL" = (
@@ -42313,9 +42192,9 @@
 "jsb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "jse" = (
@@ -42332,6 +42211,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "jsH" = (
@@ -42342,12 +42222,12 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "jsN" = (
@@ -42364,10 +42244,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "jsW" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "jsX" = (
@@ -42380,9 +42260,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "jti" = (
@@ -42459,7 +42339,6 @@
 	c_tag = "Atmospherics - South";
 	network = list("ss13","engineering")
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -42478,7 +42357,6 @@
 	id = "supplybridge";
 	name = "Shuttle Bay Space Bridge Control"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -42492,7 +42370,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/xmastree,
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "juX" = (
@@ -42500,6 +42377,7 @@
 /obj/machinery/computer/records/medical/laptop{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "jvm" = (
@@ -42516,7 +42394,6 @@
 "jvF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -42544,6 +42421,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/genetics)
 "jwf" = (
@@ -42586,7 +42464,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -42602,6 +42479,7 @@
 	dir = 5;
 	name = "medical blue"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -42620,6 +42498,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "jyP" = (
@@ -42712,20 +42591,20 @@
 	},
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "jzI" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "jzO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "jzU" = (
@@ -42766,7 +42645,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "jAG" = (
@@ -42774,10 +42652,10 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jAW" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "jBa" = (
@@ -42791,6 +42669,7 @@
 /obj/structure/window/reinforced/spawner/directional/east{
 	layer = 2.9
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "jBr" = (
@@ -42816,7 +42695,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "jBK" = (
@@ -42920,13 +42798,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "jEf" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "jEh" = (
@@ -43021,10 +42899,12 @@
 	name = "Unisex Restrooms"
 	},
 /obj/effect/turf_decal/siding/thinplating/light,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "jFX" = (
 /obj/machinery/dna_scannernew,
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/genetics)
 "jGc" = (
@@ -43045,7 +42925,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/lobby)
 "jGp" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -43143,14 +43022,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "jIP" = (
 /obj/machinery/power/smes,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/solars/port/aft)
 "jIW" = (
@@ -43182,7 +43060,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "jJh" = (
@@ -43190,9 +43067,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "jJs" = (
@@ -43241,7 +43118,6 @@
 "jKi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "jKt" = (
@@ -43270,10 +43146,10 @@
 /area/station/science/genetics)
 "jKP" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /obj/effect/spawner/random/engineering/toolbox,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "jKU" = (
@@ -43298,12 +43174,12 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/lockers)
 "jLA" = (
@@ -43312,7 +43188,6 @@
 /area/station/maintenance/department/medical)
 "jMa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -43320,6 +43195,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jMc" = (
@@ -43356,11 +43232,11 @@
 	name = "Solars Camera";
 	network = list("ss13","engineering")
 	},
-/obj/structure/cable,
 /obj/structure/closet/emcloset,
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/solars/port/aft)
 "jNm" = (
@@ -43377,7 +43253,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -43403,7 +43278,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "jOr" = (
@@ -43430,7 +43304,6 @@
 	color = "#4169E1";
 	name = "Command blue corner"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "jOV" = (
@@ -43475,7 +43348,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "jQo" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -43500,9 +43372,14 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "jQA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "jQD" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -43545,13 +43422,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/station_engineer,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jSl" = (
@@ -43621,6 +43498,7 @@
 	dir = 1
 	},
 /obj/structure/sink/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "jTl" = (
@@ -43637,9 +43515,9 @@
 	name = "MiniSat Foyer"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/layer3,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "jTv" = (
@@ -43689,15 +43567,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "jUi" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "jUj" = (
 /obj/structure/rack,
 /obj/item/storage/box/masks{
@@ -43728,7 +43603,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
@@ -43836,12 +43710,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jWx" = (
@@ -43853,14 +43727,13 @@
 /area/station/engineering/atmos/office)
 "jWB" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "jWD" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -43871,7 +43744,6 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "jWR" = (
@@ -43891,7 +43763,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "jXc" = (
@@ -43977,7 +43848,6 @@
 "jZd" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "perma-entrance"
@@ -44019,7 +43889,6 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/lobby)
 "jZp" = (
-/obj/structure/cable,
 /obj/structure/dresser,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -44032,6 +43901,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "jZu" = (
@@ -44083,14 +43953,16 @@
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "kaY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "kbl" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "kbr" = (
@@ -44104,7 +43976,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/shreds,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -44118,10 +43989,10 @@
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/lobby)
 "kbJ" = (
@@ -44154,8 +44025,8 @@
 /area/station/science/lobby)
 "kbQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "kcp" = (
@@ -44169,7 +44040,6 @@
 /area/station/medical/morgue)
 "kcy" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction{
@@ -44185,11 +44055,11 @@
 /area/station/security/checkpoint)
 "kdc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/engineering/gravity_generator)
 "kdd" = (
@@ -44240,11 +44110,11 @@
 /area/station/security/execution/education)
 "kee" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/structure/table,
 /obj/item/ai_module/toy_ai{
 	pixel_y = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "kel" = (
@@ -44259,21 +44129,19 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "keF" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "kfa" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "kff" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -44297,7 +44165,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -44312,11 +44179,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/janitor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "kgk" = (
@@ -44337,12 +44204,12 @@
 "kgL" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm/directional/north,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -44354,6 +44221,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "kgX" = (
@@ -44375,12 +44243,12 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/lockers)
 "khh" = (
@@ -44487,7 +44355,6 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "kjp" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
@@ -44559,7 +44426,6 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -44569,8 +44435,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/sign/warning/vacuum/external/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "kkK" = (
@@ -44708,14 +44574,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "koK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/secondary/command)
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "koL" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
@@ -44743,6 +44608,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "kpo" = (
@@ -44765,12 +44631,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kpu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/cargo/warehouse)
 "kpv" = (
@@ -44824,6 +44690,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "krz" = (
@@ -44906,8 +44773,8 @@
 "ktd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ktu" = (
@@ -44939,7 +44806,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ktW" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
@@ -44978,7 +44844,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -45011,7 +44876,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "kuB" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -45028,13 +44892,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/structure/steam_vent,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/department/science/central)
 "kuO" = (
@@ -45130,7 +44994,6 @@
 "kwe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -45147,6 +45010,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "kwM" = (
@@ -45155,32 +45019,32 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "kxe" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "kxg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/area/station/engineering/atmos)
 "kxi" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Patient's Room"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/medical/patients_rooms)
 "kxr" = (
@@ -45191,13 +45055,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kxE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "kxL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -45313,7 +45175,6 @@
 	dir = 8;
 	name = "Mix to Gas"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/box,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -45393,12 +45254,12 @@
 /area/station/maintenance/starboard/fore)
 "kCi" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "scipostdesk";
 	name = "Security Post Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/science/research)
 "kCv" = (
@@ -45408,16 +45269,17 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/ai)
 "kCy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "kCJ" = (
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "kCU" = (
 /obj/machinery/door/airlock/external,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -45433,13 +45295,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "kDe" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "kDh" = (
@@ -45449,6 +45311,7 @@
 	fax_name = "Head of Personnel's Office";
 	name = "Head of Personnel's Fax Machine"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "kDD" = (
@@ -45504,7 +45367,6 @@
 /area/station/science/ordnance)
 "kFt" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "kFD" = (
@@ -45530,13 +45392,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "kGr" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/solars/port/aft)
 "kGU" = (
@@ -45563,10 +45424,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "kHL" = (
@@ -45737,7 +45598,6 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "kKD" = (
@@ -45791,15 +45651,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "kLl" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "kLm" = (
@@ -45835,7 +45695,6 @@
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "kMl" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -45844,14 +45703,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "kMP" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/turf/open/floor/plating,
+/area/station/engineering/lobby)
 "kMV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -45938,13 +45793,12 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "kNP" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/yjunction,
@@ -45954,7 +45808,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -45962,12 +45815,12 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/breakroom)
 "kON" = (
@@ -45987,6 +45840,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/ce)
 "kPn" = (
@@ -45997,10 +45851,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "kPA" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/engineering/tank,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "kPC" = (
@@ -46010,7 +45864,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kPE" = (
@@ -46025,11 +45878,11 @@
 "kPM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "kQd" = (
@@ -46077,7 +45930,6 @@
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "kQI" = (
@@ -46097,7 +45949,6 @@
 /area/station/hallway/primary/fore)
 "kRA" = (
 /obj/effect/turf_decal/trimline/red/filled/warning,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/storage)
 "kRR" = (
@@ -46128,6 +45979,7 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/turf_decal/delivery,
 /obj/structure/tank_dispenser,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "kSV" = (
@@ -46212,9 +46064,9 @@
 /turf/closed/wall,
 /area/station/cargo/miningoffice)
 "kUm" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "kUC" = (
@@ -46227,6 +46079,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "kUO" = (
@@ -46249,13 +46102,13 @@
 /turf/closed/wall,
 /area/station/engineering/atmos/hfr_room)
 "kVm" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/warning/electric_shock/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "kVw" = (
@@ -46264,6 +46117,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "kVC" = (
@@ -46353,7 +46207,6 @@
 /area/station/maintenance/department/science)
 "kXh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "kXG" = (
@@ -46386,6 +46239,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kYI" = (
@@ -46398,7 +46252,6 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "kYQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -46472,12 +46325,12 @@
 /area/station/maintenance/department/security/upper)
 "laG" = (
 /obj/machinery/airalarm/directional/south,
-/obj/structure/cable,
 /obj/structure/table,
 /obj/item/aicard{
 	pixel_x = -3;
 	pixel_y = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "laN" = (
@@ -46553,7 +46406,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "ldB" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -46588,11 +46440,11 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Morgue Maintenance"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical)
 "leP" = (
@@ -46624,10 +46476,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "lfq" = (
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/engineering/gravity_generator)
 "lfs" = (
@@ -46651,7 +46503,6 @@
 /area/station/maintenance/department/security/upper)
 "lfJ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -46662,6 +46513,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "lge" = (
@@ -46679,14 +46531,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "lgn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "lgu" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input,
 /turf/open/floor/engine/plasma,
@@ -46713,8 +46562,8 @@
 /turf/closed/wall,
 /area/station/command/heads_quarters/ce)
 "lhm" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "lhK" = (
@@ -46730,16 +46579,19 @@
 	},
 /area/station/science/ordnance)
 "lhQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/area/station/maintenance/department/security/upper)
 "lhS" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgewindows";
 	name = "Bridge View Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "lhY" = (
@@ -46768,13 +46620,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "lim" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "liL" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46825,7 +46676,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/blobstart,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -46834,12 +46684,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "lkl" = (
@@ -46858,7 +46708,6 @@
 "lkp" = (
 /obj/machinery/vending/assist,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 4
@@ -46866,6 +46715,7 @@
 /obj/effect/turf_decal/delivery/white{
 	color = "#D381C9"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "lkQ" = (
@@ -46879,12 +46729,12 @@
 /area/station/maintenance/department/medical)
 "lkV" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "llp" = (
@@ -46897,7 +46747,6 @@
 "llB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Delivery Office"
 	},
@@ -46912,10 +46761,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "llO" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "lmc" = (
@@ -46954,6 +46803,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	name = "server vent"
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
 "lmS" = (
@@ -46976,21 +46826,22 @@
 "lnF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 2
 	},
 /obj/effect/mapping_helpers/mail_sorting/supply/qm_office,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "lnI" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/detectives_office)
-"lnQ" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
+"lnQ" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47019,14 +46870,15 @@
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "lob" = (
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/engineering/atmos/hfr_room)
 "loq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "lov" = (
@@ -47045,12 +46897,12 @@
 /area/station/ai_monitored/security/armory)
 "loz" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id = "rdoffice";
 	name = "Research Director's Office Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
 "loE" = (
@@ -47063,12 +46915,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "loG" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 1;
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "lpg" = (
@@ -47083,7 +46935,6 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/security/checkpoint/medical)
 "lpB" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -47154,7 +47005,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "lrq" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -47242,7 +47092,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "ltZ" = (
@@ -47282,10 +47131,10 @@
 	pixel_x = -2;
 	pixel_y = 6
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "lvo" = (
@@ -47295,11 +47144,11 @@
 /area/station/science/auxlab/firing_range)
 "lvs" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgewindows";
 	name = "Bridge View Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "lvx" = (
@@ -47337,9 +47186,9 @@
 /area/station/cargo/office)
 "lvY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "lwm" = (
@@ -47381,9 +47230,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "lxa" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/security/prison/mess)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "lxh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47422,7 +47276,6 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "lxX" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -47430,6 +47283,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "lya" = (
@@ -47458,6 +47312,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/reagent_dispensers/fueltank,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "lzr" = (
@@ -47500,7 +47355,6 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "lzM" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -47509,6 +47363,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/graffiti,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "lzO" = (
@@ -47604,6 +47459,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/prison/visit)
 "lBA" = (
@@ -47642,7 +47498,6 @@
 /turf/open/floor/iron/textured_half,
 /area/station/maintenance/department/eva/abandoned)
 "lCH" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -47657,7 +47512,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lDa" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/green{
 	dir = 9
 	},
@@ -47674,7 +47528,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "lDu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/south,
@@ -47699,8 +47552,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "lEw" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "lEL" = (
@@ -47729,7 +47582,6 @@
 /obj/effect/mapping_helpers/mail_sorting/security/detectives_office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "lFl" = (
@@ -47766,12 +47618,12 @@
 /turf/open/floor/wood/large,
 /area/station/service/abandoned_gambling_den)
 "lGo" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "lGE" = (
@@ -47827,7 +47679,6 @@
 /turf/open/floor/iron/textured_large,
 /area/station/maintenance/department/medical)
 "lHw" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -47853,10 +47704,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "lIW" = (
@@ -47909,6 +47760,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "lKc" = (
@@ -47927,7 +47779,6 @@
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "lKG" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -47999,13 +47850,13 @@
 "lLs" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "lLw" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/misc/asteroid,
 /area/station/security/prison/safe/exterior)
 "lLx" = (
@@ -48041,16 +47892,15 @@
 	},
 /area/station/security/prison/garden)
 "lLP" = (
-/obj/structure/cable,
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/engineering_all,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "lLR" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
@@ -48068,6 +47918,7 @@
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "lLY" = (
@@ -48105,14 +47956,13 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/tank_holder/extinguisher,
-/obj/structure/cable,
 /obj/effect/turf_decal/box,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
 /area/station/science/server)
 "lMv" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48131,7 +47981,6 @@
 /area/station/commons/vacant_room/office)
 "lML" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -48146,18 +47995,19 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "engi-entrance"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "lMU" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "lNc" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "lNe" = (
@@ -48289,13 +48139,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "lQp" = (
@@ -48322,10 +48172,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "lQB" = (
@@ -48339,19 +48189,18 @@
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "lQG" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/chair/office{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/engineering/gravity_generator)
 "lQH" = (
@@ -48361,16 +48210,12 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/aft)
 "lQN" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "lRd" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -48399,8 +48244,8 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "lRt" = (
@@ -48488,10 +48333,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "lTL" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage_shared)
 "lTX" = (
@@ -48505,7 +48350,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
 "lUl" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
@@ -48541,13 +48385,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "lVZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -48611,11 +48454,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "lWW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/maintenance/department/medical)
 "lWY" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
 	},
@@ -48623,6 +48469,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/port/aft)
 "lXH" = (
@@ -48634,6 +48481,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "lXJ" = (
@@ -48649,12 +48497,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "lXP" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/hallway)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "lXV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -48662,7 +48511,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -48688,12 +48536,12 @@
 /area/station/hallway/secondary/command)
 "lYs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "lYA" = (
@@ -48722,10 +48570,10 @@
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "lYT" = (
@@ -48813,7 +48661,6 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
 "maJ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -48823,6 +48670,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "maL" = (
@@ -48843,11 +48691,9 @@
 /turf/open/floor/carpet,
 /area/station/service/abandoned_gambling_den)
 "mbf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/escape)
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "mbh" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark/telecomms,
@@ -48856,7 +48702,6 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
@@ -48869,13 +48714,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "mbx" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "mbH" = (
@@ -48894,6 +48739,7 @@
 	},
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "mcj" = (
@@ -48903,12 +48749,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "mcy" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/solarpanel_small,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "mcT" = (
@@ -48918,7 +48764,6 @@
 "mde" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
@@ -48926,6 +48771,7 @@
 	dir = 2
 	},
 /obj/effect/mapping_helpers/mail_sorting/science/research,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mdh" = (
@@ -49036,8 +48882,8 @@
 /obj/machinery/door/airlock{
 	name = "Prison Garden"
 	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "mfV" = (
@@ -49051,10 +48897,10 @@
 	name = "Research Director's Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 1
 	},
@@ -49080,11 +48926,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "mgS" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/box/corners,
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/xenobiology)
 "mhg" = (
@@ -49092,17 +48938,17 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/abandoned_gambling_den)
 "mhz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "mhC" = (
@@ -49119,9 +48965,8 @@
 /area/station/science/ordnance)
 "mhJ" = (
 /obj/structure/cable,
-/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/medical)
 "mhM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -49153,7 +48998,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "miE" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -49179,7 +49023,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/fire/directional/south,
@@ -49206,6 +49049,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "mjz" = (
@@ -49243,6 +49087,7 @@
 	network = list("ss13","security")
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "mjW" = (
@@ -49280,18 +49125,17 @@
 /turf/open/space/basic,
 /area/space)
 "mkC" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mkD" = (
 /obj/item/radio/intercom/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -49323,8 +49167,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/abandoned_gambling_den)
 "mlc" = (
@@ -49345,7 +49189,6 @@
 "mlo" = (
 /obj/structure/railing,
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/command/storage/eva)
 "mls" = (
@@ -49370,8 +49213,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "mma" = (
@@ -49424,30 +49267,30 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "mnK" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/turf/open/floor/iron/dark,
+/area/station/security/detectives_office)
 "mnP" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "mok" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "mou" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/engineering/gravity_generator)
 "moy" = (
@@ -49467,12 +49310,12 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "mpg" = (
@@ -49499,6 +49342,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/grille_or_waste,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "mpp" = (
@@ -49531,7 +49375,6 @@
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "mqi" = (
@@ -49544,17 +49387,16 @@
 "mqr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/upper)
 "mqs" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "mqB" = (
@@ -49568,7 +49410,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 8
 	},
@@ -49596,6 +49437,7 @@
 "mrt" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "mrE" = (
@@ -49642,12 +49484,14 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "msu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison/mess)
+/area/station/hallway/secondary/command)
 "msK" = (
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/machinery/light/directional/south,
@@ -49729,7 +49573,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "mtO" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -49738,14 +49581,13 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "muk" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
@@ -49760,12 +49602,12 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "muW" = (
@@ -49872,7 +49714,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
@@ -49897,20 +49738,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "mxm" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
 /obj/effect/landmark/start/depsec/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "mxo" = (
@@ -49928,10 +49769,10 @@
 "mxr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/cargo/warehouse)
 "mxw" = (
@@ -50022,6 +49863,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "myZ" = (
@@ -50037,7 +49879,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "mzy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -50085,12 +49926,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "mAz" = (
@@ -50125,7 +49966,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mAR" = (
@@ -50139,10 +49979,10 @@
 	dir = 9
 	},
 /obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "mBa" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -50224,14 +50064,12 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "mCL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/siding/green{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/service/hydroponics/garden)
 "mCR" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
 	dir = 4
@@ -50243,11 +50081,13 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "mDp" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/security/prison)
 "mDL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -50267,7 +50107,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "mEc" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
@@ -50281,8 +50120,8 @@
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/start/prisoner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "mEC" = (
@@ -50292,7 +50131,6 @@
 	name = "AI Solar Control"
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/aisat/solars)
 "mED" = (
@@ -50319,8 +50157,8 @@
 	name = "Starboard Quarter Solar Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/starboard/aft)
 "mFQ" = (
@@ -50381,7 +50219,6 @@
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -50480,7 +50317,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -50543,7 +50379,6 @@
 "mJt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -50565,6 +50400,7 @@
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "mJR" = (
@@ -50574,6 +50410,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
@@ -50688,24 +50525,24 @@
 /area/station/maintenance/port/greater)
 "mMo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/prison/work)
 "mMt" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "mMy" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "mMJ" = (
@@ -50715,10 +50552,10 @@
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "mNb" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "mNg" = (
@@ -50729,7 +50566,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip{
@@ -50817,9 +50653,9 @@
 "mQx" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "mQB" = (
@@ -50840,6 +50676,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "mRc" = (
@@ -50901,7 +50738,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -50924,7 +50760,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "mSn" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "perma-entrance"
 	},
@@ -50942,14 +50777,13 @@
 "mTm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "mTs" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -50981,6 +50815,7 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "mTM" = (
@@ -51095,30 +50930,29 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "mVM" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "mVV" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/mail_sorting/science/genetics,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "mWw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/office)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/prison/garden)
 "mWx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
@@ -51134,7 +50968,6 @@
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
 "mWN" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
@@ -51195,8 +51028,8 @@
 /area/station/maintenance/department/science/xenobiology)
 "mYS" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "mZp" = (
@@ -51264,6 +51097,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/landmark/start/station_engineer,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "naR" = (
@@ -51343,6 +51177,7 @@
 /obj/structure/urinal/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "ncx" = (
@@ -51434,8 +51269,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/effect/landmark/start/scientist,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/auxlab/firing_range)
 "neh" = (
@@ -51466,8 +51301,8 @@
 /area/station/maintenance/port/greater)
 "nfc" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "nfd" = (
@@ -51482,6 +51317,7 @@
 	id = "AI"
 	},
 /obj/machinery/porta_turret/ai,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "nfs" = (
@@ -51543,8 +51379,8 @@
 "nfY" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "ngg" = (
@@ -51571,8 +51407,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "ngH" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
 "ngS" = (
@@ -51584,18 +51420,22 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "ngT" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "ngU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "nhc" = (
@@ -51657,7 +51497,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse/upper)
 "niQ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51666,12 +51505,13 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "niR" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "niS" = (
@@ -51736,7 +51576,6 @@
 /area/station/science/research)
 "nkb" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -51744,6 +51583,7 @@
 	name = "Engineering Secondary Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "nkg" = (
@@ -51770,12 +51610,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "nkU" = (
-/obj/structure/cable,
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/dim/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "nlb" = (
@@ -51805,7 +51645,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "nlx" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51816,6 +51655,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/solars)
 "nlQ" = (
@@ -51837,7 +51677,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "nmp" = (
@@ -51872,6 +51711,7 @@
 	department = "Hydroponics"
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "nmH" = (
@@ -51958,13 +51798,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/eva/abandoned)
 "nno" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
-"nnD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"nnD" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
@@ -51996,11 +51836,11 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "noh" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "nor" = (
@@ -52062,6 +51902,7 @@
 	pixel_x = 3;
 	pixel_y = -2
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "noS" = (
@@ -52081,7 +51922,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "npq" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -52104,10 +51944,10 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "nqm" = (
@@ -52164,19 +52004,19 @@
 /obj/item/pinpointer/nuke,
 /obj/item/disk/nuclear,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "nqU" = (
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/teleporter)
 "nrn" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/bot,
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage)
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "nrv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/oxygen_output{
 	dir = 4
@@ -52184,16 +52024,15 @@
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "nrA" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "nsc" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -52215,7 +52054,6 @@
 "nsn" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1
@@ -52225,18 +52063,18 @@
 "nsH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "nsS" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "ntr" = (
@@ -52249,19 +52087,17 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "ntG" = (
 /obj/machinery/door/airlock/maintenance/external{
 	name = "Escape Pod Access"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
 "ntM" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 6
 	},
@@ -52273,11 +52109,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "ntX" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "ntY" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plating,
@@ -52292,7 +52126,6 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "nup" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 8
 	},
@@ -52302,6 +52135,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "nuu" = (
@@ -52312,18 +52146,18 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "nuY" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "nvh" = (
@@ -52409,7 +52243,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/caution,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -52426,7 +52259,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/auxlab/firing_range)
 "nwP" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
@@ -52437,11 +52269,11 @@
 /area/station/science/research)
 "nwV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "nyk" = (
@@ -52449,7 +52281,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "nyJ" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
 	},
@@ -52457,6 +52288,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/starboard/fore)
 "nzh" = (
@@ -52500,7 +52332,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "nzM" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -52523,9 +52354,9 @@
 /turf/open/floor/iron/textured,
 /area/station/engineering/gravity_generator)
 "nAC" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "nAD" = (
@@ -52537,12 +52368,14 @@
 /area/station/hallway/primary/port)
 "nAS" = (
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nBo" = (
 /obj/effect/turf_decal/tile/command/half{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nBw" = (
@@ -52552,6 +52385,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/warden)
 "nBD" = (
@@ -52574,9 +52408,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nBI" = (
-/obj/structure/cable,
 /obj/structure/sign/warning/fire/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "nBO" = (
@@ -52585,6 +52419,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "nBS" = (
@@ -52595,7 +52431,6 @@
 /area/station/engineering/supermatter/room)
 "nBT" = (
 /obj/item/radio/intercom/directional/west,
-/obj/structure/cable,
 /obj/structure/table,
 /obj/item/folder/yellow{
 	pixel_x = 2;
@@ -52606,6 +52441,7 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "nBX" = (
@@ -52624,10 +52460,10 @@
 /obj/effect/turf_decal/siding/green/end{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "nCl" = (
@@ -52647,6 +52483,7 @@
 "nCF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "nCJ" = (
@@ -52654,14 +52491,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nCK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "nCM" = (
@@ -52686,11 +52522,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "nDb" = (
@@ -52713,6 +52549,7 @@
 "nDF" = (
 /obj/effect/spawner/random/trash/box,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nDG" = (
@@ -52731,6 +52568,13 @@
 /obj/machinery/power/emitter,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
+"nEX" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "nFa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -52769,7 +52613,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "nFy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/warning/secure_area/directional/south,
@@ -52777,6 +52620,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "nFE" = (
@@ -52804,11 +52648,11 @@
 /area/station/engineering/atmos/pumproom)
 "nGr" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "hopblast";
 	name = "HoP Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "nGv" = (
@@ -52846,7 +52690,6 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "nGY" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "nHd" = (
@@ -52865,7 +52708,6 @@
 /area/station/science/ordnance/storage)
 "nHl" = (
 /obj/machinery/newscaster/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -52878,7 +52720,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "nHn" = (
@@ -52906,6 +52747,7 @@
 "nHu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "nHy" = (
@@ -52915,7 +52757,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "nHA" = (
@@ -52926,7 +52767,6 @@
 	name = "AI Intercom"
 	},
 /obj/machinery/light/dim/directional/north,
-/obj/structure/cable,
 /obj/structure/table,
 /obj/item/ai_module/supplied/freeform{
 	pixel_x = -2
@@ -52934,18 +52774,19 @@
 /obj/item/ai_module/reset{
 	pixel_y = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "nHB" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "nHF" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "nHK" = (
@@ -53055,10 +52896,10 @@
 /obj/machinery/light/small/broken/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/rust,
 /area/station/maintenance/department/science)
 "nIW" = (
@@ -53145,7 +52986,6 @@
 	},
 /area/station/science/ordnance)
 "nKs" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
@@ -53157,7 +52997,6 @@
 "nKC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53167,7 +53006,6 @@
 "nKE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/mail_sorting/supply/cargo_bay,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 2
@@ -53217,8 +53055,8 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/start/prisoner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "nLb" = (
@@ -53238,7 +53076,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "nLM" = (
@@ -53253,6 +53090,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "nMg" = (
@@ -53316,6 +53154,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "nNd" = (
@@ -53353,13 +53192,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "nNE" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nNH" = (
@@ -53379,7 +53218,6 @@
 "nNX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "nOb" = (
@@ -53405,7 +53243,6 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "nPU" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -53421,10 +53258,10 @@
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "nQf" = (
@@ -53434,7 +53271,6 @@
 /area/station/science/ordnance)
 "nQm" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -53487,6 +53323,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/medical)
 "nRb" = (
@@ -53570,7 +53407,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "nSd" = (
-/obj/structure/cable,
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -53591,7 +53427,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -53649,6 +53484,7 @@
 "nTE" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/dna_infuser,
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/genetics)
 "nTK" = (
@@ -53720,7 +53556,6 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "nVU" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53816,6 +53651,7 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/official/do_not_question/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "nYN" = (
@@ -53842,9 +53678,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nZa" = (
@@ -53864,10 +53700,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "nZP" = (
@@ -53904,8 +53740,8 @@
 "oaI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "oaL" = (
@@ -53924,15 +53760,14 @@
 /area/station/maintenance/department/security/upper)
 "obr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/structure/cable,
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "obv" = (
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53946,12 +53781,12 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/greater)
 "ocb" = (
-/obj/structure/cable,
 /obj/machinery/camera/directional/south{
 	c_tag = "Bar";
 	name = "Bar Camera"
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "och" = (
@@ -53994,7 +53829,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "ocs" = (
@@ -54051,6 +53885,7 @@
 /obj/item/reagent_containers/condiment/peppermill{
 	pixel_x = -3
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "odj" = (
@@ -54069,11 +53904,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/plasmaman)
 "odq" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "odr" = (
@@ -54100,9 +53935,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oex" = (
@@ -54110,15 +53945,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "oeE" = (
-/obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "oeM" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "ofc" = (
@@ -54143,6 +53977,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /mob/living/simple_animal/parrot/poly,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "ofh" = (
@@ -54176,11 +54011,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ofP" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "ofU" = (
-/obj/structure/cable,
 /obj/structure/table,
 /obj/item/paper/guides/jobs/engi/gravity_gen{
 	pixel_x = 4
@@ -54190,6 +54023,7 @@
 	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "ofV" = (
@@ -54198,9 +54032,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "oga" = (
@@ -54240,6 +54074,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "ogN" = (
@@ -54253,7 +54088,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
@@ -54310,11 +54144,11 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "ohT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/science/xenobiology)
 "ohU" = (
@@ -54329,13 +54163,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "oil" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Distribution Loop"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "oin" = (
@@ -54359,9 +54193,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "oit" = (
@@ -54374,7 +54208,6 @@
 /area/station/cargo/office)
 "oiz" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/brown,
@@ -54388,6 +54221,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "oiI" = (
@@ -54409,12 +54243,12 @@
 /area/station/engineering/storage/tech)
 "oiZ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "ojo" = (
@@ -54430,26 +54264,35 @@
 /area/station/security/checkpoint/supply)
 "ojt" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "ojw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"ojF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "okb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "okf" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/lobby)
 "oko" = (
@@ -54498,12 +54341,12 @@
 /area/station/engineering/atmos)
 "olk" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "olm" = (
@@ -54523,6 +54366,7 @@
 	name = "medical blue"
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -54561,7 +54405,6 @@
 /area/station/medical/pharmacy)
 "omJ" = (
 /obj/machinery/door/airlock/external,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -54577,6 +54420,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "omY" = (
@@ -54602,10 +54446,10 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "onb" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "ono" = (
@@ -54618,7 +54462,6 @@
 /area/station/hallway/secondary/service)
 "onr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -54661,7 +54504,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -54670,8 +54512,8 @@
 	},
 /area/station/engineering/hallway)
 "opg" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "opk" = (
@@ -54710,8 +54552,8 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -54742,7 +54584,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 1
 	},
@@ -54814,14 +54655,15 @@
 	},
 /area/station/hallway/secondary/command)
 "ora" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/service/cafeteria)
 "orb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "orf" = (
@@ -54831,13 +54673,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/abandoned_gambling_den)
 "orq" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "orJ" = (
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
@@ -54894,7 +54735,6 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/solars)
 "otT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -54924,6 +54764,7 @@
 "ouC" = (
 /obj/machinery/griddle,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "ouE" = (
@@ -54952,6 +54793,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "ouY" = (
@@ -54988,13 +54830,13 @@
 /turf/closed/wall,
 /area/station/medical/cryo)
 "ovL" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "owp" = (
@@ -55002,9 +54844,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "owq" = (
@@ -55086,9 +54928,13 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
 "oxL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/brig)
 "oxN" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 8
@@ -55100,7 +54946,6 @@
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -55133,12 +54978,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
 "oyo" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/science/research)
 "oyr" = (
@@ -55160,13 +55005,13 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "oyA" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "oyG" = (
@@ -55246,11 +55091,11 @@
 /area/station/maintenance/department/science)
 "oAm" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hopqueue";
 	name = "HoP Queue Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/command)
 "oAv" = (
@@ -55284,15 +55129,16 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "oAR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oAS" = (
@@ -55300,16 +55146,16 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "oBq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/space_heater,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/maintenance/port/greater)
 "oBx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/graffiti,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "oBL" = (
@@ -55421,9 +55267,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "oCX" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "oCZ" = (
@@ -55448,18 +55294,17 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
 "oDI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden/abandoned)
 "oEg" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/starboard/fore)
 "oEh" = (
@@ -55503,8 +55348,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "oFl" = (
@@ -55532,12 +55377,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "oFO" = (
@@ -55556,12 +55401,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "oFR" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "oGj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/iron,
@@ -55574,19 +55419,20 @@
 "oGG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "oGT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/newscaster/directional/west,
 /obj/item/flashlight{
 	pixel_x = 1;
 	pixel_y = 5
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "oHg" = (
@@ -55620,10 +55466,10 @@
 "oHT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/effect/turf_decal/trimline/neutral/warning,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/lobby)
 "oIE" = (
@@ -55651,6 +55497,7 @@
 /area/station/security/prison/visit)
 "oJD" = (
 /obj/effect/spawner/random/engineering/tank,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "oJF" = (
@@ -55682,7 +55529,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/lab)
 "oKk" = (
@@ -55744,9 +55590,9 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "oKR" = (
@@ -55783,13 +55629,13 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "oLf" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "oLh" = (
@@ -55958,21 +55804,21 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
 	name = "Warehouse Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/cargo/warehouse)
 "oNV" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "oOc" = (
@@ -55992,11 +55838,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "oON" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/transit_tube/crossing,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/science/xenobiology)
 "oOR" = (
@@ -56041,17 +55887,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 1
 	},
 /area/station/science/lab)
 "oPp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "oPB" = (
@@ -56084,8 +55931,8 @@
 /area/station/maintenance/port/greater)
 "oPM" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "oPV" = (
@@ -56114,7 +55961,6 @@
 "oQB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -56150,7 +55996,6 @@
 /obj/machinery/keycard_auth/directional/west{
 	pixel_x = -38
 	},
-/obj/structure/cable,
 /obj/machinery/button/door/directional/west{
 	id = "atmos";
 	name = "Atmospherics Lockdown";
@@ -56184,7 +56029,6 @@
 /turf/open/space/basic,
 /area/space)
 "oRQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -56266,6 +56110,7 @@
 	dir = 4
 	},
 /obj/machinery/light/broken/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "oUu" = (
@@ -56275,8 +56120,8 @@
 /area/station/maintenance/department/security/upper)
 "oUx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/spawner/random/trash/grille_or_waste,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "oUE" = (
@@ -56295,7 +56140,6 @@
 /obj/machinery/status_display/supply{
 	pixel_x = 32
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "oVc" = (
@@ -56347,13 +56191,13 @@
 /turf/open/floor/stone,
 /area/station/service/kitchen/abandoned)
 "oVV" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "oWc" = (
@@ -56399,7 +56243,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -56425,7 +56268,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
 "oXf" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56436,6 +56278,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "oXs" = (
@@ -56462,7 +56305,6 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "oXM" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair{
 	dir = 1
@@ -56499,7 +56341,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "oYF" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -56525,7 +56366,6 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "oYR" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -56598,7 +56438,6 @@
 /area/station/science/auxlab/firing_range)
 "oZs" = (
 /obj/effect/turf_decal/bot_white,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/command/gateway)
 "oZu" = (
@@ -56618,7 +56457,6 @@
 /obj/item/newspaper{
 	pixel_x = 4
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/plastic,
 /area/station/commons/toilet/auxiliary)
@@ -56634,8 +56472,8 @@
 /area/station/maintenance/disposal/incinerator)
 "oZW" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
+/obj/structure/cable,
 /turf/open/floor/plating/rust,
 /area/station/security/prison/safe/exterior)
 "oZX" = (
@@ -56706,13 +56544,14 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "pbj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/maintenance/port/greater)
 "pbY" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "pcd" = (
@@ -56757,7 +56596,6 @@
 /obj/machinery/door/window/left/directional/east{
 	name = "Outer Window"
 	},
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "scipostdesk";
@@ -56787,7 +56625,6 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "pdl" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
 /obj/structure/disposalpipe/segment{
@@ -56828,7 +56665,6 @@
 /obj/effect/turf_decal/tile/brown/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/mining/glass{
 	id_tag = "innercargo";
 	name = "Cargo Bay"
@@ -56838,6 +56674,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "pdO" = (
@@ -56862,7 +56699,6 @@
 /area/station/maintenance/department/medical)
 "peV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
@@ -56870,7 +56706,6 @@
 "pfD" = (
 /obj/effect/spawner/random/structure/girder,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -56886,6 +56721,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/grille_or_waste,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "pge" = (
@@ -56907,7 +56743,6 @@
 	charge = 5e+006
 	},
 /obj/structure/sign/warning/electric_shock/directional/south,
-/obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
 "pgy" = (
@@ -56924,15 +56759,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "phc" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "phf" = (
@@ -56970,7 +56805,6 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "pid" = (
@@ -56998,7 +56832,6 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "pih" = (
-/obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/modular_computer/preset/engineering{
 	dir = 4
@@ -57029,8 +56862,8 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -57049,8 +56882,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -57067,7 +56900,6 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "pjl" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -57117,6 +56949,7 @@
 	dir = 1;
 	pixel_y = -30
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "pkk" = (
@@ -57142,7 +56975,6 @@
 "pkB" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
@@ -57171,9 +57003,9 @@
 "pll" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/green/half,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/edge,
 /area/station/security/prison/garden)
 "plv" = (
@@ -57245,12 +57077,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "pmT" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "pnc" = (
@@ -57274,7 +57106,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/botanical_waste,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -57282,7 +57113,6 @@
 "pnL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "pod" = (
@@ -57406,13 +57236,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "prr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "prJ" = (
@@ -57449,10 +57277,10 @@
 	dir = 10
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "psm" = (
@@ -57469,14 +57297,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "psF" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "psH" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "psW" = (
@@ -57484,7 +57313,6 @@
 /area/station/science/ordnance/testlab)
 "psZ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/warden)
 "ptc" = (
@@ -57500,14 +57328,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/lab)
 "ptU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/engineering/storage)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "ptZ" = (
 /obj/machinery/biogenerator,
 /obj/effect/decal/cleanable/dirt,
@@ -57564,9 +57392,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/navigate_destination/research,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "puA" = (
@@ -57630,11 +57458,11 @@
 "puT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "puW" = (
@@ -57671,7 +57499,6 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/pen,
-/obj/structure/cable,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -57687,6 +57514,7 @@
 	id = "seccheckpointshutters";
 	name = "Checkpoint Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs/fore)
 "pvt" = (
@@ -57728,12 +57556,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "pwf" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/ai_monitored/command/storage/eva)
 "pwp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
@@ -57769,10 +57596,10 @@
 "pyd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/engineering/gravity_generator)
 "pyz" = (
@@ -57850,13 +57677,13 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "pzK" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
@@ -57885,9 +57712,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "pAM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/pumproom)
 "pAU" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8
@@ -57899,15 +57729,14 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "pAZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "pBg" = (
 /obj/structure/chair,
-/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "pBh" = (
@@ -57927,7 +57756,6 @@
 /area/station/science/ordnance/testlab)
 "pCf" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/command/glass{
@@ -57938,7 +57766,6 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "pCn" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -57951,12 +57778,10 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "pCO" = (
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
@@ -57997,9 +57822,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 1
 	},
@@ -58011,9 +57836,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pDm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/escape)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "pDn" = (
 /obj/item/radio/intercom/directional/west,
 /obj/structure/chair{
@@ -58073,13 +57898,11 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "pEl" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/xenobiology)
 "pEr" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -58091,22 +57914,22 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/chair/office/light,
 /obj/effect/landmark/blobstart,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "pEV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "pEW" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "pFt" = (
@@ -58138,7 +57961,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/camera/directional/north{
 	c_tag = "Service Hallway East"
 	},
@@ -58146,6 +57968,7 @@
 	dir = 1
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "pGn" = (
@@ -58171,7 +57994,6 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "pGI" = (
@@ -58179,7 +58001,6 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "pGO" = (
@@ -58203,12 +58024,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pHo" = (
@@ -58242,6 +58063,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "pIh" = (
@@ -58259,6 +58081,7 @@
 /area/station/cargo/storage)
 "pIz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "pID" = (
@@ -58290,7 +58113,6 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Space Bridge Access"
 	},
-/obj/structure/cable,
 /obj/machinery/button/door/directional/north{
 	id = "supplybridge";
 	name = "Shuttle Bay Space Bridge Control"
@@ -58362,14 +58184,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "pMa" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/area/station/maintenance/port/fore)
 "pMb" = (
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -58414,9 +58236,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -58448,6 +58270,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plastic,
 /area/station/commons/toilet/auxiliary)
 "pNH" = (
@@ -58468,7 +58291,6 @@
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "pNV" = (
@@ -58480,7 +58302,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "pOd" = (
@@ -58504,8 +58325,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pOw" = (
@@ -58516,7 +58337,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "pOx" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Gravity Generator Anteroom"
 	},
@@ -58532,6 +58352,7 @@
 	name = "Engineering yellow corner"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/engineering/gravity_generator)
 "pON" = (
@@ -58609,7 +58430,6 @@
 /area/station/command/heads_quarters/hop)
 "pQc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -58664,7 +58484,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/button/door/incinerator_vent_atmos_aux{
 	pixel_x = -8;
@@ -58675,6 +58494,7 @@
 	pixel_y = -36
 	},
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "pRE" = (
@@ -58731,10 +58551,10 @@
 "pTg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "pTN" = (
@@ -58819,10 +58639,10 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/electrical)
 "pVo" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "pVz" = (
@@ -58836,13 +58656,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "pVU" = (
 /obj/structure/sign/warning/electric_shock/directional/north,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
@@ -58862,7 +58681,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "pXg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
@@ -58873,11 +58691,11 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "pXy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "pXP" = (
@@ -58903,7 +58721,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
 "pYl" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -58917,10 +58734,10 @@
 	name = "Testing Lab Maintenance"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "pYo" = (
@@ -58943,18 +58760,18 @@
 /area/station/hallway/secondary/entry)
 "pYy" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /obj/item/kirbyplants/random,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "pYL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "pYP" = (
@@ -58992,9 +58809,9 @@
 	name = "0perating Theater"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "pZt" = (
@@ -59009,10 +58826,10 @@
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "pZF" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/depsec/medical,
 /obj/effect/turf_decal/tile/blue/anticorner{
@@ -59038,12 +58855,14 @@
 	c_tag = "Science - Genetics Lab";
 	network = list("ss13","rd")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/genetics)
 "qad" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/girder,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "qai" = (
@@ -59143,7 +58962,6 @@
 /area/station/ai_monitored/security/armory)
 "qbX" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
@@ -59201,6 +59019,7 @@
 /area/station/hallway/secondary/service)
 "qdm" = (
 /obj/effect/turf_decal/bot_white,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qds" = (
@@ -59216,12 +59035,12 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "qdB" = (
@@ -59360,6 +59179,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qfH" = (
@@ -59373,14 +59193,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "qfO" = (
-/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "qge" = (
 /obj/structure/sign/poster/official/random/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -59391,7 +59209,6 @@
 /obj/structure/broken_flooring/corner/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "qgO" = (
@@ -59405,6 +59222,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qhb" = (
@@ -59421,11 +59239,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "qhg" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "qhs" = (
@@ -59444,9 +59262,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "qix" = (
@@ -59455,11 +59273,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/ce)
 "qiA" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
@@ -59469,14 +59287,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "qiW" = (
-/obj/structure/cable,
 /obj/structure/closet/crate/wooden/toy,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -59491,6 +59308,7 @@
 /obj/item/stamp/clown,
 /obj/item/toy/mecha/honk,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "qja" = (
@@ -59508,7 +59326,6 @@
 "qjx" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -59518,18 +59335,17 @@
 	name = "Engineering Hallway"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "qjP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qjW" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "qjY" = (
@@ -59555,7 +59371,6 @@
 "qkw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
@@ -59573,10 +59388,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "qkE" = (
@@ -59598,7 +59413,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "qlL" = (
@@ -59606,17 +59420,17 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution/education)
 "qlX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/maintenance/fore)
 "qmb" = (
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
 	dir = 4
 	},
@@ -59670,10 +59484,10 @@
 "qnY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "qoc" = (
@@ -59705,7 +59519,6 @@
 /area/station/security/prison)
 "qoh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "qos" = (
@@ -59724,6 +59537,7 @@
 "qoP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qoY" = (
@@ -59765,12 +59579,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -59779,7 +59593,6 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Spacebucks Coffee"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -59788,6 +59601,7 @@
 /obj/effect/mapping_helpers/airlock_note_placer{
 	note_info = "We apologize for the loud noises caused by the nearby Gravity Generator, this was the cheapest place to make a Cafe."
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/service/cafeteria)
 "qpm" = (
@@ -59865,7 +59679,6 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "qre" = (
@@ -59888,7 +59701,6 @@
 "qrn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "qrq" = (
@@ -59935,7 +59747,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "qsx" = (
@@ -59968,10 +59779,10 @@
 	c_tag = "Security - Brig Hallway";
 	network = list("ss13","security")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "qtj" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
@@ -59990,7 +59801,6 @@
 /obj/effect/spawner/random/trash/garbage,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "qtD" = (
@@ -60011,15 +59821,14 @@
 "qtQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/teleporter)
 "qtS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
@@ -60027,6 +59836,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "quw" = (
@@ -60050,6 +59860,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "quR" = (
@@ -60102,9 +59913,16 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "qvG" = (
-/obj/effect/turf_decal/trimline/purple/line,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/port)
 "qvH" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -60133,6 +59951,8 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -60185,31 +60005,27 @@
 	color = "#52B4E9";
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "qxq" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "qxr" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "qxH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -60228,7 +60044,6 @@
 /turf/open/floor/iron/textured_large,
 /area/station/maintenance/department/medical)
 "qxV" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -60237,6 +60052,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "qxY" = (
@@ -60287,20 +60103,18 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "qzA" = (
 /obj/effect/decal/cleanable/glass,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qzE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -60348,6 +60162,7 @@
 /area/station/maintenance/aft/lesser)
 "qAA" = (
 /obj/effect/landmark/navigate_destination/bridge,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "qAF" = (
@@ -60360,11 +60175,11 @@
 "qAH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/mail_sorting/medbay/chemistry,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "qAI" = (
@@ -60373,12 +60188,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "qAV" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60425,7 +60239,6 @@
 "qBP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "qCk" = (
@@ -60516,7 +60329,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/kitchen/abandoned)
 "qDd" = (
@@ -60553,6 +60365,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "qEd" = (
@@ -60564,9 +60377,9 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "qEA" = (
@@ -60594,11 +60407,9 @@
 	name = "Chapel"
 	},
 /obj/effect/landmark/navigate_destination/chapel,
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "qFQ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -60632,12 +60443,12 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "qGh" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "qGw" = (
@@ -60655,14 +60466,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/security/upper)
 "qGS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "qGY" = (
 /obj/structure/rack,
 /obj/item/raw_anomaly_core/random{
@@ -60681,16 +60488,15 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qHy" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -60699,6 +60505,7 @@
 	},
 /obj/machinery/light/small/broken/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "qHE" = (
@@ -60707,9 +60514,9 @@
 /area/station/maintenance/port/greater)
 "qIa" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "qIk" = (
@@ -60761,7 +60568,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -60815,7 +60621,6 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "qJs" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair,
 /turf/open/floor/plating,
@@ -60825,11 +60630,11 @@
 	dir = 8;
 	name = "RD's Junction"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/mail_sorting/science/rd_office,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "qKh" = (
@@ -60874,7 +60679,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "qKr" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
@@ -60896,12 +60700,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/light/dim/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "qKN" = (
@@ -60912,6 +60716,7 @@
 /area/station/command/heads_quarters/hop)
 "qLc" = (
 /obj/structure/sign/poster/official/obey/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "qLj" = (
@@ -60937,7 +60742,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "qLZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -60955,12 +60759,10 @@
 /area/station/hallway/primary/aft)
 "qMK" = (
 /obj/item/clothing/head/helmet/old,
-/obj/structure/cable,
 /turf/open/misc/asteroid,
 /area/station/security/prison/safe/exterior)
 "qMM" = (
 /obj/machinery/computer/records/security,
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
@@ -61009,12 +60811,12 @@
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/mechbay)
 "qNA" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "qNG" = (
@@ -61080,7 +60882,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/science/xenobiology)
 "qOO" = (
@@ -61089,7 +60890,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "qPg" = (
@@ -61214,7 +61014,6 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "qSc" = (
@@ -61251,7 +61050,6 @@
 "qSv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -61264,7 +61062,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
@@ -61273,10 +61070,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "qTm" = (
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qTr" = (
@@ -61292,13 +61089,13 @@
 /area/station/maintenance/department/medical)
 "qTs" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "qTy" = (
@@ -61325,9 +61122,9 @@
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "qTO" = (
@@ -61343,7 +61140,6 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
 "qUc" = (
@@ -61352,10 +61148,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "qUl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "qUs" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -61366,7 +61165,6 @@
 /turf/open/floor/wood/tile,
 /area/station/service/kitchen/abandoned)
 "qUI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -61375,11 +61173,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qUJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/grille_or_waste,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "qUQ" = (
@@ -61400,9 +61200,9 @@
 "qVe" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "qVp" = (
@@ -61447,7 +61247,6 @@
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "qWq" = (
-/obj/structure/cable,
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/spawner/random/contraband/prison,
@@ -61471,10 +61270,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qWN" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qWU" = (
@@ -61490,9 +61289,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs/fore)
 "qXa" = (
@@ -61506,10 +61305,10 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/breakroom)
 "qXK" = (
@@ -61532,7 +61331,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "qYp" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -61540,13 +61338,14 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "qYs" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "qYA" = (
@@ -61562,6 +61361,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security/upper)
 "qYL" = (
@@ -61571,6 +61371,7 @@
 	dir = 8;
 	pixel_y = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "qYY" = (
@@ -61585,9 +61386,9 @@
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/lab)
 "qZc" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/xenobiology)
 "qZn" = (
@@ -61683,6 +61484,7 @@
 /area/station/engineering/atmos/office)
 "rbo" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rbM" = (
@@ -61696,7 +61498,6 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "rbT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
@@ -61722,14 +61523,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rcL" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
 /turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/area/station/maintenance/port/greater)
 "rdd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 10
@@ -61743,8 +61540,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/prison)
 "rdj" = (
@@ -61760,15 +61557,15 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "rdq" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "rdx" = (
@@ -61781,7 +61578,6 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "rea" = (
@@ -61809,7 +61605,6 @@
 "rel" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
@@ -61834,7 +61629,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -61846,7 +61640,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
@@ -61874,6 +61667,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rfi" = (
@@ -61904,9 +61698,9 @@
 "rfy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "rfK" = (
@@ -61931,13 +61725,14 @@
 "rgf" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/command,
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/bridge)
 "rgk" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/item/cultivator,
-/obj/structure/cable,
 /obj/machinery/hydroponics/constructable,
+/obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "rgr" = (
@@ -61958,6 +61753,7 @@
 	cycle_id = "bridge-left"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/bridge)
 "rgt" = (
@@ -61997,17 +61793,16 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Teleporter Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/bridge)
 "rhi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/bridge)
 "rhq" = (
@@ -62059,16 +61854,17 @@
 "rhV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "rib" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rif" = (
@@ -62117,8 +61913,8 @@
 "riS" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/command/storage/eva)
 "rja" = (
@@ -62162,23 +61958,24 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
 "rjW" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "rkl" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/status_display/evac/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "rkO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "rkT" = (
@@ -62194,7 +61991,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "rla" = (
@@ -62224,9 +62020,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "rlk" = (
@@ -62240,12 +62036,12 @@
 /area/station/cargo/storage)
 "rlM" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "rlO" = (
@@ -62255,17 +62051,17 @@
 "rlX" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "rlZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "rmj" = (
@@ -62280,7 +62076,6 @@
 /area/station/service/bar)
 "rmk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -62288,7 +62083,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rml" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance{
@@ -62296,6 +62090,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "rmt" = (
@@ -62313,7 +62108,6 @@
 "rmH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "rmM" = (
@@ -62349,15 +62143,14 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/poster/official/safety_internals/directional/west,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/main)
 "rny" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "rnC" = (
@@ -62425,7 +62218,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "roI" = (
@@ -62435,8 +62227,8 @@
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "rpc" = (
@@ -62536,12 +62328,15 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "rrb" = (
-/obj/effect/landmark/start/hangover,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/commons/lounge)
+/area/station/maintenance/department/medical)
 "rrm" = (
 /obj/structure/rack,
 /obj/item/storage/medkit/regular{
@@ -62648,7 +62443,6 @@
 /area/station/science/research)
 "rsA" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
@@ -62666,7 +62460,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
@@ -62707,6 +62500,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
@@ -62737,7 +62531,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom/directional/west,
-/obj/structure/cable,
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -62780,14 +62573,10 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
 "rvx" = (
+/obj/structure/bookcase/random/adult,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/turf/open/floor/carpet/green,
+/area/station/service/library)
 "rvC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -62849,7 +62638,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -62905,8 +62693,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/maintenance/department/eva/abandoned)
 "rxm" = (
@@ -62972,7 +62760,6 @@
 "ryL" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ryP" = (
@@ -63028,10 +62815,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "rzW" = (
@@ -63054,10 +62841,10 @@
 	c_tag = "Engineering - SMES Room";
 	network = list("ss13","engineering")
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -63088,6 +62875,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/half,
 /area/station/maintenance/port/greater)
 "rBf" = (
@@ -63095,7 +62883,6 @@
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -63108,11 +62895,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/upper)
 "rBn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/cable/layer3,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "rBp" = (
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
@@ -63124,7 +62910,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/toilet/auxiliary)
 "rBU" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -63132,6 +62917,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/maintenance/department/electrical)
 "rCg" = (
@@ -63198,16 +62984,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "rEs" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rEF" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -63215,11 +63000,13 @@
 	name = "Surgery A"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "rEP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "rEQ" = (
@@ -63263,9 +63050,9 @@
 "rFN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "rGo" = (
@@ -63279,7 +63066,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
 "rGw" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -63306,6 +63092,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"rHh" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "rHv" = (
 /obj/item/food/meat/slab/goliath,
 /turf/open/misc/asteroid,
@@ -63329,8 +63122,8 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
 "rHR" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/engineering)
 "rHS" = (
@@ -63350,9 +63143,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination/disposals,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/maintenance/department/science/xenobiology)
 "rIy" = (
@@ -63366,7 +63159,6 @@
 /area/station/science/ordnance)
 "rIB" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Break Room"
@@ -63376,6 +63168,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "rIU" = (
@@ -63424,6 +63217,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/item/radio/intercom/directional/south,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rJx" = (
@@ -63454,7 +63248,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "rKd" = (
@@ -63518,7 +63311,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
 "rMj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -63532,6 +63324,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "rMo" = (
@@ -63682,15 +63475,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "rPj" = (
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "rPA" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "rPN" = (
@@ -63729,11 +63522,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/light/dim/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "rQC" = (
@@ -63784,7 +63577,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -63835,7 +63627,6 @@
 	},
 /area/station/hallway/secondary/command)
 "rSo" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
@@ -63845,6 +63636,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
 "rSW" = (
@@ -63862,7 +63654,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "rTh" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
@@ -63870,6 +63661,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "rTy" = (
@@ -63905,6 +63697,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/science/robotics/lab)
 "rTO" = (
@@ -63922,12 +63715,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port)
 "rUk" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	dir = 10
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/wood/large,
+/area/station/command/bridge)
 "rUq" = (
 /obj/structure/lattice,
 /obj/item/toy/gun,
@@ -63945,19 +63735,17 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "rVh" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
 "rVJ" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
 "rVS" = (
@@ -63999,13 +63787,17 @@
 /area/station/command/gateway)
 "rWy" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "rWX" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/storage)
 "rXB" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -64044,7 +63836,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Prison - Labor Shuttle"
 	},
@@ -64070,7 +63861,6 @@
 "rYD" = (
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64093,6 +63883,7 @@
 	name = "Hydroponics Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "sae" = (
@@ -64106,10 +63897,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "sal" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "saO" = (
@@ -64133,7 +63924,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "sbK" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -64151,10 +63941,10 @@
 /area/station/engineering/atmos)
 "scg" = (
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "scx" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
@@ -64176,7 +63966,6 @@
 "scz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -64236,17 +64025,16 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/port/aft)
 "sfo" = (
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "celock";
 	name = "CE Office Lockdown Door"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
 "sfA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -64254,6 +64042,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sfT" = (
@@ -64292,9 +64081,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "sht" = (
@@ -64306,18 +64095,17 @@
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "shu" = (
-/obj/structure/cable,
 /obj/machinery/power/solar{
 	id = "aisolar";
 	name = "AI Solar Array"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/ai)
 "shR" = (
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/atmos/glass{
@@ -64341,7 +64129,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -64362,10 +64149,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "sin" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "six" = (
@@ -64377,18 +64164,18 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "siz" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "siC" = (
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/start/depsec/supply,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/supply)
 "siF" = (
@@ -64421,6 +64208,7 @@
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "sjW" = (
@@ -64449,15 +64237,14 @@
 "ski" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable,
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "skn" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "skw" = (
@@ -64498,6 +64285,7 @@
 "slE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/cup/bottle/ammonia,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
 "smd" = (
@@ -64510,7 +64298,6 @@
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -64551,8 +64338,8 @@
 /turf/open/floor/iron/textured_large,
 /area/station/maintenance/department/medical)
 "snh" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/prison)
 "snm" = (
@@ -64599,15 +64386,16 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "snP" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "sor" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "sov" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 1
@@ -64625,9 +64413,9 @@
 /obj/structure/sink/kitchen/directional/west,
 /obj/structure/mirror/directional/east,
 /obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "spe" = (
@@ -64670,7 +64458,6 @@
 /turf/open/floor/plating,
 /area/station/security/prison)
 "sqI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
@@ -64678,24 +64465,25 @@
 	dir = 9
 	},
 /obj/effect/landmark/start/scientist,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "sqN" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "sqP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "sqR" = (
@@ -64771,11 +64559,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "ssn" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/fore)
+/area/station/hallway/primary/central)
 "ssK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64785,17 +64572,16 @@
 /area/station/security/courtroom)
 "ssV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
 /area/station/command/gateway)
 "ssX" = (
+/obj/structure/bookcase/random/fiction,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/turf/open/floor/carpet/green,
+/area/station/service/library)
 "ste" = (
 /obj/structure/closet/wardrobe/black,
 /obj/effect/landmark/start/hangover/closet,
@@ -64805,11 +64591,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Auxiliary Power"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/structure/cable,
 /turf/open/floor/iron/half,
 /area/station/maintenance/department/electrical)
 "stF" = (
@@ -64899,6 +64685,7 @@
 /obj/item/stamp/head/hop{
 	pixel_x = -7
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "svg" = (
@@ -64934,10 +64721,10 @@
 "svL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "svQ" = (
@@ -64945,9 +64732,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
 "swJ" = (
@@ -64959,10 +64746,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "swT" = (
@@ -65015,11 +64802,11 @@
 	color = "#52B4E9";
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics - Distro Loop";
 	network = list("ss13","engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/half{
 	dir = 8
 	},
@@ -65032,11 +64819,11 @@
 	name = "Science Break Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/half{
 	dir = 8
 	},
@@ -65160,6 +64947,7 @@
 	name = "Shutters Control Button";
 	req_access = list("security")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/checkpoint/science/research)
 "szX" = (
@@ -65207,7 +64995,6 @@
 "sAB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -65218,7 +65005,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "sAK" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -65226,12 +65012,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "sBl" = (
@@ -65241,10 +65027,10 @@
 /obj/effect/turf_decal/tile/command/opposingcorners,
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
 /obj/effect/landmark/navigate_destination/vault,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "sBt" = (
@@ -65358,6 +65144,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/research_director,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "sDc" = (
@@ -65367,12 +65154,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "sDe" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/lobby)
 "sDA" = (
@@ -65405,11 +65192,11 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/poster/official/random/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "sEE" = (
@@ -65453,7 +65240,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -65461,15 +65247,16 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "sFv" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "sFA" = (
@@ -65478,6 +65265,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "sFE" = (
@@ -65501,7 +65289,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/rd)
 "sGg" = (
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/item/computer_disk/engineering{
 	pixel_x = -6;
@@ -65569,6 +65356,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -65635,11 +65423,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "sIe" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "sIq" = (
@@ -65648,13 +65436,12 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "sIs" = (
-/obj/structure/cable,
 /obj/structure/sign/warning/no_smoking/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "sIx" = (
@@ -65697,10 +65484,11 @@
 	},
 /area/station/hallway/secondary/command)
 "sJj" = (
-/obj/structure/railing,
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/ai_monitored/command/storage/eva)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/girder,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/port/greater)
 "sJn" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -65743,10 +65531,10 @@
 /area/station/service/hydroponics/garden/abandoned)
 "sJH" = (
 /obj/structure/sink/directional/east,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "sJQ" = (
@@ -65769,14 +65557,13 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Post - Science"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/checkpoint/science/research)
 "sKr" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
@@ -65799,7 +65586,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/atmos/glass{
@@ -65810,6 +65596,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "engi-entrance"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
 "sKN" = (
@@ -65855,16 +65642,17 @@
 /area/station/hallway/secondary/service)
 "sMr" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
 	name = "Prison Lockdown Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
 "sMD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sMV" = (
@@ -65885,7 +65673,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/science/robotics/lab)
 "sNC" = (
@@ -65899,6 +65686,7 @@
 	},
 /obj/machinery/light/no_nightlight/directional/east,
 /obj/structure/table/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "sNL" = (
@@ -65922,6 +65710,7 @@
 /area/station/maintenance/starboard/fore)
 "sNV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -65933,7 +65722,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "sOx" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65970,6 +65758,7 @@
 	name = "Radiation Shutters Control";
 	req_access = list("engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "sPi" = (
@@ -65979,11 +65768,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "sPl" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/service/hydroponics)
+/area/station/engineering/atmos)
 "sPm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -66027,8 +65818,8 @@
 	name = "Kitchen Coldroom"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen)
 "sQJ" = (
@@ -66039,8 +65830,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/department/security/upper)
 "sQO" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "sQR" = (
@@ -66122,7 +65913,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "sSf" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -66142,8 +65932,8 @@
 	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "sSt" = (
@@ -66215,7 +66005,6 @@
 "sUh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
@@ -66244,11 +66033,11 @@
 "sUA" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "sVb" = (
@@ -66269,11 +66058,11 @@
 	name = "Bar Storage Maintenance"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "sVl" = (
@@ -66302,17 +66091,17 @@
 	pixel_y = -10
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "sVB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/prison)
 "sVE" = (
@@ -66342,7 +66131,6 @@
 /turf/open/floor/iron/textured_half,
 /area/station/cargo/warehouse)
 "sVZ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
@@ -66373,13 +66161,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "sWt" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "sWv" = (
@@ -66394,7 +66182,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "sWC" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
@@ -66448,9 +66235,9 @@
 /area/station/engineering/atmos)
 "sXi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "sXH" = (
@@ -66465,7 +66252,6 @@
 /obj/machinery/door/airlock{
 	name = "Detective's Office"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -66474,7 +66260,6 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "sYm" = (
@@ -66509,6 +66294,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "sZq" = (
@@ -66544,8 +66330,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "tal" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "tas" = (
@@ -66561,7 +66347,6 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "tbf" = (
@@ -66607,33 +66392,32 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "tbY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "tcg" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "tcu" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "tcv" = (
@@ -66643,7 +66427,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "tcB" = (
@@ -66660,8 +66443,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/command/bridge)
 "tcU" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/courtroom)
 "tdd" = (
@@ -66669,8 +66452,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "tdn" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "tdu" = (
@@ -66693,7 +66476,6 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/security/upper)
 "tdC" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -66733,7 +66515,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge Access"
 	},
@@ -66741,6 +66522,7 @@
 	cycle_id = "bridge-right"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/bridge)
 "tef" = (
@@ -66776,27 +66558,27 @@
 "tes" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "tet" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "teu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "tev" = (
@@ -66894,8 +66676,8 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/cell_10k,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "tfj" = (
@@ -66940,7 +66722,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/cafeteria)
 "tfy" = (
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -66995,18 +66776,18 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/prison/visit)
 "thn" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "thy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "thR" = (
@@ -67077,7 +66858,6 @@
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "tjT" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -67086,8 +66866,8 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "tkb" = (
-/obj/structure/cable,
 /obj/item/broken_bottle,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "tkg" = (
@@ -67103,7 +66883,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "tkB" = (
-/obj/structure/cable,
 /obj/structure/sign/warning/vacuum/external/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
@@ -67124,7 +66903,6 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/maintenance/department/science/xenobiology)
 "tls" = (
@@ -67182,7 +66960,6 @@
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -67249,8 +67026,8 @@
 /area/station/maintenance/department/science)
 "tnT" = (
 /obj/machinery/light/directional/north,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "tnV" = (
@@ -67258,9 +67035,9 @@
 	name = "Maintenance Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "toh" = (
@@ -67310,10 +67087,10 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "toQ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "toY" = (
@@ -67333,7 +67110,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -67342,6 +67118,7 @@
 "tpy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "tpE" = (
@@ -67354,20 +67131,19 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/qm)
 "tpJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/upper)
 "tpS" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "tpU" = (
@@ -67417,18 +67193,18 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/security/warden)
 "tqZ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "tra" = (
@@ -67442,6 +67218,7 @@
 	pixel_x = 5;
 	pixel_y = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "trD" = (
@@ -67450,14 +67227,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "trE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "trL" = (
@@ -67494,7 +67269,6 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "tsK" = (
@@ -67505,7 +67279,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
@@ -67560,11 +67333,11 @@
 /area/station/commons/vacant_room/office)
 "ttX" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
 	name = "Prison Lockdown Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/visit)
 "tud" = (
@@ -67588,7 +67361,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "tuv" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -67623,12 +67395,14 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "tuE" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
 	},
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter)
 "tuV" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/light/directional/north,
@@ -67654,7 +67428,6 @@
 "twf" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -67687,6 +67460,7 @@
 /area/station/command/heads_quarters/hop)
 "twK" = (
 /obj/effect/spawner/random/engineering/tank,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "twQ" = (
@@ -67716,7 +67490,6 @@
 /area/station/maintenance/aft/lesser)
 "txz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "txG" = (
@@ -67747,18 +67520,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "tyl" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/command/heads_quarters/rd)
 "tyw" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -67788,9 +67554,9 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "tzh" = (
@@ -67813,12 +67579,12 @@
 	},
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "tzt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/area/station/maintenance/department/science)
 "tzF" = (
 /obj/structure/chair{
 	dir = 4
@@ -67829,12 +67595,12 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "tzN" = (
@@ -67882,7 +67648,6 @@
 /area/station/cargo/lobby)
 "tAP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
@@ -67896,7 +67661,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "tBf" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/mess,
@@ -67916,13 +67680,13 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "tBu" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/broken/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "tBw" = (
@@ -67938,13 +67702,12 @@
 /obj/structure/sign/warning/electric_shock/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/structure/steam_vent,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "tBD" = (
 /obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
@@ -67987,19 +67750,18 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port)
 "tCI" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "tCL" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "tCY" = (
@@ -68019,6 +67781,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable/layer3,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "tDo" = (
@@ -68057,6 +67820,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/checkpoint/science/research)
 "tDS" = (
@@ -68111,12 +67875,12 @@
 	name = "Engineering Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "tED" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/mail_sorting/service/theater,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
@@ -68125,6 +67889,7 @@
 	dir = 1
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "tEG" = (
@@ -68142,7 +67907,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "tEO" = (
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -68167,6 +67931,7 @@
 	id = "hopblast";
 	name = "HoP Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
 "tEW" = (
@@ -68206,11 +67971,11 @@
 	id = "rdxeno";
 	name = "Xenobiology Containment Door"
 	},
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdxenowindows";
 	name = "Xenobiology Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "tFM" = (
@@ -68272,7 +68037,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "tGE" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/tcomms_all,
@@ -68280,6 +68044,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "tGS" = (
@@ -68302,13 +68067,14 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "tHh" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "tHp" = (
@@ -68379,8 +68145,8 @@
 "tIT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/cargo/warehouse)
 "tJK" = (
@@ -68399,7 +68165,6 @@
 /area/station/security/prison/visit)
 "tJT" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/effect/landmark/navigate_destination/techstorage,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -68408,6 +68173,7 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/half,
 /area/station/engineering/storage/tech)
 "tJU" = (
@@ -68451,11 +68217,11 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/genetics)
 "tKH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/cargo/storage)
 "tKM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
@@ -68566,15 +68332,16 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/breakroom)
 "tMf" = (
-/obj/structure/cable,
 /obj/machinery/camera/directional/west{
 	c_tag = "Cargo - Mining Office";
 	network = list("ss13","cargo")
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "tMm" = (
@@ -68602,10 +68369,10 @@
 /obj/item/hand_labeler_refill,
 /obj/item/storage/briefcase,
 /obj/item/storage/secure/briefcase,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "tMB" = (
@@ -68619,7 +68386,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "tMP" = (
@@ -68635,13 +68401,13 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "tNk" = (
@@ -68650,9 +68416,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "tNo" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/science/research)
 "tNB" = (
@@ -68671,6 +68437,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/breakroom)
 "tNV" = (
@@ -68683,7 +68450,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/kitchen/abandoned)
 "tOG" = (
@@ -68730,7 +68496,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tPm" = (
@@ -68738,9 +68503,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "tPM" = (
@@ -68756,6 +68521,7 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "tQe" = (
@@ -68793,8 +68559,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/prison)
 "tQC" = (
@@ -68805,7 +68571,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "tQF" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
@@ -68818,6 +68583,7 @@
 /obj/machinery/light_switch/directional/south,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "tRq" = (
@@ -68839,7 +68605,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge Access"
 	},
@@ -68847,12 +68612,14 @@
 	cycle_id = "bridge-right"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/bridge)
 "tRR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "tRY" = (
@@ -68861,8 +68628,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/sign/warning/vacuum/external/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "tSo" = (
@@ -68908,10 +68675,10 @@
 /turf/open/floor/iron,
 /area/station/security/execution/education)
 "tSE" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tSI" = (
@@ -68926,6 +68693,7 @@
 "tSJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/mopbucket,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "tSM" = (
@@ -68949,7 +68717,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tTl" = (
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood/large,
 /area/station/security/prison/visit)
@@ -68960,11 +68727,11 @@
 "tTJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "tTV" = (
@@ -69015,9 +68782,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "tWR" = (
@@ -69102,6 +68869,7 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "tYG" = (
@@ -69140,15 +68908,14 @@
 "tZO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/holopad,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/box,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "tZW" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -69161,11 +68928,12 @@
 "tZX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "uar" = (
@@ -69228,7 +68996,6 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/roboticist,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/lab)
 "uaW" = (
@@ -69238,7 +69005,6 @@
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 5
 	},
@@ -69270,7 +69036,6 @@
 /area/station/science/lab)
 "ucq" = (
 /obj/machinery/power/smes,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ucC" = (
@@ -69303,6 +69068,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "udb" = (
@@ -69325,21 +69091,26 @@
 	},
 /area/station/maintenance/department/science/xenobiology)
 "udi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "udo" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "udG" = (
@@ -69391,14 +69162,15 @@
 	charge = 5e+006
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/sign/warning/electric_shock/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "ufr" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/closet/firecloset,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "ufv" = (
@@ -69450,7 +69222,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "ugM" = (
@@ -69459,11 +69230,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/science/xenobiology)
 "uhg" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "uhj" = (
@@ -69488,6 +69259,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "uhP" = (
@@ -69526,6 +69298,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "uiE" = (
@@ -69564,7 +69337,6 @@
 /area/station/maintenance/aft/lesser)
 "ujm" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -69584,7 +69356,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ujw" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -69603,7 +69374,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard)
 "ujS" = (
@@ -69679,8 +69449,8 @@
 /area/station/command/heads_quarters/ce)
 "ule" = (
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/space/basic,
+/area/space)
 "ulm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/plastic{
@@ -69695,12 +69465,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "ulE" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "celock";
 	name = "CE Office Lockdown Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
 "ulM" = (
@@ -69733,10 +69503,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "umj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "umo" = (
@@ -69777,7 +69547,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
@@ -69817,16 +69586,15 @@
 "uob" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/rnd_secure_all,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/storage/tech)
 "uod" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "uog" = (
@@ -69842,7 +69610,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -69855,14 +69622,13 @@
 	name = "Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/main)
 "uoC" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "uoJ" = (
@@ -69890,11 +69656,11 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/qm)
 "upg" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/decoration/glowstick,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "upl" = (
@@ -69904,7 +69670,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},
@@ -69919,8 +69684,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "uqc" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "uqg" = (
@@ -69952,7 +69717,6 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
@@ -69998,11 +69762,11 @@
 	},
 /area/station/engineering/hallway)
 "urM" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "urY" = (
@@ -70079,15 +69843,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/half,
 /area/station/science/lab)
 "utQ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "uus" = (
@@ -70131,6 +69896,7 @@
 "uvB" = (
 /obj/effect/spawner/random/trash/mopbucket,
 /obj/effect/spawner/random/trash/soap,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "uwF" = (
@@ -70138,11 +69904,13 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "uwK" = (
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/security/upper)
 "uwO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -70258,8 +70026,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/solars/starboard/fore)
 "uyy" = (
@@ -70273,14 +70041,13 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "uzh" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "uzr" = (
@@ -70345,10 +70112,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "uBf" = (
@@ -70366,12 +70133,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "uBx" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison)
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "uCg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/girder,
@@ -70418,7 +70183,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/science/robotics/mechbay)
 "uDg" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
@@ -70455,6 +70219,7 @@
 /obj/item/stock_parts/cell/emproof{
 	pixel_x = -1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "uDC" = (
@@ -70485,14 +70250,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "uDT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "uEo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -70513,9 +70274,9 @@
 	name = "Prison Workshop"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/prison/work)
 "uFJ" = (
@@ -70551,10 +70312,10 @@
 "uGn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "uGE" = (
@@ -70567,10 +70328,10 @@
 /obj/effect/turf_decal/box/white{
 	color = "#D381C9"
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "uGI" = (
@@ -70607,19 +70368,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/prison/visit)
 "uHo" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "uHA" = (
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp{
 	pixel_x = -3;
@@ -70638,7 +70399,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -70702,7 +70462,6 @@
 "uJd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "uJe" = (
@@ -70710,9 +70469,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "uJf" = (
@@ -70748,7 +70507,6 @@
 "uJP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
@@ -70759,6 +70517,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "uJQ" = (
@@ -70766,12 +70525,12 @@
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "uJW" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "uKd" = (
@@ -70783,11 +70542,11 @@
 /obj/machinery/door/airlock/security{
 	name = "Prisoner Education Chamber"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "uKj" = (
@@ -70800,8 +70559,8 @@
 /area/station/medical/surgery/aft)
 "uKz" = (
 /obj/structure/sign/warning/secure_area/directional/east,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "uKK" = (
@@ -70822,24 +70581,25 @@
 /area/station/security/prison/visit)
 "uKY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "uLd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "uLj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "uLG" = (
@@ -70992,6 +70752,7 @@
 "uPG" = (
 /obj/structure/chair/stool/directional/east,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/prison/visit)
 "uPO" = (
@@ -71040,14 +70801,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "uQV" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Pharmacy Maintenance"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -71057,12 +70816,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "uRq" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "uRr" = (
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71102,11 +70862,11 @@
 	req_access = list("security")
 	},
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/prison/visit)
 "uSb" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "uSm" = (
@@ -71119,12 +70879,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/spawner/random/trash/mess,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "uSv" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71154,8 +70913,8 @@
 	charge = 5e+006
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "uTy" = (
@@ -71165,7 +70924,6 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/science/research)
 "uTP" = (
@@ -71212,7 +70970,6 @@
 	},
 /obj/effect/turf_decal/trimline/white/filled/corner,
 /obj/effect/turf_decal/trimline/blue/corner,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "uUv" = (
@@ -71235,7 +70992,6 @@
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
 "uUG" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -71247,7 +71003,6 @@
 "uUR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "uVi" = (
@@ -71270,7 +71025,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port)
 "uVT" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -71300,18 +71054,16 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "uWL" = (
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side,
+/area/station/engineering/storage)
 "uWZ" = (
 /obj/structure/sign/warning/secure_area/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -71339,7 +71091,6 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "uXL" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -71350,12 +71101,14 @@
 	},
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "uXW" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "uYl" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab"
@@ -71371,8 +71124,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/box,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "uYI" = (
@@ -71412,9 +71165,9 @@
 /area/station/maintenance/port/fore)
 "uZG" = (
 /obj/effect/spawner/random/trash/mess,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "uZK" = (
@@ -71430,6 +71183,7 @@
 /area/station/maintenance/disposal/incinerator)
 "uZL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security/upper)
@@ -71471,7 +71225,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/sign/warning/electric_shock/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71479,6 +71232,7 @@
 	c_tag = "Security - Prison - Cell Block B";
 	network = list("ss13","security","prison")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "vaf" = (
@@ -71511,10 +71265,10 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/solars/port/aft)
 "vbd" = (
@@ -71524,11 +71278,14 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vbp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/engineering/lobby)
+/area/station/hallway/secondary/command)
 "vbP" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -71549,6 +71306,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/no_nightlight/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
@@ -71557,13 +71315,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/mail_sorting/engineering/ce_office,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "vcw" = (
@@ -71571,14 +71329,13 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "vcI" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "vcN" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/garbage{
@@ -71586,6 +71343,7 @@
 	spawn_scatter_radius = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "vcS" = (
@@ -71593,6 +71351,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "vcU" = (
@@ -71654,8 +71413,8 @@
 /area/station/maintenance/solars/starboard/fore)
 "veg" = (
 /obj/structure/chair/stool/directional/west,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/prison/visit)
 "vej" = (
@@ -71668,10 +71427,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "veI" = (
@@ -71731,13 +71490,13 @@
 /area/station/maintenance/department/science/xenobiology)
 "vfB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/hydroponics,
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "vgf" = (
@@ -71752,6 +71511,7 @@
 	id = "bridgedoors";
 	name = "Bridge Access Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/bridge)
 "vgk" = (
@@ -71808,19 +71568,19 @@
 "vgE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "vgR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "vgS" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/visit)
 "vgZ" = (
@@ -71843,9 +71603,9 @@
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "vhI" = (
@@ -71870,24 +71630,25 @@
 "viJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "vjF" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "vjN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "vke" = (
@@ -71922,8 +71683,8 @@
 "vkt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "vkL" = (
@@ -71933,6 +71694,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "vly" = (
@@ -71981,14 +71743,13 @@
 /area/station/science/robotics/mechbay)
 "vmj" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/office)
 "vmu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/prison/visit)
 "vmC" = (
@@ -72071,18 +71832,19 @@
 /area/station/science/lab)
 "vnD" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/security{
 	name = "Security Post - Engineering"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "vnF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/structure/girder,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "vnG" = (
@@ -72093,11 +71855,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "vnL" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
 "vnO" = (
@@ -72131,7 +71893,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "von" = (
@@ -72169,6 +71930,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "vpb" = (
@@ -72191,7 +71953,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -72206,15 +71967,14 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "vpS" = (
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/department/science/xenobiology)
@@ -72237,12 +71997,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "vqo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "vqt" = (
@@ -72271,10 +72032,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "vqF" = (
@@ -72312,6 +72073,7 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "vqX" = (
@@ -72319,7 +72081,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "vri" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -72342,11 +72103,11 @@
 	},
 /area/station/command/gateway)
 "vrp" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "vrr" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
 "vrI" = (
@@ -72397,13 +72158,14 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vsK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "vsM" = (
@@ -72430,17 +72192,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "vtF" = (
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/sign/poster/official/wtf_is_co2/directional/west,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "vtN" = (
@@ -72453,7 +72214,6 @@
 "vtX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/science/explab)
 "vtY" = (
@@ -72476,12 +72236,12 @@
 /area/station/security/courtroom)
 "vuj" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "justiceshutter";
 	name = "Justice Shutter"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "vum" = (
@@ -72492,14 +72252,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "vuP" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "vuZ" = (
@@ -72507,10 +72266,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "vvt" = (
@@ -72529,14 +72288,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "vvw" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -72581,7 +72338,6 @@
 /area/station/service/kitchen/abandoned)
 "vwt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "vwG" = (
@@ -72600,10 +72356,10 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /mob/living/simple_animal/bot/secbot/pingsky,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "vwW" = (
@@ -72658,6 +72414,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plastic,
 /area/station/commons/toilet/auxiliary)
 "vxT" = (
@@ -72683,7 +72440,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/freezer,
 /area/station/security/warden)
@@ -72707,10 +72463,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "vzx" = (
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72732,7 +72488,6 @@
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
 "vAr" = (
-/obj/structure/cable,
 /turf/open/floor/iron/half{
 	dir = 8
 	},
@@ -72764,7 +72519,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "vBz" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72788,14 +72542,12 @@
 /turf/closed/wall,
 /area/station/medical/abandoned)
 "vCc" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "vCh" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /obj/structure/cable,
@@ -72869,13 +72621,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "vEy" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "vEV" = (
@@ -72919,7 +72671,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vFP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -72941,6 +72692,7 @@
 "vGI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/ce)
 "vGJ" = (
@@ -72973,8 +72725,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/cable/layer3,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "vHx" = (
@@ -72999,7 +72751,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "vHF" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -73065,7 +72816,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "vIm" = (
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "vIp" = (
@@ -73094,6 +72844,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "vJd" = (
@@ -73209,7 +72960,6 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "vKv" = (
-/obj/structure/cable,
 /obj/effect/spawner/random/structure/girder,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73239,10 +72989,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
 /obj/machinery/airalarm/directional/west,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "vLe" = (
@@ -73287,6 +73037,7 @@
 	name = "Robotics Lab Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "vMr" = (
@@ -73296,15 +73047,15 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vMu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "vMv" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/machinery/space_heater,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/solars)
 "vMw" = (
@@ -73350,6 +73101,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/xenobiology)
 "vNd" = (
@@ -73385,6 +73137,7 @@
 "vNS" = (
 /obj/machinery/computer/rdconsole,
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vNV" = (
@@ -73430,6 +73183,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "vOK" = (
@@ -73456,6 +73210,7 @@
 	pixel_x = 3;
 	pixel_y = -10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "vPj" = (
@@ -73486,7 +73241,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "vPH" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -73494,7 +73248,6 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/xenobiology)
 "vPN" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -73581,16 +73334,15 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "vRl" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "vRn" = (
@@ -73667,17 +73419,16 @@
 "vTa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "vTd" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "vTg" = (
@@ -73704,7 +73455,6 @@
 "vTo" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -73712,6 +73462,7 @@
 	name = "Chief Engineer"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "vTQ" = (
@@ -73759,7 +73510,6 @@
 	name = "Fore Starboard Solars Control"
 	},
 /obj/structure/sign/warning/vacuum/external/directional/north,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "vUB" = (
@@ -73792,9 +73542,9 @@
 	name = "Kitchen Maintenance"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "vVy" = (
@@ -73897,6 +73647,7 @@
 /obj/item/clothing/glasses/meson/engine{
 	pixel_y = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "vXo" = (
@@ -73907,6 +73658,7 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "vXx" = (
@@ -73948,7 +73700,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -73956,7 +73707,6 @@
 /area/station/science/ordnance)
 "vYa" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -74004,24 +73754,25 @@
 /turf/open/floor/plating,
 /area/station/science/lab)
 "vZF" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "vZI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/south,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "vZR" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/iv_drip,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
 "wab" = (
@@ -74064,6 +73815,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "wbq" = (
@@ -74157,7 +73909,6 @@
 "wdg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "wdz" = (
@@ -74327,16 +74078,15 @@
 "wgL" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/status_display/evac/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "wgS" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 4
 	},
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "wgY" = (
@@ -74361,10 +74111,10 @@
 	dir = 8;
 	name = "engineering yellow"
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "whl" = (
@@ -74415,26 +74165,25 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "wjC" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/loading_area,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "wjE" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "wjS" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
@@ -74492,6 +74241,7 @@
 /obj/item/reagent_containers/cup/glass/coffee{
 	pixel_x = -7
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "wkU" = (
@@ -74501,15 +74251,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "wlb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden/abandoned)
 "wld" = (
@@ -74517,7 +74266,6 @@
 	dir = 1
 	},
 /obj/structure/chair/office,
-/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "wlg" = (
@@ -74528,6 +74276,7 @@
 /area/station/engineering/atmos/hfr_room)
 "wlo" = (
 /obj/machinery/light/dim/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -74541,7 +74290,6 @@
 /area/station/security/prison/safe/exterior)
 "wlx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wlz" = (
@@ -74557,7 +74305,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/education)
 "wmD" = (
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/reagent_containers/cup/bottle/multiver{
@@ -74571,8 +74318,8 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "wmK" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "wmL" = (
@@ -74607,12 +74354,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "wmZ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "wng" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -74624,6 +74370,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "wnp" = (
@@ -74667,14 +74414,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "woz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "woJ" = (
@@ -74683,20 +74428,19 @@
 	network = list("ss13","engineering","engine")
 	},
 /obj/machinery/airalarm/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "woK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "woM" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -74704,6 +74448,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "wph" = (
@@ -74720,7 +74465,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "wpO" = (
@@ -74778,6 +74522,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/decoration/glowstick,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "wqI" = (
@@ -74803,6 +74548,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "wrt" = (
@@ -74818,7 +74564,6 @@
 /area/station/engineering/atmos/pumproom)
 "wrL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -74872,13 +74617,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/mail_sorting/engineering/general,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "wsO" = (
@@ -74908,12 +74653,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/security{
 	name = "Security Post - Cargo"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "wud" = (
@@ -74942,9 +74687,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "wuL" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
 "wvg" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -74964,6 +74710,7 @@
 "wwr" = (
 /obj/structure/sign/departments/telecomms/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "wwF" = (
@@ -75076,8 +74823,8 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/court,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "wyC" = (
@@ -75130,6 +74877,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "wAz" = (
@@ -75169,7 +74917,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -75256,6 +75003,7 @@
 	c_tag = "Security - Prison - Cells";
 	network = list("ss13","security","prison")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "wDN" = (
@@ -75326,7 +75074,6 @@
 "wEP" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "perma-entrance"
@@ -75340,6 +75087,7 @@
 "wET" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/visit)
 "wEW" = (
@@ -75359,7 +75107,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "wFe" = (
@@ -75411,7 +75158,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "wFX" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -75420,9 +75166,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "wGk" = (
@@ -75492,7 +75238,6 @@
 /area/station/maintenance/department/electrical)
 "wHh" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "wHj" = (
@@ -75501,6 +75246,7 @@
 /obj/item/canvas/twentythree_nineteen{
 	pixel_x = 3
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "wHn" = (
@@ -75514,6 +75260,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "wHE" = (
@@ -75560,10 +75307,12 @@
 "wIx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "wIJ" = (
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "wIW" = (
@@ -75574,12 +75323,12 @@
 /area/station/science/lobby)
 "wIX" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "wJc" = (
@@ -75630,7 +75379,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "wLo" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -75640,6 +75388,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
@@ -75649,10 +75398,10 @@
 	c_tag = "Engineering - Engine NW";
 	network = list("ss13","engineering","engine")
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "wLu" = (
@@ -75678,6 +75427,7 @@
 "wMw" = (
 /obj/machinery/computer/station_alert,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "wMy" = (
@@ -75737,7 +75487,6 @@
 /area/station/hallway/secondary/command)
 "wNe" = (
 /obj/structure/closet/emcloset,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "wNj" = (
@@ -75751,14 +75500,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "wNp" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/machinery/computer/security/labor,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "wNq" = (
@@ -75828,6 +75576,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/prison)
 "wOH" = (
@@ -75837,7 +75586,6 @@
 "wON" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -75855,7 +75603,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "wPT" = (
@@ -75866,9 +75613,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "wPV" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "wPX" = (
@@ -75904,10 +75651,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "wQZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage_shared)
 "wRs" = (
@@ -75918,7 +75665,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip,
@@ -75938,13 +75684,13 @@
 /area/station/maintenance/starboard/fore)
 "wRN" = (
 /obj/machinery/suit_storage_unit/ce,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/ce)
 "wRO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -76004,10 +75750,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "wSV" = (
@@ -76051,6 +75797,7 @@
 	name = "Research Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
@@ -76116,18 +75863,18 @@
 "wVf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/sign/warning/electric_shock/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "wVg" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/sign/poster/contraband/random/directional/north,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "wVh" = (
@@ -76199,7 +75946,6 @@
 /area/station/maintenance/port/fore)
 "wWy" = (
 /obj/effect/spawner/random/structure/steam_vent,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -76208,12 +75954,10 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "wXH" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
 "wYg" = (
@@ -76258,20 +76002,20 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Surgery Maintenance"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "wZB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/decoration/glowstick,
 /obj/effect/spawner/random/trash/garbage{
 	spawn_loot_count = 3;
 	spawn_scatter_radius = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "wZH" = (
@@ -76296,7 +76040,6 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/landmark/start/depsec/engineering,
@@ -76306,7 +76049,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload"
 	},
@@ -76315,6 +76057,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/navigate_destination/aiupload,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "xaK" = (
@@ -76334,6 +76077,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Command Hallway - Entrance"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -76350,6 +76094,7 @@
 	id = "AI"
 	},
 /obj/machinery/porta_turret/ai,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "xbA" = (
@@ -76401,29 +76146,26 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/west{
 	broadcasting = 1;
 	frequency = 1447;
 	listening = 0;
 	name = "Private Channel"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "xdD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
-"xdI" = (
 /obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel/monastery)
+"xdI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xdO" = (
@@ -76443,11 +76185,11 @@
 /turf/closed/wall,
 /area/station/science/lobby)
 "xdW" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "xee" = (
@@ -76567,7 +76309,6 @@
 /area/station/maintenance/department/eva/abandoned)
 "xgK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
@@ -76607,7 +76348,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -76617,6 +76357,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "xhp" = (
@@ -76625,6 +76366,7 @@
 	},
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xhy" = (
@@ -76635,7 +76377,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xip" = (
@@ -76649,12 +76390,12 @@
 "xis" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "xiI" = (
@@ -76701,7 +76442,6 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "xiV" = (
@@ -76766,6 +76506,7 @@
 /area/station/maintenance/department/medical)
 "xjM" = (
 /obj/machinery/light/dim/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -76780,9 +76521,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xkb" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/starboard/aft)
 "xke" = (
@@ -76948,9 +76689,9 @@
 /area/station/science/genetics)
 "xnY" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "xox" = (
@@ -76969,7 +76710,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
 "xoO" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -77025,10 +76765,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xpK" = (
@@ -77066,6 +76806,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xqp" = (
@@ -77182,8 +76923,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xsU" = (
@@ -77196,7 +76937,6 @@
 /area/station/security/prison/safe)
 "xsY" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -77205,12 +76945,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "xsZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/aisat/solars)
 "xtk" = (
@@ -77242,7 +76983,6 @@
 /obj/machinery/modular_computer/preset/engineering,
 /obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom/directional/west,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
@@ -77268,7 +77008,6 @@
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Antechamber"
 	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/layer3,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
@@ -77320,17 +77059,16 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "xuU" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "xuV" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/science/xenobiology)
 "xva" = (
@@ -77409,9 +77147,12 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/safe)
 "xwu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/hallway)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/textured_half,
+/area/station/cargo/warehouse)
 "xww" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
@@ -77494,7 +77235,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/item/folder{
 	pixel_x = 6
@@ -77553,7 +77293,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "xyy" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -77610,7 +77349,6 @@
 "xzV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/navigate_destination/incinerator,
@@ -77618,6 +77356,7 @@
 	name = "Turbine Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "xzY" = (
@@ -77647,7 +77386,6 @@
 /obj/structure/sign/warning/electric_shock/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "xAK" = (
@@ -77738,12 +77476,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/aft/lesser)
 "xBJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/security/prison/safe/exterior)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/storage/gas)
 "xCy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/engine,
@@ -77768,7 +77505,6 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/lab)
 "xDa" = (
@@ -77823,17 +77559,16 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "xEI" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -77855,7 +77590,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
@@ -77865,10 +77599,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "xFs" = (
-/turf/open/misc/asteroid,
-/area/station/security/prison/safe/exterior)
-"xFv" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
+"xFv" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -77886,7 +77621,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/service/general,
@@ -77894,10 +77628,10 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "xGe" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -77906,6 +77640,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xGh" = (
@@ -77929,7 +77664,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
 "xGK" = (
@@ -77973,13 +77707,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "xHw" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "xHE" = (
@@ -77996,7 +77730,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/upper)
 "xHI" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
@@ -78026,7 +77759,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -78056,10 +77788,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "xIR" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/security/lockers)
 "xIT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -78077,13 +77811,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xIZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "xJf" = (
@@ -78118,17 +77851,17 @@
 "xJR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "xKl" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "xKo" = (
@@ -78164,6 +77897,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "xLd" = (
@@ -78293,7 +78027,6 @@
 /area/station/hallway/primary/starboard)
 "xNT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -78321,10 +78054,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "xOc" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "xOi" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
@@ -78339,7 +78074,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "xOV" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -78474,7 +78208,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_half,
 /area/station/science/robotics/lab)
 "xRm" = (
@@ -78490,7 +78223,6 @@
 /area/station/maintenance/disposal/incinerator)
 "xRG" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -78499,11 +78231,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "xRK" = (
 /obj/structure/sign/poster/official/random/directional/east,
-/obj/structure/cable,
 /obj/machinery/camera/directional/east{
 	c_tag = "Aft Primary Hallway - Central";
 	name = "Hallway Camera"
@@ -78556,8 +78288,8 @@
 /area/station/medical/medbay/central)
 "xTg" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "xTp" = (
@@ -78569,14 +78301,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/grille_or_waste,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "xTF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/cargo/storage)
 "xUc" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/corner,
@@ -78606,10 +78338,10 @@
 	c_tag = "Engineering - Engine SW";
 	network = list("ss13","engineering","engine")
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xUJ" = (
@@ -78636,7 +78368,6 @@
 /area/station/engineering/atmos)
 "xVb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -78648,10 +78379,10 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 6
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "xVF" = (
@@ -78734,9 +78465,9 @@
 	name = "Vacant Office Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "xXJ" = (
@@ -78762,11 +78493,11 @@
 /area/station/maintenance/department/medical)
 "xYu" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "seccheckpointshutters";
 	name = "Checkpoint Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs/fore)
 "xYx" = (
@@ -78856,9 +78587,9 @@
 	name = "Ordnance Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/science/ordnance/storage)
 "yaX" = (
@@ -78872,17 +78603,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "ybn" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ybs" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/hfr_room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/command/bridge)
 "ybA" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -78900,12 +78630,10 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "yci" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/maintenance/port)
+/area/station/command/heads_quarters/ce)
 "yck" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/trimline/purple/line,
@@ -78914,11 +78642,11 @@
 "yco" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/ai_all,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/storage/tech)
 "ycq" = (
@@ -78932,7 +78660,6 @@
 "ydd" = (
 /obj/effect/turf_decal/bot,
 /obj/item/stack/cable_coil,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/lab)
 "ydo" = (
@@ -79000,6 +78727,7 @@
 /area/station/science/xenobiology)
 "yeW" = (
 /obj/structure/lattice/catwalk,
+/obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/ai)
 "yfb" = (
@@ -79030,15 +78758,16 @@
 /area/station/command/gateway)
 "yfy" = (
 /obj/structure/chair/comfy/black,
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/bridge)
 "yfM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "yfU" = (
@@ -79065,9 +78794,9 @@
 	},
 /area/station/cargo/sorting)
 "ygu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "ygz" = (
@@ -79087,7 +78816,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "ygL" = (
@@ -79191,11 +78919,9 @@
 "yiz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "yiJ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
@@ -79219,7 +78945,6 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/window{
 	id = "gateshutter";
 	name = "Gateway Access Shutter"
@@ -79239,6 +78964,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/xenobiology)
 "yjC" = (
@@ -79308,7 +79034,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/item/kirbyplants/organic/plant20,
 /turf/open/floor/iron/dark,
@@ -79358,6 +79083,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/upper)
 "ylg" = (
@@ -79389,7 +79115,6 @@
 /obj/effect/turf_decal/bot,
 /obj/item/robot_suit,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/lab)
 "ylx" = (
@@ -88027,7 +87752,7 @@ aaa
 aaa
 bdQ
 cvS
-bgD
+bKG
 bYd
 bdQ
 aaa
@@ -88254,7 +87979,7 @@ aak
 aak
 bdQ
 bhY
-bgD
+bKG
 bkR
 bdQ
 aaa
@@ -88272,7 +87997,7 @@ aaa
 aaa
 bdQ
 bEq
-bgD
+bKG
 bhY
 bdQ
 aaa
@@ -88284,7 +88009,7 @@ aaa
 aaa
 bdQ
 bpe
-bgD
+bKG
 pMb
 bdQ
 aaa
@@ -88768,7 +88493,7 @@ bdQ
 bdQ
 bgC
 bhZ
-bgD
+bKG
 bhZ
 bgC
 bdQ
@@ -88786,7 +88511,7 @@ bdQ
 bdQ
 bgC
 bhZ
-bgD
+bKG
 bhZ
 bgC
 bdQ
@@ -88798,7 +88523,7 @@ aaa
 aaa
 bdQ
 bVR
-bgD
+bKG
 boX
 bdQ
 aaa
@@ -88811,7 +88536,7 @@ aae
 aae
 aak
 aak
-cgj
+cFl
 aak
 aae
 aae
@@ -89023,11 +88748,11 @@ aaa
 aaa
 bdQ
 oYj
-bgD
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
+bKG
 oOR
 bdQ
 bdQ
@@ -89040,12 +88765,12 @@ aaa
 aaa
 bdQ
 bdQ
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
 bJU
 bdQ
 aaa
@@ -89055,7 +88780,7 @@ aaa
 aaa
 bdQ
 bVS
-bgD
+bKG
 bYe
 bdQ
 aaa
@@ -89068,7 +88793,7 @@ aak
 aak
 aak
 aak
-cgj
+cFl
 aak
 aak
 aak
@@ -89280,12 +89005,12 @@ aak
 aak
 bdQ
 bfl
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
 boX
 bdR
 aaa
@@ -89297,12 +89022,12 @@ aaa
 aaa
 bdR
 boX
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
 bJV
 bdR
 aaa
@@ -89311,9 +89036,9 @@ aaa
 aaa
 aaa
 bdR
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 bdR
 aak
 aae
@@ -89325,7 +89050,7 @@ ceV
 ceV
 ceV
 aaa
-cgj
+cFl
 aaa
 ceV
 ceV
@@ -89537,12 +89262,12 @@ aaa
 aaa
 bdR
 bfm
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
 boY
 bdR
 aaa
@@ -89554,12 +89279,12 @@ aaa
 aaa
 bdR
 boY
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 mcT
 bvD
-bgD
+bKG
 bJW
 bdR
 aaa
@@ -89576,19 +89301,19 @@ aaa
 aae
 aak
 mCl
+cFl
+cFl
+cFl
+cFl
+cFl
+cAu
 cgj
-cgj
-cgj
-cgj
-cgj
-aOd
-cmO
-aOd
-cgj
-cgj
-cgj
-cgj
-cgj
+cAu
+cFl
+cFl
+cFl
+cFl
+cFl
 ceV
 aak
 aae
@@ -89794,10 +89519,10 @@ bdR
 bdR
 bdR
 srq
-bgD
+bKG
 bia
 mcT
-bgD
+bKG
 bmn
 bdR
 bdR
@@ -89813,10 +89538,10 @@ bdR
 bdR
 bdR
 bCQ
-bgD
+bKG
 mcT
-bgD
-bgD
+bKG
+bKG
 bJV
 bdR
 aaa
@@ -89825,8 +89550,8 @@ aaa
 aaa
 aaa
 bdR
-bgD
-bgD
+bKG
+bKG
 mcT
 bdR
 aaa
@@ -89839,7 +89564,7 @@ ceV
 ceV
 ceV
 aaa
-cmO
+cgj
 aaa
 ceV
 ceV
@@ -90050,12 +89775,12 @@ bnI
 boZ
 boZ
 bqp
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 bjk
 bkS
-bgD
+bKG
 jJa
 boZ
 qet
@@ -90069,11 +89794,11 @@ aaa
 bnI
 boZ
 bqp
-bgD
+bKG
 bEr
 bFP
-bgD
-bgD
+bKG
+bKG
 bJV
 bdR
 aaa
@@ -90082,8 +89807,8 @@ aaa
 aaa
 aaa
 bdR
-bgD
-bgD
+bKG
+bKG
 mcT
 bdR
 aaa
@@ -90096,7 +89821,7 @@ ceV
 ceV
 ceV
 aaa
-cmO
+cgj
 aaa
 ceV
 ceV
@@ -90114,21 +89839,21 @@ aae
 aak
 azn
 azn
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 azn
 azn
 aak
@@ -90307,9 +90032,9 @@ bdR
 bdR
 bdR
 bdR
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 bjl
 bkT
 bmn
@@ -90329,8 +90054,8 @@ bdR
 bCQ
 bEs
 bFQ
-bgD
-bgD
+bKG
+bKG
 abT
 bdQ
 aaa
@@ -90347,19 +90072,19 @@ aaa
 aae
 aak
 mCl
+cFl
+cFl
+cFl
+cFl
+cFl
+cAu
 cgj
-cgj
-cgj
-cgj
-cgj
-aOd
-cmO
-aOd
-cgj
-cgj
-cgj
-cgj
-cgj
+cAu
+cFl
+cFl
+cFl
+cFl
+cFl
 ceV
 aak
 aae
@@ -90371,7 +90096,7 @@ aae
 aak
 azn
 azn
-aOd
+cAu
 cAS
 cAS
 cAS
@@ -90385,7 +90110,7 @@ cAS
 cAS
 cAS
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -90565,12 +90290,12 @@ aaa
 aaa
 bdR
 cXQ
-bgD
-bgD
+bKG
+bKG
 bjm
 bkU
-bgD
-bgD
+bKG
+bKG
 bpa
 bdQ
 brQ
@@ -90582,12 +90307,12 @@ aaa
 aaQ
 bdQ
 bVS
-bgD
-bgD
+bKG
+bKG
 bEt
 bFR
-bgD
-bgD
+bKG
+bKG
 bJY
 bdQ
 aaa
@@ -90597,7 +90322,7 @@ aaa
 aaa
 bdQ
 dES
-bgD
+bKG
 mcT
 bdQ
 aak
@@ -90610,7 +90335,7 @@ ceV
 ceV
 ceV
 aaa
-cmO
+cgj
 aaa
 ceV
 ceV
@@ -90626,23 +90351,23 @@ aaa
 aaa
 aae
 aak
+ntX
 azn
-azn
-aOd
+cAu
 cAS
 cCf
-cDw
 cEI
-cDw
-cDw
+buT
 cEI
-cDw
-cDw
 cEI
-cDw
+buT
+cEI
+cEI
+buT
+cEI
 cMb
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -90822,12 +90547,12 @@ aaa
 aaa
 bdR
 bfp
-bgD
-bgD
+bKG
+bKG
 bjn
 bkV
-bgD
-bgD
+bKG
+bKG
 bpb
 bdR
 aaa
@@ -90839,12 +90564,12 @@ aaa
 aaa
 bdR
 vIK
-bgD
-bgD
+bKG
+bKG
 bEu
 bFS
-bgD
-bgD
+bKG
+bKG
 bJV
 bdR
 aaa
@@ -90853,8 +90578,8 @@ aaa
 aaa
 aaa
 bdR
-bgD
-bgD
+bKG
+bKG
 mcT
 bdR
 aDq
@@ -90867,7 +90592,7 @@ ceV
 ceV
 ceV
 aaa
-cmO
+cgj
 aaa
 ceV
 ceV
@@ -90885,21 +90610,21 @@ aae
 aak
 azn
 azn
-aOd
+cAu
 cAS
-cCg
+cCh
 cDx
 bZD
 bZD
-cDw
+cEI
 aaa
 cDy
 bZD
 bZD
 cJe
-cJf
+cMc
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -91079,12 +90804,12 @@ aaa
 aaa
 bdR
 bfm
-bgD
-bgD
+bKG
+bKG
 bjo
 bkW
-bgD
-bgD
+bKG
+bKG
 bpc
 bdR
 aaa
@@ -91096,12 +90821,12 @@ aaa
 aaa
 bdR
 bzD
-bgD
-bgD
+bKG
+bKG
 bEv
 bFT
-bgD
-bgD
+bKG
+bKG
 bJV
 bdR
 aaa
@@ -91110,27 +90835,27 @@ aaa
 aaa
 aaa
 bdR
-bgD
-bgD
+bKG
+bKG
 mcT
 bdR
 aaa
 aae
 aak
 ceV
+cFl
+cFl
+cFl
+cFl
+cFl
 cgj
 cgj
 cgj
-cgj
-cgj
-cmO
-cmO
-cmO
-cgj
-cgj
-cgj
-cgj
-cgj
+cFl
+cFl
+cFl
+cFl
+cFl
 ceV
 aak
 aae
@@ -91142,9 +90867,9 @@ aae
 aak
 azn
 azn
-aOd
+cAu
 cAS
-cCh
+sor
 bZD
 aaa
 aaa
@@ -91154,9 +90879,9 @@ cDy
 aaa
 aaa
 bZD
-cMc
+cRN
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -91336,12 +91061,12 @@ aaa
 aaa
 bdR
 bfm
-bgD
-bgD
+bKG
+bKG
 bjp
 bkX
-bgD
-bgD
+bKG
+bKG
 bpd
 bdQ
 brQ
@@ -91354,11 +91079,11 @@ aaQ
 bdQ
 bzE
 bBj
-bgD
+bKG
 bEw
 bFU
-bgD
-bgD
+bKG
+bKG
 bJV
 bdR
 aaa
@@ -91367,8 +91092,8 @@ aaa
 aaa
 aaa
 bdR
-bgD
-bgD
+bKG
+bKG
 mcT
 bdR
 aaa
@@ -91381,7 +91106,7 @@ ceV
 ceV
 ceV
 aaa
-cmO
+cgj
 aaa
 ceV
 ceV
@@ -91399,9 +91124,9 @@ aaf
 aak
 azn
 azn
-aOd
+cAu
 cAS
-cCg
+cCh
 bZD
 aaa
 cDy
@@ -91411,9 +91136,9 @@ cDy
 cDy
 aaa
 bZD
-cJf
+cMc
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -91592,9 +91317,9 @@ bdR
 bdR
 bdR
 bdR
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 bjq
 bkY
 bmn
@@ -91614,8 +91339,8 @@ bdR
 bCQ
 bEx
 bFV
-bgD
-bgD
+bKG
+bKG
 bJV
 bdR
 aaa
@@ -91624,7 +91349,7 @@ cmR
 bie
 aaa
 bdR
-bgD
+bKG
 bib
 wZV
 bdR
@@ -91638,7 +91363,7 @@ aak
 aak
 aak
 aak
-cmO
+cgj
 aak
 aak
 aak
@@ -91656,21 +91381,21 @@ aae
 aak
 azn
 azn
-aOd
+cAu
 cAS
-cCg
-cCg
+cCh
+cCh
 cDy
 cDy
 cDx
-cDw
+cEI
 cJe
 cDy
 cDy
 cDy
-cJf
+cMc
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -91849,12 +91574,12 @@ bnI
 boZ
 boZ
 bqp
-bgD
-bgD
+bKG
+bKG
 bib
 wZV
-bgD
-bgD
+bKG
+bKG
 jJa
 boZ
 qet
@@ -91868,11 +91593,11 @@ aaa
 bnI
 boZ
 bqp
-bgD
-bgD
+bKG
+bKG
 wZV
 bHi
-bgD
+bKG
 bJZ
 bdQ
 aaa
@@ -91882,7 +91607,7 @@ bdR
 aaa
 bdQ
 bVS
-bgD
+bKG
 bYg
 bdQ
 aaa
@@ -91913,21 +91638,21 @@ aae
 aak
 azn
 azn
-aOd
+cAu
 cAS
+sor
+aaa
+bZD
+cDy
 cCh
-aaa
-bZD
-cDy
-cCg
 aQC
-cJf
+cMc
 cDy
 bZD
 aaa
-cMc
+cRN
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -92107,10 +91832,10 @@ bdR
 bdR
 bdR
 jIh
-bgD
-bgD
+bKG
+bKG
 wZV
-bgD
+bKG
 bmn
 bdR
 bdR
@@ -92126,10 +91851,10 @@ bdR
 bdR
 bdR
 bCQ
-bgD
+bKG
 wZV
-bgD
-bgD
+bKG
+bKG
 uJo
 bdQ
 aaa
@@ -92138,8 +91863,8 @@ boZ
 bdR
 aaa
 bdQ
-bgD
-bgD
+bKG
+bKG
 wZV
 bdR
 aak
@@ -92152,7 +91877,7 @@ aaa
 aaa
 aaa
 aak
-cgj
+cFl
 aak
 aaa
 aaa
@@ -92170,21 +91895,21 @@ aae
 aak
 azn
 azn
-aOd
+cAu
 cAS
-cCg
+cCh
 cDy
 cDy
 cDy
 cDz
-cIh
+cDA
 cJg
 cDy
 cDy
-cJf
-cJf
+cMc
+cMc
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -92364,12 +92089,12 @@ aaa
 aaa
 bdR
 bfm
-bgD
-bgD
+bKG
+bKG
 wZV
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 boX
 bdR
 aaa
@@ -92381,12 +92106,12 @@ aaa
 aaa
 bdR
 boX
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 wZV
-bgD
-bgD
+bKG
+bKG
 bKb
 bdR
 bdR
@@ -92395,8 +92120,8 @@ boZ
 bdR
 bdR
 bdR
-bgD
-bgD
+bKG
+bKG
 wZV
 bdR
 aak
@@ -92404,12 +92129,12 @@ aaa
 aaa
 aaa
 aaa
-cgj
-cgj
-cgj
-cgj
-cgj
-cgj
+cFl
+cFl
+cFl
+cFl
+cFl
+cFl
 aaa
 aaa
 aaa
@@ -92427,9 +92152,9 @@ aae
 aak
 azn
 azn
-aOd
+cAu
 cAS
-cCg
+cCh
 bZD
 aaa
 cDy
@@ -92439,9 +92164,9 @@ cDy
 cDy
 aaa
 bZD
-cJf
+cMc
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -92621,12 +92346,12 @@ aaa
 aaa
 bdR
 bfm
-bgD
-bgD
+bKG
+bKG
 wZV
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 hxF
 bdR
 aaa
@@ -92638,22 +92363,22 @@ aaa
 aaa
 bdR
 hxF
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 wZV
-bgD
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
+bKG
 bdR
 bQp
 bdR
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
 wZV
 bdR
 aak
@@ -92684,9 +92409,9 @@ aae
 aak
 azn
 azn
-aOd
+cAu
 cAS
-cCh
+sor
 bZD
 aaa
 aaa
@@ -92696,9 +92421,9 @@ cDy
 aaa
 aaa
 bZD
-cMc
+cRN
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -92857,7 +92582,7 @@ aae
 aae
 aak
 aak
-aGh
+aJV
 aak
 aak
 aae
@@ -92878,12 +92603,12 @@ aaa
 aaa
 bdR
 bfs
-bgD
-bgD
+bKG
+bKG
 wZV
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 bpf
 bdQ
 bdQ
@@ -92895,8 +92620,8 @@ bdQ
 bdQ
 bdQ
 bzF
-bgD
-bgD
+bKG
+bKG
 wZV
 wZV
 wZV
@@ -92941,21 +92666,21 @@ aae
 aak
 azn
 azn
-aOd
+cAu
 cAS
-cCg
+cCh
 cDz
 bZD
 bZD
 cDy
 aaa
-cIh
+cDA
 bZD
 bZD
 cJg
-cJf
+cMc
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -93114,7 +92839,7 @@ aak
 aak
 aak
 aak
-aGh
+aJV
 aak
 aak
 aak
@@ -93135,14 +92860,14 @@ aaa
 aaa
 bdR
 bfm
-bgD
-bgD
+bKG
+bKG
 wZV
 wZV
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
 tmp
 bgC
 btI
@@ -93150,9 +92875,9 @@ bum
 bvi
 bvB
 bwI
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 wZV
 wZV
 bvG
@@ -93161,14 +92886,14 @@ bHj
 bHj
 bHj
 bNd
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
 bdR
 aaa
 aaa
@@ -93198,21 +92923,21 @@ aae
 aak
 azn
 azn
-aOd
+cAu
 cAS
 cCi
-cDA
-cDA
-cDA
-cDA
-cDA
-cDA
-cDA
-cDA
-cDA
+fxZ
+fxZ
+fxZ
+fxZ
+fxZ
+fxZ
+fxZ
+fxZ
+fxZ
 cMd
 cAS
-aOd
+cAu
 azn
 azn
 aak
@@ -93371,7 +93096,7 @@ aFj
 aFj
 aFj
 aaa
-aGh
+aJV
 aaa
 aFj
 aFj
@@ -93392,38 +93117,38 @@ aaa
 aaa
 bdQ
 bfy
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 wZV
 wZV
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
+bKG
 wZV
 wZV
 bvG
 bxG
-bgD
-bgD
 bKG
-bLV
+bKG
+bVM
+abd
 dJx
-bgD
+bKG
 bQS
 bSz
 bTt
-bVm
-bgD
+bLV
+bKG
 bXz
 boX
 bdQ
@@ -93455,21 +93180,21 @@ aae
 aak
 azn
 azn
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
 cAu
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+aWH
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 azn
 azn
 aak
@@ -93622,19 +93347,19 @@ aaa
 aae
 aak
 aFj
-aGh
-aGh
-aGh
-aGh
-aGh
+aJV
+aJV
 aJV
 aJV
 aJV
 aGh
 aGh
 aGh
-aGh
-aGh
+aJV
+aJV
+aJV
+aJV
+aJV
 aFj
 aak
 aae
@@ -93649,22 +93374,22 @@ aak
 aak
 bdQ
 bfA
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
 wZV
 wZV
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
 bsz
 btK
 bun
 btK
 bsz
-bgD
-bgD
+bKG
+bKG
 wZV
 wZV
 bvG
@@ -93713,19 +93438,19 @@ aak
 azn
 azn
 azn
-aOd
+cAu
 azn
 azn
-cCj
-cCj
-cCj
 cIi
-cCj
-cCj
-cCj
+cIi
+cIi
+gLu
+cIi
+cIi
+cIi
 azn
 azn
-aOd
+cAu
 azn
 azn
 azn
@@ -93885,7 +93610,7 @@ aFj
 aFj
 aFj
 aaa
-aJV
+aGh
 aaa
 aFj
 aFj
@@ -93907,28 +93632,28 @@ aae
 bdS
 azQ
 bgI
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
 wZV
 wZV
-bgD
-bgD
+bKG
+bKG
 bsz
 bsz
 bsz
 bsz
 bsz
-bgD
+bKG
 wZV
 wZV
 bvG
 bxG
 bKG
 bKG
-bgD
-bgD
+bKG
+bKG
 nCC
 nCC
 gOx
@@ -93970,19 +93695,19 @@ aak
 azn
 aak
 aak
-aOd
+cAu
 aak
 aak
-cCj
+cIi
 cFG
 cGV
-cGV
+aVk
 cGV
 cJU
-cCj
+cIi
 aak
 aak
-aOd
+cAu
 aak
 aak
 azn
@@ -94142,7 +93867,7 @@ aFj
 aFj
 aFj
 aaa
-aJV
+aGh
 aaa
 aFj
 aFj
@@ -94167,14 +93892,14 @@ azQ
 bif
 bju
 bvK
-bgD
-bgD
+bKG
+bKG
 wZV
 wZV
-bgD
+bKG
 bib
 xDE
-bgD
+bKG
 mcT
 bvD
 wZV
@@ -94227,19 +93952,19 @@ aak
 aaj
 aak
 aak
-aOd
+cAu
 aak
 aak
-cCj
+cIi
 cFH
+cJi
 cDB
-cDB
-cDB
+cJi
 cJV
-cCj
+cIi
 aak
 aak
-aOd
+cAu
 aak
 aak
 aae
@@ -94393,19 +94118,19 @@ aaa
 aae
 aak
 aFj
-aGh
-aGh
-aGh
-aGh
-aGh
 aJV
+aJV
+aJV
+aJV
+aJV
+aGh
 aKN
+aGh
 aJV
-aGh
-aGh
-aGh
-aGh
-aGh
+aJV
+aJV
+aJV
+aJV
 aFj
 aak
 aae
@@ -94425,13 +94150,13 @@ azQ
 bjC
 ble
 bvK
-bgD
-bgD
+bKG
+bKG
 wZV
 wZV
-bgD
+bKG
 xDE
-bgD
+bKG
 mcT
 wZV
 wZV
@@ -94483,21 +94208,21 @@ aak
 aak
 aaj
 aak
-aOd
-aOd
+cAu
+cAu
 aak
 aak
 cEJ
 cFI
+cJi
 cDB
-cDB
-cGW
+cJh
 cJW
 cEJ
 aak
 aak
-aOd
-aOd
+cAu
+cAu
 aak
 aae
 aak
@@ -94656,7 +94381,7 @@ aFj
 aFj
 aFj
 aaa
-aJV
+aGh
 aaa
 aFj
 aFj
@@ -94683,8 +94408,8 @@ azQ
 blf
 bwp
 bvK
-bgD
-bgD
+bKG
+bKG
 wZV
 wZV
 wZV
@@ -94722,7 +94447,7 @@ qnC
 nCC
 nCC
 nCC
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -94740,21 +94465,21 @@ aak
 aak
 aaj
 aak
-aOd
-cCj
-cCj
-cCj
+cAu
+cIi
+cIi
+cIi
 cEK
 cFH
+cJi
 cDB
-cDB
-cDB
+cJi
 gPq
 cEK
-cCj
-cCj
-cCj
-aOd
+cIi
+cIi
+cIi
+cAu
 aak
 aae
 aak
@@ -94913,7 +94638,7 @@ aFj
 aFj
 aFj
 aaa
-aJV
+aGh
 aaa
 aFj
 aFj
@@ -94941,12 +94666,12 @@ azQ
 bmI
 bwp
 bvK
-bgD
-bgD
-bgD
-bgD
+bKG
+bKG
+bKG
+bKG
 wZV
-bgD
+bKG
 bvG
 bxG
 bKG
@@ -94958,7 +94683,7 @@ nCC
 nCC
 nCC
 nCC
-wgY
+aqD
 wra
 qNV
 rFw
@@ -94997,21 +94722,21 @@ aak
 aak
 aaj
 aak
-aOd
+cAu
 cSk
-cJi
-ngT
+cDB
+cDB
 cXV
-cFH
+lnI
 cGW
 iSn
-cJh
-cJV
+cGW
+dPM
 cXW
-cJi
-cJi
+cDB
+cDB
 cXY
-aOd
+cAu
 aak
 aae
 aak
@@ -95164,19 +94889,19 @@ aaa
 aae
 aak
 aFw
-aGh
-aGh
-aGh
-aGh
-aGh
+aJV
+aJV
 aJV
 aJV
 aJV
 aGh
 aGh
 aGh
-aGh
-aGh
+aJV
+aJV
+aJV
+aJV
+aJV
 aFj
 aak
 aae
@@ -95185,7 +94910,7 @@ aVf
 aWg
 aXb
 aXW
-caE
+aWu
 bam
 aXd
 bcC
@@ -95199,10 +94924,10 @@ azQ
 rvs
 bpi
 bvK
-bgD
-bgD
-bgD
-bTj
+bKG
+bKG
+bKG
+wZV
 bKG
 cRm
 bKG
@@ -95212,31 +94937,31 @@ fUB
 nCC
 nCC
 bWu
-dPM
-dPM
+cKk
+cKk
 gfs
-dPM
+cKk
 uUR
 fGO
 bWu
 wgY
 gXw
 uNc
-fzn
+qjW
 gae
 nCC
 jAb
 qxH
 mLN
 bWu
-fzn
+qjW
 gYn
 cbP
 fGN
 nCC
 nCC
 nCC
-aOd
+cAu
 aaa
 aaa
 aae
@@ -95254,21 +94979,21 @@ aak
 aak
 aaj
 aak
-aOd
-cCj
-cCj
-cCj
+cAu
+cIi
+cIi
+cIi
 cEM
 cFJ
-cDB
-cDB
 cJi
 cDB
+cJi
+cJi
 cEM
-cCj
-cCj
-cCj
-aOd
+cIi
+cIi
+cIi
+cAu
 aak
 aae
 aaa
@@ -95427,7 +95152,7 @@ aFj
 aFj
 aFj
 aaa
-aJV
+aGh
 aaa
 aFj
 aFj
@@ -95442,7 +95167,7 @@ aVf
 qDa
 aXc
 aXX
-caE
+aWu
 ban
 aXd
 bcD
@@ -95456,13 +95181,13 @@ azQ
 azQ
 bpo
 nis
-bgD
-bgD
-bgD
-bTj
-bgD
-bvH
-bgD
+bKG
+bKG
+bKG
+wZV
+bKG
+cRm
+bKG
 oxF
 hOh
 nCC
@@ -95511,8 +95236,8 @@ aak
 aak
 aak
 aak
-aOd
-aOd
+cAu
+cAu
 aak
 aak
 cEM
@@ -95524,9 +95249,9 @@ cLn
 cEM
 aak
 aak
-aOd
-aOd
-aOd
+cAu
+cAu
+cAu
 aae
 aaa
 aaa
@@ -95632,7 +95357,7 @@ aaa
 aaa
 aaa
 aak
-aOd
+cAu
 uPb
 uPb
 aGm
@@ -95684,7 +95409,7 @@ aak
 aak
 aak
 aak
-aJV
+aGh
 aak
 aak
 aak
@@ -95699,7 +95424,7 @@ aVf
 aWx
 aTS
 aWk
-aWu
+xdD
 bay
 bbK
 bdm
@@ -95713,13 +95438,13 @@ bfv
 azQ
 azQ
 bqz
-bgD
-bgD
-bgD
-bTj
-bgD
-bvH
-bgD
+bKG
+bKG
+bKG
+wZV
+bKG
+cRm
+bKG
 aDl
 nCC
 nCC
@@ -95768,7 +95493,7 @@ aak
 aak
 aak
 aak
-aOd
+cAu
 aaj
 aaj
 aaj
@@ -95783,9 +95508,9 @@ aae
 aae
 aae
 aak
-aOd
+cAu
 aae
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -95941,7 +95666,7 @@ aae
 aae
 aaa
 aaa
-aJV
+aGh
 aaa
 aaa
 aaa
@@ -95971,17 +95696,17 @@ azQ
 azQ
 azQ
 brZ
-bgD
-bgD
-bTj
-bgD
+bKG
+bKG
+wZV
+bKG
 bwF
 bwZ
 nCC
 nCC
-xIZ
-xIZ
-yci
+rhq
+rhq
+lEh
 uGE
 tnV
 uGE
@@ -96023,27 +95748,27 @@ aak
 aak
 aak
 aak
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 aak
 aak
 aak
@@ -96215,8 +95940,8 @@ aCR
 aXY
 aWw
 baV
-aAi
-aAi
+aCR
+aCR
 bet
 bfL
 eLa
@@ -96235,7 +95960,7 @@ aLY
 bON
 nCC
 nCC
-yci
+lEh
 xIZ
 nNa
 uiC
@@ -96297,7 +96022,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aak
 aaa
 aaa
@@ -96412,7 +96137,7 @@ sxa
 sxa
 uPb
 uPb
-aOd
+cAu
 aak
 aaa
 aaa
@@ -96455,9 +96180,9 @@ aaa
 aaa
 aaa
 aaa
-aGh
-aGh
-aGh
+aJV
+aJV
+aJV
 bfo
 aRj
 aRj
@@ -96467,23 +96192,23 @@ aSf
 aTd
 aUd
 aCR
-aWl
-aAi
-caF
+btS
+aCR
+bJf
 aAi
 qgO
 azQ
 ovt
 aAi
-aAi
-aAi
+aCR
+aCR
 bio
-aAi
-aAi
-aAi
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
+aCR
+aCR
+aCR
 bio
 qfG
 bsI
@@ -96554,7 +96279,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aak
 aaa
 aaa
@@ -96670,7 +96395,7 @@ sxa
 uPb
 uPb
 uPb
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -96724,9 +96449,9 @@ aSs
 aTy
 azQ
 aCp
-aWl
+btS
 aXe
-caF
+bJf
 azQ
 azQ
 azQ
@@ -96743,10 +96468,10 @@ azQ
 azQ
 aIT
 bsI
-bsI
-xTF
+bWo
+wFX
 lpB
-wRO
+uXW
 oir
 cKk
 rfy
@@ -96811,7 +96536,7 @@ aae
 aae
 aak
 aak
-aOd
+cAu
 aak
 aak
 aak
@@ -96981,9 +96706,9 @@ myn
 myn
 azQ
 azQ
-aWl
+btS
 aBB
-caF
+bJf
 azQ
 baq
 baq
@@ -97011,7 +96736,7 @@ nCC
 nCC
 nCC
 uGE
-kuB
+dqG
 uGE
 oZE
 qge
@@ -97068,7 +96793,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aak
 aaa
 aaa
@@ -97238,9 +96963,9 @@ aaa
 aaa
 azQ
 aGQ
-aWl
+btS
 aGU
-caF
+bJf
 azQ
 baq
 baq
@@ -97257,10 +96982,10 @@ bpk
 rxH
 brU
 pHZ
-btP
-xTF
-bsI
-bsI
+bLr
+wFX
+bWo
+bWo
 bwM
 vGW
 qZI
@@ -97325,7 +97050,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aak
 aaa
 aaa
@@ -97430,13 +97155,13 @@ akK
 akK
 akK
 akK
-ajP
+fGv
 awx
 akK
 fjj
 aGn
 erK
-dMJ
+lLI
 lLI
 dMJ
 ane
@@ -97495,9 +97220,9 @@ aaa
 aaa
 azQ
 aGU
-aWl
+btS
 ovt
-caF
+bJf
 azQ
 baq
 baq
@@ -97514,10 +97239,10 @@ bpk
 rxH
 brU
 pHZ
-btP
+bLr
 buu
-tKH
-tKH
+lpB
+lpB
 bwN
 peV
 qiA
@@ -97525,7 +97250,7 @@ diS
 diS
 lvY
 xXC
-fKe
+pbj
 uGE
 twr
 twr
@@ -97676,7 +97401,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 uPb
 uPb
 afJ
@@ -97687,28 +97412,28 @@ akK
 akK
 ajO
 awc
-ajP
+fGv
 awx
 ajP
 fjj
 aHV
-eLL
-agl
+eBL
 hBG
-agl
+mWw
+hBG
 anS
 aDC
-abd
-abd
+agM
+agM
 vHl
 vHl
 ahI
 xSp
-abd
-abd
+agM
+agM
 vHl
-qUl
-qUl
+jQo
+jQo
 hgQ
 qFR
 lWQ
@@ -97752,9 +97477,9 @@ aDr
 azQ
 azQ
 azQ
-aWl
+btS
 aBB
-caF
+bJf
 azQ
 baq
 baq
@@ -97771,10 +97496,10 @@ bpl
 bqt
 aZp
 aJy
-btP
-xTF
-bsI
-bsI
+bLr
+wFX
+bWo
+bWo
 bwM
 slx
 cuo
@@ -97791,7 +97516,7 @@ noc
 hyO
 maP
 mSK
-uNc
+qvG
 ioE
 rhq
 cXm
@@ -97949,17 +97674,17 @@ awy
 awx
 aDC
 rgk
-eLL
+eBL
 hBG
 lMU
 agX
 pll
 apt
-ahg
+mDp
 ght
-ahg
-ahg
-ahg
+mDp
+mDp
+mDp
 rYD
 dXk
 obv
@@ -97972,11 +97697,11 @@ giP
 xMT
 wSH
 xRd
-xFs
-xFs
+hFH
+hFH
 wSH
 wSH
-aOd
+cAu
 aak
 aaa
 aaa
@@ -98009,9 +97734,9 @@ fYE
 eLa
 azQ
 lFl
-aWl
+btS
 aXf
-caF
+bJf
 azQ
 baq
 baq
@@ -98029,9 +97754,9 @@ bqu
 bsa
 bsG
 btQ
-xTF
-bsI
-bsI
+wFX
+bWo
+bWo
 bwM
 vCl
 tpU
@@ -98039,7 +97764,7 @@ tQk
 gCS
 ykM
 uGE
-pNZ
+vsK
 sJt
 mSK
 dnV
@@ -98063,7 +97788,7 @@ aak
 uyy
 coW
 kWl
-cwt
+qTm
 jse
 gkR
 dyp
@@ -98076,7 +97801,7 @@ fdm
 npJ
 hci
 hja
-cwt
+qTm
 jSV
 coW
 aaa
@@ -98188,7 +97913,7 @@ aaa
 aaa
 aaa
 aak
-aOd
+cAu
 uPb
 uPb
 uPb
@@ -98207,7 +97932,7 @@ ajP
 aDC
 mMJ
 eBL
-agl
+hBG
 lNc
 adz
 ptZ
@@ -98229,9 +97954,9 @@ wJJ
 nSD
 szE
 dtl
-xFs
+hFH
 arD
-xFs
+hFH
 wSH
 wSH
 xRd
@@ -98266,9 +97991,9 @@ aAi
 aAi
 aOc
 aAi
-aWl
+btS
 aXg
-caF
+bJf
 azQ
 baq
 baq
@@ -98286,9 +98011,9 @@ bqv
 aZp
 pHZ
 btR
-tKH
+lpB
 aUO
-bsI
+bWo
 bwM
 evl
 isd
@@ -98296,7 +98021,7 @@ bba
 pmJ
 kBP
 uGE
-pNZ
+vsK
 mFd
 mSK
 esw
@@ -98464,9 +98189,9 @@ ajP
 fjj
 aNA
 eBL
-agl
+hBG
 ajJ
-agl
+hBG
 pYV
 wJJ
 sgL
@@ -98485,11 +98210,11 @@ eFX
 wNO
 hXo
 mkQ
-xFs
+hFH
 lRl
 alv
-xFs
-xFs
+hFH
+hFH
 wSH
 wSH
 aaa
@@ -98523,9 +98248,9 @@ aAi
 aCp
 azQ
 aEm
-aWl
+btS
 aBB
-caF
+bJf
 azQ
 baq
 baq
@@ -98542,10 +98267,10 @@ bFi
 bqw
 aZp
 bsH
-btP
-xTF
-bsI
-bsI
+bLr
+wFX
+bWo
+bWo
 bwM
 jmX
 oPG
@@ -98553,7 +98278,7 @@ hya
 vCl
 biK
 uGE
-roC
+hfI
 aSE
 mSK
 oZh
@@ -98780,9 +98505,9 @@ aDr
 azQ
 azQ
 aVi
-aWl
+btS
 aBB
-caF
+bJf
 azQ
 baq
 baq
@@ -98800,9 +98525,9 @@ bqx
 aZp
 aTN
 bLr
-xTF
-bsI
-bsI
+wFX
+bWo
+bWo
 bwM
 bwM
 tEm
@@ -98810,8 +98535,8 @@ bwM
 bBn
 bwM
 uGE
-roC
-dqG
+hfI
+kuB
 mSK
 vgZ
 mla
@@ -98972,7 +98697,7 @@ ajP
 akK
 akK
 ajP
-ajP
+fGv
 akK
 akK
 fjj
@@ -98993,7 +98718,7 @@ qNq
 nOb
 wJJ
 ixP
-yag
+bse
 wJJ
 wJJ
 wJJ
@@ -99001,8 +98726,8 @@ nSD
 sov
 xLp
 jQM
-xFs
-xFs
+hFH
+hFH
 wSH
 wSH
 xRd
@@ -99056,9 +98781,9 @@ hws
 bqA
 aZp
 bsJ
-btP
-xTF
-bsI
+bLr
+wFX
+bWo
 bvN
 bwM
 suO
@@ -99067,7 +98792,7 @@ mdh
 nRe
 trM
 uGE
-ntr
+cmO
 qtA
 mSK
 oZh
@@ -99234,11 +98959,11 @@ afJ
 akK
 xFG
 aQL
-lxa
-lxa
-msu
-lxa
-lxa
+aoe
+aoe
+oaI
+aoe
+aoe
 rsm
 dVU
 lLk
@@ -99257,7 +98982,7 @@ dyK
 wbW
 wSH
 xRd
-xFs
+hFH
 fHa
 wSH
 wSH
@@ -99294,9 +99019,9 @@ aaa
 aaa
 azQ
 eLa
-aWl
+btS
 aGU
-caF
+bJf
 azQ
 azQ
 azQ
@@ -99313,9 +99038,9 @@ azQ
 azQ
 azQ
 bsS
-btP
-xTF
-bsI
+bLr
+wFX
+bWo
 bvO
 bwM
 ohO
@@ -99324,21 +99049,21 @@ giA
 gsn
 gVY
 uGE
-mFd
+sJj
 pNZ
 mSK
 mSK
-fLL
+cjZ
 iTN
 vrI
 xCE
 mSK
-ntr
+cmO
 kuB
 etg
 kPE
 eUt
-lhQ
+rSo
 aak
 cKh
 cKh
@@ -99486,7 +99211,7 @@ ajP
 avs
 avx
 avx
-avx
+bGx
 avx
 akK
 xFG
@@ -99506,8 +99231,8 @@ rQv
 jJh
 ggI
 vhC
-tdC
-iMP
+bvz
+cxi
 aqB
 ajB
 uYI
@@ -99518,7 +99243,7 @@ lLw
 ydB
 wSH
 wSH
-aOd
+cAu
 kpo
 aaa
 aaa
@@ -99552,27 +99277,27 @@ azQ
 azQ
 aVj
 aWm
-ovt
-caF
+gtn
+aWw
 aAi
 aAi
 azQ
-aCR
-aCR
-aCR
-aCR
-aCR
-aCR
+aAi
+aAi
+aAi
+aAi
+aAi
+aAi
 bJf
-byn
-byn
-byn
+uJd
+uJd
+uJd
 uJd
 bsf
 rdy
-btS
-xTF
-bsI
+wRO
+wFX
+bWo
 cXw
 bwM
 nbZ
@@ -99582,20 +99307,20 @@ hyj
 vCl
 uGE
 nAS
-dqG
+kuB
 rql
 mSK
 wVg
-elM
+fLL
 teD
 lPj
 mSK
-nnH
+rcL
 duS
 etg
 kPE
 nnH
-lhQ
+rSo
 aak
 cKh
 cLO
@@ -99743,11 +99468,11 @@ ajP
 avr
 ajP
 awi
-avx
+bGx
 avx
 awz
 xFG
-lxa
+aoe
 fAy
 hZD
 mEw
@@ -99809,27 +99534,27 @@ aTg
 azQ
 vQJ
 byn
+uJd
+aWw
 byn
-bJf
-byn
-byn
-byn
-byn
+uJd
+uJd
+uJd
 mZH
 wWi
 bgW
 vaz
 mZH
-caF
+bJf
 aAi
 aIp
 lFl
 aCp
 azQ
 bsM
-btP
-xTF
-bsI
+bLr
+wFX
+bWo
 cXx
 bwO
 bwO
@@ -99838,7 +99563,7 @@ bwO
 uGE
 uGE
 uGE
-uGE
+fXO
 nCJ
 llH
 mSK
@@ -99850,9 +99575,9 @@ mSK
 lEg
 sUh
 uGE
-pMa
+kPE
 ntr
-lhQ
+rSo
 aak
 cKh
 uky
@@ -100000,7 +99725,7 @@ ajP
 avr
 ajP
 awj
-awu
+awA
 awu
 awA
 aFg
@@ -100029,7 +99754,7 @@ okU
 wbW
 hwe
 hFH
-xFs
+hFH
 wSH
 wSH
 wSH
@@ -100064,7 +99789,7 @@ aQa
 aQa
 aTh
 azQ
-aVk
+aWl
 byn
 azQ
 azQ
@@ -100084,9 +99809,9 @@ azQ
 azQ
 azQ
 cXr
-btP
-xTF
-bsI
+bLr
+wFX
+bWo
 rSW
 bwO
 xKp
@@ -100096,8 +99821,8 @@ xAQ
 lEg
 lEg
 jBK
-fxZ
-gtn
+fKe
+pNZ
 mSK
 tkg
 kIv
@@ -100107,7 +99832,7 @@ mSK
 fvO
 uGE
 uGE
-pMa
+kPE
 efg
 uGE
 aak
@@ -100132,7 +99857,7 @@ uFJ
 uFJ
 fvH
 uFJ
-uFJ
+qGS
 jul
 vhN
 jsN
@@ -100156,17 +99881,17 @@ mRm
 aak
 aak
 xHL
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
-aOd
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
+cAu
 xHL
 aak
 aak
@@ -100284,10 +100009,10 @@ trL
 nLb
 cMk
 wbW
-xFs
+hFH
 qMK
-xFs
-fXO
+hFH
+wXH
 wSH
 wSH
 wSH
@@ -100321,7 +100046,7 @@ aQa
 aRn
 aTi
 azQ
-aVk
+aWl
 byn
 azQ
 aYc
@@ -100341,10 +100066,10 @@ bfE
 bfI
 aXj
 aHf
-btP
-xTF
-bsI
-bsI
+bLr
+wFX
+bWo
+bWo
 plk
 wSZ
 jYD
@@ -100354,7 +100079,7 @@ uGE
 bKp
 efg
 vUi
-fde
+kuB
 mSK
 mSK
 mSK
@@ -100364,7 +100089,7 @@ mSK
 lEg
 tdd
 uGE
-pMa
+kPE
 rql
 uGE
 aak
@@ -100412,7 +100137,7 @@ aak
 mRm
 aak
 aaa
-aOd
+cAu
 aak
 aaa
 aak
@@ -100424,7 +100149,7 @@ aaa
 aak
 aaa
 aak
-aOd
+cAu
 aak
 aaa
 aaa
@@ -100578,7 +100303,7 @@ aQa
 aQa
 aQa
 ngq
-aVk
+aWl
 byn
 azQ
 aYd
@@ -100597,11 +100322,11 @@ bnR
 bpq
 bfF
 brX
-bsI
-btP
-xTF
-bsI
-bsI
+bWo
+bLr
+wFX
+bWo
+bWo
 hxr
 tFI
 rAl
@@ -100612,18 +100337,18 @@ eoX
 jSw
 tnO
 pkB
-fde
 kuB
-vsK
+kuB
+pNZ
 kuB
 dwB
 uGE
-pwf
+roC
 jKZ
 hLY
-pMa
+kPE
 qBN
-lhQ
+rSo
 aak
 cKh
 cLQ
@@ -100646,9 +100371,9 @@ xyg
 uPO
 uPO
 uPO
-uPO
+gii
 rRm
-cwt
+qTm
 gsl
 iNN
 qBJ
@@ -100669,7 +100394,7 @@ aaa
 mRm
 aak
 aaa
-aOd
+cAu
 aak
 aaa
 aak
@@ -100681,7 +100406,7 @@ aaa
 aak
 aaa
 aak
-aOd
+cAu
 aak
 aaa
 aaa
@@ -100779,7 +100504,7 @@ dkw
 foR
 iHe
 nMK
-lxa
+aoe
 acI
 rtS
 agk
@@ -100790,7 +100515,7 @@ agk
 bFO
 exl
 pQc
-ajG
+bFO
 adx
 pwp
 wmT
@@ -100839,7 +100564,7 @@ uZF
 byn
 azQ
 aYe
-cfe
+aZs
 bat
 bbD
 aXj
@@ -100854,11 +100579,11 @@ bnS
 bjy
 bfK
 brX
-bsI
-btP
-xTF
-bsI
-bsI
+bWo
+bLr
+wFX
+bWo
+bWo
 bwR
 rgB
 kcN
@@ -100872,15 +100597,15 @@ uGE
 kuB
 dsF
 dmZ
-pwf
-pwf
+roC
+roC
 wWy
-pwf
+roC
 wTj
 hLY
-pMa
+kPE
 qBN
-lhQ
+rSo
 aak
 cKh
 eGd
@@ -100903,9 +100628,9 @@ crj
 crj
 crj
 crj
-crj
+aSX
 rRm
-cwt
+qTm
 iNN
 iNN
 xIT
@@ -100926,7 +100651,7 @@ aaa
 mRm
 aak
 aaa
-aOd
+cAu
 aak
 aaa
 aak
@@ -100938,7 +100663,7 @@ aaa
 aak
 aaa
 aak
-aOd
+cAu
 aak
 aaa
 aaa
@@ -101033,31 +100758,31 @@ avx
 pkx
 xFG
 xFG
-lxa
+aoe
 iPA
 oaI
-aoe
-aoe
+bWE
+bWE
 duF
-agM
-uBx
-jQo
-jQo
-jQo
-pAZ
-jQo
-uBx
+cCg
 fyd
-qUl
-abd
+aYz
+aYz
+aYz
+pAZ
+aYz
+fyd
+fyd
+jQo
+agM
 aqB
 bkM
 dOP
 tVm
 wbW
-xFs
+hFH
 wXH
-fXO
+wXH
 wSH
 wSH
 wSH
@@ -101092,7 +100817,7 @@ aQa
 aRn
 aQa
 azQ
-aVk
+aWl
 byn
 azQ
 aXi
@@ -101105,7 +100830,7 @@ bfE
 bfF
 bfG
 bjy
-big
+bGn
 bjy
 bnT
 bpr
@@ -101137,7 +100862,7 @@ jDR
 uGE
 ovL
 nnH
-lhQ
+rSo
 aak
 cKh
 cLQ
@@ -101160,7 +100885,7 @@ ood
 crj
 crj
 rCg
-crj
+aSX
 rRm
 tQh
 iNN
@@ -101183,9 +100908,9 @@ aaa
 mRm
 aak
 aaa
-aOd
+cAu
 aak
-aOd
+cAu
 cDD
 cFL
 cDD
@@ -101195,7 +100920,7 @@ cFL
 cDD
 cFL
 aak
-aOd
+cAu
 aak
 aaa
 aaa
@@ -101292,13 +101017,13 @@ akK
 xFG
 haH
 jaf
-iET
+caP
 iET
 aeh
 uKU
 uKU
 uHl
-vgS
+amw
 uKU
 uKU
 uKU
@@ -101360,18 +101085,18 @@ bcF
 bdY
 bfF
 bgK
-big
+bGn
 bjy
-big
+bGn
 bjy
 bnU
 bmu
 bfI
 brX
 bsN
-btP
-xTF
-bsI
+bLr
+wFX
+bWo
 bvS
 bwO
 uts
@@ -101392,7 +101117,7 @@ wDx
 gsU
 vwl
 iSZ
-pMa
+kPE
 rql
 uGE
 aak
@@ -101417,7 +101142,7 @@ crj
 crj
 crj
 crj
-pRz
+crm
 gzw
 kym
 jqq
@@ -101440,7 +101165,7 @@ aak
 mRm
 aak
 aak
-aOd
+cAu
 aaa
 llp
 cEN
@@ -101452,7 +101177,7 @@ rxm
 cEN
 vff
 aaa
-aOd
+cAu
 aak
 aak
 aak
@@ -101617,19 +101342,19 @@ bcF
 bdZ
 bfG
 bgL
-big
+bGn
 bjz
-big
+bGn
 bjz
 bnV
 bjz
 bfJ
 brY
-cpG
-btP
-xTF
-bsI
-bsI
+bVy
+bLr
+wFX
+bWo
+bWo
 bwO
 bwO
 bwO
@@ -101649,9 +101374,9 @@ btG
 dBU
 yky
 gYz
-pMa
+kPE
 efg
-lhQ
+rSo
 aak
 cKh
 oBL
@@ -101674,7 +101399,7 @@ crj
 crj
 crj
 crj
-crj
+aSX
 rRm
 vRW
 kVc
@@ -101697,7 +101422,7 @@ aaa
 mRm
 aak
 aaa
-aOd
+cAu
 aaa
 ioj
 cEN
@@ -101709,7 +101434,7 @@ rxm
 cEN
 lqo
 aaa
-aOd
+cAu
 aak
 aaa
 aaa
@@ -101823,7 +101548,7 @@ snh
 hCL
 ntG
 ngH
-xBJ
+ajD
 chm
 aoH
 rVh
@@ -101856,9 +101581,9 @@ aDr
 aDr
 azQ
 azQ
-aOd
-aOd
-aOd
+cAu
+cAu
+cAu
 aak
 aak
 aak
@@ -101875,7 +101600,7 @@ bea
 bnW
 bgM
 bih
-bdd
+bnW
 bdd
 bdd
 juV
@@ -101884,9 +101609,9 @@ bGn
 qFg
 bVy
 bLr
-xTF
-bsI
-bsI
+wFX
+bWo
+bWo
 bwS
 byc
 bzR
@@ -101906,9 +101631,9 @@ vzh
 bsw
 nVB
 iSZ
-pMa
+kPE
 jTm
-lhQ
+rSo
 aak
 cKh
 wlz
@@ -101922,17 +101647,17 @@ tnE
 mBw
 crj
 aAO
-uGc
-crj
-crj
-crj
-crj
-crj
-crj
-crj
-crj
-crj
-rRm
+aOd
+aSX
+aSX
+aSX
+aSX
+aSX
+aSX
+aSX
+aSX
+aSX
+udi
 gjw
 jZn
 wNm
@@ -101954,7 +101679,7 @@ aaa
 mRm
 aak
 aak
-aOd
+cAu
 aaa
 llp
 cEN
@@ -101966,7 +101691,7 @@ rxm
 cEN
 vff
 aaa
-aOd
+cAu
 aak
 aaa
 aaa
@@ -102131,19 +101856,19 @@ bcF
 beb
 bfG
 bgL
-big
+bGn
 bgg
-big
+bGn
 bjA
 bnX
 bjA
 bfE
 brY
-cpG
-btP
-xTF
-bsI
-bsI
+bVy
+bLr
+wFX
+bWo
+bWo
 bwS
 byd
 bzS
@@ -102163,9 +101888,9 @@ tLr
 gYU
 jDR
 tNG
-pMa
+kPE
 nnH
-lhQ
+rSo
 aak
 cKh
 oBL
@@ -102179,7 +101904,7 @@ oHA
 kjx
 gmt
 hVb
-uGc
+sPl
 crj
 pDh
 kvX
@@ -102188,7 +101913,7 @@ crj
 crj
 crj
 lPY
-crj
+aSX
 rRm
 oWx
 iNN
@@ -102211,7 +101936,7 @@ aak
 cXM
 hCP
 ltZ
-aOd
+cAu
 aaa
 ioj
 cEN
@@ -102223,7 +101948,7 @@ rxm
 cEN
 lqo
 aaa
-aOd
+cAu
 aak
 aaa
 aaa
@@ -102388,18 +102113,18 @@ bcF
 bec
 bfI
 bgK
-big
+bGn
 blb
-big
+bGn
 bjy
 bnY
 bmv
 bfF
 brX
 bsN
-btP
-xTF
-bsI
+bLr
+wFX
+bWo
 bvT
 bwS
 bye
@@ -102419,8 +102144,8 @@ tNV
 qDb
 nMg
 oCz
-roC
-pMa
+hfI
+kPE
 tZs
 uGE
 aak
@@ -102440,14 +102165,14 @@ sMD
 fyO
 crj
 crj
+aSX
 crj
 crj
 crj
 crj
-crj
-crj
+aSX
 rRm
-cwt
+qTm
 iNN
 iNN
 wNm
@@ -102470,7 +102195,7 @@ bXs
 vBM
 aaa
 aaa
-aOd
+cAu
 cFo
 uVi
 cIw
@@ -102480,7 +102205,7 @@ uVi
 cIw
 bUe
 aaa
-aOd
+cAu
 aak
 aaa
 aaa
@@ -102556,7 +102281,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 uPb
 uPb
 uPb
@@ -102564,8 +102289,8 @@ aaa
 aaa
 uPb
 uPb
-aOd
-aOd
+cAu
+cAu
 uPb
 uPb
 uPb
@@ -102588,7 +102313,7 @@ ffb
 tJQ
 abp
 ahz
-glO
+brO
 jzO
 xTg
 otF
@@ -102635,7 +102360,7 @@ aSl
 aTk
 aUg
 aVn
-bJf
+aWw
 azQ
 aXj
 aXj
@@ -102647,16 +102372,16 @@ bfJ
 bfI
 bfG
 blb
-big
+bGn
 bjy
 bnZ
 bps
 bfK
 brX
-bsI
-btP
-xTF
-bsI
+bWo
+bLr
+wFX
+bWo
 wGo
 bwT
 qMb
@@ -102697,22 +102422,22 @@ rqO
 mhM
 jGc
 jGc
-jGc
+agr
 jGc
 jGc
 uMv
 jGc
 vXo
 wAP
-cwt
+qTm
 gsl
 iNN
 dxH
-iaL
+lob
 tEJ
 sSt
-ybs
-ybs
+iaL
+iaL
 rnC
 fbu
 hKb
@@ -102727,7 +102452,7 @@ kCU
 vBM
 xHL
 aaa
-aOd
+cAu
 cFp
 qpP
 aak
@@ -102736,7 +102461,7 @@ aak
 wNj
 cLt
 vff
-aOd
+cAu
 xHL
 aak
 iGu
@@ -102814,7 +102539,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 uPb
 uPb
 aaa
@@ -102845,9 +102570,9 @@ ahA
 abp
 abp
 ajp
-glO
-xIR
-hkC
+brO
+siz
+tuv
 jTY
 cEL
 anj
@@ -102910,10 +102635,10 @@ boa
 bjy
 bfK
 brX
-bsI
-btP
-xTF
-bsI
+bWo
+bLr
+wFX
+bWo
 bvT
 bwS
 byg
@@ -102947,14 +102672,14 @@ uGE
 myZ
 weM
 tCc
-cwt
+qTm
 rrX
-cwt
+qTm
 iPp
 qDQ
 rxk
 rxk
-rxk
+aIu
 rxk
 rxk
 qDQ
@@ -102984,16 +102709,16 @@ bXs
 cXM
 hCP
 aDS
-aOd
-aOd
+cAu
+cAu
 cMj
-aOd
-aOd
-aOd
+cAu
+cAu
+cAu
 cMj
-aOd
-aOd
-aOd
+cAu
+cAu
+cAu
 cyo
 cyo
 cyo
@@ -103097,14 +102822,14 @@ xFG
 abp
 agP
 vEt
-agr
+ajK
 wjE
 jNt
 ail
 vvw
 ujm
 xTg
-hkC
+tuv
 aoG
 cEL
 cEL
@@ -103148,7 +102873,7 @@ aOK
 aAi
 aAi
 aAi
-aVk
+aWl
 byn
 azQ
 aYl
@@ -103167,11 +102892,11 @@ bob
 bpt
 bfI
 brX
-bsI
-btP
-xTF
-bsI
-bsI
+bWo
+bLr
+wFX
+bWo
+bWo
 bwS
 byh
 kYI
@@ -103195,12 +102920,12 @@ oyA
 hfI
 hfI
 uzh
-kuB
-kuB
+dqG
+dqG
 thy
 keF
 umj
-tzt
+umj
 nQQ
 nlb
 qFV
@@ -103211,11 +102936,11 @@ xsY
 qDQ
 mBv
 mBv
-mBv
+xOc
 mBv
 mBv
 kyu
-cwt
+qTm
 omW
 qTm
 ulE
@@ -103340,14 +103065,14 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 uPb
 abp
 aAP
 aaN
 aer
 aaL
-agr
+ajK
 afW
 aks
 aks
@@ -103355,13 +103080,13 @@ rYr
 tcg
 vFP
 vFP
-vFP
+lgn
 aoK
 wET
 kUI
 glO
 fOi
-hkC
+tuv
 aoG
 cEL
 aaa
@@ -103405,7 +103130,7 @@ xlx
 aAi
 rmD
 aGQ
-aVk
+aWl
 byn
 azQ
 aYx
@@ -103426,9 +103151,9 @@ bfF
 aXj
 cXs
 aMc
-xTF
-bsI
-bsI
+wFX
+bWo
+bWo
 bwS
 byk
 xVe
@@ -103453,7 +103178,7 @@ uGE
 uGE
 uGE
 uGE
-efg
+cEf
 ipl
 myZ
 myZ
@@ -103468,12 +103193,12 @@ rIW
 qDQ
 lCN
 nCu
-crj
+aSX
 lAV
 crj
 kyu
-cwt
-kMP
+qTm
+omW
 qTm
 ulE
 mqe
@@ -103597,27 +103322,27 @@ aaa
 aaa
 aaa
 aaa
-aOd
-aOd
+cAu
+cAu
 abp
 aAS
 aaO
 abp
 abA
-arY
+ajI
 tUf
 xku
-arY
+ajI
 aav
 tUf
-arY
-arY
-arY
+ajI
+ajI
+ajI
 aic
 aim
 hRk
 vrn
-ajI
+eqr
 tUf
 cNa
 cNa
@@ -103681,11 +103406,11 @@ aXj
 aXj
 aXj
 aXj
-bsI
-btP
-xTF
-bsI
-bsI
+bWo
+bLr
+wFX
+bWo
+bWo
 uGE
 uGE
 kgg
@@ -103725,7 +103450,7 @@ wrF
 wei
 crj
 nlQ
-xTb
+cEx
 crj
 hrt
 qDQ
@@ -103734,7 +103459,7 @@ qHx
 xKH
 ulE
 ofg
-qoh
+yci
 mke
 tfj
 wTZ
@@ -103753,17 +103478,17 @@ fOF
 atI
 oiZ
 hmD
-cAW
+czV
 dHt
-cAW
-cAW
+czV
+czV
 leK
-cAW
-cAW
-cAW
+czV
+czV
+czV
 dbj
-cAW
-cAW
+czV
+czV
 nfc
 rlM
 tal
@@ -103861,20 +103586,20 @@ abp
 abp
 abp
 abp
-aaB
+vgS
 oxt
-aaB
+vgS
 rnL
-aaB
+vgS
 teH
-aaB
+vgS
 wMy
 xAK
 aAl
 abp
 abp
 iTd
-vgS
+amw
 qQA
 cNa
 nTK
@@ -103940,8 +103665,8 @@ bwL
 bzp
 bvm
 btV
-xTF
-bsI
+wFX
+bWo
 bvS
 uGE
 qHE
@@ -103954,13 +103679,13 @@ mRA
 cxV
 uGE
 cxz
-qGS
+eII
 tRR
 fHV
 jsm
 uGE
 vPj
-cFl
+dBL
 uGE
 fAO
 hgd
@@ -103982,7 +103707,7 @@ lwm
 nID
 iUB
 iUB
-lja
+kxg
 dJz
 niA
 coW
@@ -104010,7 +103735,7 @@ kdt
 rmR
 qmj
 cKH
-cAW
+czV
 xqd
 kYF
 kYF
@@ -104118,20 +103843,20 @@ aaa
 aaa
 aaa
 aaa
-aaB
+vgS
 oEn
-aaB
+vgS
 abp
-aaB
+vgS
 oEn
-aaB
+vgS
 abp
 abp
 abp
 abp
 aAl
 cyV
-ajK
+bsr
 xqp
 cNa
 kel
@@ -104177,19 +103902,19 @@ qEd
 azQ
 lmt
 aVp
-bRh
+aWs
 aXB
-bRh
-bRh
-bRh
-bRh
+aWs
+aWs
+aWs
+aWs
 cob
-cvA
-cvA
+aWt
+aWt
 aYI
 aYJ
-cvA
-cvA
+aWt
+aWt
 din
 cGg
 wFX
@@ -104201,30 +103926,30 @@ wFX
 wFX
 lpB
 tsX
-vsK
-kuB
+pNZ
+dqG
 tSJ
-mFd
-sJt
+sJj
+arY
 nDF
 nYX
-drN
+tRR
 hQe
-drN
+tRR
 uJe
 ntr
 tdd
 nhl
 uGE
 vEV
-cFl
+dBL
 uGE
 mtM
 tLZ
 fxb
 vcU
 uGE
-pGR
+uBx
 sml
 myZ
 sxj
@@ -104235,11 +103960,11 @@ fKB
 oil
 ilI
 xnY
-wrF
-wei
-crj
-lAV
-crj
+pAM
+bks
+aSX
+bNP
+aSX
 crj
 ePq
 kyu
@@ -104267,21 +103992,21 @@ rym
 xiZ
 bXs
 rcn
-cAW
+czV
 oAO
 pjB
 mer
 loE
-gZa
 emQ
-gZa
+tuE
+emQ
 cDI
-tpJ
+wIs
 dJa
 gpN
 cyo
 vnn
-cNs
+tbf
 aou
 sIs
 cyo
@@ -104377,9 +104102,9 @@ aaa
 aaa
 abp
 oJh
-aaB
+vgS
 aak
-aaB
+vgS
 ukf
 abp
 aaa
@@ -104387,8 +104112,8 @@ aak
 aaa
 abp
 aAR
-xKR
-xIR
+qtS
+siz
 bQN
 wHh
 hPe
@@ -104399,7 +104124,7 @@ cNa
 cNa
 cNa
 cNa
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -104449,14 +104174,14 @@ bjU
 aYy
 bmV
 bsS
-bsI
-bsI
-bsI
-bsI
-bsI
-xTF
-bsI
-bsI
+bWo
+bWo
+bWo
+bWo
+bWo
+wFX
+bWo
+bWo
 uGE
 uGE
 uGE
@@ -104481,7 +104206,7 @@ pGR
 vFh
 urb
 uGE
-ntr
+cmO
 pfD
 myZ
 eJm
@@ -104491,7 +104216,7 @@ vnO
 plv
 ggE
 twq
-xnY
+eqx
 lKR
 qDQ
 uxf
@@ -104524,14 +104249,14 @@ vYC
 esV
 bXs
 pzj
-cAW
+czV
 gtu
 dzt
 mer
 cEV
-cEX
 cIq
-cEX
+aKB
+cIq
 cEV
 kPC
 ukL
@@ -104644,8 +104369,8 @@ aak
 aaa
 ttX
 aAR
-xKR
-fny
+qtS
+jzO
 adV
 uKf
 yfM
@@ -104656,7 +104381,7 @@ aoO
 wAC
 kec
 fUp
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -104683,7 +104408,7 @@ aak
 aak
 aak
 cDx
-cDw
+cEI
 cJe
 aak
 aak
@@ -104691,7 +104416,7 @@ aak
 azQ
 aAi
 aVp
-aWt
+cvA
 bmV
 aYp
 aZE
@@ -104711,7 +104436,7 @@ bii
 bii
 bsT
 btX
-xTF
+wFX
 aUO
 nAD
 bwX
@@ -104738,7 +104463,7 @@ sKc
 kok
 urb
 uGE
-yfZ
+cOl
 oQB
 aWh
 kXG
@@ -104781,7 +104506,7 @@ oKB
 bXs
 bXs
 noK
-cAW
+czV
 rJu
 cEV
 cEV
@@ -104902,7 +104627,7 @@ aaa
 ttX
 wNp
 qtS
-brO
+glO
 lKO
 wHh
 hPe
@@ -104913,7 +104638,7 @@ aoP
 iTz
 vCj
 fUp
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -104940,7 +104665,7 @@ aak
 aak
 aak
 cDz
-cIh
+cDA
 cJg
 aak
 aak
@@ -104948,7 +104673,7 @@ aak
 azQ
 aUh
 aVp
-aWt
+cvA
 bmV
 aYq
 aZF
@@ -104967,17 +104692,17 @@ bpv
 nDG
 bii
 bsU
-bsI
-xTF
-bsI
+bWo
+wFX
+bWo
 bvW
 bwX
 rop
 xvt
-sPl
-sPl
-sPl
-sPl
+aKc
+aKc
+aKc
+aKc
 sXH
 rja
 bwW
@@ -104995,7 +104720,7 @@ ogs
 kBn
 ruN
 uGE
-sJt
+arY
 jmd
 myZ
 exW
@@ -105038,7 +104763,7 @@ tzV
 cGf
 qmj
 wIs
-cAW
+czV
 xhp
 cDJ
 xAW
@@ -105170,7 +104895,7 @@ apb
 ibk
 kuO
 fUp
-aOd
+cAu
 aak
 aak
 aak
@@ -105205,7 +104930,7 @@ aak
 azQ
 aGU
 aVp
-aWt
+cvA
 bmV
 aYr
 aZG
@@ -105225,8 +104950,8 @@ bqB
 bsg
 btY
 btY
-xTF
-bsI
+wFX
+bWo
 nAD
 bwX
 bAb
@@ -105271,7 +104996,7 @@ evC
 eid
 pgK
 tsp
-mzd
+cRF
 hAn
 jAW
 iyx
@@ -105295,21 +105020,21 @@ gnO
 iDa
 uOY
 wIs
-cAW
+czV
 iSH
 cKF
-cEX
+cIq
 cFW
-cEX
+cIq
 cIr
-cEX
+cIq
 cKd
 nwK
 dJa
 noS
 cyt
 cNT
-wIJ
+hQY
 cNT
 iES
 cyo
@@ -105415,7 +105140,7 @@ aak
 aaa
 ttX
 aBD
-xKR
+qtS
 siz
 kwf
 cNa
@@ -105427,7 +105152,7 @@ cNa
 cNa
 cNa
 cNa
-aOd
+cAu
 aaa
 aak
 aaa
@@ -105462,7 +105187,7 @@ aak
 aDr
 aGU
 aVp
-aWt
+cvA
 bmV
 aXm
 aXm
@@ -105476,14 +105201,14 @@ bii
 bii
 bii
 bii
-bWh
+fPv
 bpx
 bqC
 bsb
 btZ
 btZ
-xTF
-bsI
+wFX
+bWo
 nAD
 bwX
 bAb
@@ -105552,7 +105277,7 @@ vYC
 aJA
 qmj
 wIs
-cAW
+czV
 mbY
 cEp
 qyn
@@ -105668,7 +105393,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 abp
 abp
 abp
@@ -105738,9 +105463,9 @@ bpy
 oEh
 bii
 bsU
-bsI
-xTF
-bsI
+bWo
+wFX
+bWo
 nAD
 bwX
 uIm
@@ -105809,7 +105534,7 @@ mVl
 bXs
 bXs
 vUC
-cAW
+czV
 sOU
 cEV
 cEV
@@ -105925,12 +105650,12 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 kzt
 thb
 aCg
 aRC
-tuv
+xTg
 mxq
 cNa
 mRc
@@ -105976,7 +105701,7 @@ cJg
 aDr
 aGU
 aVp
-aWt
+cvA
 bmV
 aYt
 aZI
@@ -105994,11 +105719,11 @@ cMJ
 bii
 bii
 bii
-bsI
-bsI
-xTF
 bWo
-oBq
+bWo
+wFX
+bWo
+nAD
 aHj
 lDa
 bZC
@@ -106023,7 +105748,7 @@ uGE
 uGE
 uGE
 uGE
-efg
+cEf
 kbu
 myZ
 cUh
@@ -106066,20 +105791,20 @@ tzV
 vgo
 bXs
 rQM
-cAW
+czV
 jlp
 xip
 ooW
 cEV
-cEX
 cIq
-cEX
+aKB
+cIq
 cEV
 wkU
 wdc
 cCr
 iGF
-hQY
+wIJ
 cNR
 cNR
 tal
@@ -106233,7 +105958,7 @@ aak
 aDr
 rmD
 aVp
-aWt
+cvA
 bmV
 aYu
 aZJ
@@ -106252,15 +105977,15 @@ bpz
 bqD
 bii
 aJd
-bsI
-xTF
-bsI
+bWo
+wFX
+bWo
 nAD
 bxq
 mCJ
 bAw
-bAc
-bAc
+ofP
+ofP
 bFk
 bNF
 ofP
@@ -106276,11 +106001,11 @@ usi
 kfY
 uuX
 uGE
-tnO
+oBq
 iOM
-ntr
+cmO
 scg
-yfZ
+cOl
 pEV
 dpQ
 rih
@@ -106308,8 +106033,8 @@ kZb
 dsP
 mcy
 qvc
+hXO
 pyz
-nrn
 pyz
 qvc
 bXo
@@ -106323,14 +106048,14 @@ rym
 guv
 bXs
 rcn
-cAW
+czV
 jlp
 xip
 ooW
 cDI
-gZa
 emQ
-gZa
+tuE
+emQ
 loE
 xIY
 drt
@@ -106443,7 +106168,7 @@ nQY
 ahO
 ain
 aiV
-aEO
+qtS
 siz
 mxq
 aoj
@@ -106490,7 +106215,7 @@ aak
 azQ
 aGU
 aVp
-aWt
+cvA
 bmV
 aXm
 aXm
@@ -106509,9 +106234,9 @@ bii
 bii
 bii
 bsX
-bsI
-xTF
-bsI
+bWo
+wFX
+bWo
 bvZ
 bwX
 hHR
@@ -106533,7 +106258,7 @@ dvd
 kfY
 bzq
 uGE
-nnH
+rcL
 ntr
 qCC
 oPI
@@ -106547,7 +106272,7 @@ ejD
 uIJ
 tYR
 pDQ
-mWw
+ena
 nql
 ejD
 grP
@@ -106562,11 +106287,11 @@ jYp
 nJa
 hIR
 nmL
-ptU
 nmL
+cIU
 cxH
+cIU
 nmL
-ptU
 nmL
 eey
 bXo
@@ -106580,12 +106305,12 @@ kdt
 rmR
 qmj
 ofc
-cAW
+czV
 qgX
-brm
-brm
+koK
+koK
 rfa
-brm
+koK
 uYv
 brm
 vUj
@@ -106595,7 +106320,7 @@ gQG
 cyt
 cNS
 cNs
-wIJ
+hQY
 tal
 cyo
 aaa
@@ -106739,7 +106464,7 @@ aak
 aak
 aak
 cDx
-cDw
+cEI
 cJe
 aak
 aak
@@ -106747,7 +106472,7 @@ aak
 azQ
 eLa
 aVp
-aWt
+cvA
 bmV
 aYv
 aZK
@@ -106790,7 +106515,7 @@ cNV
 kfY
 nmM
 uGE
-efg
+cEf
 pGR
 ntr
 yfZ
@@ -106803,8 +106528,8 @@ yjX
 oLF
 kEM
 rbm
-mWw
-mWw
+ena
+ena
 iSw
 ejD
 fCo
@@ -106821,7 +106546,7 @@ tas
 mtO
 sVZ
 hSW
-sVZ
+rWX
 sVZ
 sVZ
 dbi
@@ -106837,8 +106562,8 @@ gHM
 thn
 agv
 ipI
-czV
-czV
+fde
+fde
 czV
 czV
 kAQ
@@ -106958,7 +106683,7 @@ aul
 aip
 tje
 aGe
-vgS
+amw
 akL
 aoj
 anE
@@ -106996,7 +106721,7 @@ aak
 aak
 aak
 cDz
-cIh
+cDA
 cJg
 aak
 aak
@@ -107004,13 +106729,13 @@ aak
 azQ
 aUj
 aVp
-aWt
+cvA
 bmV
 aYw
 aZL
 aXm
 bbX
-cpn
+aYH
 aXm
 bfT
 bgV
@@ -107023,10 +106748,10 @@ bii
 bii
 bii
 bsZ
-bjW
+bwl
 fxK
-bjW
-eHp
+bwl
+cfx
 bxb
 byp
 bAf
@@ -107082,7 +106807,7 @@ kSG
 noR
 vXi
 ack
-kRA
+uWL
 jBR
 cVm
 nmD
@@ -107260,14 +106985,14 @@ azQ
 azQ
 azQ
 azQ
-aVp
+qxr
 qad
 bmV
 aYW
 aZM
 baD
 bbP
-cpn
+aYH
 bek
 bfU
 bhl
@@ -107280,10 +107005,10 @@ bpN
 bqE
 bii
 btE
-bjW
+bwl
 fxK
-bjW
-eHp
+bwl
+cfx
 bxc
 vsM
 bAg
@@ -107309,7 +107034,7 @@ uGE
 uGE
 uGE
 uGE
-rSo
+bqM
 uGE
 myZ
 vXx
@@ -107339,7 +107064,7 @@ aJp
 miT
 vma
 kBt
-kRA
+uWL
 jBR
 kdm
 ncI
@@ -107459,7 +107184,7 @@ aak
 acu
 abj
 abF
-afi
+ahG
 acT
 ahG
 ajm
@@ -107470,12 +107195,12 @@ agz
 krd
 dRQ
 pqP
-vmj
+caE
 aHm
 btD
 fib
 anE
-amw
+ami
 bSn
 anU
 aoq
@@ -107517,14 +107242,14 @@ rmD
 aAQ
 loF
 azQ
-aVp
+qxr
 oYI
 bmV
 bmV
 bmV
 aXm
 bbV
-cpn
+aYH
 aXm
 aXm
 aXm
@@ -107537,10 +107262,10 @@ bii
 bii
 bii
 cXt
-bjW
+bwl
 fxK
-bjW
-eHp
+bwl
+cfx
 bxb
 byr
 byq
@@ -107558,7 +107283,7 @@ cNH
 cNH
 cNH
 cNH
-cEf
+vpk
 eDO
 uGE
 kVm
@@ -107614,10 +107339,10 @@ cCZ
 hou
 uzx
 jTx
-cAW
+czV
 vFD
 qmk
-cAW
+czV
 cyo
 sBA
 cyo
@@ -107723,16 +107448,16 @@ ajt
 afm
 abj
 aqa
-aqD
+adA
 ass
 aum
 ais
-vmj
+caE
 aHv
 bvg
 fPB
 anE
-ami
+xIR
 jrH
 pnp
 tJU
@@ -107774,30 +107499,30 @@ aAi
 aAi
 aAi
 azQ
-aVp
+qxr
 oYI
 aXn
 aYy
 bmV
 ste
 fbw
-cpn
+aYH
 bel
 aXm
 bgX
 bij
 bjK
 blq
-bik
-bik
+ivj
+ivj
 bpC
 bqF
 bhf
 wTY
-bjW
+bwl
 rkZ
-bjW
-bjW
+bwl
+bwl
 bxa
 bys
 ncQ
@@ -107819,7 +107544,7 @@ mwM
 fpR
 uGE
 irD
-rSo
+bqM
 aaa
 xcw
 bXv
@@ -108033,27 +107758,27 @@ aMH
 aUt
 aVA
 cvA
-aXo
+mbf
 xPt
 bmV
 baF
 bbX
-cpn
+aYH
 bel
 aXm
 bgY
 bik
 bik
 bik
-rrb
+bHf
 bik
-bGx
+bik
 bqG
 bhf
 gGo
-bjW
+bwl
 fxK
-bjW
+bwl
 dzf
 bxa
 byL
@@ -108070,13 +107795,13 @@ iJE
 kbQ
 bQU
 wPX
-bNP
+hnV
 cNH
 vpk
 iMZ
 uGE
-pMa
-rSo
+kPE
+bqM
 aaa
 phc
 yco
@@ -108098,9 +107823,9 @@ rHR
 rHR
 csI
 csI
-oxL
+sKr
 qjx
-oxL
+sKr
 iXf
 iXf
 iXf
@@ -108243,7 +107968,7 @@ auy
 awC
 ajf
 aLg
-vgS
+amw
 sBP
 aoj
 amm
@@ -108269,7 +107994,7 @@ aaa
 aaa
 azQ
 aAi
-aWl
+btS
 aAi
 azQ
 aGW
@@ -108279,17 +108004,17 @@ aAi
 ovt
 aAi
 aAi
+pMa
+bJf
+bJf
+bJf
 bqR
-caF
-caF
-caF
-bab
-caF
-caF
-caF
+bJf
+bJf
+bJf
 aUw
 aVH
-aWH
+aXp
 aXp
 aYA
 bmV
@@ -108298,7 +108023,7 @@ bbX
 fvI
 bel
 bfV
-bgZ
+fny
 bil
 bjL
 bjO
@@ -108307,10 +108032,10 @@ bik
 bHf
 bqH
 bly
-bjW
-bjW
+bwl
+bwl
 fxK
-bjW
+bwl
 odr
 bxa
 bxa
@@ -108332,8 +108057,8 @@ vVt
 dSA
 fpR
 uGE
-pMa
-rSo
+kPE
+bqM
 aaa
 bXv
 hsj
@@ -108496,9 +108221,9 @@ aff
 afH
 agF
 ahq
-avz
+ahU
 aiu
-vmj
+caE
 aMK
 cGG
 wxk
@@ -108547,27 +108272,27 @@ azQ
 aUm
 bmV
 bmV
-cvA
+aWt
 aYB
 bmV
 baH
 bbX
-cpn
+aYH
 bel
 bfV
-bik
+ivj
 bim
 bjM
 bjR
 bmF
 bik
-bGx
+bik
 bqI
 bly
-bjW
-bjW
+bwl
+bwl
 fxK
-bjW
+bwl
 bwc
 bxd
 byu
@@ -108581,9 +108306,9 @@ bIX
 bPJ
 bxa
 kTC
-hnV
+cOi
 bQW
-bNP
+hnV
 bMj
 cNH
 fVw
@@ -108809,22 +108534,22 @@ aYC
 bmV
 baI
 bbY
-cpn
+aYH
 bel
 bfV
-bik
+ivj
 bil
 bjN
 bjR
 bmF
 bik
-bGx
+bik
 bqJ
 bly
-bjW
-bjW
+bwl
+bwl
 fxK
-bjW
+bwl
 qyu
 eax
 bAk
@@ -109014,7 +108739,7 @@ avI
 axN
 ajd
 bkL
-dMG
+bmK
 aCn
 anE
 aAn
@@ -109034,7 +108759,7 @@ axW
 gNx
 gNx
 nBw
-hXO
+voN
 aBh
 voN
 qpv
@@ -109061,15 +108786,15 @@ aTm
 aUo
 aVt
 bmV
-cvA
+aWt
 aYD
 bmV
 baJ
 bbX
-cpn
+aYH
 bel
 bfV
-bhb
+nrn
 bik
 bik
 bik
@@ -109078,8 +108803,8 @@ bik
 bjQ
 bqK
 bly
-bjW
-bjW
+bwl
+bwl
 fxK
 ccu
 qyu
@@ -109274,7 +108999,7 @@ bmh
 ajU
 akP
 aoj
-amw
+ami
 amY
 qoz
 aoj
@@ -109318,15 +109043,15 @@ aTn
 aUp
 vmY
 bmV
-cvA
+aWt
 aYE
 bmV
 baK
 bbX
-bgH
+ngT
 bmE
-bfW
-bik
+hkC
+ivj
 bik
 aYP
 bUO
@@ -109335,10 +109060,10 @@ bik
 boh
 bik
 bmJ
-bjW
-bjW
+bwl
+bwl
 fxK
-bjW
+bwl
 qyu
 bxg
 eoR
@@ -109370,7 +109095,7 @@ xXz
 xgI
 bXv
 mvw
-hAy
+lQn
 sbK
 gDs
 nWr
@@ -109386,23 +109111,23 @@ vMw
 mXk
 kxe
 ase
-vbp
+ase
 oYF
 pYL
 dPP
 dst
-kxg
+dAg
 ycq
 bXq
 kKB
 kKB
-hAG
-hAG
+ixx
+ixx
 dDX
 toJ
 fma
-ixx
-ixx
+hAG
+hAG
 hXy
 cCZ
 gQf
@@ -109517,9 +109242,9 @@ aaa
 abK
 acf
 acZ
-adA
+eXy
 aed
-aeE
+aff
 aff
 aqx
 agF
@@ -109575,7 +109300,7 @@ aTo
 aUq
 aVv
 bmV
-cvA
+aWt
 aYF
 aXk
 baL
@@ -109590,12 +109315,12 @@ blr
 bmG
 cXJ
 bpD
-bqM
+bmG
 bwY
 fxK
 fxK
 fxK
-bjW
+bwl
 qyu
 bxg
 byx
@@ -109631,7 +109356,7 @@ lQn
 kUm
 fBX
 sIe
-sbK
+xBJ
 kUm
 lYs
 sKH
@@ -109643,12 +109368,12 @@ bgN
 pVo
 sFv
 uzX
-uzX
+rYP
 doa
 ifZ
 bXq
 kfL
-dAg
+gCl
 rqG
 nun
 nDq
@@ -109657,7 +109382,7 @@ bZN
 bZN
 eFu
 nHm
-bZN
+bYv
 lHL
 bYv
 qTy
@@ -109779,11 +109504,11 @@ sPm
 ios
 afg
 aIR
-aIR
-aIR
+avn
+avn
 avn
 axU
-vmj
+caE
 aom
 ajU
 aCn
@@ -109798,15 +109523,15 @@ aoS
 jpA
 xgU
 jCl
-rWy
+ojt
 jCl
 fTJ
 fTJ
 lIG
-psZ
-psZ
+cCj
+cCj
 mVI
-psZ
+cCj
 fTJ
 fTJ
 fTJ
@@ -109832,7 +109557,7 @@ aTp
 aUr
 aVw
 bmV
-cvA
+aWt
 aYy
 bmV
 baM
@@ -109850,9 +109575,9 @@ boi
 bik
 bmJ
 ccu
-bjW
+bwl
 fxK
-bjW
+bwl
 qyu
 bxg
 byx
@@ -109895,7 +109620,7 @@ jaa
 eJc
 okf
 kbJ
-sKr
+kMP
 wFI
 fSy
 diU
@@ -110035,28 +109760,28 @@ abM
 mKo
 egr
 afh
-aqy
+aBi
 agH
 ahv
-ajh
+aqy
 ayF
-vmj
+caE
 ajw
 mqs
 awM
 alE
 apI
 afE
-aCn
+bRh
 gxz
 ajV
 alp
 aqH
 alX
 wIx
-jCl
+avH
 rWy
-jCl
+avH
 mjV
 wHn
 jpg
@@ -110089,7 +109814,7 @@ lTv
 bsy
 muW
 bmV
-cvA
+aWt
 aYG
 bmV
 baN
@@ -110102,7 +109827,7 @@ bik
 bik
 blt
 bik
-rrb
+bHf
 bok
 bqN
 bly
@@ -110132,7 +109857,7 @@ pGi
 xEU
 aem
 uGE
-pMa
+kPE
 uGE
 gdf
 lmS
@@ -110149,14 +109874,14 @@ jaa
 jaa
 hMm
 hMm
-sKr
+kMP
 lML
-sKr
+kMP
 rLU
 rLU
-sKr
+kMP
 sZq
-sKr
+kMP
 rLU
 cCZ
 iDw
@@ -110308,14 +110033,14 @@ qhg
 uWs
 wRt
 xVb
-xVb
+oxL
 xVb
 ezQ
 fIu
 aaD
 awS
 qIB
-xVb
+oxL
 kcy
 xVb
 tZO
@@ -110363,10 +110088,10 @@ bik
 bik
 bqO
 bly
-bjW
-bjW
 bwl
-bjW
+bwl
+bwl
+bwl
 bwf
 bxd
 byy
@@ -110389,7 +110114,7 @@ nCU
 oEC
 eEJ
 uGE
-pMa
+kPE
 uGE
 xQZ
 lmS
@@ -110560,7 +110285,7 @@ hoJ
 hoJ
 hoJ
 aom
-anc
+dMG
 anH
 gPJ
 aoY
@@ -110569,7 +110294,7 @@ mhz
 wyW
 ath
 auN
-ojt
+rWy
 vXb
 xmr
 ayL
@@ -110603,7 +110328,7 @@ aTs
 aUu
 aDc
 bmV
-cvA
+aWt
 gaH
 bmV
 kTS
@@ -110620,10 +110345,10 @@ bik
 bik
 bqP
 bly
-bjW
-bjW
 bwl
-bjW
+bwl
+bwl
+bwl
 cXy
 bxd
 bxd
@@ -110646,7 +110371,7 @@ qKM
 xEU
 lRV
 uGE
-pMa
+kPE
 uGE
 cxv
 oYR
@@ -110656,9 +110381,9 @@ lgE
 xQs
 ehP
 xHE
-xwu
+awl
 fCR
-xwu
+awl
 ttI
 ttI
 ttI
@@ -110817,7 +110542,7 @@ exj
 akV
 ipH
 hSd
-anc
+dMG
 qtc
 gPJ
 apu
@@ -110860,8 +110585,8 @@ fgW
 aUv
 aVy
 bmV
-cvA
-aYz
+aWt
+aXo
 bmV
 baQ
 bcc
@@ -110877,11 +110602,11 @@ bik
 bik
 bqQ
 bly
-bjW
-bjW
 bwl
-bjW
-bjW
+bwl
+bwl
+bwl
+bwl
 bxh
 byz
 bAp
@@ -110907,7 +110632,7 @@ sqN
 rBe
 mQM
 bXp
-rcL
+bXp
 aBJ
 aBJ
 tJT
@@ -110917,15 +110642,15 @@ uUo
 eWj
 uaW
 jkH
-lXP
+caU
 pdl
 mWN
 mWN
 gCF
 tCI
 awl
-lXP
-lXP
+caU
+caU
 caU
 lvI
 ttI
@@ -111110,7 +110835,7 @@ kxL
 qcG
 uGf
 aOY
-aQq
+vIm
 eEo
 aSr
 yiJ
@@ -111131,13 +110856,13 @@ bik
 blt
 bik
 bik
-rrb
+bHf
 bBO
 bhf
 btd
-bjW
 bwl
-bjW
+bwl
+bwl
 fPW
 bxd
 byA
@@ -111182,7 +110907,7 @@ tlD
 feL
 mqB
 caU
-lXP
+caU
 caU
 caU
 sRb
@@ -111297,13 +111022,13 @@ aaa
 aaf
 aak
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aak
 aaf
@@ -111554,13 +111279,13 @@ aaa
 aae
 aak
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aak
 aae
@@ -111589,7 +111314,7 @@ hxN
 hoJ
 amL
 ans
-aCn
+bRh
 aov
 apu
 kQd
@@ -111649,9 +111374,9 @@ bly
 bhf
 bhf
 btf
-bjW
+bwl
 fjZ
-bjW
+bwl
 cXz
 bxd
 bxd
@@ -111709,7 +111434,7 @@ cWI
 wSV
 mMe
 cWI
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -111811,13 +111536,13 @@ aaa
 aae
 aak
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aak
 aae
@@ -111854,17 +111579,17 @@ qWW
 aAq
 aAq
 aux
-ssn
-ssn
+uza
+uza
 oJF
-ssn
-ssn
-els
-ssn
-ssn
+uza
+uza
 els
 uza
-ssn
+uza
+els
+uza
+uza
 aEc
 aEc
 aEA
@@ -111883,72 +111608,72 @@ aIM
 alc
 alc
 alc
-aXu
+alc
 alc
 alc
 alc
 aSC
 bzQ
-nHu
+bzQ
 aHp
-nHu
+bzQ
 alc
 aqp
 aHw
-bjW
+bwl
 axK
-bjW
+bwl
 bjV
-bjW
-bjW
-bjW
-bjW
+bwl
+bwl
+bwl
+bwl
 vCx
-bjW
+bwl
 bwl
 bwl
 fjZ
 bwl
-caP
-bjW
+ccu
+bwl
 byC
-bjW
-bjW
-bjW
-bjW
-bjW
-bjW
+bwl
+bwl
+bwl
+bwl
+bwl
+bwl
 bqS
 cXC
 bMn
-bJe
-bJe
+bJB
+bJB
 bRf
 bJd
 bJe
 bJe
 gzE
-rpc
+ajh
 rbo
 rbo
 jSU
 xlb
-bJe
-bJe
-bJe
+bJB
+bJB
+bJB
 svg
-bJe
-bJe
-bJe
-bJe
-bJe
-bJe
-bJe
-bJe
-bJe
+bJB
+bJB
+bJB
+bJB
+bJB
+bJB
+bJB
+bJB
+bJB
 ehT
-bJe
-bJe
+bJB
+bJB
 jIf
 kHY
 opk
@@ -111956,7 +111681,7 @@ pZt
 kgw
 wMG
 kHY
-gQf
+lXP
 cWI
 rfi
 mbx
@@ -111966,7 +111691,7 @@ fWt
 pVi
 gyU
 gEt
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -112068,13 +111793,13 @@ aaa
 aae
 aak
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aak
 aae
@@ -112087,7 +111812,7 @@ abJ
 aax
 arj
 hyr
-loq
+tpJ
 fss
 aax
 aax
@@ -112120,7 +111845,7 @@ aSj
 alc
 alc
 alc
-aXu
+alc
 alc
 kRi
 fpS
@@ -112140,72 +111865,72 @@ apd
 alc
 alc
 alc
-aXu
 alc
 alc
 alc
 alc
-aXu
 alc
 alc
-nHu
+alc
+alc
+bzQ
 bcf
-alb
+bcJ
 ccu
-bjW
-bjW
+bwl
+bwl
 ccu
-bjW
-bjW
+bwl
+bwl
 ccu
-bjW
-bjW
+bwl
+bwl
 bqT
-bjW
+bwl
 bwl
 bud
 wRu
 bud
 bwl
-bjW
+bwl
 byD
-bjW
-bjW
-bjW
-bjW
-bjW
-bjW
-bjW
+bwl
+bwl
+bwl
+bwl
+bwl
+bwl
+bwl
 cJN
-bJe
-bJe
-bJe
+bJB
+bJB
+bJB
 bRg
 bJe
-bJe
+bJB
 bVf
 kff
 bXy
-bJe
-bJe
-abO
-bJe
-bJe
-bJe
+bJB
+bJB
+rkT
+bJB
+bJB
+bJB
 cgM
 bXy
-bJe
-bJe
-bJe
-bJe
-bJe
-bJe
-bJe
-bJe
-bJe
+bJB
+bJB
+bJB
+bJB
+bJB
+bJB
+bJB
+bJB
+bJB
 ehT
 cgM
-bJe
+bJB
 teQ
 kHY
 qjY
@@ -112213,11 +111938,11 @@ gQf
 wCE
 uyp
 kHY
-gQf
+lXP
 cWI
 jsW
 eDY
-mEc
+xFs
 cWI
 cWI
 cWI
@@ -112325,13 +112050,13 @@ aaa
 aak
 aak
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aak
 aaa
@@ -112380,33 +112105,33 @@ pXg
 bzQ
 bzQ
 bzQ
-diw
+amx
 bzQ
 bzQ
 bzQ
 aHe
 jWG
-aLU
-aLU
-aXu
-aXu
-aXu
-aXu
-aXu
-aKB
-aXu
-aXu
-aXu
-aXu
-aXu
-aXu
-aXu
-aXu
-aXu
-aXu
-aXu
+bzQ
+bzQ
+alc
+alc
+alc
+alc
+alc
+apd
+alc
+alc
+alc
+alc
+alc
+alc
+alc
+alc
+alc
+alc
+alc
 diw
-aXu
+alc
 bcJ
 bwl
 bwl
@@ -112425,44 +112150,44 @@ buI
 bxk
 bvs
 daF
-bjW
+bwl
 ccu
-bjW
-bjW
-bjW
-bjW
-bjW
-bjW
+bwl
+bwl
+bwl
+bwl
+bwl
+bwl
 cJN
+bJB
+bJB
+bJB
+bJB
 bJe
-bJe
-bJe
-bJe
-bJe
-bJe
-bJe
+bJB
+bJB
 kff
 bXy
-bJe
-bJe
-abO
-bJe
+bJB
+bJB
+rkT
+bJB
 lZY
-rbo
-mDp
+mok
+ffy
 fRj
-mDp
-mDp
-mDp
-mDp
-mDp
+ffy
+ffy
+ffy
+ffy
+ffy
 hTY
 joB
-mDp
+ffy
 oZX
 rmk
 rkT
-bJe
+bJB
 kKf
 kHY
 sVE
@@ -112470,13 +112195,13 @@ hBM
 gQf
 pwG
 kHY
-gQf
+lXP
 cWI
 hzf
 rBU
 wGX
-pAM
-aOd
+mEc
+cAu
 aak
 aak
 aak
@@ -112582,13 +112307,13 @@ aak
 aak
 aak
 aaa
-aJV
+aGh
 aaa
 aaa
-aJV
+aGh
 aaa
 aaa
-aJV
+aGh
 aaa
 aak
 aat
@@ -112641,7 +112366,7 @@ nHu
 alc
 alc
 alc
-alb
+bcJ
 alc
 alc
 aJU
@@ -112664,19 +112389,19 @@ alc
 alc
 diw
 bcr
-alb
-bjW
-bjW
-bjW
-bjW
-bjW
+bcJ
+bwl
+bwl
+bwl
+bwl
+bwl
 ccu
-bjW
-bjW
-bjW
+bwl
+bwl
+bwl
 bqZ
-bjW
-bjW
+bwl
+bwl
 bud
 edr
 bud
@@ -112695,31 +112420,31 @@ mok
 mok
 mok
 mok
-pCn
+cpG
 pCn
 bWt
 lMv
 rpc
-rbo
-rbo
+mok
+mok
 ffy
-rbo
+mok
 rHz
-bJe
-cgY
-bXy
-bJe
-bJe
-bJe
-bJe
-bJe
-bJe
-kCy
-bJe
-bJe
 bJB
 cgY
-bJe
+bXy
+bJB
+bJB
+bJB
+bJB
+bJB
+bJB
+kff
+bJB
+bJB
+bJB
+cgY
+bJB
 mCo
 kHY
 tWX
@@ -112727,7 +112452,7 @@ xBC
 kND
 kui
 kHY
-gQf
+lXP
 cWI
 jEG
 vZo
@@ -112836,18 +112561,18 @@ aaa
 aae
 aak
 aaE
-aGh
-aGh
-aGh
-aJV
-aJV
-aJV
-aJV
-aJV
 aJV
 aJV
 aJV
 aGh
+aGh
+aGh
+aGh
+aGh
+aGh
+aGh
+aGh
+aJV
 oEg
 dDK
 dDK
@@ -112922,30 +112647,30 @@ alc
 aYX
 alc
 aqp
-bjW
-bjW
+bwl
+bwl
 cXo
 ccu
-bjW
+bwl
 bwk
 bwk
 bwk
 bwk
 brd
-bjW
-bjW
-bjW
+bwl
+bwl
+bwl
 gXc
 bwl
 bwl
 bxj
 byF
 cXB
-bjW
-bjW
-bjW
+bwl
+bwl
+bwl
 bGR
-bjW
+bwl
 lmc
 cXC
 bMM
@@ -112974,9 +112699,9 @@ bJB
 kff
 bJB
 bJB
-bUa
-bJe
-bJe
+bPY
+bJB
+bJB
 nGI
 kHY
 fBs
@@ -112984,13 +112709,13 @@ sSD
 gQf
 xDv
 vJY
-gQf
+lXP
 cWI
 ixm
 dqe
 ucq
-pAM
-aOd
+mEc
+cAu
 aaa
 aaa
 aaa
@@ -113096,10 +112821,10 @@ aak
 aak
 aak
 aaa
-aJV
+aGh
 aaa
 aaa
-aJV
+aGh
 aaa
 aaa
 aKN
@@ -113185,16 +112910,16 @@ bev
 bev
 bev
 blB
-bmK
-bmK
+bIH
+bIH
 blB
 bev
 bev
 btg
-bjW
+bwl
 gXc
-bjW
-bjW
+bwl
+bwl
 cNr
 cNr
 tdu
@@ -113241,7 +112966,7 @@ kHY
 kHY
 kHY
 kHY
-gQf
+lXP
 cWI
 bSJ
 cWI
@@ -113353,13 +113078,13 @@ aaa
 aak
 aak
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aak
 aaa
@@ -113393,15 +113118,15 @@ jBG
 hNo
 cjt
 vKI
-trE
-jBG
-trE
+lhQ
+uwK
+lhQ
 vKI
 vKI
 jNC
 och
 fMa
-eTY
+uod
 azV
 aAr
 aBa
@@ -113413,20 +113138,20 @@ daf
 aKq
 lGh
 eya
-lnI
+aKm
 dad
 toQ
-aKm
+mnK
 urM
-ent
-wod
-vtj
+jUi
+orq
+qlX
 tNj
 ygu
 gqY
 mkD
-ygu
-ygu
+qCq
+qCq
 oeE
 nHl
 tjT
@@ -113442,8 +113167,8 @@ bhg
 lWq
 bjX
 blC
+mCL
 buB
-cEx
 bpE
 bqW
 bev
@@ -113498,7 +113223,7 @@ cXF
 cDa
 cEq
 kHY
-gQf
+lXP
 qAz
 cIQ
 cJD
@@ -113610,13 +113335,13 @@ aaa
 aae
 aak
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aak
 aaf
@@ -113627,26 +113352,26 @@ aaa
 aaa
 aak
 aax
-nll
+gZa
 wHj
 wqt
 hyr
-loq
+tpJ
 nmz
 hyr
-loq
+tpJ
 hyr
 tpb
 lNJ
-jBG
-trE
+uwK
+lhQ
 vKI
 vKI
-trE
+lhQ
 pIh
-oNz
-oNz
-ebz
+bTj
+bTj
+nmz
 kpk
 abM
 abM
@@ -113660,8 +113385,8 @@ sFA
 lEV
 orb
 nfY
-oUE
-oUE
+wuL
+wuL
 oUE
 sXN
 lKc
@@ -113698,16 +113423,16 @@ bfZ
 bhh
 pcp
 bjY
-bjZ
 bDP
-bjZ
-bjZ
+pDm
+bDP
+bDP
 bqX
 blB
 vxy
-bjW
 bwl
-ccu
+bwl
+ssn
 jtK
 vWD
 byH
@@ -113742,24 +113467,24 @@ jEQ
 cmc
 coh
 cpk
-lim
-lim
-lim
+cpk
+cpk
+cpk
 wjS
-lim
-lim
-lim
-lim
-lim
-lim
+cpk
+cpk
+cpk
+cpk
+cpk
+cpk
 lim
 cEr
 hne
-rbT
+bvL
 uKz
-tAP
-rsA
-rbT
+btP
+aXu
+bvL
 uZG
 hFE
 tBA
@@ -113867,13 +113592,13 @@ aaa
 aae
 aak
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aak
 aae
@@ -113954,15 +113679,15 @@ aYK
 abh
 bhi
 csm
-bjZ
-bjZ
 bDP
-bjZ
-bjZ
+bDP
+pDm
+bDP
+bDP
 bsF
-bmK
+bIH
 vxy
-bjW
+bwl
 bwl
 bjW
 cNr
@@ -114014,11 +113739,11 @@ cEs
 kHY
 kHY
 kHY
-cIU
-cIU
-cIU
-cIU
-cIU
+uzr
+uzr
+uzr
+uzr
+uzr
 kHY
 kHY
 kHY
@@ -114124,13 +113849,13 @@ aaa
 aae
 aak
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aak
 aae
@@ -114218,7 +113943,7 @@ bom
 kQG
 pGs
 bIH
-bVM
+vxy
 bwl
 bwl
 rkl
@@ -114381,13 +114106,13 @@ aaa
 aae
 aak
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aao
-aGh
+aJV
 aao
 aak
 aae
@@ -114429,12 +114154,12 @@ abM
 aax
 vcS
 fqP
-uod
+eTY
 iEF
 hdW
 aPr
 tMo
-eJQ
+pvk
 wmZ
 aDK
 aEE
@@ -114478,7 +114203,7 @@ blB
 vxy
 bub
 fxK
-bvq
+nno
 bxe
 jgB
 kaW
@@ -114686,7 +114411,7 @@ eQe
 sGL
 xaT
 fqP
-eTY
+uod
 okb
 qer
 aPr
@@ -114700,11 +114425,11 @@ aFD
 kBL
 azU
 azU
-aJn
-qzi
-wod
+aEO
+anc
+orq
 lxB
-vtj
+qlX
 fnc
 azU
 jry
@@ -114732,10 +114457,10 @@ aTV
 lFR
 aTV
 blB
-bjW
-bjW
+bwl
+bwl
 jKi
-fxK
+alb
 qpj
 ora
 hky
@@ -114792,7 +114517,7 @@ gNi
 uEv
 ykc
 aaa
-cIU
+uzr
 rbT
 uql
 kHY
@@ -114936,7 +114661,7 @@ tsZ
 abM
 mEo
 qOO
-iZV
+unw
 qWo
 tEO
 xkq
@@ -114957,7 +114682,7 @@ aGP
 azU
 azU
 ntY
-vtj
+qlX
 azU
 nVh
 azU
@@ -114990,7 +114715,7 @@ lRm
 brj
 bev
 btj
-bjW
+bwl
 fxK
 bjW
 bxe
@@ -115044,12 +114769,12 @@ cVV
 cHW
 wOw
 cVX
-bkO
+blc
 bkO
 jVd
 ykc
 aaa
-cIU
+uzr
 efw
 ldT
 uzr
@@ -115198,8 +114923,8 @@ suT
 nGr
 fRz
 oAm
-wfH
-fqP
+bAc
+msu
 uIt
 azU
 azU
@@ -115214,9 +114939,9 @@ awT
 awT
 frZ
 kGl
-aJn
+aEO
 orJ
-aBi
+ent
 tzF
 azU
 aHZ
@@ -115247,7 +114972,7 @@ bkc
 bhm
 bhm
 btk
-bjW
+bwl
 fxK
 bjW
 cNr
@@ -115302,11 +115027,11 @@ sBl
 hej
 cJI
 bmD
-blc
+bkO
 rwz
 ykc
 aaa
-cIU
+uzr
 rsA
 odN
 uzr
@@ -115456,7 +115181,7 @@ amB
 fRz
 oAm
 wfH
-fqP
+msu
 kfa
 fTw
 aJn
@@ -115469,7 +115194,7 @@ mqi
 azU
 wNI
 rHD
-wod
+orq
 doq
 ufr
 azU
@@ -115503,8 +115228,8 @@ bon
 bpG
 bra
 bhm
-bjW
-bjW
+bwl
+bwl
 fxK
 bjW
 wbo
@@ -115531,7 +115256,7 @@ ugK
 cam
 hxC
 bJp
-ivj
+xxm
 iAN
 cnv
 cGK
@@ -115563,7 +115288,7 @@ blc
 blc
 ykc
 aaa
-cIU
+uzr
 gRu
 fGI
 kHY
@@ -115712,21 +115437,21 @@ kDh
 amB
 fVY
 oAm
-koK
-fqP
+wfH
+msu
 nNU
 azU
 azU
 fkb
 azU
 azU
-aBi
+ent
 aJn
 hbj
 azU
 xQm
 rHD
-wod
+orq
 azU
 azU
 azU
@@ -115750,20 +115475,20 @@ aYK
 aYK
 qUQ
 qaS
-dLp
+nEX
 bqf
 sSr
 nCK
 nCK
 ePH
-feu
+evs
 feu
 mUO
 bkc
-tyl
-bjW
+bWa
+bwl
 fxK
-bjW
+bwl
 wkN
 bxe
 fVq
@@ -115820,7 +115545,7 @@ blc
 tnw
 ykc
 aaa
-cIU
+uzr
 gRu
 qAz
 kHY
@@ -115970,11 +115695,11 @@ nGr
 fRz
 oAm
 wfH
-fqP
+msu
 nvp
 azU
 sdt
-aBi
+ent
 hwR
 tlv
 lwy
@@ -115983,7 +115708,7 @@ aJn
 taQ
 wod
 wod
-aJn
+aEO
 azU
 qJi
 psm
@@ -116013,12 +115738,12 @@ bix
 bkf
 bkg
 bmS
-bkg
+bDW
 xoT
 kpp
-bse
-tyl
-bjW
+bTk
+bWa
+bwl
 fxK
 ccu
 vsg
@@ -116227,8 +115952,8 @@ amB
 fRz
 oAm
 wfH
-fqP
-eTY
+msu
+uod
 awT
 awT
 awT
@@ -116240,7 +115965,7 @@ awT
 awT
 awT
 awT
-qzi
+anc
 vHE
 qyG
 hPV
@@ -116270,15 +115995,15 @@ nRH
 bkg
 bkg
 bmT
-bkg
+bDW
 xoT
 kpp
 tuC
-tyl
-bjW
+bWa
+bwl
 fxK
-bjW
-bwi
+bwl
+bjZ
 cNr
 cNr
 cNr
@@ -116302,7 +116027,7 @@ pac
 nhM
 pac
 bJp
-udi
+nsH
 lsM
 cnv
 cnv
@@ -116484,7 +116209,7 @@ amB
 vSx
 uCT
 rSj
-fqP
+msu
 dey
 apj
 hGY
@@ -116494,7 +116219,7 @@ ful
 spE
 iXT
 wcn
-mlo
+pwf
 gED
 awT
 qvv
@@ -116529,12 +116254,12 @@ bkg
 bmU
 bDW
 bpJ
-qxr
+kpp
 bTk
 bWa
 bwl
 fxK
-bjW
+bwl
 eHp
 bxm
 byM
@@ -116552,7 +116277,7 @@ bJp
 bRm
 bSK
 bTG
-cem
+oJW
 jJX
 qja
 oFO
@@ -116574,7 +116299,7 @@ tVd
 csX
 tVd
 czo
-vwt
+pIz
 iqG
 rlk
 pIw
@@ -116614,17 +116339,17 @@ aaa
 aaa
 aaR
 aak
-aOd
+cAu
 aak
 aaR
 aaa
 aaa
-aOd
+cAu
 aaa
 aaa
 aaR
 aak
-aOd
+cAu
 aak
 aaR
 aaa
@@ -116741,7 +116466,7 @@ amB
 lqS
 sGL
 ltu
-fqP
+msu
 par
 apj
 oOc
@@ -116754,7 +116479,7 @@ hes
 dUf
 lPD
 awT
-wod
+orq
 azU
 azU
 azU
@@ -116788,11 +116513,11 @@ adu
 esG
 tFQ
 bkc
-tyl
-bjW
+bWa
+bwl
 fxK
 bwl
-cfx
+eHp
 crF
 cfy
 cfy
@@ -116809,7 +116534,7 @@ bJp
 bJp
 bJp
 lsM
-cem
+oJW
 jJX
 bXB
 tKt
@@ -116824,7 +116549,7 @@ cjY
 ckM
 cgV
 tDo
-tVd
+cVa
 vTa
 hKX
 tVd
@@ -116832,7 +116557,7 @@ xyS
 bUl
 xyS
 pIz
-qlX
+iqG
 tHh
 coq
 lMf
@@ -116876,7 +116601,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -116998,7 +116723,7 @@ amB
 gAL
 sGL
 dDP
-fqP
+msu
 wNc
 wYi
 oOc
@@ -117011,11 +116736,11 @@ eqZ
 lPP
 fgg
 awT
-wod
-wod
+orq
+orq
 naR
 azU
-aOd
+cAu
 aak
 aak
 aOn
@@ -117045,15 +116770,15 @@ aYK
 aYK
 aYK
 aYK
-bjW
-bjW
+bwl
+bwl
 fxK
-bjW
-eHp
+bwl
+cfx
 bxm
 byO
-cfy
-bBY
+byN
+rvx
 bBY
 bBY
 byN
@@ -117066,7 +116791,7 @@ bJp
 bRP
 bSK
 bTG
-cem
+oJW
 jJX
 bXC
 niG
@@ -117074,19 +116799,19 @@ can
 cmo
 tIT
 kpu
-xxk
+xwu
 cGF
 cih
-cjZ
+ckO
 ckO
 oNS
 cnx
 hGo
-vTa
-xyS
-tVd
-czo
-tVd
+aXy
+xTF
+cVa
+tKH
+cVa
 cvz
 pIz
 wAs
@@ -117095,8 +116820,8 @@ cAH
 gIt
 cDu
 vjN
-rHS
-rHS
+uDT
+uDT
 uXv
 deO
 cLf
@@ -117131,11 +116856,11 @@ aaa
 aak
 aak
 aak
-aOd
+cAu
 aak
 fSP
 aak
-aOd
+cAu
 aak
 aak
 aak
@@ -117247,15 +116972,15 @@ anm
 anm
 eBI
 prM
-eXy
+jkn
 cKp
 mRn
 cgl
 eBi
-fPv
+lhm
 oqX
 vDs
-fqP
+msu
 efz
 apj
 dmo
@@ -117272,7 +116997,7 @@ azU
 hkO
 azU
 azU
-aOd
+cAu
 aaa
 aaa
 aOn
@@ -117309,8 +117034,8 @@ bip
 bxl
 bxo
 byP
-cfy
 byN
+cfy
 bDH
 byN
 byN
@@ -117345,7 +117070,7 @@ tVd
 xyS
 tVd
 csX
-pIz
+vwt
 flZ
 bUl
 coq
@@ -117390,7 +117115,7 @@ aaa
 aaa
 aaa
 aaa
-yeW
+cSW
 aaa
 aaa
 aaa
@@ -117492,10 +117217,10 @@ aaa
 aaa
 lhS
 rXO
-kXh
+uKY
 oxw
-kXh
-kXh
+uKY
+uKY
 wPT
 kjz
 lhm
@@ -117503,16 +117228,16 @@ uAh
 rOi
 wxd
 dvk
-cGd
+ybs
 gHx
 rgs
 vgf
 cgl
 gwr
-fPv
+lhm
 wfH
-psH
-fqP
+azv
+msu
 iau
 fJX
 eVC
@@ -117529,7 +117254,7 @@ tIH
 kku
 oxj
 aMM
-aOd
+cAu
 aaa
 aaa
 aOn
@@ -117561,13 +117286,13 @@ qrn
 aYK
 btm
 btm
-crm
+qLZ
 btm
 bwq
 bxo
 byQ
 bAy
-bBZ
+ssX
 bBZ
 bBZ
 bGF
@@ -117618,12 +117343,12 @@ dju
 cBL
 aak
 aak
-aOd
+cAu
 kHY
 kHY
 pJk
 kHY
-aOd
+cAu
 aak
 aak
 kpo
@@ -117647,7 +117372,7 @@ cTK
 cTK
 cTK
 aaa
-yeW
+cSW
 aaa
 cTK
 cTK
@@ -117756,11 +117481,11 @@ dbz
 gZH
 thR
 fQj
+ybs
 cGd
 cGd
 cGd
-cGd
-cGd
+ybs
 kpv
 anm
 anm
@@ -117768,8 +117493,8 @@ hfM
 cKp
 anm
 wYA
-psH
-fqP
+azv
+msu
 ifj
 apj
 hbS
@@ -117786,7 +117511,7 @@ iXK
 kku
 toy
 aMM
-aOd
+cAu
 xMD
 aaa
 aOn
@@ -117805,7 +117530,7 @@ fcp
 lBc
 wBm
 aYK
-jIL
+bVm
 aYK
 aYK
 qAt
@@ -117818,28 +117543,28 @@ qrn
 dnD
 mzy
 qLZ
-crm
+qLZ
 btm
 btm
 bxm
 byO
 gnv
-gnv
-gnv
-gnv
-nNX
+bvH
+bvH
+bvH
+nCF
 xfK
 bJs
-nNX
-nNX
+nCF
+nCF
 bOh
 bPB
 bRq
 bSM
 bJp
 cem
-bTG
-bWD
+bVv
+cAW
 bVq
 rTq
 opg
@@ -117876,11 +117601,11 @@ kUi
 aaa
 aaa
 aak
-aOd
+cAu
 tGD
 woz
 xva
-aOd
+cAu
 aaa
 aaa
 aak
@@ -117899,17 +117624,17 @@ aaa
 aaa
 aaR
 aak
-yeW
-yeW
-yeW
-yeW
-yeW
-yeW
+cSW
+cSW
+cSW
+cSW
+cSW
+cSW
 ivS
-yeW
-yeW
-yeW
-yeW
+cSW
+cSW
+cSW
+cSW
 aak
 aaR
 aaa
@@ -118012,13 +117737,13 @@ jNs
 vTg
 nqI
 uQU
-fPv
+lhm
 iGI
 xWv
 xWv
 xWv
-xWv
-eXy
+rUk
+jkn
 kcp
 mWC
 rod
@@ -118032,18 +117757,18 @@ apj
 rjD
 nYj
 mev
-sJj
+mlo
 spE
 iAO
 uMV
-sJj
+mlo
 uqm
 awT
 jDi
 kku
 kIa
 aMM
-aOd
+cAu
 aaa
 aaa
 aOn
@@ -118084,7 +117809,7 @@ byN
 bCb
 bCb
 bCb
-nCF
+nNX
 bHX
 bJt
 nXp
@@ -118094,14 +117819,14 @@ bxo
 bRR
 bTo
 bJp
-bVr
-bWE
+aPB
+cfz
 qJs
 nzM
 oXM
-bWE
+cfz
 cfF
-kxE
+bVr
 pOw
 cgV
 cit
@@ -118133,11 +117858,11 @@ kUi
 aaa
 aaa
 aak
-aOd
+cAu
 krG
-wuL
+gQf
 quV
-aOd
+cAu
 aaa
 aaa
 aak
@@ -118275,15 +118000,15 @@ xWv
 lgG
 tcB
 bQq
-eXy
+jkn
 tzb
 anm
 xjM
 cfC
 cfC
 jyQ
-psH
-fqP
+azv
+msu
 wtg
 apj
 apj
@@ -118300,7 +118025,7 @@ azU
 syw
 azU
 azU
-aOd
+cAu
 aak
 aak
 aOn
@@ -118319,7 +118044,7 @@ eRw
 ndL
 vnv
 aEd
-gMT
+iJQ
 aEd
 jiy
 nHd
@@ -118390,11 +118115,11 @@ aak
 aaa
 aaa
 aak
-aOd
+cAu
 krG
-wuL
+gQf
 quV
-aOd
+cAu
 aaa
 aaa
 aak
@@ -118520,28 +118245,28 @@ aaa
 lhS
 jfe
 uKY
-wPT
+wTJ
 pNH
 pJz
 nTw
 mvM
 qXt
 sSk
-xWv
+rUk
 xWv
 xMJ
 hcy
 bQq
-eXy
+jkn
 yhW
 gxD
-kYR
+vbp
 fGH
 fGH
-psH
-psH
-fqP
-uod
+azv
+azv
+msu
+eTY
 axD
 aaa
 aaa
@@ -118598,7 +118323,7 @@ byN
 bCc
 bCc
 bCc
-nCF
+nNX
 bHY
 bxo
 byN
@@ -118647,11 +118372,11 @@ aak
 aaa
 aaa
 aak
-aOd
+cAu
 krG
-wuL
+gQf
 quV
-aOd
+cAu
 aaa
 aaa
 aak
@@ -118661,7 +118386,7 @@ aaa
 xcV
 aaa
 aaa
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -118776,7 +118501,7 @@ aaa
 aaa
 lhS
 eyn
-pGI
+qUl
 qqX
 pGn
 lqx
@@ -118784,20 +118509,20 @@ fWq
 xiN
 qXt
 mGY
-xWv
-xWv
+rUk
+rUk
 yfy
 rgf
-xMJ
+czy
 jkn
 cxm
 gxD
 tYj
-kYR
-fGH
+vbp
+uRq
 qAA
 psH
-fqP
+msu
 qLy
 aAd
 aAd
@@ -118826,14 +118551,14 @@ uKd
 toY
 qCq
 ruP
-bwG
+bwu
 gzq
 aEd
 epG
 vKm
 kkR
 aEd
-nHy
+elM
 aEd
 rdx
 rdx
@@ -118855,7 +118580,7 @@ byN
 byN
 byN
 byN
-nCF
+nNX
 bHX
 bxm
 bKE
@@ -118904,11 +118629,11 @@ aak
 aaa
 aaa
 aak
-aOd
+cAu
 krG
-wuL
+gQf
 quV
-aOd
+cAu
 aaa
 aaa
 aak
@@ -118918,7 +118643,7 @@ aaa
 aak
 aaa
 aaa
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -118932,7 +118657,7 @@ shu
 shu
 shu
 aaa
-yeW
+cSW
 aaa
 shu
 shu
@@ -119041,7 +118766,7 @@ cGt
 wyd
 qXt
 lQp
-xWv
+rUk
 xWv
 xMJ
 hwb
@@ -119049,12 +118774,12 @@ bQq
 jkn
 dDc
 gxD
-fGH
+uRq
 kYR
 gVf
-psH
-psH
-fqP
+azv
+azv
+msu
 oPD
 aAd
 dfV
@@ -119090,7 +118815,7 @@ aEd
 aEd
 aEd
 aEd
-gMT
+iJQ
 aEd
 krz
 ozQ
@@ -119121,9 +118846,9 @@ bMz
 bPE
 bRu
 bSO
-kRR
+mMt
 bVv
-cfE
+bgD
 twK
 bZe
 cao
@@ -119161,11 +118886,11 @@ aak
 aaa
 aaa
 aak
-aOd
+cAu
 krG
-wuL
+gQf
 quV
-aOd
+cAu
 aaa
 aaa
 aak
@@ -119184,17 +118909,17 @@ aaa
 aaa
 aaR
 aak
-yeW
-yeW
-yeW
-yeW
+cSW
+cSW
+cSW
+cSW
 cSp
-yeW
-yeW
-yeW
-yeW
-yeW
-yeW
+cSW
+cSW
+cSW
+cSW
+cSW
+cSW
 iGu
 aaR
 aaa
@@ -119310,12 +119035,12 @@ wlo
 iTX
 iTX
 mlc
-psH
+azv
 xDa
 cUd
 bXt
 mHf
-gKb
+afi
 gKb
 iPZ
 uTi
@@ -119341,11 +119066,11 @@ vny
 vny
 vny
 jfu
-dTc
+lWW
 uJf
-oFR
-dTc
-oFR
+brN
+lWW
+brN
 yhi
 qYA
 leM
@@ -119379,7 +119104,7 @@ jtD
 byO
 bJp
 oJW
-bVv
+bTG
 vBS
 cfz
 cfz
@@ -119418,11 +119143,11 @@ dCa
 aaa
 aaa
 aak
-aOd
+cAu
 vtY
 ltO
 qnz
-aOd
+cAu
 aaa
 aaa
 aak
@@ -119446,7 +119171,7 @@ cTK
 cTK
 cTK
 cTi
-yeW
+cSW
 aaa
 shu
 shu
@@ -119554,12 +119279,12 @@ rXM
 oAS
 fww
 uXd
-fPv
+lhm
 iGI
 xWv
 xWv
 xWv
-xWv
+rUk
 dnp
 foA
 mWC
@@ -119572,7 +119297,7 @@ jKg
 phf
 aAd
 mxo
-gXe
+hAy
 rUY
 gmN
 nXw
@@ -119617,7 +119342,7 @@ qIa
 bgi
 nBH
 btm
-mnK
+qBP
 btm
 bwr
 bxo
@@ -119636,12 +119361,12 @@ bPD
 bKD
 bJp
 hxc
-bVv
+bTG
 hdg
 fQK
 hdg
 nMy
-cfE
+bgD
 ccC
 bTG
 cfI
@@ -119671,15 +119396,15 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aak
 aak
-aOd
+cAu
 kHY
 kHY
 jux
 kHY
-aOd
+cAu
 aak
 aak
 kpo
@@ -119806,17 +119531,17 @@ aaa
 lhS
 fRX
 qRT
-kaY
+iXh
 eVQ
 tEW
 oRt
 tfW
 tZX
+aSg
 txz
 txz
 txz
-txz
-txz
+aSg
 iCb
 anm
 anm
@@ -119825,8 +119550,8 @@ dTV
 anm
 wVJ
 vNV
-fqP
-eTY
+msu
+uod
 aAd
 wvi
 msn
@@ -119874,7 +119599,7 @@ jnr
 bgi
 btn
 btm
-mnK
+qBP
 btm
 bws
 bxo
@@ -119898,7 +119623,7 @@ pjl
 pjl
 pjl
 pjl
-xdD
+iar
 bJp
 oZg
 bWD
@@ -119928,7 +119653,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -119936,7 +119661,7 @@ kHY
 riu
 woz
 kHY
-ule
+aQC
 aaa
 aaa
 aak
@@ -120062,31 +119787,31 @@ aaa
 aaa
 lhS
 wMw
-kXh
-kXh
+uKY
+uKY
 qsx
-kXh
-iXh
+uKY
+kCy
 yeh
-fPv
+lhm
 xrM
 nRL
 vgs
 eMr
-txz
+aSg
 oYT
 tRA
 kyw
 wQe
 gwr
-fPv
+lhm
 wfH
-psH
-fqP
+azv
+msu
 uIt
 aAd
 iPF
-gXe
+hAy
 vob
 uWc
 uog
@@ -120131,7 +119856,7 @@ bgi
 bgi
 btq
 btm
-mnK
+qBP
 btm
 cXA
 bxo
@@ -120217,7 +119942,7 @@ shu
 shu
 shu
 aaa
-cSW
+yeW
 aaa
 shu
 shu
@@ -120336,10 +120061,10 @@ dTV
 mRn
 rRI
 wRY
-fPv
+lhm
 wfH
-psH
-fqP
+azv
+msu
 dey
 aAd
 gXe
@@ -120388,7 +120113,7 @@ hty
 wLA
 cXv
 btm
-mnK
+qBP
 btm
 btm
 bxm
@@ -120412,7 +120137,7 @@ bVx
 pjl
 pjl
 pjl
-xdD
+iar
 bJp
 bJp
 aIh
@@ -120450,7 +120175,7 @@ kHY
 dNj
 rbT
 kHY
-wuL
+gQf
 kHY
 aaa
 yjs
@@ -120461,27 +120186,27 @@ wKY
 oKk
 eWn
 sRZ
-aOd
+cAu
 aaa
 aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aak
-yeW
-yeW
-yeW
-cSW
-cSW
 cSW
 cSW
 cSW
 yeW
 yeW
 yeW
+yeW
+yeW
+cSW
+cSW
+cSW
 iGu
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -120610,10 +120335,10 @@ mZp
 aAc
 aaa
 aEd
-hIt
+vCc
 aEd
 wND
-rBn
+hIt
 uif
 xuu
 dLe
@@ -120634,9 +120359,9 @@ hDX
 jMl
 uDQ
 pZn
-qkw
+jQA
 gTG
-cDj
+tKM
 iiB
 hZQ
 rGU
@@ -120645,7 +120370,7 @@ dsw
 wLA
 btr
 btm
-mnK
+qBP
 btm
 btm
 bxm
@@ -120663,13 +120388,13 @@ bOm
 bPG
 bRw
 aWS
-uwK
+lET
 byY
 wer
 fQK
 bTG
 uus
-cfE
+bgD
 ccL
 bJp
 bJp
@@ -120731,7 +120456,7 @@ shu
 shu
 shu
 aaa
-cSW
+yeW
 aaa
 shu
 shu
@@ -120852,9 +120577,9 @@ iGu
 aaa
 axD
 yjU
-azv
-fqP
-eTY
+psH
+msu
+uod
 aAd
 xeQ
 oPp
@@ -120902,7 +120627,7 @@ hTp
 wLA
 btm
 btm
-mnK
+qBP
 btm
 btm
 bxo
@@ -120919,12 +120644,12 @@ bKI
 bKI
 bKI
 bKI
-bSQ
+eJQ
 lET
 byY
 tKl
 gfZ
-bWG
+byY
 ppG
 dTH
 bIn
@@ -120952,7 +120677,7 @@ ckj
 ikF
 tMM
 tMM
-tMM
+cOA
 hYv
 hax
 hax
@@ -120960,10 +120685,10 @@ hax
 hax
 uSp
 gCM
-tMM
+cOA
 kkE
 vgR
-tMM
+cOA
 hHB
 tRY
 lxh
@@ -120988,7 +120713,7 @@ aaa
 aaa
 aaa
 aaa
-cSW
+yeW
 aaa
 aaa
 aaa
@@ -121109,8 +120834,8 @@ iGu
 aaa
 gAL
 jrq
-psH
-fqP
+azv
+msu
 uIt
 aAd
 pHF
@@ -121127,18 +120852,18 @@ aPX
 xZU
 atH
 oNJ
-dTc
+lWW
 koM
 yhi
-dTc
-dTc
+lWW
+lWW
 yhi
-oFR
+brN
 lkQ
 qTr
 qTr
 qTr
-oFR
+brN
 eUa
 nEe
 aEd
@@ -121159,7 +120884,7 @@ wLA
 wLA
 btm
 btm
-mnK
+qBP
 btm
 btm
 bKI
@@ -121173,13 +120898,13 @@ bKI
 bKI
 bKJ
 cpR
-cxi
+bSQ
 bPH
 byY
+bWG
+lET
 byY
-uwK
-byY
-mhJ
+ebB
 hqW
 byY
 wer
@@ -121205,7 +120930,7 @@ bTs
 bTs
 bTs
 bTs
-uRq
+hax
 wVf
 uvB
 ftf
@@ -121238,7 +120963,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aaa
 aak
 aaa
@@ -121252,7 +120977,7 @@ aaa
 aaa
 aak
 aaa
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -121366,14 +121091,14 @@ avX
 aaa
 gAL
 cuK
-psH
+azv
 pdD
 nvp
 aAd
 tlM
 wxG
-gKb
-gKb
+afi
+afi
 cOO
 rbM
 udG
@@ -121382,7 +121107,7 @@ aAc
 aaa
 aPX
 wdZ
-nHy
+elM
 eaD
 aEd
 aQK
@@ -121406,7 +121131,7 @@ bDQ
 rYj
 csf
 igg
-gTG
+aSF
 dhb
 dBD
 uRr
@@ -121416,8 +121141,8 @@ iaF
 wLA
 btt
 btm
-mnK
-buR
+qBP
+btm
 xFv
 bxy
 byY
@@ -121427,23 +121152,23 @@ byY
 byY
 byY
 byY
-byY
-byY
+bWG
+bWG
 bWG
 bWG
 bQb
-nno
-nno
-nno
-nno
-nno
-nno
-cfW
-cfW
-cfW
+vTd
+vTd
+vTd
+vTd
+vTd
+vTd
+vTd
+vTd
+vTd
 niQ
 vTd
-cfW
+vTd
 wFe
 ciy
 tFk
@@ -121495,21 +121220,21 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aaa
 aak
 aaa
 aaa
 aaa
 exs
-cSW
 yeW
+cSW
 xUk
 aaa
 aaa
 aak
 aaa
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -121623,9 +121348,9 @@ avX
 sGN
 sGN
 lAx
-psH
-fqP
-eTY
+azv
+msu
+uod
 aAd
 aAd
 aAd
@@ -121639,7 +121364,7 @@ aAc
 aaa
 aPX
 qIG
-gMT
+iJQ
 waF
 smd
 aQK
@@ -121664,7 +121389,7 @@ wvg
 lAU
 rli
 bmZ
-cDj
+tKM
 fRf
 rsk
 eYr
@@ -121673,12 +121398,12 @@ lfj
 wLA
 btm
 btm
-buT
+qBP
 btm
 btm
 bKI
 bzl
-bWG
+byY
 giN
 ebB
 bSP
@@ -121713,9 +121438,9 @@ jhd
 xIW
 eqc
 cnz
-cRN
 cSC
-cRN
+cSC
+cSC
 cnz
 szr
 vAr
@@ -121727,7 +121452,7 @@ ubt
 cnz
 jhC
 mgS
-pHT
+caF
 sCl
 jhC
 xuH
@@ -121875,18 +121600,18 @@ uwP
 ldk
 oZi
 jkz
-jUi
+hNv
 avX
 myQ
 sGN
 qTO
-psH
-fqP
+azv
+msu
 gsR
 awY
 hec
 rhi
-rhi
+fzn
 kJt
 aAc
 aAc
@@ -121921,7 +121646,7 @@ csf
 csf
 nFi
 cLv
-cDj
+tKM
 fRf
 rif
 uqp
@@ -121975,7 +121700,7 @@ cSD
 cTn
 cnz
 nhu
-cVa
+cGR
 cVA
 cnz
 nhu
@@ -122138,7 +121863,7 @@ vBn
 wZZ
 knt
 qQY
-fqP
+msu
 dey
 aAa
 rhd
@@ -122177,8 +121902,8 @@ bdt
 nfv
 qCk
 kZH
-gTG
-cDj
+aSF
+tKM
 iaG
 iaG
 iaG
@@ -122187,7 +121912,7 @@ iaG
 tTW
 rnk
 btm
-buT
+qBP
 btm
 bws
 bxt
@@ -122394,8 +122119,8 @@ avX
 hks
 sGN
 yaz
-psH
-fqP
+azv
+msu
 par
 gdE
 xfr
@@ -122410,7 +122135,7 @@ vCb
 vCb
 vCb
 vYw
-gMT
+iJQ
 ryS
 aQK
 aMe
@@ -122432,9 +122157,9 @@ eGI
 mIb
 bjc
 kwe
-cCy
-cNm
-cNm
+oFR
+cBm
+cBm
 fCC
 blQ
 bnf
@@ -122444,7 +122169,7 @@ brs
 nty
 qrq
 btm
-buT
+qBP
 btm
 btm
 cLh
@@ -122476,7 +122201,7 @@ wUo
 nCT
 vgy
 ecs
-qvG
+bda
 cnz
 tuV
 hyx
@@ -122643,7 +122368,7 @@ aak
 avX
 avX
 mRl
-uXW
+uUc
 cqi
 dLD
 ijX
@@ -122651,8 +122376,8 @@ avX
 sGN
 sGN
 cRX
-psH
-fqP
+azv
+msu
 wNc
 dIz
 xfr
@@ -122667,7 +122392,7 @@ gsb
 gcp
 vCb
 lLc
-nHy
+elM
 dQt
 aQK
 aMf
@@ -122676,7 +122401,7 @@ aNM
 lEw
 aPt
 aNc
-imr
+xhy
 ovA
 kZC
 aXH
@@ -122688,7 +122413,7 @@ qTB
 yau
 kxi
 csU
-kwe
+lxa
 bgn
 tTW
 tTW
@@ -122701,7 +122426,7 @@ sRX
 blP
 qep
 cJH
-rWX
+qLZ
 cVL
 vDa
 wCv
@@ -122712,7 +122437,7 @@ ydd
 oKd
 upl
 azc
-azc
+cfW
 sNd
 xRi
 mAL
@@ -122735,7 +122460,7 @@ aZl
 frA
 sAK
 eYv
-sor
+dEi
 xgK
 cQs
 dEi
@@ -122749,8 +122474,8 @@ cUf
 cVe
 cVB
 cED
+kaY
 epe
-fGv
 gXR
 ibG
 jjA
@@ -122908,8 +122633,8 @@ avX
 aaa
 gAL
 nJV
-psH
-fqP
+azv
+msu
 xvL
 dIz
 isQ
@@ -122924,7 +122649,7 @@ pEP
 hLe
 vCb
 qNr
-gMT
+iJQ
 yba
 aQK
 aMy
@@ -122945,8 +122670,8 @@ oLo
 jTF
 twB
 gjk
-lgn
-cDj
+frI
+tKM
 blP
 biP
 pDn
@@ -122958,7 +122683,7 @@ kKA
 blP
 btm
 btm
-rWX
+qLZ
 btm
 ebH
 cLh
@@ -122985,7 +122710,7 @@ dPd
 idQ
 sUi
 dTy
-iJQ
+giK
 fRS
 qwE
 eWd
@@ -123055,13 +122780,13 @@ aaa
 aaa
 aaa
 aak
-aOd
+cAu
 aak
 aak
 snm
 aak
 aak
-aOd
+cAu
 aak
 aaa
 aaa
@@ -123165,8 +122890,8 @@ aak
 aaa
 gAL
 inl
-psH
-fqP
+azv
+msu
 wNc
 dIz
 isQ
@@ -123181,7 +122906,7 @@ qYL
 kMd
 vCb
 neP
-nHy
+elM
 aEd
 aQK
 aLp
@@ -123202,7 +122927,7 @@ twB
 twB
 twB
 bdv
-lgn
+frI
 tKM
 blP
 cWg
@@ -123215,7 +122940,7 @@ bru
 tTW
 btm
 btm
-rWX
+qLZ
 btm
 xox
 bxt
@@ -123247,7 +122972,7 @@ lkp
 qwE
 pSh
 jAB
-qvG
+bda
 cnz
 iXW
 nTf
@@ -123263,7 +122988,7 @@ sjU
 sSN
 pzG
 oRq
-ntX
+xke
 xke
 mnj
 cnz
@@ -123295,8 +123020,8 @@ aak
 aak
 aak
 gPG
-aOd
-aOd
+cAu
+cAu
 bIi
 aaa
 jrL
@@ -123311,7 +123036,7 @@ aak
 aak
 aak
 aak
-aOd
+cAu
 lnm
 lnm
 lnm
@@ -123319,10 +123044,10 @@ lnm
 lnm
 lnm
 lnm
-aOd
+cAu
 aak
 aak
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -123420,10 +123145,10 @@ aaa
 aaa
 aak
 aaa
-axD
+gDd
 sXS
 kKC
-fqP
+msu
 ifj
 aAa
 okw
@@ -123451,16 +123176,16 @@ bnM
 aSQ
 gLD
 bsO
-cKJ
-gLD
+cwt
+ptU
 gLD
 gLD
 gLD
 xQc
 gLD
 ctZ
-lgn
-cDj
+frI
+tKM
 tTW
 tTW
 tTW
@@ -123472,7 +123197,7 @@ tTW
 tTW
 cpH
 btm
-rWX
+qLZ
 btm
 btm
 wEW
@@ -123680,8 +123405,8 @@ azW
 azW
 azW
 yfU
-fqP
-eTY
+msu
+uod
 gdE
 isQ
 gAa
@@ -123702,7 +123427,7 @@ aMi
 aMV
 aNP
 aOz
-bdG
+aNc
 sAB
 uDg
 baa
@@ -123716,8 +123441,8 @@ ccj
 bqi
 bcy
 cun
-lgn
-cDj
+frI
+tKM
 bhD
 biS
 hqK
@@ -123729,7 +123454,7 @@ jyW
 bhD
 btn
 btm
-rWX
+qLZ
 btm
 xNP
 bxt
@@ -123745,7 +123470,7 @@ lDt
 bze
 eiR
 vri
-qvG
+bda
 caq
 wdf
 kTA
@@ -123761,7 +123486,7 @@ ceW
 cvH
 pSh
 fLB
-qvG
+bda
 cnz
 jUj
 lSQ
@@ -123774,11 +123499,11 @@ uTa
 eKv
 cnz
 szr
-vAr
+cJf
 ubt
 cnz
 szr
-vAr
+cJf
 ubt
 cnz
 jwI
@@ -123805,7 +123530,7 @@ aaa
 aaa
 cUC
 aaa
-aOd
+cAu
 aaa
 aak
 bIi
@@ -123937,7 +123662,7 @@ eQy
 tkU
 azW
 oyd
-fqP
+msu
 joy
 jwf
 eXt
@@ -123973,8 +123698,8 @@ piO
 piO
 piO
 cuR
-lgn
-kFt
+frI
+avz
 bhG
 cWC
 bkw
@@ -123986,7 +123711,7 @@ jXq
 bhD
 esy
 btm
-rWX
+qLZ
 bws
 bxr
 bxr
@@ -124001,7 +123726,7 @@ bIp
 bIp
 bIp
 xrf
-rvx
+eOR
 bda
 loz
 egf
@@ -124018,7 +123743,7 @@ mew
 cvH
 pSh
 jAB
-qvG
+bda
 cnz
 fRC
 lSQ
@@ -124031,11 +123756,11 @@ cSI
 cTr
 cnz
 nhu
-cGR
+bab
 cDq
 cnz
 nhu
-cGR
+bab
 hIF
 cnz
 xjf
@@ -124062,7 +123787,7 @@ aaa
 aaa
 cUC
 aaa
-aOd
+cAu
 aaa
 aak
 bIi
@@ -124072,7 +123797,7 @@ bIi
 ruA
 sUq
 gKv
-xOV
+aLU
 puW
 rQC
 sUq
@@ -124194,7 +123919,7 @@ sNV
 lDA
 myR
 gJq
-fqP
+msu
 faq
 aAa
 nqU
@@ -124209,14 +123934,14 @@ ewz
 uie
 vCb
 gMT
-bwv
+aaB
 aEd
 bqm
 aMz
 aNk
 aOb
 aLr
-bdG
+aNc
 tPa
 piO
 piO
@@ -124243,7 +123968,7 @@ wiK
 bsh
 bsL
 buh
-rWX
+qLZ
 qvL
 bxr
 eBC
@@ -124262,7 +123987,7 @@ efC
 eNn
 caq
 jVB
-kTA
+iZV
 qrL
 wKH
 uHo
@@ -124288,16 +124013,16 @@ uTa
 cTv
 cnz
 vIp
-vAr
+cJf
 cDn
 cnz
 vIp
-vAr
+cJf
 cDn
 cnz
 jDF
-nKs
-vpb
+yjy
+big
 sCl
 vNa
 yjy
@@ -124451,7 +124176,7 @@ rFN
 pnL
 yjq
 iVa
-fqP
+msu
 uIt
 aQK
 aQK
@@ -124473,7 +124198,7 @@ aLr
 aLr
 aLr
 aLr
-cuR
+bUa
 xhy
 piO
 aSM
@@ -124488,7 +124213,7 @@ bbn
 nRZ
 bdA
 frI
-bks
+kFt
 nFE
 biV
 pPi
@@ -124500,7 +124225,7 @@ lRO
 kAc
 bsL
 btm
-buT
+qBP
 gCt
 qNz
 dIC
@@ -124532,7 +124257,7 @@ cvH
 pMp
 pSh
 fLB
-qvG
+bda
 cnz
 jzs
 uSm
@@ -124708,7 +124433,7 @@ ssV
 yff
 myR
 gJq
-fqP
+msu
 rWg
 aEd
 ppL
@@ -124723,7 +124448,7 @@ ghk
 jti
 vCb
 nHy
-aHx
+mhJ
 uif
 aEd
 aMl
@@ -124757,7 +124482,7 @@ xNO
 kAc
 bsL
 btm
-buT
+qBP
 gCt
 cYb
 vmg
@@ -124772,11 +124497,11 @@ fvV
 tNo
 sKj
 vZF
-uUG
+cIh
 nmI
 caq
 kiG
-kiG
+fnt
 wOj
 mlh
 uHo
@@ -124789,7 +124514,7 @@ oZk
 siF
 pSh
 jAB
-qvG
+bda
 waP
 waP
 waP
@@ -124797,7 +124522,7 @@ waP
 waP
 waP
 waP
-aOd
+cAu
 aaa
 aaa
 aak
@@ -124841,8 +124566,8 @@ tDf
 vHw
 tet
 jTo
-lKG
-lKG
+rBn
+rBn
 uXL
 vzx
 lKG
@@ -124861,7 +124586,7 @@ lnm
 lnm
 eTK
 cer
-jQA
+lnm
 lnm
 lnm
 lnm
@@ -124965,7 +124690,7 @@ kwL
 qFZ
 azW
 pDb
-fqP
+msu
 gPn
 aEd
 iBK
@@ -124980,14 +124705,14 @@ lwt
 ngv
 vCb
 csK
-qmO
+cpn
 fxD
 brf
 aMm
 bgr
 bgr
 aOB
-bdA
+rHh
 tPa
 piO
 aSO
@@ -125002,7 +124727,7 @@ bbB
 nRZ
 bdA
 cAA
-bks
+kFt
 bhH
 cXp
 bnj
@@ -125014,7 +124739,7 @@ brx
 kAc
 bsL
 btm
-buT
+qBP
 gCt
 jJs
 dJo
@@ -125029,10 +124754,10 @@ uTM
 lLd
 bIq
 pSh
-cfN
+cDw
 bda
 loz
-kiG
+fnt
 eJY
 wOj
 nRT
@@ -125046,7 +124771,7 @@ oZk
 cww
 pSh
 fLB
-qvG
+bda
 waP
 aaa
 ijt
@@ -125054,7 +124779,7 @@ cqX
 fZI
 cQV
 cRy
-aOd
+cAu
 cSJ
 cyj
 cTD
@@ -125088,8 +124813,8 @@ cQB
 cQO
 cQO
 cQB
-evm
-evm
+cQB
+cQB
 oWc
 end
 wSu
@@ -125222,7 +124947,7 @@ iTq
 aXZ
 azW
 sJc
-fqP
+msu
 lYf
 aEd
 oDh
@@ -125237,7 +124962,7 @@ vUr
 vCb
 vCb
 gMT
-oDh
+rrb
 bwu
 aLu
 aMn
@@ -125271,7 +124996,7 @@ bry
 bsh
 bsL
 btm
-buT
+qBP
 gQe
 bxr
 otq
@@ -125286,12 +125011,12 @@ szH
 tDQ
 bIW
 pSh
-vri
+imr
 jhB
 caq
 kiG
-kiG
-wOj
+fnt
+tyl
 dnA
 rzS
 hrs
@@ -125358,8 +125083,8 @@ stW
 lLx
 bDX
 cqW
-lLx
-lLx
+bDX
+bDX
 aJk
 bAz
 gxM
@@ -125479,7 +125204,7 @@ omm
 omm
 fKZ
 sEE
-fqP
+msu
 nHX
 aEd
 aHx
@@ -125495,7 +125220,7 @@ dTc
 dTc
 qZn
 xZU
-hIt
+vCc
 aEd
 aEd
 bdK
@@ -125528,7 +125253,7 @@ brE
 bhD
 esy
 btm
-buT
+qBP
 bws
 bxr
 bxr
@@ -125597,12 +125322,12 @@ ckj
 ckj
 ckj
 ckj
-aOd
+cAu
 aak
 aak
 aak
 aak
-aOd
+cAu
 aaa
 aaa
 bIi
@@ -125739,27 +125464,27 @@ pPR
 ujS
 wEb
 uJf
-dTc
+lWW
 yhi
 yhi
 gaG
-oFR
+brN
 yhi
-oFR
+brN
 gIm
 dqK
 aNd
 jiT
 tpy
 aEd
-hIt
+vCc
 qLz
 aEd
 fWc
 hBv
 bdK
 bdG
-vCc
+frI
 aSd
 bgo
 ejX
@@ -125785,7 +125510,7 @@ fiZ
 bhW
 btn
 cJH
-rWX
+qLZ
 cVL
 kZt
 xdQ
@@ -125800,19 +125525,19 @@ ugm
 jhn
 eBR
 lxl
-cfN
+cDw
 ewa
-uWL
-uWL
+nup
+nup
 nup
 jIz
-uWL
+nup
 qxV
 hYJ
 vVD
 jiD
-uWL
-uWL
+nup
+nup
 xjR
 jIz
 wyj
@@ -126009,27 +125734,27 @@ kCa
 tef
 aEd
 aEd
-hIt
+vCc
 kGY
 aEd
 aNn
 aTz
 iHB
-aPB
-vCc
-aSg
-aSX
-cBm
+qkw
+frI
+cCy
+mJt
+cNm
 rtd
-cBm
-cBm
+cNm
+cNm
 arM
 bZT
 sfA
-mJt
-cNm
+ojF
+cBm
 cuY
-cLv
+bgs
 bgv
 bhK
 biZ
@@ -126042,7 +125767,7 @@ brA
 bhK
 btm
 btm
-buT
+qBP
 btm
 rOX
 xdQ
@@ -126103,7 +125828,7 @@ nsS
 qNA
 qYp
 ybn
-pbj
+ckk
 uoC
 psF
 hYB
@@ -126111,7 +125836,7 @@ cPj
 cPA
 cPR
 ckj
-aOd
+cAu
 aak
 aak
 cQX
@@ -126254,9 +125979,9 @@ gDd
 gDd
 aEd
 tHU
-aOd
-aOd
-aOd
+cAu
+cAu
+cAu
 aEd
 aEd
 aEd
@@ -126287,7 +126012,7 @@ aTU
 aTU
 xTe
 bgs
-bhI
+cDj
 bhL
 fmY
 bkD
@@ -126299,7 +126024,7 @@ brB
 bhK
 btm
 btm
-buT
+qBP
 btm
 btm
 oNO
@@ -126359,7 +126084,7 @@ mYp
 mHE
 cmv
 ckj
-uDT
+cOh
 cOh
 ckj
 ckj
@@ -126515,7 +126240,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aEd
 aEd
 aEd
@@ -126544,7 +126269,7 @@ bbr
 aTU
 cuz
 bgs
-bhI
+cDj
 bhK
 oHm
 lid
@@ -126556,7 +126281,7 @@ qBs
 bhK
 xpL
 btm
-buT
+qBP
 btm
 btm
 qqB
@@ -126617,7 +126342,7 @@ ckj
 ckj
 ckj
 chq
-lWW
+chq
 cOv
 cJd
 ckj
@@ -126772,7 +126497,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aOq
 aHx
 bhJ
@@ -126781,8 +126506,8 @@ uif
 oQz
 aEd
 xZU
-hIt
-hIt
+vCc
+vCc
 bwG
 xZU
 rml
@@ -126813,7 +126538,7 @@ brF
 bhK
 buR
 btm
-buT
+qBP
 btm
 btm
 xdQ
@@ -126874,7 +126599,7 @@ ckj
 cOn
 egX
 chq
-xOc
+cQh
 irp
 oPH
 ckj
@@ -126893,8 +126618,8 @@ aak
 aak
 aak
 tzh
-aOd
-aOd
+cAu
+cAu
 bIi
 aaa
 sUq
@@ -126909,7 +126634,7 @@ aak
 aak
 aak
 aak
-aOd
+cAu
 lnm
 lnm
 lnm
@@ -126917,10 +126642,10 @@ lnm
 lnm
 lnm
 lnm
-aOd
+cAu
 aak
 aak
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -127029,7 +126754,7 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aEd
 aEd
 aEd
@@ -127070,7 +126795,7 @@ brG
 bhK
 btx
 btm
-buT
+qBP
 btm
 btm
 xdQ
@@ -127167,13 +126892,13 @@ aaa
 aaa
 aaa
 aak
-aOd
+cAu
 aak
 aak
 rQo
 aak
 aak
-aOd
+cAu
 aak
 aaa
 aaa
@@ -127327,7 +127052,7 @@ imS
 bhK
 bty
 btm
-buT
+qBP
 btm
 btm
 kbN
@@ -127342,7 +127067,7 @@ jQD
 bNu
 ubP
 bCB
-yiz
+cEX
 vZD
 gje
 tNR
@@ -127381,14 +127106,14 @@ hDp
 iyr
 ckj
 oMg
-cOy
+cPs
 tBX
 wMC
 ckj
 ckj
 ckj
 hDk
-cOi
+hDk
 ckj
 ckj
 ckj
@@ -127558,7 +127283,7 @@ rrF
 aFd
 jVy
 aPH
-bhC
+ebz
 cDj
 aQK
 aQK
@@ -127584,7 +127309,7 @@ aQK
 aQK
 rPj
 btm
-buT
+qBP
 btm
 btm
 rND
@@ -127599,7 +127324,7 @@ yiz
 aNB
 iiK
 iiK
-iiK
+evm
 utO
 fqV
 abu
@@ -127632,7 +127357,7 @@ cUB
 cCQ
 cFd
 dRF
-fnt
+cRj
 xaK
 ckj
 izb
@@ -127644,7 +127369,7 @@ xaV
 ckj
 cNn
 mPE
-cOy
+cPs
 cPs
 cOx
 rxP
@@ -127652,9 +127377,9 @@ ckj
 pia
 wWH
 wWH
-rUk
+fCF
 ckj
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -127815,7 +127540,7 @@ aNf
 aNY
 aOF
 aQd
-aSF
+gTG
 cDj
 aQK
 xjL
@@ -127832,10 +127557,10 @@ oFi
 bgy
 bhO
 aEd
-bvL
+bwu
 bmb
 qAH
-eqr
+onb
 qYs
 onb
 oXf
@@ -127889,7 +127614,7 @@ cUD
 cCL
 cFd
 cGw
-fnt
+cRj
 xaK
 oPb
 izY
@@ -127903,7 +127628,7 @@ cNo
 cNI
 cNX
 qON
-cOy
+cPs
 ure
 pia
 ktW
@@ -128075,11 +127800,11 @@ aQm
 aRm
 cXg
 aTq
-eqr
-eqr
-eqr
-eqr
-eqr
+onb
+onb
+onb
+onb
+onb
 ePy
 bai
 cjI
@@ -128089,14 +127814,14 @@ oFi
 gGW
 lNg
 aEd
-bvL
+bwu
 bmc
 aEd
 aEd
 aEd
 aEd
 aEd
-btn
+agl
 btm
 buX
 btm
@@ -128159,7 +127884,7 @@ sns
 cNp
 cNY
 cNY
-cOl
+cNY
 cQh
 lNY
 cOV
@@ -128319,9 +128044,9 @@ aLE
 aNb
 aFd
 aPs
-aIr
+kxE
 aKS
-aJM
+aJO
 nSd
 aEe
 aFd
@@ -128338,7 +128063,7 @@ aQK
 aQK
 aQK
 aQK
-aXy
+xHt
 lyM
 aEd
 bdN
@@ -128346,14 +128071,14 @@ wGd
 cjT
 bhQ
 aEd
-bvL
+bwu
 bmd
 aEd
 boK
 bpX
 brH
 eKq
-aJu
+cOy
 btU
 bIQ
 btU
@@ -128414,10 +128139,10 @@ ugM
 xpK
 pmM
 cNW
-cOy
+cPs
 cNZ
 tkY
-cOA
+cNX
 xIl
 cOW
 lNl
@@ -128595,7 +128320,7 @@ aWa
 cVn
 aXP
 aPX
-aXy
+xHt
 vnF
 aEd
 bgE
@@ -128603,16 +128328,16 @@ bjv
 vRl
 pUf
 aEd
-bvL
+bwu
 bme
 aEd
 boL
 bpY
 brI
 otW
+buR
 btm
-btm
-lQN
+bva
 btm
 btm
 dGR
@@ -128674,13 +128399,13 @@ ocs
 cIg
 cPi
 tCh
-cOy
+cPs
 dsx
 pia
 rYM
 hOM
 rYM
-tuE
+rYM
 cQw
 cSh
 aaa
@@ -128852,7 +128577,7 @@ exy
 aRf
 aXQ
 aPX
-aXy
+xHt
 pgc
 aEd
 aEd
@@ -128867,7 +128592,7 @@ boM
 cXK
 brJ
 bsk
-qBP
+lQN
 qBP
 cec
 btm
@@ -128920,7 +128645,7 @@ xaK
 aak
 aak
 aak
-aOd
+cAu
 aak
 aak
 aaa
@@ -128931,7 +128656,7 @@ cFv
 cNX
 iEP
 rvI
-cOy
+cPs
 dsx
 cOV
 sWC
@@ -129090,7 +128815,7 @@ aLF
 aNV
 aHa
 aRD
-aIu
+aIr
 iNA
 aJP
 iqe
@@ -129124,9 +128849,9 @@ boN
 bqa
 tRh
 eKq
+buR
 btm
-btm
-mCL
+gzW
 btm
 btm
 dAW
@@ -129177,15 +128902,15 @@ xaK
 aaa
 aaa
 aaa
-aOd
-aOd
+cAu
+cAu
 aak
 aak
 uxu
 aak
 ckj
 ipJ
-cOy
+cPs
 cNX
 rDN
 cNX
@@ -129196,7 +128921,7 @@ pCD
 pCD
 xiR
 ckj
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -129704,7 +129429,7 @@ ckj
 ckj
 ckj
 ckj
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -129896,10 +129621,10 @@ kEc
 nJv
 tLs
 nBo
-buR
+btm
 gzW
-buT
-buT
+qBP
+qBP
 pQx
 bJT
 bBg
@@ -130160,7 +129885,7 @@ noW
 fkH
 sAV
 mTm
-evs
+hJu
 bJT
 fje
 eLr
@@ -130206,13 +129931,13 @@ rMV
 aaa
 aaa
 aaa
-aOd
+cAu
 aak
 cUW
 xHL
 aak
 aak
-aOd
+cAu
 aaa
 aaR
 aaa
@@ -130410,8 +130135,8 @@ eHD
 sJz
 otW
 buR
-buR
-orq
+btm
+bva
 btm
 btm
 rmt
@@ -130451,7 +130176,7 @@ cQG
 xaK
 xaK
 xaK
-cSr
+cSf
 cSY
 cRA
 mJe
@@ -130666,7 +130391,7 @@ rGN
 tBp
 nfd
 eKq
-btn
+agl
 bul
 gzW
 bvI
@@ -130677,7 +130402,7 @@ oQT
 eAX
 bJT
 lGN
-wUA
+tzt
 bIw
 bJT
 xwH
@@ -130706,9 +130431,9 @@ bTe
 cPO
 nAC
 cPO
-cRj
-cRj
-czy
+aJM
+aJM
+cSl
 cSZ
 cSZ
 cTY
@@ -130923,8 +130648,8 @@ lmv
 lmv
 lmv
 pzw
+bhI
 btF
-lob
 bvc
 btF
 btF
@@ -130964,7 +130689,7 @@ cPP
 cQH
 cQH
 cRk
-cRF
+cSr
 ozT
 cTa
 bsA
@@ -131178,9 +130903,9 @@ bsp
 btB
 oZu
 vXK
-cek
+eLL
 tSE
-jfH
+bst
 jfH
 bvd
 bvw
@@ -131201,9 +130926,9 @@ aPa
 xcv
 bJT
 bUu
-poi
+aQq
 tNk
-bBg
+ajG
 oUs
 qUJ
 dbT
@@ -131216,7 +130941,7 @@ xaK
 ces
 bCG
 cDr
-czy
+cQH
 cPS
 xaK
 xaK
@@ -131237,10 +130962,10 @@ aaa
 cAR
 aak
 aak
-aOd
+cAu
 aak
 aak
-aOd
+cAu
 aaa
 aaR
 aaa
@@ -131431,7 +131156,7 @@ wxQ
 aOG
 aaa
 aaa
-cek
+eLL
 fYD
 ijT
 giD
@@ -131459,8 +131184,8 @@ mtm
 bJT
 tBu
 xuU
-ssX
-ssX
+wUA
+wUA
 imM
 gZi
 iJu
@@ -131470,8 +131195,8 @@ cda
 afl
 afl
 sEW
-czy
-czy
+cSl
+cSl
 cGC
 vcN
 cQd
@@ -131690,19 +131415,19 @@ aaa
 aaa
 bsp
 mIM
-mbf
+giY
 ibh
-cek
+eLL
 tSE
-jfH
+bst
 jfH
 erB
-bst
-bst
-bst
-bst
-bst
-bst
+jfH
+jfH
+jfH
+jfH
+jfH
+jfH
 bEl
 bJT
 xTA
@@ -131946,20 +131671,20 @@ aOG
 aDH
 aDH
 bsp
-pDm
+cek
 ppp
-pDm
+cek
 lmv
 phy
 bst
 jfH
 erB
 bvy
-bst
-bst
-bst
+jfH
+jfH
+jfH
 bBi
-bst
+jfH
 bEm
 bJT
 vgE
@@ -132204,19 +131929,19 @@ aaa
 aaa
 bsp
 bnE
-mbf
+giY
 bol
-cek
+eLL
 bOn
 cGH
 jfH
 erB
-bst
-bst
-bst
-bst
-bst
-bst
+jfH
+jfH
+jfH
+jfH
+jfH
+jfH
 vCh
 bOO
 mVM
@@ -132459,20 +132184,20 @@ wxQ
 aOG
 aak
 aak
-cek
+eLL
 bnF
 giY
 bqj
 brP
 bOo
 cGI
-bsr
 erB
-bvz
-bvz
-bvz
-bvz
-bvz
+erB
+wlx
+wlx
+wlx
+wlx
+wlx
 bCP
 bEo
 bxD
@@ -132720,16 +132445,16 @@ bsp
 bnQ
 boW
 bzC
-cek
+eLL
 bOn
 btH
 bvh
 bvA
 bwa
 bwH
-bst
+jfH
 btH
-bst
+jfH
 btH
 bEB
 bxD
@@ -132770,19 +132495,19 @@ xaK
 aaa
 oCj
 aaa
-aak
-aaa
-aaa
-aaa
-aaa
+aeE
+ule
+ule
+ule
+ule
 aaa
 iGq
 aaa
-aaa
-aaa
-aaa
-aaa
-aak
+ule
+ule
+ule
+ule
+aeE
 aaa
 aaR
 aaa
@@ -132975,9 +132700,9 @@ aak
 aak
 bsp
 bsp
-pDm
+cek
 bql
-pDm
+cek
 bss
 boU
 bmm
@@ -133232,9 +132957,9 @@ aaa
 aaa
 aaa
 aaa
-pDm
+cek
 pXq
-pDm
+cek
 bHT
 boU
 aaa
@@ -133489,23 +133214,23 @@ aaa
 aaa
 aaa
 aaa
-pDm
+cek
 tbN
-pDm
-bst
+cek
+jfH
 boU
 aaa
 aaa
 aaa
 boU
-bst
+jfH
 boU
-bst
+jfH
 boU
 aak
-aOd
-aOd
-aOd
+cAu
+cAu
+cAu
 aak
 aak
 aaa
@@ -133746,9 +133471,9 @@ aaa
 aaa
 aaa
 aaa
-pDm
+cek
 bqn
-pDm
+cek
 bxF
 boU
 aak
@@ -133798,19 +133523,19 @@ aak
 aak
 oCj
 aaa
-aak
-aaa
-aaa
-aaa
-aaa
+aeE
+ule
+ule
+ule
+ule
 aaa
 iGq
 aaa
-aaa
-aaa
-aaa
-aaa
-aak
+ule
+ule
+ule
+ule
+aeE
 aaa
 aaR
 aaa
@@ -135346,7 +135071,7 @@ aaa
 aaa
 wAa
 aaa
-aOd
+cAu
 aaa
 aak
 aaa
@@ -135597,19 +135322,19 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aak
 aak
 aaR
 aak
 aaa
-aOd
+cAu
 aaa
 aak
 aaR
 aak
 aak
-aOd
+cAu
 aaa
 aaa
 aaa
@@ -136096,9 +135821,9 @@ aaa
 aaa
 aaa
 aaa
-aOd
+cAu
 aak
-aOd
+cAu
 aaa
 aaa
 aaa

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -3772,10 +3772,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "avn" = (
-/obj/effect/spawner/random/structure/girder,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical)
 "avp" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 6
@@ -9585,12 +9585,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"aXp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/girder,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical)
 "aXs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -9602,7 +9596,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "aXy" = (
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aXz" = (
@@ -18317,6 +18315,10 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"bLr" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "bLB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/west,
@@ -21217,10 +21219,6 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/maintenance/department/science/xenobiology)
-"cmO" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/maintenance/port/greater)
 "cmR" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -21776,6 +21774,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "csN" = (
@@ -24630,7 +24629,6 @@
 "cPy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cPA" = (
@@ -32325,12 +32323,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"fxZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "fyd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32362,7 +32354,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/girder,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "fym" = (
@@ -35313,10 +35304,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/maintenance/port/greater)
 "gMZ" = (
 /obj/structure/closet/radiation,
 /obj/structure/sign/warning/secure_area/directional/south,
@@ -35714,6 +35705,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "gUf" = (
@@ -38244,6 +38236,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "hQu" = (
@@ -39374,6 +39367,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "ipo" = (
@@ -40679,7 +40673,6 @@
 "iOM" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "iOT" = (
@@ -41387,7 +41380,6 @@
 "jbX" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/structure/grille,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "jce" = (
@@ -41884,7 +41876,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "jlw" = (
@@ -41915,6 +41906,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "jmi" = (
@@ -43929,7 +43921,6 @@
 "kbl" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "kbr" = (
@@ -43947,6 +43938,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "kbw" = (
@@ -45842,14 +45834,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"kPE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "kPM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46607,6 +46591,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "lja" = (
@@ -49262,12 +49247,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"mok" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "mou" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49323,7 +49302,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/grille_or_waste,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "mpp" = (
@@ -52341,7 +52319,6 @@
 /area/station/hallway/primary/port)
 "nAS" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nBo" = (
@@ -52463,6 +52440,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nCK" = (
@@ -52714,15 +52692,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"nHy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical)
 "nHA" = (
 /obj/item/radio/intercom/directional/north{
 	broadcasting = 1;
@@ -55106,7 +55075,6 @@
 "oBx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/graffiti,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "oBL" = (
@@ -55286,11 +55254,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
-"oEJ" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "oES" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
@@ -55453,7 +55416,6 @@
 /area/station/security/prison/visit)
 "oJD" = (
 /obj/effect/spawner/random/engineering/tank,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "oJF" = (
@@ -57669,12 +57631,6 @@
 /obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
-"pAM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical)
 "pAU" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8
@@ -59769,6 +59725,7 @@
 /obj/effect/spawner/random/trash/garbage,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "qtD" = (
@@ -60227,6 +60184,7 @@
 "qCC" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "qCF" = (
@@ -63935,6 +63893,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "scy" = (
@@ -64287,6 +64246,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "smE" = (
@@ -67490,13 +67450,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
-"tyl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/space_heater,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/port/greater)
 "tyw" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -68492,7 +68445,6 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "tQe" = (
@@ -70860,6 +70812,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "uSM" = (
@@ -72473,6 +72426,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "vBM" = (
@@ -74521,6 +74475,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "wrR" = (
@@ -99020,8 +98975,8 @@ giA
 gsn
 gVY
 uGE
-big
-vsK
+mFd
+pNZ
 mSK
 mSK
 fLL
@@ -99248,7 +99203,7 @@ azQ
 azQ
 aVj
 aWm
-oEJ
+ovt
 bJf
 aCR
 aCR
@@ -99278,7 +99233,7 @@ hyj
 vCl
 uGE
 nAS
-dqG
+kuB
 rql
 mSK
 wVg
@@ -99505,7 +99460,7 @@ aTg
 azQ
 vQJ
 abd
-byn
+abd
 bJf
 abd
 byn
@@ -99534,7 +99489,7 @@ bwO
 uGE
 uGE
 uGE
-cmO
+uGE
 nCJ
 llH
 mSK
@@ -99792,7 +99747,7 @@ xAQ
 lEg
 lEg
 jBK
-fxZ
+fKe
 vsK
 mSK
 tkg
@@ -103149,7 +103104,7 @@ uGE
 uGE
 uGE
 uGE
-avn
+efg
 ipl
 myZ
 myZ
@@ -104435,7 +104390,7 @@ kok
 urb
 uGE
 rcL
-kPE
+pMa
 aWh
 kXG
 hnr
@@ -104691,7 +104646,7 @@ ogs
 kBn
 ruN
 uGE
-jBB
+sJt
 jmd
 myZ
 exW
@@ -105157,7 +105112,7 @@ aak
 aak
 aDr
 aGU
-aVp
+hax
 aWt
 bmV
 aXm
@@ -105414,7 +105369,7 @@ cDx
 cJe
 aDr
 aGU
-aVp
+hax
 mpn
 bmV
 aYs
@@ -105671,7 +105626,7 @@ cDz
 cJg
 aDr
 aGU
-aVp
+hax
 aWt
 bmV
 aYt
@@ -105719,7 +105674,7 @@ uGE
 uGE
 uGE
 uGE
-avn
+efg
 kbu
 myZ
 cUh
@@ -105972,7 +105927,7 @@ usi
 kfY
 uuX
 uGE
-tyl
+tnO
 iOM
 hAy
 scg
@@ -106229,7 +106184,7 @@ dvd
 kfY
 bzq
 uGE
-bWo
+nnH
 ntr
 qCC
 oPI
@@ -106486,12 +106441,12 @@ cNV
 kfY
 nmM
 uGE
-avn
+efg
 pGR
-ntr
+hAy
 yfZ
 xut
-dBL
+gMT
 vUi
 myZ
 rze
@@ -123133,7 +123088,7 @@ nXS
 vqW
 cFy
 vCb
-wdZ
+avn
 qpm
 aEd
 bou
@@ -123391,7 +123346,7 @@ vCb
 vCb
 vCb
 gUa
-qZn
+aXy
 aEd
 bph
 aMi
@@ -123647,7 +123602,7 @@ pID
 vZR
 bAa
 vCb
-nHy
+aBi
 oBx
 aEd
 bpM
@@ -123904,8 +123859,8 @@ rmH
 ewz
 uie
 vCb
-gMT
-mok
+dEi
+bwv
 aEd
 bqm
 aMz
@@ -124161,8 +124116,8 @@ xGI
 gdq
 lKt
 vCb
-gMT
-dqK
+dEi
+bLr
 aEd
 aEd
 aLr
@@ -124418,8 +124373,8 @@ qgB
 ghk
 jti
 vCb
-nHy
-aXy
+aBi
+aHx
 uif
 aEd
 aMl
@@ -124676,7 +124631,7 @@ lwt
 ngv
 vCb
 csK
-aXp
+qmO
 fxD
 brf
 aMm
@@ -124932,8 +124887,8 @@ vCb
 vUr
 vCb
 vCb
-gMT
-pAM
+dEi
+oDh
 bvL
 aLu
 aMn

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -1317,7 +1317,7 @@
 	name = "Supermatter Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "agx" = (
@@ -3552,7 +3552,6 @@
 "atI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "atJ" = (
@@ -6070,20 +6069,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aJA" = (
-/obj/structure/table/reinforced,
-/obj/item/wrench{
-	pixel_x = -2;
-	pixel_y = 1
-	},
-/obj/item/wrench{
-	pixel_x = 5
-	},
-/obj/item/pipe_dispenser{
-	pixel_y = 1
-	},
-/obj/item/pipe_dispenser{
-	pixel_y = -2
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -9595,7 +9580,7 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "aXu" = (
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "aXz" = (
@@ -13970,6 +13955,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/depsec/medical,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "boE" = (
@@ -13989,6 +13975,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/depsec/medical,
 /obj/effect/turf_decal/tile/blue/anticorner,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
 	},
@@ -16091,6 +16078,7 @@
 /area/station/security/checkpoint)
 "bwQ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint)
 "bwR" = (
@@ -19817,7 +19805,7 @@
 	dir = 9
 	},
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "bYY" = (
@@ -20004,13 +19992,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "caE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "caF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -20823,7 +20808,7 @@
 	dir = 5
 	},
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "cjk" = (
@@ -21144,6 +21129,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/supply)
 "cmh" = (
@@ -21259,6 +21245,7 @@
 /area/station/medical/virology)
 "cnu" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/supply)
 "cnv" = (
@@ -24564,6 +24551,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display/ai/directional/north,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cPe" = (
@@ -26670,21 +26658,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "cZj" = (
-/obj/structure/table/reinforced,
-/obj/item/electronics/apc{
-	pixel_y = -2
-	},
-/obj/item/t_scanner{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/t_scanner{
-	pixel_x = -2;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/secure_area/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/machinery/modular_computer/preset/engineering{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "cZm" = (
@@ -26700,6 +26680,7 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cZv" = (
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "cZw" = (
@@ -26813,6 +26794,7 @@
 	name = "Gas to Mix"
 	},
 /obj/effect/turf_decal/box,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dbH" = (
@@ -27170,6 +27152,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/office)
+"diT" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "diU" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -27939,6 +27926,7 @@
 "dBm" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/sign/poster/contraband/random/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "dBx" = (
@@ -28279,6 +28267,7 @@
 	name = "Atmos to Loop"
 	},
 /obj/effect/turf_decal/box,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dHC" = (
@@ -29708,6 +29697,10 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/clothing/glasses/meson/engine{
+	pixel_x = -4;
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "esY" = (
@@ -31058,7 +31051,7 @@
 	dir = 8
 	},
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "eSX" = (
@@ -31120,6 +31113,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/structure/sign/warning/electric_shock/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "eUP" = (
@@ -31834,7 +31828,7 @@
 	dir = 4
 	},
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "fmY" = (
@@ -31924,7 +31918,7 @@
 	dir = 8
 	},
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "fpd" = (
@@ -32803,6 +32797,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fJU" = (
@@ -33066,7 +33061,6 @@
 "fOF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "fOM" = (
@@ -34216,6 +34210,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "goa" = (
@@ -34263,7 +34258,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gpk" = (
@@ -34378,7 +34372,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gsl" = (
@@ -34715,6 +34709,7 @@
 /obj/effect/turf_decal/trimline/red/filled/shrink_ccw{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
 "gzG" = (
@@ -35008,6 +35003,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "gGo" = (
@@ -35078,7 +35074,7 @@
 "gHM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "gHS" = (
@@ -35127,7 +35123,6 @@
 	dir = 4
 	},
 /obj/machinery/light/dim/directional/east,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gIW" = (
@@ -36038,9 +36033,10 @@
 /turf/open/space/basic,
 /area/space)
 "har" = (
-/obj/machinery/computer/station_alert,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "hax" = (
@@ -36782,7 +36778,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hmV" = (
@@ -37272,6 +37267,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "hxq" = (
@@ -37294,6 +37290,7 @@
 /obj/effect/turf_decal/trimline/red/filled/shrink_cw{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint)
 "hxz" = (
@@ -37786,6 +37783,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
+"hEw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "hEH" = (
 /obj/item/surgical_drapes,
 /obj/item/scalpel,
@@ -38387,6 +38391,10 @@
 	dir = 1
 	},
 /area/station/cargo/sorting)
+"hSV" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/aft/lesser)
 "hSW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -38908,6 +38916,7 @@
 	c_tag = "Engineering - Foyer";
 	network = list("ss13","engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "igb" = (
@@ -39122,6 +39131,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ijT" = (
@@ -39431,7 +39441,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ipJ" = (
@@ -39556,7 +39566,6 @@
 "iqv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "iqA" = (
@@ -39942,6 +39951,7 @@
 "iyZ" = (
 /obj/effect/turf_decal/trimline/red/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
 "izb" = (
@@ -40213,6 +40223,7 @@
 /area/station/maintenance/port/greater)
 "iDa" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "iDg" = (
@@ -41715,11 +41726,21 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "jhZ" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/incident_display/delam/directional/north,
-/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/t_scanner{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/t_scanner{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/electronics/apc{
+	pixel_y = -2
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "jiy" = (
@@ -41895,7 +41916,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "jlu" = (
@@ -43407,13 +43427,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/station_engineer,
-/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1;
+	cable_layer = 1
+	},
+/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jSl" = (
@@ -44037,6 +44058,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
 "kdc" = (
@@ -44837,6 +44859,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kuo" = (
@@ -45168,6 +45191,7 @@
 	name = "Mix to Gas"
 	},
 /obj/effect/turf_decal/box,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kAZ" = (
@@ -45694,6 +45718,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"kMz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/layer1,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "kMP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45860,6 +45891,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kPE" = (
@@ -46235,7 +46267,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kYI" = (
@@ -48336,11 +48367,10 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "lTE" = (
-/obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "lTL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48518,6 +48548,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lXY" = (
@@ -48748,7 +48779,6 @@
 	},
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "mcj" = (
@@ -49593,6 +49623,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/security/med,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "muR" = (
@@ -50897,13 +50928,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "mVl" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/station/engineering/main)
+/obj/structure/cable/layer1,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "mVn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -51259,8 +51286,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/sign/departments/maint/directional/east,
-/obj/machinery/light/dim/directional/east,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ned" = (
@@ -52081,6 +52108,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "ntG" = (
@@ -52241,6 +52269,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/caution,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "nwM" = (
@@ -52404,9 +52433,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nBI" = (
-/obj/structure/sign/warning/fire/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "nBO" = (
@@ -53909,13 +53936,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "oei" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/hallway)
 "oex" = (
 /obj/effect/spawner/random/structure/table,
 /turf/open/floor/plating,
@@ -53992,7 +54017,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "ofU" = (
@@ -54229,7 +54254,6 @@
 	name = "Supermatter Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "ojo" = (
@@ -54241,6 +54265,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/supply)
 "ojt" = (
@@ -56475,6 +56500,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"pal" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/aft/lesser)
 "par" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark/side,
@@ -58010,12 +58040,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1;
+	cable_layer = 1
+	},
+/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pHo" = (
@@ -58313,7 +58344,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pOw" = (
@@ -58823,6 +58853,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
 	},
@@ -59209,7 +59240,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qhb" = (
@@ -59330,6 +59360,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qjW" = (
@@ -59427,6 +59458,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
 	dir = 4
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qmj" = (
@@ -61048,6 +61080,7 @@
 /area/station/maintenance/port/greater)
 "qSK" = (
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "qSN" = (
@@ -61636,6 +61669,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "reH" = (
@@ -61660,7 +61694,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rfi" = (
@@ -61770,6 +61803,7 @@
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
 "rgC" = (
@@ -62136,9 +62170,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "rmR" = (
-/obj/structure/closet/radiation,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "rnk" = (
@@ -62701,6 +62735,7 @@
 	name = "Engineering Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "rxk" = (
@@ -62873,6 +62908,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/evac/directional/north,
 /obj/structure/cable,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Central Power Station"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -65005,6 +65044,9 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/status_display/ai/directional/north,
+/obj/structure/cable,
+/obj/structure/sign/departments/maint/directional/east,
+/obj/machinery/light/dim/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "sAd" = (
@@ -65791,7 +65833,6 @@
 	name = "Radiation Shutters Control";
 	req_access = list("engineering")
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "sPi" = (
@@ -65876,6 +65917,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/sign/warning/electric_shock/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "sRd" = (
@@ -66459,7 +66501,6 @@
 	name = "Laser Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/supermatter/room)
 "tcv" = (
@@ -66820,7 +66861,7 @@
 "thn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "thy" = (
@@ -68001,6 +68042,7 @@
 /obj/effect/turf_decal/trimline/red/filled/shrink_cw{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
 "tFJ" = (
@@ -70750,6 +70792,7 @@
 	name = "Supermatter Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "uPa" = (
@@ -71160,7 +71203,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "uYI" = (
@@ -71392,6 +71435,7 @@
 "vcW" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "vdb" = (
@@ -71430,6 +71474,7 @@
 "vdR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "vdY" = (
@@ -74108,7 +74153,7 @@
 	dir = 4
 	},
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "wgY" = (
@@ -74184,6 +74229,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "wjC" = (
@@ -74273,6 +74319,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "wlb" = (
@@ -75428,7 +75475,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "wLu" = (
@@ -76055,9 +76101,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "wZH" = (
-/obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "wZS" = (
@@ -76488,9 +76536,12 @@
 /area/station/medical/chemistry)
 "xiZ" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/glasses/meson/engine{
-	pixel_x = -4;
-	pixel_y = 8
+/obj/item/wrench{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/wrench{
+	pixel_x = 5
 	},
 /obj/item/pipe_dispenser{
 	pixel_y = 1
@@ -76499,9 +76550,21 @@
 	pixel_y = -2
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/warning/radiation/directional/south,
-/obj/machinery/light/dim/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/wrench{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/wrench{
+	pixel_x = 5
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = -2
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = 1
+	},
+/obj/structure/sign/warning/radiation/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "xjf" = (
@@ -77021,10 +77084,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xtR" = (
-/obj/machinery/modular_computer/preset/engineering,
 /obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "xuc" = (
@@ -77856,6 +77920,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xIZ" = (
@@ -103531,7 +103596,7 @@ wRN
 gqB
 bal
 sfo
-lTE
+har
 pOt
 fOF
 atI
@@ -103791,7 +103856,7 @@ cbY
 qre
 pOt
 kdt
-rmR
+cGf
 qmj
 cKH
 czV
@@ -103808,7 +103873,7 @@ dum
 cCr
 cyt
 cNR
-wIJ
+hQY
 cNR
 tal
 cyo
@@ -104060,12 +104125,12 @@ emQ
 ofP
 emQ
 cDI
-tpJ
+kMz
 dJa
 gpN
 cyo
 vnn
-cNs
+tbf
 aou
 sIs
 cyo
@@ -104819,7 +104884,7 @@ cNJ
 jHw
 eyz
 tzV
-cGf
+aJA
 qmj
 tpJ
 czV
@@ -105078,8 +105143,8 @@ jce
 gnO
 iDa
 uOY
-tpJ
-czV
+hEw
+aIu
 iSH
 cKF
 cIq
@@ -105589,7 +105654,7 @@ cNJ
 cNJ
 bXs
 rAq
-mVl
+qmj
 bXs
 bXs
 vUC
@@ -106123,7 +106188,7 @@ cyo
 kkK
 cNR
 aou
-nBI
+tal
 cyo
 aak
 aak
@@ -106366,10 +106431,10 @@ qmj
 ofc
 czV
 qgX
-caE
-caE
+brm
+brm
 rfa
-caE
+brm
 uYv
 brm
 vUj
@@ -106621,22 +106686,22 @@ gHM
 thn
 agv
 ipI
-aIu
-aIu
-czV
-czV
+mVl
+mVl
+mVl
+mVl
 kAQ
-czV
-czV
-czV
+mVl
+mVl
+mVl
 dbB
-czV
+mVl
 ipP
 pqL
 tcu
 iqv
 iqv
-tal
+nBI
 woJ
 cyo
 aaa
@@ -107130,7 +107195,7 @@ ncI
 ozJ
 bXo
 sAc
-oei
+hXO
 ndQ
 cZj
 cCZ
@@ -108158,10 +108223,10 @@ wuL
 iHp
 qxm
 jSd
-wuL
-wuL
-wuL
-ncL
+gQf
+gQf
+gQf
+pal
 vZh
 jTv
 ncL
@@ -108418,7 +108483,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-ncL
+pal
 oLn
 kHY
 kdR
@@ -108932,7 +108997,7 @@ caK
 caI
 vtc
 cCZ
-jSd
+diT
 fGI
 kHY
 wOr
@@ -109189,7 +109254,7 @@ hAG
 hAG
 hXy
 cCZ
-wuL
+gQf
 qxm
 kHY
 kHY
@@ -109446,7 +109511,7 @@ lHL
 bYv
 qTy
 cCZ
-wuL
+gQf
 dgI
 kHY
 qVV
@@ -109703,7 +109768,7 @@ kNp
 kNp
 nPb
 cCZ
-wuL
+gQf
 ncL
 kHY
 kJa
@@ -109960,8 +110025,8 @@ caJ
 caI
 ijA
 cCZ
-wuL
-ncL
+gQf
+pal
 kHY
 xYm
 wuL
@@ -110218,7 +110283,7 @@ ntU
 mVc
 cCZ
 xRm
-fBc
+caE
 kHY
 wuL
 wuL
@@ -110474,8 +110539,8 @@ cCZ
 cCZ
 cCZ
 cCZ
-wuL
-wuL
+gQf
+gQf
 pSR
 tHp
 gtD
@@ -110712,26 +110777,26 @@ caU
 caU
 caU
 lvI
-ttI
+oei
 wjy
-wuL
-wuL
-heg
-ncL
-ncL
-wuL
-wuL
+gQf
+gQf
+hSV
+pal
+pal
+gQf
+gQf
 cZv
 vdR
 vcW
-wuL
-fBc
-wuL
+gQf
+caE
+gQf
 qSK
-wuL
-wuL
-wuL
-fBc
+gQf
+gQf
+gQf
+caE
 kHY
 kHY
 kHY
@@ -122482,7 +122547,7 @@ bnr
 boH
 bqo
 sRX
-blP
+lTE
 qep
 cJH
 qLZ
@@ -122734,12 +122799,12 @@ cDj
 blP
 biP
 pDn
-blP
+lTE
 muk
 pZF
 lpg
 kKA
-blP
+lTE
 buR
 buR
 qLZ
@@ -123250,8 +123315,8 @@ tTW
 tTW
 tTW
 tTW
-blP
-blP
+lTE
+lTE
 tTW
 tTW
 cpH

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -6071,6 +6071,8 @@
 "aJA" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/camera/directional/west,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "aJB" = (
@@ -29700,6 +29702,7 @@
 	pixel_x = -4;
 	pixel_y = 8
 	},
+/obj/machinery/camera/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "esY" = (
@@ -42970,7 +42973,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "jHw" = (
-/obj/structure/closet/radiation,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -44235,6 +44237,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -49263,9 +49266,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "mlW" = (
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/radiation,
+/obj/machinery/light/dim/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "mma" = (
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
@@ -105447,7 +105453,7 @@ cNJ
 jHw
 hXO
 vYC
-aJA
+mlW
 qmj
 tpJ
 czV
@@ -107512,7 +107518,7 @@ cCZ
 hou
 uzx
 jTx
-mlW
+czV
 vFD
 qmk
 czV

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -18317,10 +18317,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"bLr" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "bLB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/west,
@@ -22644,11 +22640,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
-"cAW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "cBg" = (
 /obj/effect/gibspawner/human/bodypartless,
 /obj/effect/decal/cleanable/dirt,
@@ -32951,6 +32942,7 @@
 	name = "Atmospherics"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "fMF" = (
@@ -39236,6 +39228,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "imQ" = (
@@ -53047,6 +53040,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "nLM" = (
@@ -56074,7 +56068,6 @@
 	dir = 4
 	},
 /obj/machinery/light/broken/directional/west,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "oUu" = (
@@ -61151,7 +61144,6 @@
 "qUJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/grille_or_waste,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "qUQ" = (
@@ -64570,12 +64562,6 @@
 	dir = 8
 	},
 /area/station/command/gateway)
-"ssX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "ste" = (
 /obj/structure/closet/wardrobe/black,
 /obj/effect/landmark/start/hangover/closet,
@@ -71543,11 +71529,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"vgE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "vgR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -130916,9 +130897,9 @@ aPa
 xcv
 bJT
 bUu
-cAW
+poi
 tNk
-bLr
+bBg
 oUs
 qUJ
 dbT
@@ -131173,9 +131154,9 @@ tOS
 mtm
 bJT
 tBu
-vgE
-ssX
-ssX
+lXP
+wUA
+wUA
 imM
 gZi
 iJu

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -24642,7 +24642,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cPA" = (
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -876,6 +876,7 @@
 /area/station/security/prison/mess)
 "aek" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "aem" = (
@@ -3771,11 +3772,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
-"avn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical)
 "avp" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 6
@@ -6048,7 +6044,6 @@
 "aJv" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "aJy" = (
@@ -6689,7 +6684,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/break_room)
 "aMl" = (
@@ -6959,6 +6953,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/break_room)
 "aMW" = (
@@ -6968,7 +6963,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/break_room)
 "aMY" = (
@@ -7265,6 +7259,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/break_room)
 "aNQ" = (
@@ -9193,11 +9188,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aVp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/area/station/maintenance/department/medical)
 "aVq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -9595,14 +9589,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"aXy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "aXz" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -9713,7 +9699,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aXZ" = (
@@ -10389,6 +10374,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "baq" = (
@@ -18316,7 +18302,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bLr" = (
-/obj/effect/spawner/random/structure/girder,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bLB" = (
@@ -18710,6 +18700,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/upper)
 "bPB" = (
@@ -19550,9 +19541,13 @@
 /area/station/hallway/primary/starboard)
 "bWo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/maintenance/port/greater)
+/area/station/maintenance/department/medical)
 "bWt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -19859,7 +19854,6 @@
 /obj/item/book/random,
 /obj/item/pen,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bZg" = (
@@ -19968,7 +19962,6 @@
 /obj/structure/rack,
 /obj/item/tape,
 /obj/item/flashlight/lamp/green,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cap" = (
@@ -20619,12 +20612,10 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science/xenobiology)
 "chq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/department/security/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "cht" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -20873,7 +20864,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/reagent_dispensers/watertank,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "cjT" = (
@@ -22639,6 +22629,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
+"cAW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical)
 "cBg" = (
 /obj/effect/gibspawner/human/bodypartless,
 /obj/effect/decal/cleanable/dirt,
@@ -23650,7 +23645,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "cIU" = (
@@ -26859,7 +26853,6 @@
 /obj/structure/rack,
 /obj/item/book/random,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "ddo" = (
@@ -27893,6 +27886,12 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"dzF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/upper)
 "dAg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29035,6 +29034,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "ees" = (
@@ -30467,6 +30467,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/built/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "eGZ" = (
@@ -30533,6 +30534,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"eHX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "eIl" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
@@ -30778,6 +30786,7 @@
 "eNc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "eNh" = (
@@ -31824,7 +31833,6 @@
 /area/station/medical/pharmacy)
 "fnc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "fnt" = (
@@ -31968,10 +31976,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "fqV" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
@@ -32049,7 +32056,6 @@
 /area/station/maintenance/department/medical)
 "ftf" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ftl" = (
@@ -32151,7 +32157,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "fvf" = (
@@ -32196,7 +32201,6 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "fvV" = (
@@ -32907,6 +32911,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "fMm" = (
@@ -34543,6 +34548,12 @@
 	dir = 9
 	},
 /area/station/cargo/sorting)
+"gwC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/upper)
 "gxp" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table/reinforced,
@@ -34693,7 +34704,6 @@
 "gzN" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "gzW" = (
@@ -35301,13 +35311,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "gMT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/area/station/maintenance/department/medical)
 "gMZ" = (
 /obj/structure/closet/radiation,
 /obj/structure/sign/warning/secure_area/directional/south,
@@ -35481,7 +35487,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gPn" = (
@@ -39129,6 +39134,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ikI" = (
@@ -40007,6 +40013,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/upper)
 "iBu" = (
@@ -40022,7 +40029,6 @@
 /area/station/security/office)
 "iBI" = (
 /obj/effect/spawner/random/engineering/tank,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "iBJ" = (
@@ -40247,9 +40253,7 @@
 /area/station/cargo/lobby)
 "iEF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/landmark/start/hangover,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "iEP" = (
@@ -45335,6 +45339,7 @@
 "kFD" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "kFH" = (
@@ -45834,6 +45839,14 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"kPE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "kPM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47276,7 +47289,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "lzr" = (
@@ -47547,6 +47559,7 @@
 /obj/effect/mapping_helpers/mail_sorting/security/detectives_office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "lFl" = (
@@ -47735,6 +47748,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "lKt" = (
@@ -47790,6 +47804,7 @@
 "lLc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "lLd" = (
@@ -49440,6 +49455,7 @@
 /area/station/science/xenobiology)
 "msn" = (
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "msu" = (
@@ -51243,6 +51259,7 @@
 "neP" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/closet/crate/trashcart/filled,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "neX" = (
@@ -53009,7 +53026,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "nLM" = (
@@ -53586,7 +53602,6 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/official/do_not_question/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "nYN" = (
@@ -54589,7 +54604,6 @@
 "orb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "orf" = (
@@ -55338,7 +55352,6 @@
 "oGG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "oGT" = (
@@ -56045,8 +56058,9 @@
 /area/station/maintenance/port)
 "oUE" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/grimy,
-/area/station/security/detectives_office)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "oUH" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -56640,7 +56654,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/grille_or_waste,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "pge" = (
@@ -58785,7 +58798,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/girder,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "qai" = (
@@ -59535,7 +59547,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "qpq" = (
@@ -59802,6 +59813,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/upper)
 "quV" = (
@@ -60512,6 +60524,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "qJi" = (
@@ -60701,6 +60714,7 @@
 "qNr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/engineering/tank,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "qNx" = (
@@ -61798,7 +61812,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rif" = (
@@ -64021,6 +64034,10 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/safe)
+"sha" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "shs" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -64351,6 +64368,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "soK" = (
@@ -65206,7 +65224,6 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "sFE" = (
@@ -65297,7 +65314,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -65901,6 +65917,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"sSU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/upper)
 "sTf" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced/rglass,
@@ -66188,6 +66211,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "sXS" = (
@@ -66817,6 +66841,7 @@
 /area/station/maintenance/disposal)
 "tkB" = (
 /obj/structure/sign/warning/vacuum/external/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "tkH" = (
@@ -67391,7 +67416,6 @@
 /area/station/command/heads_quarters/hop)
 "twK" = (
 /obj/effect/spawner/random/engineering/tank,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "twQ" = (
@@ -68296,7 +68320,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "tMB" = (
@@ -68307,11 +68330,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "tMM" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/maintenance/department/medical)
 "tMP" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped,
 /turf/open/floor/iron,
@@ -69813,7 +69838,6 @@
 "uvB" = (
 /obj/effect/spawner/random/trash/mopbucket,
 /obj/effect/spawner/random/trash/soap,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "uwF" = (
@@ -71268,7 +71292,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "vcU" = (
@@ -71482,6 +71505,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"vgE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "vgR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71756,7 +71784,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/structure/girder,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "vnG" = (
@@ -72661,6 +72688,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "vHK" = (
@@ -73088,7 +73116,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "vOK" = (
@@ -73634,6 +73661,7 @@
 "vYw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/botanical_waste,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "vYA" = (
@@ -73815,6 +73843,7 @@
 "wdg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "wdz" = (
@@ -74429,7 +74458,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/decoration/glowstick,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "wqI" = (
@@ -75153,7 +75181,6 @@
 /obj/item/canvas/twentythree_nineteen{
 	pixel_x = 3
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "wHn" = (
@@ -75440,6 +75467,11 @@
 /obj/item/bedsheet/cosmos,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"wNJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "wNO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -75996,6 +76028,7 @@
 	c_tag = "Command Hallway - Entrance"
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -76810,6 +76843,12 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
+"xsd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical)
 "xsj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/engineering/atmospherics_portable,
@@ -78213,7 +78252,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/grille_or_waste,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "xTF" = (
@@ -78415,6 +78453,7 @@
 "xYx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/upper)
 "xZl" = (
@@ -95862,7 +95901,7 @@ aTc
 azQ
 aVg
 aWl
-aAi
+aCR
 aXY
 bJf
 baV
@@ -96120,8 +96159,8 @@ aUd
 aAi
 hJu
 aAi
-aWw
-aCR
+bJf
+aAi
 qgO
 azQ
 ovt
@@ -98984,7 +99023,7 @@ iTN
 vrI
 xCE
 mSK
-hAy
+ntr
 dqG
 etg
 pMa
@@ -99204,7 +99243,7 @@ azQ
 aVj
 aWm
 ovt
-bJf
+aWw
 aCR
 aCR
 azQ
@@ -99241,7 +99280,7 @@ elM
 teD
 lPj
 mSK
-bWo
+nnH
 duS
 etg
 pMa
@@ -99498,7 +99537,7 @@ xqN
 itJ
 scy
 mSK
-lEg
+chq
 sUh
 uGE
 pMa
@@ -100012,7 +100051,7 @@ mSK
 mSK
 mSK
 mSK
-lEg
+chq
 tdd
 uGE
 pMa
@@ -103827,7 +103866,7 @@ dop
 qEd
 azQ
 lmt
-aVp
+hax
 aWs
 aXB
 aWs
@@ -104084,8 +104123,8 @@ azQ
 azQ
 azQ
 azQ
-aVp
-aWs
+hax
+wNJ
 bmV
 bmV
 bmV
@@ -104341,8 +104380,8 @@ aak
 aak
 azQ
 aCR
-aVp
-aWt
+hax
+cvA
 bmV
 aYp
 aZE
@@ -104598,8 +104637,8 @@ aak
 aak
 azQ
 aUh
-aVp
-aWt
+hax
+cvA
 bmV
 aYq
 aZF
@@ -104855,8 +104894,8 @@ aak
 aak
 azQ
 aGU
-aVp
-aWt
+hax
+cvA
 bmV
 aYr
 aZG
@@ -105113,7 +105152,7 @@ aak
 aDr
 aGU
 hax
-aWt
+cvA
 bmV
 aXm
 aXm
@@ -105627,7 +105666,7 @@ cJg
 aDr
 aGU
 hax
-aWt
+cvA
 bmV
 aYt
 aZI
@@ -105883,8 +105922,8 @@ aak
 aak
 aDr
 rmD
-aVp
-aWt
+hax
+cvA
 bmV
 aYu
 aZJ
@@ -106140,8 +106179,8 @@ aak
 aak
 azQ
 aGU
-aVp
-aWt
+hax
+cvA
 bmV
 aXm
 aXm
@@ -106397,8 +106436,8 @@ aak
 aak
 azQ
 eLa
-aVp
-aWt
+hax
+cvA
 bmV
 aYv
 aZK
@@ -106446,7 +106485,7 @@ pGR
 hAy
 yfZ
 xut
-gMT
+kPE
 vUi
 myZ
 rze
@@ -106654,8 +106693,8 @@ aak
 aak
 azQ
 aUj
-aVp
-aWt
+hax
+cvA
 bmV
 aYw
 aZL
@@ -113021,7 +113060,7 @@ iQm
 iQm
 iQm
 abM
-hyr
+gwC
 loq
 loq
 loq
@@ -113278,16 +113317,16 @@ aaa
 aaa
 aak
 aax
-chq
+nll
 wHj
 wqt
-hyr
-ckO
-nmz
-hyr
-ckO
-hyr
-tpb
+gwC
+loq
+dzF
+gwC
+loq
+gwC
+sSU
 lNJ
 bgD
 ase
@@ -113313,7 +113352,7 @@ orb
 nfY
 jzO
 jzO
-oUE
+jzO
 sXN
 lKc
 qnY
@@ -113565,8 +113604,8 @@ nYD
 oBM
 aax
 nYE
-fqP
-uod
+cOl
+eTY
 azV
 pBg
 aBc
@@ -113584,7 +113623,7 @@ iYK
 aKo
 azU
 mbK
-vtj
+vCc
 aJv
 azU
 qYo
@@ -113822,8 +113861,8 @@ qvH
 xbM
 aax
 fvd
-fqP
-uod
+cOl
+eTY
 sGL
 sGL
 aKq
@@ -113841,7 +113880,7 @@ lYP
 mUy
 azU
 mbK
-vtj
+vCc
 rib
 azU
 poO
@@ -114079,8 +114118,8 @@ abM
 abM
 aax
 vcS
-fqP
-uod
+cOl
+eTY
 iEF
 hdW
 aPr
@@ -114098,7 +114137,7 @@ aKq
 aKq
 azU
 rFM
-wod
+hkC
 gzN
 azU
 ogN
@@ -114336,7 +114375,7 @@ nGr
 eQe
 sGL
 xaT
-fqP
+cOl
 eTY
 okb
 qer
@@ -114593,7 +114632,7 @@ tEO
 xkq
 kiw
 sGH
-fqP
+cOl
 vAE
 okb
 rIU
@@ -114849,7 +114888,7 @@ suT
 nGr
 fRz
 oAm
-wfH
+koK
 cOl
 uIt
 azU
@@ -115363,7 +115402,7 @@ kDh
 amB
 fVY
 oAm
-koK
+wfH
 cOl
 nNU
 azU
@@ -117161,8 +117200,8 @@ vgf
 cgl
 gwr
 fPv
-koK
-psH
+wfH
+azv
 cOl
 iau
 fJX
@@ -118774,7 +118813,7 @@ bRu
 bSO
 kRR
 bTG
-cCg
+cfE
 twK
 bZe
 cao
@@ -119030,11 +119069,11 @@ jtD
 byO
 bJp
 cem
-bVv
-vBS
-cfz
-cfz
-cfz
+bTG
+eHX
+oUE
+oUE
+oUE
 voZ
 bJp
 bVv
@@ -119731,8 +119770,8 @@ kyw
 wQe
 gwr
 fPv
-koK
-psH
+wfH
+azv
 cOl
 uIt
 aAd
@@ -120601,8 +120640,8 @@ ckj
 ckj
 ckj
 ikF
-tMM
-tMM
+cEX
+cEX
 cEX
 hYv
 uRq
@@ -122318,7 +122357,7 @@ gsb
 gcp
 vCb
 lLc
-aBi
+bWo
 dQt
 aQK
 aMf
@@ -122575,7 +122614,7 @@ pEP
 hLe
 vCb
 qNr
-dEi
+tMM
 yba
 aQK
 aMy
@@ -122832,7 +122871,7 @@ qYL
 kMd
 vCb
 neP
-aBi
+bWo
 aEd
 aQK
 aLp
@@ -123088,7 +123127,7 @@ nXS
 vqW
 cFy
 vCb
-avn
+cAW
 qpm
 aEd
 bou
@@ -123346,7 +123385,7 @@ vCb
 vCb
 vCb
 gUa
-aXy
+bLr
 aEd
 bph
 aMi
@@ -124117,7 +124156,7 @@ gdq
 lKt
 vCb
 dEi
-bLr
+gMT
 aEd
 aEd
 aLr
@@ -124374,8 +124413,8 @@ ghk
 jti
 vCb
 aBi
-aHx
-uif
+sha
+aVp
 aEd
 aMl
 aMY
@@ -124889,7 +124928,7 @@ vCb
 vCb
 dEi
 oDh
-bvL
+bwG
 aLu
 aMn
 aNa
@@ -125145,7 +125184,7 @@ hXV
 dTc
 dTc
 qZn
-xZU
+xsd
 hIt
 aEd
 aEd
@@ -127989,7 +128028,7 @@ aQK
 aQK
 aQK
 aQK
-xHt
+fqP
 lyM
 aEd
 bdN
@@ -128246,7 +128285,7 @@ aWa
 cVn
 aXP
 lqP
-xHt
+fqP
 vnF
 aEd
 bgE
@@ -128503,7 +128542,7 @@ exy
 aRf
 aXQ
 lqP
-xHt
+fqP
 pgc
 aEd
 aEd
@@ -131613,7 +131652,7 @@ bBi
 jfH
 bEm
 bJT
-lXP
+vgE
 bIz
 sWt
 fuy

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -12448,7 +12448,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "biZ" = (
@@ -13343,7 +13342,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bmm" = (
@@ -13667,6 +13665,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bnv" = (
@@ -14013,6 +14012,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "boJ" = (
@@ -14022,7 +14022,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "boK" = (
@@ -14505,7 +14504,6 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "bqq" = (
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bqr" = (
@@ -32389,7 +32387,6 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/chemical,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fyO" = (
@@ -54052,7 +54049,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "ogN" = (
@@ -62989,7 +62985,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rEF" = (
@@ -69056,7 +69051,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "udb" = (
@@ -70805,6 +70799,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "uRq" = (

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -1319,7 +1319,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable/layer1,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "agx" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/storage/medkit/regular{
@@ -26666,7 +26666,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "cZm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -27152,11 +27152,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/office)
-"diT" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
 "diU" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -30882,6 +30877,9 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/cafeteria)
+"eOz" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/engine_smes)
 "eOB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 8
@@ -33957,6 +33955,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plastic,
 /area/station/maintenance/department/medical)
+"ghJ" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/aft/lesser)
 "gim" = (
 /obj/structure/sink/directional/west,
 /obj/structure/sign/poster/official/cleanliness/directional/east,
@@ -34450,7 +34452,7 @@
 /obj/machinery/light/dim/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "guH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced,
@@ -34944,7 +34946,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "gEV" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -35076,7 +35078,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "gHS" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37269,7 +37271,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "hxq" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -37783,13 +37785,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
-"hEw" = (
+"hEB" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 10
 	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "hEH" = (
 /obj/item/surgical_drapes,
 /obj/item/scalpel,
@@ -38391,10 +38392,6 @@
 	dir = 1
 	},
 /area/station/cargo/sorting)
-"hSV" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/aft/lesser)
 "hSW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -41742,7 +41739,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "jiy" = (
 /obj/structure/table/optable,
 /obj/machinery/newscaster/directional/north,
@@ -43436,7 +43433,7 @@
 	},
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "jSl" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Courtroom Maintenance"
@@ -44136,6 +44133,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"kes" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/engineering/supermatter/room)
 "keF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45718,13 +45719,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"kMz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/layer1,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "kMP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48367,10 +48361,12 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "lTE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "lTL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50812,6 +50808,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"mTp" = (
+/obj/structure/cable/layer1,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "mTs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -50928,9 +50928,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "mVl" = (
-/obj/structure/cable/layer1,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/engine_smes)
 "mVn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -51289,7 +51289,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "ned" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51649,6 +51649,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"nld" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "nll" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -52433,9 +52438,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nBI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/engineering/supermatter/room)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "nBO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -53936,11 +53941,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "oei" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/hallway)
+/area/station/engineering/engine_smes)
 "oex" = (
 /obj/effect/spawner/random/structure/table,
 /turf/open/floor/plating,
@@ -54391,6 +54399,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"omr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/layer1,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "omD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -55130,7 +55145,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "oAS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -56500,11 +56515,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
-"pal" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/aft/lesser)
 "par" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark/side,
@@ -56986,6 +56996,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/mechbay)
+"pkR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "plj" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
@@ -57295,7 +57310,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "psF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58048,7 +58063,7 @@
 	},
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "pHo" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
@@ -62174,7 +62189,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "rnk" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/red{
@@ -62737,7 +62752,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "rxk" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/stripes/line{
@@ -62863,6 +62878,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/office)
+"rzk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "rzF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -62915,7 +62936,7 @@
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "rAr" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/dirt,
@@ -63051,6 +63072,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"rEh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "rEs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65048,7 +65076,7 @@
 /obj/structure/sign/departments/maint/directional/east,
 /obj/machinery/light/dim/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "sAd" = (
 /obj/effect/decal/cleanable/insectguts,
 /obj/effect/decal/cleanable/dirt,
@@ -66863,7 +66891,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "thy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68694,6 +68722,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/bridge)
+"tRC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/aft/lesser)
 "tRR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69234,7 +69267,7 @@
 /obj/structure/sign/warning/electric_shock/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "ufr" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/closet/firecloset,
@@ -70997,7 +71030,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "uTy" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/department/science/xenobiology)
@@ -71606,7 +71639,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "vgr" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -76107,7 +76140,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "wZS" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
@@ -104125,7 +104158,7 @@ emQ
 ofP
 emQ
 cDI
-kMz
+omr
 dJa
 gpN
 cyo
@@ -105143,7 +105176,7 @@ jce
 gnO
 iDa
 uOY
-hEw
+rEh
 aIu
 iSH
 cKF
@@ -105652,11 +105685,11 @@ cNJ
 cNJ
 cNJ
 cNJ
-bXs
+eOz
 rAq
-qmj
-bXs
-bXs
+mVl
+eOz
+eOz
 vUC
 czV
 sOU
@@ -105911,9 +105944,9 @@ jJP
 bXo
 jhZ
 oAR
-tzV
+hEB
 vgo
-bXs
+eOz
 rQM
 czV
 jlp
@@ -106168,9 +106201,9 @@ ydu
 bXo
 gEQ
 hxp
-rym
+lTE
 guv
-bXs
+eOz
 rcn
 czV
 jlp
@@ -106425,9 +106458,9 @@ fOS
 bXo
 uTo
 pHf
-kdt
+nBI
 rmR
-qmj
+mVl
 ofc
 czV
 qgX
@@ -106686,22 +106719,22 @@ gHM
 thn
 agv
 ipI
-mVl
-mVl
-mVl
-mVl
+mTp
+mTp
+mTp
+mTp
 kAQ
-mVl
-mVl
-mVl
+mTp
+mTp
+mTp
 dbB
-mVl
+mTp
 ipP
 pqL
 tcu
 iqv
 iqv
-nBI
+kes
 woJ
 cyo
 aaa
@@ -106941,7 +106974,7 @@ uTo
 pHf
 psy
 wZH
-qmj
+mVl
 syh
 ejG
 hJS
@@ -107195,7 +107228,7 @@ ncI
 ozJ
 bXo
 sAc
-hXO
+oei
 ndQ
 cZj
 cCZ
@@ -108226,7 +108259,7 @@ jSd
 gQf
 gQf
 gQf
-pal
+tRC
 vZh
 jTv
 ncL
@@ -108483,7 +108516,7 @@ cCZ
 cCZ
 cCZ
 cCZ
-pal
+tRC
 oLn
 kHY
 kdR
@@ -108997,7 +109030,7 @@ caK
 caI
 vtc
 cCZ
-diT
+nld
 fGI
 kHY
 wOr
@@ -110026,7 +110059,7 @@ caI
 ijA
 cCZ
 gQf
-pal
+tRC
 kHY
 xYm
 wuL
@@ -110777,13 +110810,13 @@ caU
 caU
 caU
 lvI
-oei
+rzk
 wjy
 gQf
 gQf
-hSV
-pal
-pal
+ghJ
+tRC
+tRC
 gQf
 gQf
 cZv
@@ -122547,7 +122580,7 @@ bnr
 boH
 bqo
 sRX
-lTE
+pkR
 qep
 cJH
 qLZ
@@ -122799,12 +122832,12 @@ cDj
 blP
 biP
 pDn
-lTE
+pkR
 muk
 pZF
 lpg
 kKA
-lTE
+pkR
 buR
 buR
 qLZ
@@ -123315,8 +123348,8 @@ tTW
 tTW
 tTW
 tTW
-lTE
-lTE
+pkR
+pkR
 tTW
 tTW
 cpH

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -37610,6 +37610,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "hBG" = (
@@ -45608,6 +45609,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "kKH" = (
@@ -60733,6 +60735,7 @@
 "qMM" = (
 /obj/machinery/computer/records/security,
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "qMO" = (
@@ -65106,6 +65109,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "sCl" = (
@@ -67101,6 +67105,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "tpy" = (

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -23645,6 +23645,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "cIU" = (
@@ -32056,6 +32057,7 @@
 /area/station/maintenance/department/medical)
 "ftf" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ftl" = (
@@ -35462,6 +35464,7 @@
 	fax_name = "Detective's Office";
 	name = "Detective's Fax Machine"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "gPe" = (
@@ -77500,6 +77503,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
+"xEq" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "xED" = (
 /obj/structure/table/wood,
 /obj/item/food/spaghetti/beefnoodle,
@@ -114381,7 +114388,7 @@ okb
 qer
 aPr
 gOZ
-eJQ
+xEq
 wmZ
 aDL
 aEF

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -77199,6 +77199,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"xxS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "xxW" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 8
@@ -115237,7 +115246,7 @@ ugK
 cam
 hxC
 bJp
-ivj
+xxS
 iAN
 cnv
 cGK
@@ -118282,7 +118291,7 @@ uif
 umN
 xBj
 nQX
-nHy
+aBi
 aEd
 tKV
 mfv

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -111,11 +111,9 @@
 /turf/closed/wall,
 /area/station/maintenance/department/security/upper)
 "aaB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/security/prison/visit)
 "aaD" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -211,10 +209,11 @@
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "abd" = (
-/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "abh" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -366,7 +365,6 @@
 "abO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "abP" = (
@@ -971,10 +969,9 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "aeE" = (
-/obj/structure/lattice,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/office)
 "aeI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
@@ -1045,9 +1042,12 @@
 /turf/open/misc/asteroid/airless,
 /area/lavaland/surface)
 "aff" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/office)
+/area/station/engineering/atmos/pumproom)
 "afg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -1068,11 +1068,13 @@
 /turf/closed/wall/r_wall,
 /area/station/security/office)
 "afi" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
+/area/station/command/heads_quarters/hos)
 "afj" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Quarters"
@@ -1260,10 +1262,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "agl" = (
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/security/prison/garden)
 "ago" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -1288,14 +1288,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/visit)
 "agr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/station/command/bridge)
 "agt" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth,
@@ -1608,13 +1606,10 @@
 /turf/open/floor/plating,
 /area/station/security/interrogation)
 "ahG" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "ahH" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -1623,7 +1618,6 @@
 /area/station/maintenance/department/security/upper)
 "ahI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "ahN" = (
@@ -1962,11 +1956,10 @@
 /turf/closed/wall,
 /area/station/security/office)
 "ajh" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/maintenance/department/security/upper)
 "ajj" = (
 /turf/closed/wall,
 /area/station/security/interrogation)
@@ -2049,13 +2042,15 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "ajG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/turf/open/floor/wood/large,
+/area/station/command/bridge)
 "ajI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "ajJ" = (
@@ -2228,11 +2223,10 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "alb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/fore)
 "alc" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -2363,6 +2357,7 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/security/lockers)
 "aml" = (
@@ -2415,10 +2410,11 @@
 /turf/closed/wall,
 /area/station/security/prison/safe/exterior)
 "amw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/prison/visit)
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/security/lockers)
 "amx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2556,12 +2552,14 @@
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "anc" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig/hallway)
 "and" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3162,10 +3160,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "aqD" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/turf/open/floor/iron,
+/area/station/security/office)
 "aqE" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
@@ -3378,20 +3380,23 @@
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
 "arY" = (
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "asa" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "ase" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/upper)
 "ask" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/airlock/medical/glass{
@@ -3764,13 +3769,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "avn" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/office)
+/obj/effect/spawner/random/structure/girder,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "avp" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 6
@@ -3815,10 +3817,9 @@
 /turf/open/floor/plating,
 /area/station/security/prison/rec)
 "avz" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/engine,
+/area/station/command/heads_quarters/rd)
 "avA" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -3871,7 +3872,6 @@
 /turf/open/misc/asteroid/airless,
 /area/lavaland/surface)
 "avH" = (
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "avI" = (
@@ -3991,6 +3991,7 @@
 "awu" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "awv" = (
@@ -4024,7 +4025,6 @@
 "awA" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "awC" = (
@@ -4201,7 +4201,6 @@
 /area/station/security/prison/visit)
 "axD" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/command)
 "axG" = (
@@ -4375,6 +4374,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "azv" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "azQ" = (
@@ -4431,6 +4431,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aAi" = (
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aAj" = (
@@ -4592,17 +4593,15 @@
 /turf/open/floor/iron/freezer,
 /area/station/security/warden)
 "aBi" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical)
 "aBl" = (
 /obj/structure/table/reinforced/rglass,
 /obj/machinery/computer/records/medical/laptop,
@@ -4756,7 +4755,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aCR" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aCT" = (
@@ -5148,11 +5146,10 @@
 /turf/open/floor/carpet/red,
 /area/station/security/courtroom)
 "aEO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/bookcase/random/fiction,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/turf/open/floor/carpet/green,
+/area/station/service/library)
 "aFc" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/green,
@@ -5845,16 +5842,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aIu" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/atmos)
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "aIv" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -5944,7 +5934,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
 "aIS" = (
@@ -6174,10 +6163,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aJM" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
+/turf/open/floor/iron,
+/area/station/security/prison)
 "aJN" = (
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -6308,6 +6301,7 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "aKn" = (
@@ -6357,9 +6351,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aKB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter)
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "aKF" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
@@ -6633,15 +6628,10 @@
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "aLU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "aLV" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/structure/table/wood,
@@ -7026,7 +7016,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNd" = (
@@ -7394,14 +7383,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aOd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aOe" = (
 /obj/item/stack/cable_coil/five,
 /obj/structure/closet/toolcloset,
@@ -7731,14 +7715,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aPB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "aPC" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Medbay - Northeast Hall";
@@ -7848,9 +7831,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "aPX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aPZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
@@ -7974,10 +7960,13 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "aQq" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/office{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "aQs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8405,10 +8394,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aSg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood/large,
-/area/station/command/bridge)
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "aSi" = (
 /obj/machinery/jukebox/disco,
 /turf/open/floor/eighties,
@@ -8537,6 +8527,7 @@
 "aSF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aSG" = (
@@ -8592,9 +8583,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aSX" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "aSZ" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
@@ -9159,13 +9155,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aVk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "aVl" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -9449,6 +9443,7 @@
 "aWt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aWu" = (
@@ -9459,7 +9454,6 @@
 "aWw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aWx" = (
@@ -9470,10 +9464,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "aWH" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "aWI" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
@@ -9584,14 +9579,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aXo" = (
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aXp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/girder,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical)
 "aXs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -9599,20 +9595,13 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "aXu" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter)
+"aXy" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
-"aXy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/maintenance/department/medical)
 "aXz" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -9905,11 +9894,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aYz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison)
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "aYA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -9955,14 +9941,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "aYH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/commons/dorms)
+/area/station/command/heads_quarters/ce)
 "aYI" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10330,11 +10312,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bab" = (
-/mob/living/simple_animal/slime,
-/obj/effect/turf_decal/box,
-/obj/structure/cable,
-/turf/open/floor/iron/large,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "bac" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -10984,10 +10968,10 @@
 /turf/open/floor/carpet/green,
 /area/station/service/chapel)
 "bcJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/engineering/lobby)
 "bcK" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Dormitories Maintenance"
@@ -11055,12 +11039,16 @@
 /turf/open/floor/iron/white,
 /area/station/commons/dorms)
 "bda" = (
-/obj/effect/turf_decal/trimline/purple/line,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/station/command/heads_quarters/rd)
 "bdd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "bdm" = (
@@ -11157,6 +11145,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bdH" = (
@@ -11801,7 +11790,6 @@
 "bgs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bgt" = (
@@ -11852,12 +11840,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bgD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/area/station/maintenance/department/security/upper)
 "bgE" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/camera/directional/north{
@@ -12122,10 +12111,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bhI" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "bhJ" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock"
@@ -12244,11 +12232,11 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
 "big" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/girder,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured_half,
-/area/station/science/xenobiology)
+/turf/open/floor/iron,
+/area/station/maintenance/port/greater)
 "bih" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -12779,10 +12767,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bjZ" = (
-/obj/machinery/light/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "bka" = (
 /obj/structure/toilet,
 /obj/item/beacon,
@@ -12823,6 +12810,7 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bkg" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bkh" = (
@@ -12846,17 +12834,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bks" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/cable,
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/station/engineering/atmos)
+/turf/open/misc/asteroid,
+/area/station/security/prison/rec)
 "bku" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -12960,7 +12940,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "bkO" = (
-/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "bkR" = (
@@ -13021,6 +13000,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "blc" = (
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "bld" = (
@@ -13501,10 +13481,10 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bmG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "bmH" = (
 /obj/structure/chair{
 	dir = 1
@@ -13529,15 +13509,11 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bmK" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/brig/hallway)
+/area/station/engineering/atmos/storage/gas)
 "bmL" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13853,7 +13829,6 @@
 "bnW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "bnX" = (
@@ -14192,8 +14167,14 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "bpk" = (
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "bpl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -14699,10 +14680,10 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "bqM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "bqN" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/machinery/light/directional/south,
@@ -14730,6 +14711,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bqS" = (
@@ -14952,15 +14934,14 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "brN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "brO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "brP" = (
@@ -15052,10 +15033,21 @@
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "bse" = (
-/obj/machinery/duct,
-/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Primary Tool Storage"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
 /turf/open/floor/iron,
-/area/station/security/prison)
+/area/station/commons/storage/primary)
 "bsf" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access"
@@ -15113,12 +15105,10 @@
 /turf/closed/wall/r_wall,
 /area/station/security/checkpoint/escape)
 "bsr" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/security/prison/visit)
+/area/station/hallway/secondary/exit/departure_lounge)
 "bss" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -15216,7 +15206,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bsI" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bsJ" = (
@@ -15348,6 +15337,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "btm" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "btn" = (
@@ -15458,11 +15448,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "btP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "btQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15479,12 +15469,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "btS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/engineering/atmos)
 "btT" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -15548,9 +15540,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "buh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/port)
 "buj" = (
 /obj/structure/sign/directions/command{
 	dir = 1;
@@ -15611,6 +15603,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "buC" = (
@@ -15648,16 +15641,14 @@
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "buR" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "buT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/engine,
+/area/station/command/heads_quarters/rd)
 "buU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -15684,13 +15675,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bva" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/office)
 "bvb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 5
@@ -15820,14 +15808,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bvz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison)
+/area/station/hallway/secondary/exit/departure_lounge)
 "bvA" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -15859,10 +15842,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bvH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/carpet/green,
-/area/station/service/library)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "bvI" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=evac";
@@ -15886,9 +15870,9 @@
 /area/station/hallway/secondary/entry)
 "bvL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
+/area/station/maintenance/department/medical)
 "bvN" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
@@ -16017,10 +16001,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bwu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "bwv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/grille,
@@ -16359,7 +16350,6 @@
 "byn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "byp" = (
@@ -16588,6 +16578,7 @@
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "byY" = (
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "byZ" = (
@@ -16721,10 +16712,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bzQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitory"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/fore)
+/area/station/commons/dorms)
 "bzR" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
@@ -16760,14 +16754,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "bAc" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/secondary/command)
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "bAe" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/siding/green{
@@ -17383,13 +17371,11 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "bDW" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bDX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "bEj" = (
@@ -17562,7 +17548,6 @@
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "bFi" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "bFj" = (
@@ -17721,10 +17706,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bGx" = (
-/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/prison/rec)
+/turf/open/floor/iron,
+/area/station/security/brig)
 "bGz" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -17807,9 +17795,10 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "bHf" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "bHi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -18118,6 +18107,7 @@
 "bJf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bJl" = (
@@ -18326,11 +18316,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bLr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "bLB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/west,
@@ -18385,6 +18373,7 @@
 /area/station/engineering/break_room)
 "bLV" = (
 /obj/machinery/light/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bMa" = (
@@ -18555,10 +18544,9 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "bNP" = (
-/obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/commons/lounge)
 "bNR" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/directional/west,
@@ -18790,9 +18778,14 @@
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "bPY" = (
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "bQb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -18900,10 +18893,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bRh" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/brig/hallway)
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "bRk" = (
 /obj/machinery/icecream_vat,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -19166,6 +19158,7 @@
 /area/station/maintenance/starboard)
 "bSQ" = (
 /obj/structure/closet/firecloset,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bSR" = (
@@ -19204,26 +19197,15 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bTj" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
+"bTk" = (
+/obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/department/security/upper)
-"bTk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Primary Tool Storage"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/cargo/storage)
 "bTo" = (
 /obj/structure/sign/painting/library_private{
 	pixel_x = 32;
@@ -19317,6 +19299,7 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bTG" = (
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bTV" = (
@@ -19324,13 +19307,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bUa" = (
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "bUe" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -19423,14 +19402,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bVm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "bVo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19464,7 +19438,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bVv" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bVx" = (
@@ -19473,16 +19446,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bVy" = (
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/security/prison/visit)
 "bVD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
@@ -19516,8 +19485,8 @@
 /area/station/science/ordnance/freezerchamber)
 "bVM" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "bVN" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
@@ -19581,8 +19550,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bWo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/maintenance/port/greater)
 "bWt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -19631,12 +19602,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bWE" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/mess)
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "bWG" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bWK" = (
@@ -20015,10 +19992,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "caE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/office)
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "caF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -20044,11 +20024,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "caP" = (
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/security/prison/mess)
+/area/station/hallway/primary/central)
 "caS" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 8
@@ -20201,6 +20179,7 @@
 /area/station/maintenance/department/cargo)
 "ccu" = (
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ccv" = (
@@ -20276,10 +20255,13 @@
 	},
 /area/station/science/ordnance/testlab)
 "cde" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance/testlab)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "cdf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -20351,12 +20333,12 @@
 /area/station/maintenance/department/cargo)
 "cek" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/escape)
 "cem" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cep" = (
@@ -20468,6 +20450,7 @@
 	alpha = 255;
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cfy" = (
@@ -20520,15 +20503,9 @@
 /area/station/science/research)
 "cfW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/science/robotics/lab)
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "cgc" = (
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -20638,8 +20615,12 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science/xenobiology)
 "chq" = (
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/upper)
 "cht" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -20920,10 +20901,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cjZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den)
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "ckj" = (
 /turf/closed/wall,
 /area/station/maintenance/department/science/xenobiology)
@@ -20931,7 +20913,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ckm" = (
@@ -21060,8 +21041,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/upper)
 "ckP" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/fueltank,
@@ -21236,7 +21217,7 @@
 /area/station/maintenance/department/science/xenobiology)
 "cmO" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/station/maintenance/port/greater)
 "cmR" = (
 /obj/docking_port/stationary{
@@ -21397,10 +21378,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cpk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/kirbyplants/random,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/commons/lounge)
 "cpm" = (
 /obj/effect/turf_decal/tile/brown/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21414,11 +21395,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "cpn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/girder,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/department/medical)
+/area/station/commons/dorms)
 "cpx" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine,
@@ -21435,11 +21419,16 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cpG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/hallway/primary/port)
 "cpH" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -21606,10 +21595,11 @@
 /turf/open/space/basic,
 /area/space)
 "crm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/commons/storage/primary)
 "cry" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -22004,7 +21994,6 @@
 "cvA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "cvB" = (
@@ -22070,14 +22059,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "cwt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "cww" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/structure/table,
@@ -22193,11 +22176,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/ordnance/testlab)
 "cxi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison)
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "cxm" = (
 /obj/structure/table/wood,
 /obj/structure/showcase/machinery/tv{
@@ -22285,10 +22266,12 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/qm)
 "cyj" = (
-/obj/structure/transit_tube,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/textured_half,
+/area/station/cargo/warehouse)
 "cyl" = (
 /obj/structure/closet/crate/engineering/electrical,
 /obj/item/solar_assembly,
@@ -22474,9 +22457,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "czy" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/royalblack,
-/area/station/command/bridge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "czC" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -22562,6 +22547,7 @@
 /area/station/maintenance/department/science/xenobiology)
 "cAu" = (
 /obj/structure/lattice/catwalk,
+/obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
 "cAv" = (
@@ -22646,19 +22632,17 @@
 /area/station/maintenance/solars/starboard/aft)
 "cAR" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/starboard/aft)
 "cAS" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
 /turf/open/space,
 /area/space/nearstation)
 "cAW" = (
-/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/area/station/maintenance/department/science)
 "cBg" = (
 /obj/effect/gibspawner/human/bodypartless,
 /obj/effect/decal/cleanable/dirt,
@@ -22824,9 +22808,12 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cCg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison)
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "cCh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22842,9 +22829,8 @@
 /area/space/nearstation)
 "cCj" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/security/warden)
+/area/station/hallway/secondary/construction)
 "cCl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22868,6 +22854,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cCL" = (
@@ -22934,6 +22921,7 @@
 /area/station/cargo/miningoffice)
 "cDj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cDm" = (
@@ -22985,17 +22973,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "cDw" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "cDx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -23003,9 +22986,11 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cDy" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "cDz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -23016,13 +23001,15 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cDB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cDD" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -23055,10 +23042,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cEf" = (
-/obj/effect/spawner/random/structure/girder,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "cEp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -23104,11 +23098,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "cEx" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/box,
-/obj/structure/cable,
+/obj/effect/turf_decal/siding/green{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/service/hydroponics/garden)
 "cEz" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 4;
@@ -23196,11 +23190,12 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
 "cEX" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "cFa" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -23239,10 +23234,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/solars/starboard/aft)
 "cFl" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/space/basic,
-/area/station/solars/port/aft)
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "cFo" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -23463,7 +23457,6 @@
 "cGI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cGK" = (
@@ -23503,9 +23496,11 @@
 /turf/open/floor/iron/large,
 /area/station/science/xenobiology)
 "cGU" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/station/solars/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "cGV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23583,17 +23578,14 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/science/xenobiology)
 "cIh" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cIi" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "cIk" = (
@@ -23666,14 +23658,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "cIU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/engineering/storage)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "cIV" = (
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 4
@@ -23734,11 +23721,9 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cJf" = (
-/obj/structure/cable,
-/turf/open/floor/iron/half{
-	dir = 8
-	},
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cJg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -24038,6 +24023,7 @@
 "cLv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cLw" = (
@@ -24158,6 +24144,7 @@
 /area/space/nearstation)
 "cMc" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cMd" = (
@@ -24301,6 +24288,7 @@
 /area/station/service/cafeteria)
 "cNs" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "cNH" = (
@@ -24315,12 +24303,13 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage_shared)
 "cNR" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "cNS" = (
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "cNT" = (
 /obj/structure/reflector/box/anchored{
 	dir = 1
@@ -24382,17 +24371,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cOi" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/station/service/kitchen/coldroom)
+/turf/open/floor/iron,
+/area/station/security/prison)
 "cOk" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/hfr_room)
 "cOl" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "cOn" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -24448,17 +24442,17 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/science/xenobiology)
 "cOy" = (
-/obj/effect/spawner/structure/window,
+/obj/structure/chair,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
+/area/station/maintenance/department/cargo)
 "cOA" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cOD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24926,11 +24920,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cQH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "cQJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -24968,7 +24962,6 @@
 "cQO" = (
 /obj/structure/transit_tube,
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
 "cQP" = (
@@ -25118,11 +25111,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/central)
 "cRm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/rec)
 "cRn" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/robotics_cyborgs,
@@ -25220,15 +25212,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cRF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "cRG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25270,10 +25257,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cRN" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/duct,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/security/prison)
 "cRO" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -25351,11 +25341,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cSf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom)
 "cSh" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional,
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -25431,6 +25419,7 @@
 "cSr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "cSs" = (
@@ -26027,9 +26016,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cVa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/engineering/atmos/pumproom)
 "cVc" = (
 /obj/machinery/door/window/left/directional/north{
 	dir = 4;
@@ -27491,7 +27483,6 @@
 "dqG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "dqK" = (
@@ -27572,6 +27563,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "dsh" = (
@@ -27909,6 +27901,7 @@
 "dAg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "dAC" = (
@@ -28136,11 +28129,14 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "dEi" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "dEJ" = (
 /obj/structure/table{
 	color = "#B392CB"
@@ -28430,12 +28426,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "dMJ" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -28508,11 +28506,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "dPM" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/turf/open/floor/carpet/royalblack,
+/area/station/command/bridge)
 "dPP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28939,14 +28935,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/auxlab/firing_range)
 "ebz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "ebB" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -29368,15 +29360,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "elM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical)
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "elY" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/duct,
@@ -29465,6 +29451,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "epl" = (
@@ -29580,18 +29567,17 @@
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "eqr" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
+"eqx" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison/visit)
-"eqx" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/security/prison/mess)
 "eqI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -29627,10 +29613,12 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "erB" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "erK" = (
 /obj/effect/turf_decal/tile/green/anticorner{
 	dir = 1
@@ -29810,23 +29798,22 @@
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/office)
 "evm" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/box/corners,
+/obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/science/xenobiology)
 "evs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "evx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -30212,13 +30199,11 @@
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "eBL" = (
-/obj/effect/turf_decal/tile/green/half{
-	dir = 1
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/station/security/prison/garden)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "eBO" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -30395,7 +30380,6 @@
 /area/station/engineering/atmos)
 "eGq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "eGu" = (
@@ -30525,7 +30509,6 @@
 	alpha = 255;
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "eHD" = (
@@ -30619,10 +30602,8 @@
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
 "eJQ" = (
-/obj/structure/closet/firecloset,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "eJR" = (
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 4
@@ -30752,10 +30733,13 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "eLL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/escape)
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/security/prison/garden)
 "eLT" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -31086,7 +31070,6 @@
 /area/station/ai_monitored/turret_protected/ai)
 "eTY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "eUa" = (
@@ -31222,7 +31205,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/structure/sign/warning/no_smoking/directional/west,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security/upper)
 "eWM" = (
@@ -31250,15 +31232,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/teleporter)
 "eXy" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/office)
+/turf/open/floor/wood/tile,
+/area/station/command/bridge)
 "eXE" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
@@ -31462,9 +31440,11 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "fde" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/bridge)
 "fdm" = (
 /obj/effect/turf_decal/tile/security/fourcorners,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -31558,11 +31538,14 @@
 /turf/open/floor/plating,
 /area/station/security/prison/safe/exterior)
 "ffy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "fgg" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -31850,14 +31833,20 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "fnt" = (
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/iron/white,
+/area/station/commons/toilet)
 "fny" = (
-/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/commons/lounge)
+/area/station/security/prison/visit)
 "fnU" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -32022,13 +32011,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "frI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/command)
 "frK" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/structure/chair/stool/directional/south,
@@ -32343,12 +32329,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "fxZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "fyd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32414,10 +32399,9 @@
 /area/station/engineering/hallway)
 "fzn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/department/bridge)
+/turf/open/floor/wood/large,
+/area/station/command/bridge)
 "fzX" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/line{
@@ -32556,11 +32540,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "fCF" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "fCK" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
@@ -32663,9 +32647,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "fGv" = (
-/obj/structure/cable,
-/turf/open/misc/asteroid,
-/area/station/security/prison/rec)
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "fGG" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/box/white{
@@ -32835,6 +32821,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "fKf" = (
@@ -32912,6 +32899,7 @@
 /area/station/science/research)
 "fLL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "fLX" = (
@@ -33115,12 +33103,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "fPv" = (
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/commons/toilet)
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "fPA" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron{
@@ -33576,9 +33562,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/eva/abandoned)
 "fXO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /obj/structure/cable,
-/turf/closed/wall,
-/area/station/maintenance/port/greater)
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "fXR" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/o2,
@@ -33954,15 +33945,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plastic,
 /area/station/maintenance/department/medical)
-"gii" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/engineering/atmos)
 "gim" = (
 /obj/structure/sink/directional/west,
 /obj/structure/sign/poster/official/cleanliness/directional/east,
@@ -34142,7 +34124,6 @@
 "glO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "glS" = (
@@ -34416,10 +34397,9 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "gtn" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "gtu" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 4
@@ -34772,12 +34752,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/port)
-"gCl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
 "gCt" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -34846,9 +34820,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "gDd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/command)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/green,
+/area/station/service/library)
 "gDs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -35263,11 +35238,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"gLu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
 "gLD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35558,6 +35528,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "gQf" = (
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "gQi" = (
@@ -35729,7 +35700,6 @@
 "gTG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gTK" = (
@@ -35981,12 +35951,12 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "gZa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/department/security/upper)
+/area/station/engineering/atmos/hfr_room)
 "gZd" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/rust,
@@ -36053,12 +36023,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "hax" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/maintenance/department/crew_quarters/dorms)
 "haH" = (
 /obj/machinery/restaurant_portal/restaurant/prison,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -36349,7 +36319,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "hfK" = (
@@ -36610,13 +36579,12 @@
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "hkC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Dormitory"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "hkI" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
 	name = "Burn Chamber Interior Airlock"
@@ -37083,10 +37051,15 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "htc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/office)
 "htt" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/r_wall,
@@ -37550,8 +37523,8 @@
 /area/station/maintenance/department/medical/plasmaman)
 "hAy" = (
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "hAG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -37632,6 +37605,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "hBG" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "hBH" = (
@@ -37775,7 +37749,6 @@
 "hEi" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security/upper)
 "hEm" = (
@@ -37829,8 +37802,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "hFH" = (
-/turf/open/misc/asteroid,
-/area/station/security/prison/safe/exterior)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "hGb" = (
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 9
@@ -37930,6 +37910,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "hIy" = (
@@ -37990,14 +37971,12 @@
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "hJu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/port/fore)
 "hJS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38155,11 +38134,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "hNv" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "hNH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38561,11 +38543,14 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "hXO" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage)
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "hXQ" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -39232,15 +39217,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "imr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/turf/open/floor/iron/dark/textured_half,
+/area/station/science/xenobiology)
 "imM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39761,9 +39742,13 @@
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "ivj" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "ivt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -40498,14 +40483,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "iJQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "iKp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -41171,6 +41152,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "iXp" = (
@@ -41336,12 +41318,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "iZV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/hop)
 "jaa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -41724,7 +41702,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/incident_display/delam/directional/north,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "jiy" = (
@@ -41826,11 +41803,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "jkn" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/station/command/bridge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "jkr" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -42600,13 +42576,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "jzO" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
 "jzU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
@@ -42680,11 +42653,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "jBB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/maintenance/port/greater)
 "jBE" = (
 /obj/machinery/duct,
 /obj/structure/grille,
@@ -42724,6 +42696,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "jCl" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "jCJ" = (
@@ -43372,14 +43345,8 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "jQA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/ai)
 "jQD" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -43570,9 +43537,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "jUi" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai_upload)
 "jUj" = (
 /obj/structure/rack,
 /obj/item/storage/box/masks{
@@ -43953,12 +43922,11 @@
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
 "kaY" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 4
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "kbl" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/effect/decal/cleanable/dirt,
@@ -44142,10 +44110,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "kff" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/science/robotics/lab)
 "kfq" = (
 /obj/structure/chair{
 	name = "Bailiff"
@@ -44574,13 +44548,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "koK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/hallway/secondary/command)
 "koL" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
@@ -44878,6 +44852,7 @@
 "kuB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "kuG" = (
@@ -45028,10 +45003,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "kxg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/tcommsat/computer)
 "kxi" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Patient's Room"
@@ -45055,11 +45030,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kxE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer3,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "kxL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -45269,12 +45243,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/ai)
 "kCy" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "kCJ" = (
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
@@ -45703,10 +45675,14 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "kMP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "kMV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -45872,7 +45848,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "kPM" = (
@@ -45957,6 +45932,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "kSr" = (
@@ -46531,11 +46507,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "lgn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "lgu" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input,
 /turf/open/floor/engine/plasma,
@@ -46562,10 +46540,11 @@
 /turf/closed/wall,
 /area/station/command/heads_quarters/ce)
 "lhm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/command/bridge)
+/area/station/maintenance/port)
 "lhK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -46579,12 +46558,11 @@
 	},
 /area/station/science/ordnance)
 "lhQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/upper)
+/turf/open/floor/iron/dark,
+/area/station/service/chapel/monastery)
 "lhS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -46622,7 +46600,6 @@
 "lim" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "liL" = (
@@ -46817,8 +46794,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "lnm" = (
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "lnp" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/iron/dark,
@@ -46834,13 +46813,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "lnI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/turf/open/floor/iron/dark,
+/area/station/security/detectives_office)
 "lnQ" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46870,12 +46847,11 @@
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "lob" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/hfr_room)
+/area/station/commons/fitness/recreation)
 "loq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46935,10 +46911,14 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/security/checkpoint/medical)
 "lpB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "lqo" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -46981,7 +46961,6 @@
 /area/space/nearstation)
 "lqP" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "lqS" = (
@@ -47230,14 +47209,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "lxa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair{
+	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "lxh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47498,9 +47477,10 @@
 /turf/open/floor/iron/textured_half,
 /area/station/maintenance/department/eva/abandoned)
 "lCH" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/structure/lattice,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lCI" = (
 /obj/machinery/modular_computer/preset/cargochat/service,
 /obj/effect/turf_decal/bot,
@@ -47862,6 +47842,7 @@
 "lLx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "lLE" = (
@@ -47886,7 +47867,6 @@
 /obj/effect/turf_decal/tile/green/half{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -48212,7 +48192,9 @@
 "lQN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "lRd" = (
@@ -48454,13 +48436,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "lWW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/maintenance/department/science/xenobiology)
 "lWY" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
@@ -48501,9 +48478,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "lXP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
+/area/station/maintenance/department/science)
 "lXV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -48691,9 +48670,11 @@
 /turf/open/floor/carpet,
 /area/station/service/abandoned_gambling_den)
 "mbf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "mbh" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark/telecomms,
@@ -48930,7 +48911,6 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/xenobiology)
 "mhg" = (
@@ -48965,8 +48945,8 @@
 /area/station/science/ordnance)
 "mhJ" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/station/security/prison)
 "mhM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -49189,6 +49169,7 @@
 "mlo" = (
 /obj/structure/railing,
 /obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/command/storage/eva)
 "mls" = (
@@ -49271,12 +49252,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "mnK" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/detectives_office)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "mnP" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
@@ -49284,9 +49263,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "mok" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "mou" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49484,14 +49465,12 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "msu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/command)
+/area/station/security/prison/mess)
 "msK" = (
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/machinery/light/directional/south,
@@ -50064,12 +50043,10 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "mCL" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/turf/open/floor/plating,
+/area/station/security/warden)
 "mCR" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
 	dir = 4
@@ -50081,13 +50058,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "mDp" = (
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/security/prison)
+/area/station/hallway/primary/aft)
 "mDL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -50383,6 +50358,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "mJv" = (
@@ -50536,7 +50512,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "mMy" = (
@@ -50951,8 +50926,8 @@
 /area/station/maintenance/department/science)
 "mWw" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
+/turf/open/floor/wood/large,
+/area/station/command/bridge)
 "mWx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
@@ -51420,14 +51395,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "ngT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "ngU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -51511,7 +51482,6 @@
 "niR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "niS" = (
@@ -51730,6 +51700,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -51798,12 +51769,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/eva/abandoned)
 "nno" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "nnD" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
@@ -51914,7 +51885,6 @@
 /area/station/engineering/supermatter/room)
 "noW" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "noZ" = (
@@ -52013,10 +51983,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/teleporter)
 "nrn" = (
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage)
 "nrv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/oxygen_output{
 	dir = 4
@@ -52109,9 +52079,12 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "ntX" = (
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "ntY" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plating,
@@ -52483,7 +52456,6 @@
 "nCF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "nCJ" = (
@@ -52539,7 +52511,6 @@
 "nDi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "nDq" = (
@@ -52568,13 +52539,6 @@
 /obj/machinery/power/emitter,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
-"nEX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "nFa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -53218,6 +53182,7 @@
 "nNX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "nOb" = (
@@ -53738,8 +53703,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "oaI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -53937,7 +53900,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oex" = (
@@ -54011,8 +53973,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ofP" = (
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter)
 "ofU" = (
 /obj/structure/table,
 /obj/item/paper/guides/jobs/engi/gravity_gen{
@@ -54272,16 +54240,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
-"ojF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "okb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -54415,13 +54373,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "omW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "omY" = (
 /obj/effect/turf_decal/trimline/yellow/corner,
@@ -54673,12 +54630,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/abandoned_gambling_den)
 "orq" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/turf/open/floor/iron,
+/area/station/cargo/lobby)
 "orJ" = (
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
@@ -54928,13 +54884,10 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
 "oxL" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/brig)
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "oxN" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 8
@@ -55146,12 +55099,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "oBq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/space_heater,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/port/greater)
+/area/station/security/brig/hallway)
 "oBx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/graffiti,
@@ -55335,6 +55286,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"oEJ" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "oES" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
@@ -55401,12 +55357,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "oFR" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "oGj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/iron,
@@ -55523,8 +55479,9 @@
 "oJW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
 "oKd" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/stripes/line,
@@ -55959,13 +55916,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "oQB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "oQT" = (
 /obj/effect/spawner/random/engineering/tank,
 /obj/effect/turf_decal/delivery,
@@ -56544,12 +56502,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "pbj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/area/station/maintenance/department/science/xenobiology)
 "pbY" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
@@ -57305,7 +57263,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "psH" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "psW" = (
@@ -57328,14 +57285,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/lab)
 "ptU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/engineering/storage)
 "ptZ" = (
 /obj/machinery/biogenerator,
 /obj/effect/decal/cleanable/dirt,
@@ -57493,8 +57449,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pvk" = (
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pvs" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
@@ -57556,11 +57514,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "pwf" = (
-/obj/structure/railing,
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/ai_monitored/command/storage/eva)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pwp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
@@ -57605,6 +57563,7 @@
 "pyz" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "pyG" = (
@@ -57712,12 +57671,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "pAM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/maintenance/department/medical)
 "pAU" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8
@@ -57836,9 +57794,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pDm" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/escape)
 "pDn" = (
 /obj/item/radio/intercom/directional/west,
 /obj/structure/chair{
@@ -58191,7 +58149,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/area/station/maintenance/port/greater)
 "pMb" = (
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -58302,6 +58260,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "pOd" = (
@@ -59374,6 +59333,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qkB" = (
@@ -59420,12 +59380,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution/education)
 "qlX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/fore)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "qmb" = (
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line{
@@ -59826,12 +59786,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/teleporter)
 "qtS" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space,
+/area/space/nearstation)
 "quo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -59913,16 +59871,9 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "qvG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/port)
+/obj/effect/turf_decal/trimline/purple/line,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "qvH" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -59951,7 +59902,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -60020,12 +59970,10 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "qxr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/duct,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+/turf/open/floor/iron,
+/area/station/security/prison)
 "qxH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -60239,6 +60187,7 @@
 "qBP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "qCk" = (
@@ -60248,10 +60197,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qCq" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "qCv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/east,
@@ -60466,10 +60416,12 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/security/upper)
 "qGS" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "qGY" = (
 /obj/structure/rack,
 /obj/item/raw_anomaly_core/random{
@@ -61074,8 +61026,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "qTm" = (
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "qTr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -61148,13 +61103,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "qUl" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/chair/office{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "qUs" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -61361,7 +61317,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security/upper)
 "qYL" = (
@@ -61484,7 +61439,6 @@
 /area/station/engineering/atmos/office)
 "rbo" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rbM" = (
@@ -61525,7 +61479,7 @@
 "rcL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "rdd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
@@ -61806,10 +61760,14 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/bridge)
 "rhq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "rhv" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -61860,6 +61818,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"rhW" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "rib" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/structure/crate,
@@ -61979,10 +61947,15 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "rkT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "rkX" = (
 /obj/item/toy/katana,
 /turf/open/space/basic,
@@ -62218,6 +62191,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "roI" = (
@@ -62332,11 +62306,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "rrb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/maintenance/department/medical)
+/area/station/commons/lounge)
 "rrm" = (
 /obj/structure/rack,
 /obj/item/storage/medkit/regular{
@@ -62573,10 +62545,17 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
 "rvx" = (
-/obj/structure/bookcase/random/adult,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/carpet/green,
-/area/station/service/library)
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "rvC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -62895,10 +62874,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/upper)
 "rBn" = (
-/obj/structure/cable/layer3,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "rBp" = (
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
@@ -63092,13 +63072,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
-"rHh" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "rHv" = (
 /obj/item/food/meat/slab/goliath,
 /turf/open/misc/asteroid,
@@ -63715,9 +63688,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port)
 "rUk" = (
-/obj/structure/cable,
-/turf/open/floor/wood/large,
-/area/station/command/bridge)
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "rUq" = (
 /obj/structure/lattice,
 /obj/item/toy/gun,
@@ -63791,13 +63766,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "rWX" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/storage)
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "rXB" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -63867,12 +63840,17 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "rYM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/area/station/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "rYP" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "sac" = (
@@ -64390,12 +64368,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "sor" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "sov" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 1
@@ -64559,10 +64536,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "ssn" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/fore)
 "ssK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64578,10 +64556,11 @@
 	},
 /area/station/command/gateway)
 "ssX" = (
-/obj/structure/bookcase/random/fiction,
-/obj/structure/cable,
-/turf/open/floor/carpet/green,
-/area/station/service/library)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "ste" = (
 /obj/structure/closet/wardrobe/black,
 /obj/effect/landmark/start/hangover/closet,
@@ -65484,11 +65463,10 @@
 	},
 /area/station/hallway/secondary/command)
 "sJj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/girder,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/port/greater)
+/obj/structure/railing,
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/ai_monitored/command/storage/eva)
 "sJn" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -65741,13 +65719,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "sOT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/station/solars/starboard/aft)
 "sOU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 8
@@ -65768,13 +65743,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "sPl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "sPm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -66351,7 +66323,6 @@
 /area/station/maintenance/fore)
 "tbf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "tbh" = (
@@ -67131,11 +67102,11 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/qm)
 "tpJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/upper)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "tpS" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67395,14 +67366,11 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "tuE" = (
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter)
+/area/station/maintenance/department/science/xenobiology)
 "tuV" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/light/directional/north,
@@ -67520,11 +67488,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "tyl" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/space_heater,
 /obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/iron,
+/area/station/maintenance/port/greater)
 "tyw" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -67579,12 +67548,12 @@
 	},
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "tzt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/port/greater)
 "tzF" = (
 /obj/structure/chair{
 	dir = 4
@@ -68217,16 +68186,15 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/genetics)
 "tKH" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/hallway/primary/port)
 "tKM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/space/basic,
+/area/station/solars/port/aft)
 "tKV" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -68619,7 +68587,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "tRY" = (
@@ -68933,7 +68900,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "uar" = (
@@ -69091,20 +69057,12 @@
 	},
 /area/station/maintenance/department/science/xenobiology)
 "udi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
+/obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "udo" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -69448,9 +69406,11 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "ule" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "ulm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/plastic{
@@ -69503,12 +69463,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "umj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "umo" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/light/directional/south,
@@ -69569,8 +69528,11 @@
 /turf/open/floor/iron/textured_large,
 /area/station/maintenance/department/security/upper)
 "unw" = (
-/turf/open/floor/wood/large,
-/area/station/command/heads_quarters/hop)
+/obj/structure/cable,
+/turf/open/floor/iron/half{
+	dir = 8
+	},
+/area/station/science/xenobiology)
 "unz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/wood,
@@ -69595,6 +69557,7 @@
 /area/station/engineering/storage/tech)
 "uod" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "uog" = (
@@ -69904,13 +69867,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "uwK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security/upper)
+/area/station/maintenance/department/cargo)
 "uwO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -70038,11 +69999,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "uza" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "uzh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70051,9 +70011,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "uzr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery/aft)
 "uzx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -70069,7 +70031,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "uzX" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "uAh" = (
@@ -70133,10 +70094,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "uBx" = (
-/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/atmos)
 "uCg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/girder,
@@ -70250,10 +70217,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "uDT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/cargo/miningoffice)
+/area/station/engineering/atmos)
 "uEo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -70460,10 +70427,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "uJd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "uJe" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/structure/disposalpipe/segment{
@@ -70816,13 +70786,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "uRq" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/chair{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "uRr" = (
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71060,10 +71029,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "uWL" = (
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/structure/transit_tube,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/side,
-/area/station/engineering/storage)
+/turf/open/space/basic,
+/area/space/nearstation)
 "uWZ" = (
 /obj/structure/sign/warning/secure_area/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -71101,14 +71071,10 @@
 	},
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "uXW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "uYl" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab"
@@ -71183,7 +71149,6 @@
 /area/station/maintenance/disposal/incinerator)
 "uZL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security/upper)
@@ -71278,14 +71243,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vbp" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/command)
+/area/station/engineering/lobby)
 "vbP" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -71568,7 +71529,6 @@
 "vgE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "vgR" = (
@@ -71581,6 +71541,7 @@
 /area/station/maintenance/department/science/xenobiology)
 "vgS" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/visit)
 "vgZ" = (
@@ -71948,17 +71909,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "vpk" = (
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/area/station/engineering/atmos)
 "vpG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -72165,7 +72118,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "vsM" = (
@@ -72546,8 +72498,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/station/maintenance/fore)
 "vCh" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /obj/structure/cable,
@@ -72708,9 +72660,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "vHl" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison)
+/area/station/engineering/atmos)
 "vHu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -73425,12 +73378,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "vTd" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/medical)
 "vTg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -74022,6 +73976,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -74289,9 +74244,9 @@
 /turf/open/misc/asteroid,
 /area/station/security/prison/safe/exterior)
 "wlx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/service/hydroponics/garden)
 "wlz" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/vacuum,
@@ -74687,10 +74642,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "wuL" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/iron/grimy,
-/area/station/security/detectives_office)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "wvg" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75158,10 +75111,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "wFX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "wGd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -75286,6 +75240,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
+"wIk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "wIq" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -75299,11 +75259,10 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "wIs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "wIx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75609,7 +75568,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "wPV" = (
@@ -75737,10 +75695,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/central)
 "wSB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side,
+/area/station/engineering/storage)
 "wSH" = (
 /turf/closed/mineral/random/labormineral,
 /area/station/security/prison/safe/exterior)
@@ -75803,11 +75761,14 @@
 	},
 /area/station/maintenance/starboard)
 "wTJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "wTY" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/sign/map/fulp/helio/left{
@@ -75853,6 +75814,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "wUJ" = (
@@ -76032,10 +75994,13 @@
 	},
 /area/station/cargo/sorting)
 "wZV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "wZX" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -76156,11 +76121,9 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "xdD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/service/chapel/monastery)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "xdI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76527,12 +76490,10 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/starboard/aft)
 "xke" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "xki" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -76691,7 +76652,6 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "xox" = (
@@ -77043,12 +77003,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "xuH" = (
-/obj/effect/turf_decal/box/corners,
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "xuI" = (
 /obj/machinery/computer/telecomms/server{
 	dir = 1;
@@ -77059,10 +77016,20 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "xuU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "xuV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77147,12 +77114,11 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/safe)
 "xwu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/mob/living/simple_animal/slime,
+/obj/effect/turf_decal/box,
 /obj/structure/cable,
-/turf/open/floor/iron/textured_half,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/large,
+/area/station/science/xenobiology)
 "xww" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
@@ -77206,13 +77172,13 @@
 /turf/open/floor/iron/textured_half,
 /area/station/cargo/warehouse)
 "xxm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "xxp" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 8
@@ -77476,11 +77442,9 @@
 /turf/open/floor/wood,
 /area/station/maintenance/aft/lesser)
 "xBJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/storage/gas)
+/turf/open/space/basic,
+/area/space)
 "xCy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/engine,
@@ -77599,10 +77563,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "xFs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
+/turf/open/misc/asteroid,
+/area/station/security/prison/safe/exterior)
 "xFv" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/iron,
@@ -77788,12 +77750,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "xIR" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/bookcase/random/adult,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured_edge,
-/area/station/security/lockers)
+/turf/open/floor/carpet/green,
+/area/station/service/library)
 "xIT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -77816,7 +77776,6 @@
 "xIZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "xJf" = (
@@ -77897,7 +77856,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "xLd" = (
@@ -78054,12 +78012,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "xOc" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "xOi" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
@@ -78305,10 +78264,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "xTF" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/hallway/primary/port)
 "xUc" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/corner,
@@ -78609,10 +78568,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ybs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/cable,
-/turf/open/floor/wood/large,
-/area/station/command/bridge)
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/station/engineering/atmos)
 "ybA" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -78630,10 +78596,10 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "yci" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/ce)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "yck" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/trimline/purple/line,
@@ -78793,10 +78759,17 @@
 	dir = 4
 	},
 /area/station/cargo/sorting)
+"ygc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "ygu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "ygz" = (
@@ -88536,7 +88509,7 @@ aae
 aae
 aak
 aak
-cFl
+tKM
 aak
 aae
 aae
@@ -88793,7 +88766,7 @@ aak
 aak
 aak
 aak
-cFl
+tKM
 aak
 aak
 aak
@@ -89050,7 +89023,7 @@ ceV
 ceV
 ceV
 aaa
-cFl
+tKM
 aaa
 ceV
 ceV
@@ -89301,19 +89274,19 @@ aaa
 aae
 aak
 mCl
-cFl
-cFl
-cFl
-cFl
-cFl
-cAu
+tKM
+tKM
+tKM
+tKM
+tKM
+aOd
 cgj
-cAu
-cFl
-cFl
-cFl
-cFl
-cFl
+aOd
+tKM
+tKM
+tKM
+tKM
+tKM
 ceV
 aak
 aae
@@ -89839,21 +89812,21 @@ aae
 aak
 azn
 azn
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
 azn
 azn
 aak
@@ -90072,19 +90045,19 @@ aaa
 aae
 aak
 mCl
-cFl
-cFl
-cFl
-cFl
-cFl
-cAu
+tKM
+tKM
+tKM
+tKM
+tKM
+aOd
 cgj
-cAu
-cFl
-cFl
-cFl
-cFl
-cFl
+aOd
+tKM
+tKM
+tKM
+tKM
+tKM
 ceV
 aak
 aae
@@ -90096,21 +90069,21 @@ aae
 aak
 azn
 azn
-cAu
-cAS
-cAS
-cAS
-cAS
-cAS
-cAS
-cAS
-cAS
-cAS
-cAS
-cAS
-cAS
-cAS
-cAu
+aOd
+qtS
+qtS
+qtS
+qtS
+qtS
+qtS
+qtS
+qtS
+qtS
+qtS
+qtS
+qtS
+qtS
+aOd
 azn
 azn
 aak
@@ -90351,23 +90324,23 @@ aaa
 aaa
 aae
 aak
-ntX
+bRh
 azn
-cAu
-cAS
+aOd
+qtS
 cCf
 cEI
-buT
+aPX
 cEI
 cEI
-buT
+aPX
 cEI
 cEI
-buT
+aPX
 cEI
 cMb
-cAS
-cAu
+qtS
+aOd
 azn
 azn
 aak
@@ -90610,21 +90583,21 @@ aae
 aak
 azn
 azn
-cAu
-cAS
+aOd
+qtS
 cCh
 cDx
 bZD
 bZD
 cEI
 aaa
-cDy
+cAS
 bZD
 bZD
 cJe
-cMc
-cAS
-cAu
+cJf
+qtS
+aOd
 azn
 azn
 aak
@@ -90843,19 +90816,19 @@ aaa
 aae
 aak
 ceV
-cFl
-cFl
-cFl
-cFl
-cFl
+tKM
+tKM
+tKM
+tKM
+tKM
 cgj
 cgj
 cgj
-cFl
-cFl
-cFl
-cFl
-cFl
+tKM
+tKM
+tKM
+tKM
+tKM
 ceV
 aak
 aae
@@ -90867,21 +90840,21 @@ aae
 aak
 azn
 azn
-cAu
+aOd
+qtS
+cOA
+bZD
+aaa
+aaa
 cAS
-sor
 bZD
-aaa
-aaa
-cDy
-bZD
-cDy
-aaa
-aaa
-bZD
-cRN
 cAS
-cAu
+aaa
+aaa
+bZD
+cMc
+qtS
+aOd
 azn
 azn
 aak
@@ -91124,21 +91097,21 @@ aaf
 aak
 azn
 azn
-cAu
-cAS
+aOd
+qtS
 cCh
 bZD
 aaa
-cDy
-cDy
-cDy
-cDy
-cDy
+cAS
+cAS
+cAS
+cAS
+cAS
 aaa
 bZD
-cMc
-cAS
-cAu
+cJf
+qtS
+aOd
 azn
 azn
 aak
@@ -91351,7 +91324,7 @@ aaa
 bdR
 bKG
 bib
-wZV
+bTj
 bdR
 aaa
 aae
@@ -91381,21 +91354,21 @@ aae
 aak
 azn
 azn
-cAu
+aOd
+qtS
+cCh
+cCh
 cAS
-cCh
-cCh
-cDy
-cDy
+cAS
 cDx
 cEI
 cJe
-cDy
-cDy
-cDy
-cMc
 cAS
-cAu
+cAS
+cAS
+cJf
+qtS
+aOd
 azn
 azn
 aak
@@ -91577,7 +91550,7 @@ bqp
 bKG
 bKG
 bib
-wZV
+bTj
 bKG
 bKG
 jJa
@@ -91595,7 +91568,7 @@ boZ
 bqp
 bKG
 bKG
-wZV
+bTj
 bHi
 bKG
 bJZ
@@ -91638,21 +91611,21 @@ aae
 aak
 azn
 azn
-cAu
-cAS
-sor
+aOd
+qtS
+cOA
 aaa
 bZD
-cDy
+cAS
 cCh
 aQC
-cMc
-cDy
+cJf
+cAS
 bZD
 aaa
-cRN
-cAS
-cAu
+cMc
+qtS
+aOd
 azn
 azn
 aak
@@ -91834,7 +91807,7 @@ bdR
 jIh
 bKG
 bKG
-wZV
+bTj
 bKG
 bmn
 bdR
@@ -91852,7 +91825,7 @@ bdR
 bdR
 bCQ
 bKG
-wZV
+bTj
 bKG
 bKG
 uJo
@@ -91865,7 +91838,7 @@ aaa
 bdQ
 bKG
 bKG
-wZV
+bTj
 bdR
 aak
 aak
@@ -91877,7 +91850,7 @@ aaa
 aaa
 aaa
 aak
-cFl
+tKM
 aak
 aaa
 aaa
@@ -91895,21 +91868,21 @@ aae
 aak
 azn
 azn
-cAu
-cAS
+aOd
+qtS
 cCh
-cDy
-cDy
-cDy
-cDz
-cDA
-cJg
-cDy
-cDy
-cMc
-cMc
 cAS
-cAu
+cAS
+cAS
+cDz
+cIh
+cJg
+cAS
+cAS
+cJf
+cJf
+qtS
+aOd
 azn
 azn
 aak
@@ -92091,7 +92064,7 @@ bdR
 bfm
 bKG
 bKG
-wZV
+bTj
 bKG
 bKG
 bKG
@@ -92109,7 +92082,7 @@ boX
 bKG
 bKG
 bKG
-wZV
+bTj
 bKG
 bKG
 bKb
@@ -92122,19 +92095,19 @@ bdR
 bdR
 bKG
 bKG
-wZV
+bTj
 bdR
 aak
 aaa
 aaa
 aaa
 aaa
-cFl
-cFl
-cFl
-cFl
-cFl
-cFl
+tKM
+tKM
+tKM
+tKM
+tKM
+tKM
 aaa
 aaa
 aaa
@@ -92152,21 +92125,21 @@ aae
 aak
 azn
 azn
-cAu
-cAS
+aOd
+qtS
 cCh
 bZD
 aaa
-cDy
-cDy
-cDy
-cDy
-cDy
+cAS
+cAS
+cAS
+cAS
+cAS
 aaa
 bZD
-cMc
-cAS
-cAu
+cJf
+qtS
+aOd
 azn
 azn
 aak
@@ -92348,7 +92321,7 @@ bdR
 bfm
 bKG
 bKG
-wZV
+bTj
 bKG
 bKG
 bKG
@@ -92366,7 +92339,7 @@ hxF
 bKG
 bKG
 bKG
-wZV
+bTj
 bKG
 bKG
 bKG
@@ -92379,7 +92352,7 @@ bKG
 bKG
 bKG
 bKG
-wZV
+bTj
 bdR
 aak
 aaa
@@ -92409,21 +92382,21 @@ aae
 aak
 azn
 azn
-cAu
+aOd
+qtS
+cOA
+bZD
+aaa
+aaa
 cAS
-sor
 bZD
-aaa
-aaa
-cDy
-bZD
-cDy
-aaa
-aaa
-bZD
-cRN
 cAS
-cAu
+aaa
+aaa
+bZD
+cMc
+qtS
+aOd
 azn
 azn
 aak
@@ -92605,7 +92578,7 @@ bdR
 bfs
 bKG
 bKG
-wZV
+bTj
 bKG
 bKG
 bKG
@@ -92622,21 +92595,21 @@ bdQ
 bzF
 bKG
 bKG
-wZV
-wZV
-wZV
-wZV
-wZV
-wZV
-wZV
+bTj
+bTj
+bTj
+bTj
+bTj
+bTj
+bTj
 bOP
-wZV
+bTj
 bOP
-wZV
-wZV
-wZV
-wZV
-wZV
+bTj
+bTj
+bTj
+bTj
+bTj
 bdR
 aaa
 aaa
@@ -92666,21 +92639,21 @@ aae
 aak
 azn
 azn
-cAu
-cAS
+aOd
+qtS
 cCh
 cDz
 bZD
 bZD
-cDy
+cAS
 aaa
-cDA
+cIh
 bZD
 bZD
 cJg
-cMc
-cAS
-cAu
+cJf
+qtS
+aOd
 azn
 azn
 aak
@@ -92862,8 +92835,8 @@ bdR
 bfm
 bKG
 bKG
-wZV
-wZV
+bTj
+bTj
 bKG
 bKG
 bKG
@@ -92878,8 +92851,8 @@ bwI
 bKG
 bKG
 bKG
-wZV
-wZV
+bTj
+bTj
 bvG
 bHj
 bHj
@@ -92923,21 +92896,21 @@ aae
 aak
 azn
 azn
-cAu
-cAS
+aOd
+qtS
 cCi
-fxZ
-fxZ
-fxZ
-fxZ
-fxZ
-fxZ
-fxZ
-fxZ
-fxZ
+cDA
+cDA
+cDA
+cDA
+cDA
+cDA
+cDA
+cDA
+cDA
 cMd
-cAS
-cAu
+qtS
+aOd
 azn
 azn
 aak
@@ -93120,8 +93093,8 @@ bfy
 bKG
 bKG
 bKG
-wZV
-wZV
+bTj
+bTj
 bKG
 bKG
 bKG
@@ -93134,20 +93107,20 @@ bKG
 bKG
 bKG
 bKG
-wZV
-wZV
+bTj
+bTj
 bvG
 bxG
 bKG
 bKG
-bVM
-abd
+xdD
+bLV
 dJx
 bKG
 bQS
 bSz
 bTt
-bLV
+bVm
 bKG
 bXz
 boX
@@ -93180,21 +93153,21 @@ aae
 aak
 azn
 azn
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
 cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-aWH
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
 azn
 azn
 aak
@@ -93378,8 +93351,8 @@ bKG
 bKG
 bKG
 bKG
-wZV
-wZV
+bTj
+bTj
 bKG
 bKG
 bKG
@@ -93390,8 +93363,8 @@ btK
 bsz
 bKG
 bKG
-wZV
-wZV
+bTj
+bTj
 bvG
 bxG
 bKG
@@ -93438,19 +93411,19 @@ aak
 azn
 azn
 azn
-cAu
+aOd
 azn
 azn
+cCj
+cCj
+cCj
 cIi
-cIi
-cIi
-gLu
-cIi
-cIi
-cIi
+cCj
+cCj
+cCj
 azn
 azn
-cAu
+aOd
 azn
 azn
 azn
@@ -93636,8 +93609,8 @@ bKG
 bKG
 bKG
 bKG
-wZV
-wZV
+bTj
+bTj
 bKG
 bKG
 bsz
@@ -93646,8 +93619,8 @@ bsz
 bsz
 bsz
 bKG
-wZV
-wZV
+bTj
+bTj
 bvG
 bxG
 bKG
@@ -93695,19 +93668,19 @@ aak
 azn
 aak
 aak
-cAu
+aOd
 aak
 aak
-cIi
+cCj
 cFG
 cGV
-aVk
+ygc
 cGV
 cJU
-cIi
+cCj
 aak
 aak
-cAu
+aOd
 aak
 aak
 azn
@@ -93894,16 +93867,16 @@ bju
 bvK
 bKG
 bKG
-wZV
-wZV
+bTj
+bTj
 bKG
 bib
 xDE
 bKG
 mcT
 bvD
-wZV
-wZV
+bTj
+bTj
 bvG
 bxG
 bKG
@@ -93952,19 +93925,19 @@ aak
 aaj
 aak
 aak
-cAu
+aOd
 aak
 aak
-cIi
+cCj
 cFH
 cJi
-cDB
+ngT
 cJi
 cJV
-cIi
+cCj
 aak
 aak
-cAu
+aOd
 aak
 aak
 aae
@@ -94152,14 +94125,14 @@ ble
 bvK
 bKG
 bKG
-wZV
-wZV
+bTj
+bTj
 bKG
 xDE
 bKG
 mcT
-wZV
-wZV
+bTj
+bTj
 bvG
 bxG
 bKG
@@ -94208,21 +94181,21 @@ aak
 aak
 aaj
 aak
-cAu
-cAu
+aOd
+aOd
 aak
 aak
 cEJ
 cFI
 cJi
-cDB
+ngT
 cJh
 cJW
 cEJ
 aak
 aak
-cAu
-cAu
+aOd
+aOd
 aak
 aae
 aak
@@ -94410,12 +94383,12 @@ bwp
 bvK
 bKG
 bKG
-wZV
-wZV
-wZV
-wZV
-wZV
-wZV
+bTj
+bTj
+bTj
+bTj
+bTj
+bTj
 bvG
 bxG
 bKG
@@ -94447,7 +94420,7 @@ qnC
 nCC
 nCC
 nCC
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -94465,21 +94438,21 @@ aak
 aak
 aaj
 aak
-cAu
-cIi
-cIi
-cIi
+aOd
+cCj
+cCj
+cCj
 cEK
 cFH
 cJi
-cDB
+ngT
 cJi
 gPq
 cEK
-cIi
-cIi
-cIi
-cAu
+cCj
+cCj
+cCj
+aOd
 aak
 aae
 aak
@@ -94659,7 +94632,7 @@ aXd
 bcB
 aVf
 bfv
-aAi
+aCR
 bfv
 azQ
 azQ
@@ -94670,7 +94643,7 @@ bKG
 bKG
 bKG
 bKG
-wZV
+bTj
 bKG
 bvG
 bxG
@@ -94683,7 +94656,7 @@ nCC
 nCC
 nCC
 nCC
-aqD
+bHf
 wra
 qNV
 rFw
@@ -94704,7 +94677,7 @@ qjW
 fpd
 qjW
 qlJ
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -94722,21 +94695,21 @@ aak
 aak
 aaj
 aak
-cAu
+aOd
 cSk
-cDB
-cDB
+ngT
+ngT
 cXV
-lnI
+xOc
 cGW
 iSn
 cGW
-dPM
+rWX
 cXW
-cDB
-cDB
+ngT
+ngT
 cXY
-cAu
+aOd
 aak
 aae
 aak
@@ -94917,7 +94890,7 @@ bcC
 aVf
 rMK
 bgF
-aAi
+aCR
 bfv
 azQ
 azQ
@@ -94927,9 +94900,9 @@ bvK
 bKG
 bKG
 bKG
-wZV
+bTj
 bKG
-cRm
+bvH
 bKG
 qTU
 bzX
@@ -94961,7 +94934,7 @@ fGN
 nCC
 nCC
 nCC
-cAu
+aOd
 aaa
 aaa
 aae
@@ -94979,21 +94952,21 @@ aak
 aak
 aaj
 aak
-cAu
-cIi
-cIi
-cIi
+aOd
+cCj
+cCj
+cCj
 cEM
 cFJ
 cJi
-cDB
+ngT
 cJi
 cJi
 cEM
-cIi
-cIi
-cIi
-cAu
+cCj
+cCj
+cCj
+aOd
 aak
 aae
 aaa
@@ -95174,8 +95147,8 @@ bcD
 aVf
 bfv
 bgG
-aAi
-aAi
+aCR
+aCR
 bfv
 azQ
 azQ
@@ -95184,9 +95157,9 @@ nis
 bKG
 bKG
 bKG
-wZV
+bTj
 bKG
-cRm
+bvH
 bKG
 oxF
 hOh
@@ -95236,8 +95209,8 @@ aak
 aak
 aak
 aak
-cAu
-cAu
+aOd
+aOd
 aak
 aak
 cEM
@@ -95249,9 +95222,9 @@ cLn
 cEM
 aak
 aak
-cAu
-cAu
-cAu
+aOd
+aOd
+aOd
 aae
 aaa
 aaa
@@ -95357,7 +95330,7 @@ aaa
 aaa
 aaa
 aak
-cAu
+aOd
 uPb
 uPb
 aGm
@@ -95424,7 +95397,7 @@ aVf
 aWx
 aTS
 aWk
-xdD
+lhQ
 bay
 bbK
 bdm
@@ -95441,17 +95414,17 @@ bqz
 bKG
 bKG
 bKG
-wZV
+bTj
 bKG
-cRm
+bvH
 bKG
 aDl
 nCC
 nCC
 hKd
-xIZ
-xIZ
-xIZ
+lhm
+lhm
+lhm
 nCC
 nCC
 jZi
@@ -95493,7 +95466,7 @@ aak
 aak
 aak
 aak
-cAu
+aOd
 aaj
 aaj
 aaj
@@ -95508,9 +95481,9 @@ aae
 aae
 aae
 aak
-cAu
+aOd
 aae
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -95698,14 +95671,14 @@ azQ
 brZ
 bKG
 bKG
-wZV
+bTj
 bKG
 bwF
 bwZ
 nCC
 nCC
-rhq
-rhq
+xIZ
+xIZ
 lEh
 uGE
 tnV
@@ -95748,27 +95721,27 @@ aak
 aak
 aak
 aak
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
 aak
 aak
 aak
@@ -95936,12 +95909,12 @@ aTc
 azQ
 aVg
 aWl
-aCR
+aAi
 aXY
-aWw
+bJf
 baV
-aCR
-aCR
+aAi
+aAi
 bet
 bfL
 eLa
@@ -95961,7 +95934,7 @@ bON
 nCC
 nCC
 lEh
-xIZ
+lhm
 nNa
 uiC
 uGE
@@ -96022,7 +95995,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aak
 aaa
 aaa
@@ -96137,7 +96110,7 @@ sxa
 sxa
 uPb
 uPb
-cAu
+aOd
 aak
 aaa
 aaa
@@ -96191,29 +96164,29 @@ loG
 aSf
 aTd
 aUd
-aCR
-btS
-aCR
-bJf
 aAi
+hJu
+aAi
+aWw
+aCR
 qgO
 azQ
 ovt
+aCR
 aAi
-aCR
-aCR
+aAi
 bio
-aCR
-aCR
-aCR
-aCR
-aCR
-aCR
+aAi
+aAi
+aAi
+aAi
+aAi
+aAi
 bio
 qfG
-bsI
+buh
 bur
-bsI
+buh
 hEg
 nCC
 jVW
@@ -96222,7 +96195,7 @@ nCC
 nCC
 nCC
 uGE
-vsK
+pNZ
 uGE
 spL
 twr
@@ -96279,7 +96252,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aak
 aaa
 aaa
@@ -96395,7 +96368,7 @@ sxa
 uPb
 uPb
 uPb
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -96449,9 +96422,9 @@ aSs
 aTy
 azQ
 aCp
-btS
+hJu
 aXe
-bJf
+aWw
 azQ
 azQ
 azQ
@@ -96467,11 +96440,11 @@ azQ
 azQ
 azQ
 aIT
+buh
 bsI
-bWo
-wFX
-lpB
-uXW
+xTF
+tKH
+rhq
 oir
 cKk
 rfy
@@ -96536,7 +96509,7 @@ aae
 aae
 aak
 aak
-cAu
+aOd
 aak
 aak
 aak
@@ -96706,9 +96679,9 @@ myn
 myn
 azQ
 azQ
-btS
+hJu
 aBB
-bJf
+aWw
 azQ
 baq
 baq
@@ -96736,7 +96709,7 @@ nCC
 nCC
 nCC
 uGE
-dqG
+kuB
 uGE
 oZE
 qge
@@ -96793,7 +96766,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aak
 aaa
 aaa
@@ -96963,9 +96936,9 @@ aaa
 aaa
 azQ
 aGQ
-btS
+hJu
 aGU
-bJf
+aWw
 azQ
 baq
 baq
@@ -96978,14 +96951,14 @@ baq
 baq
 bmr
 bnL
-bpk
+bFi
 rxH
 brU
 pHZ
-bLr
-wFX
-bWo
-bWo
+btP
+xTF
+bsI
+bsI
 bwM
 vGW
 qZI
@@ -97050,7 +97023,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aak
 aaa
 aaa
@@ -97155,15 +97128,15 @@ akK
 akK
 akK
 akK
-fGv
+bks
 awx
 akK
 fjj
 aGn
 erK
-lLI
-lLI
 dMJ
+dMJ
+lLI
 ane
 fjj
 xMT
@@ -97206,7 +97179,7 @@ aaa
 aDr
 aDr
 aIC
-aAi
+aCR
 aJX
 aKP
 eoP
@@ -97220,9 +97193,9 @@ aaa
 aaa
 azQ
 aGU
-btS
+hJu
 ovt
-bJf
+aWw
 azQ
 baq
 baq
@@ -97235,14 +97208,14 @@ baq
 baq
 bmr
 myU
-bpk
+bFi
 rxH
 brU
 pHZ
-bLr
+btP
 buu
-lpB
-lpB
+tKH
+tKH
 bwN
 peV
 qiA
@@ -97250,7 +97223,7 @@ diS
 diS
 lvY
 xXC
-pbj
+fKe
 uGE
 twr
 twr
@@ -97401,7 +97374,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 uPb
 uPb
 afJ
@@ -97412,26 +97385,26 @@ akK
 akK
 ajO
 awc
-fGv
+bks
 awx
 ajP
 fjj
 aHV
-eBL
+eLL
+agl
 hBG
-mWw
-hBG
+agl
 anS
 aDC
 agM
 agM
-vHl
-vHl
 ahI
+ahI
+cOi
 xSp
 agM
 agM
-vHl
+ahI
 jQo
 jQo
 hgQ
@@ -97462,11 +97435,11 @@ aaa
 aaa
 aDr
 aHW
-aAi
-aAi
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
+aCR
+aCR
 aNi
 azQ
 azQ
@@ -97477,9 +97450,9 @@ aDr
 azQ
 azQ
 azQ
-btS
+hJu
 aBB
-bJf
+aWw
 azQ
 baq
 baq
@@ -97496,10 +97469,10 @@ bpl
 bqt
 aZp
 aJy
-bLr
-wFX
-bWo
-bWo
+btP
+xTF
+bsI
+bsI
 bwM
 slx
 cuo
@@ -97507,7 +97480,7 @@ brn
 kig
 gbU
 uGE
-dqG
+kuB
 kKn
 mSK
 fOz
@@ -97516,9 +97489,9 @@ noc
 hyO
 maP
 mSK
-qvG
+uNc
 ioE
-rhq
+xIZ
 cXm
 gXw
 nCC
@@ -97674,17 +97647,17 @@ awy
 awx
 aDC
 rgk
-eBL
-hBG
+eLL
+agl
 lMU
 agX
 pll
 apt
-mDp
+cRN
 ght
-mDp
-mDp
-mDp
+cRN
+cRN
+cRN
 rYD
 dXk
 obv
@@ -97697,11 +97670,11 @@ giP
 xMT
 wSH
 xRd
-hFH
-hFH
+xFs
+xFs
 wSH
 wSH
-cAu
+aOd
 aak
 aaa
 aaa
@@ -97719,24 +97692,24 @@ aaa
 aaa
 aDr
 aIg
-aAi
+aCR
 aKP
 aJY
-aAi
-aAi
+aCR
+aCR
 aKP
 azQ
 sbD
 nwa
-aAi
+aCR
 aRl
 fYE
 eLa
 azQ
 lFl
-btS
+hJu
 aXf
-bJf
+aWw
 azQ
 baq
 baq
@@ -97754,9 +97727,9 @@ bqu
 bsa
 bsG
 btQ
-wFX
-bWo
-bWo
+xTF
+bsI
+bsI
 bwM
 vCl
 tpU
@@ -97764,7 +97737,7 @@ tQk
 gCS
 ykM
 uGE
-vsK
+pNZ
 sJt
 mSK
 dnV
@@ -97788,7 +97761,7 @@ aak
 uyy
 coW
 kWl
-qTm
+cwt
 jse
 gkR
 dyp
@@ -97801,7 +97774,7 @@ fdm
 npJ
 hci
 hja
-qTm
+cwt
 jSV
 coW
 aaa
@@ -97913,7 +97886,7 @@ aaa
 aaa
 aaa
 aak
-cAu
+aOd
 uPb
 uPb
 uPb
@@ -97931,8 +97904,8 @@ ajP
 ajP
 aDC
 mMJ
-eBL
-hBG
+eLL
+agl
 lNc
 adz
 ptZ
@@ -97954,9 +97927,9 @@ wJJ
 nSD
 szE
 dtl
-hFH
+xFs
 arD
-hFH
+xFs
 wSH
 wSH
 xRd
@@ -97978,22 +97951,22 @@ aDr
 aIz
 aIB
 aJf
-aAi
+aCR
 aMs
-aAi
-aAi
+aCR
+aCR
 aOc
-aAi
-aAi
-aAi
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
+aCR
+aCR
+aCR
 aOc
-aAi
-btS
+aCR
+hJu
 aXg
-bJf
+aWw
 azQ
 baq
 baq
@@ -98011,9 +97984,9 @@ bqv
 aZp
 pHZ
 btR
-lpB
+tKH
 aUO
-bWo
+bsI
 bwM
 evl
 isd
@@ -98021,7 +97994,7 @@ bba
 pmJ
 kBP
 uGE
-vsK
+pNZ
 mFd
 mSK
 esw
@@ -98188,10 +98161,10 @@ ajP
 ajP
 fjj
 aNA
-eBL
-hBG
+eLL
+agl
 ajJ
-hBG
+agl
 pYV
 wJJ
 sgL
@@ -98210,11 +98183,11 @@ eFX
 wNO
 hXo
 mkQ
-hFH
+xFs
 lRl
 alv
-hFH
-hFH
+xFs
+xFs
 wSH
 wSH
 aaa
@@ -98233,24 +98206,24 @@ aaa
 aaa
 aDr
 aIz
-aAi
+aCR
 aMs
-aAi
+aCR
 aKP
-aAi
+aCR
 eLa
 azQ
 aGU
 aGU
 eLa
 ugl
-aAi
+aCR
 aCp
 azQ
 aEm
-btS
+hJu
 aBB
-bJf
+aWw
 azQ
 baq
 baq
@@ -98263,14 +98236,14 @@ baq
 baq
 bmr
 bnO
-bFi
+gtn
 bqw
 aZp
 bsH
-bLr
-wFX
-bWo
-bWo
+btP
+xTF
+bsI
+bsI
 bwM
 jmX
 oPG
@@ -98278,7 +98251,7 @@ hya
 vCl
 biK
 uGE
-hfI
+roC
 aSE
 mSK
 oZh
@@ -98490,11 +98463,11 @@ aaa
 aaa
 aDr
 aIA
-aAi
-aAi
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
+aCR
+aCR
 aQe
 azQ
 azQ
@@ -98505,9 +98478,9 @@ aDr
 azQ
 azQ
 aVi
-btS
+hJu
 aBB
-bJf
+aWw
 azQ
 baq
 baq
@@ -98520,14 +98493,14 @@ baq
 baq
 bmr
 bnP
-bFi
+gtn
 bqx
 aZp
 aTN
-bLr
-wFX
-bWo
-bWo
+btP
+xTF
+bsI
+bsI
 bwM
 bwM
 tEm
@@ -98535,8 +98508,8 @@ bwM
 bBn
 bwM
 uGE
-hfI
-kuB
+roC
+dqG
 mSK
 vgZ
 mla
@@ -98697,7 +98670,7 @@ ajP
 akK
 akK
 ajP
-fGv
+bks
 akK
 akK
 fjj
@@ -98718,7 +98691,7 @@ qNq
 nOb
 wJJ
 ixP
-bse
+qxr
 wJJ
 wJJ
 wJJ
@@ -98726,8 +98699,8 @@ nSD
 sov
 xLp
 jQM
-hFH
-hFH
+xFs
+xFs
 wSH
 wSH
 xRd
@@ -98748,9 +98721,9 @@ aaa
 aDr
 aDr
 aKQ
-aAi
+aCR
 aKb
-aAi
+aCR
 aNh
 aDr
 azQ
@@ -98781,9 +98754,9 @@ hws
 bqA
 aZp
 bsJ
-bLr
-wFX
-bWo
+btP
+xTF
+bsI
 bvN
 bwM
 suO
@@ -98792,7 +98765,7 @@ mdh
 nRe
 trM
 uGE
-cmO
+hAy
 qtA
 mSK
 oZh
@@ -98961,7 +98934,7 @@ xFG
 aQL
 aoe
 aoe
-oaI
+msu
 aoe
 aoe
 rsm
@@ -98982,7 +98955,7 @@ dyK
 wbW
 wSH
 xRd
-hFH
+xFs
 fHa
 wSH
 wSH
@@ -99005,7 +98978,7 @@ aaa
 aaa
 aDr
 aDr
-aAi
+aCR
 aLH
 aLq
 aDr
@@ -99019,9 +98992,9 @@ aaa
 aaa
 azQ
 eLa
-btS
+hJu
 aGU
-bJf
+aWw
 azQ
 azQ
 azQ
@@ -99038,9 +99011,9 @@ azQ
 azQ
 azQ
 bsS
-bLr
-wFX
-bWo
+btP
+xTF
+bsI
 bvO
 bwM
 ohO
@@ -99049,19 +99022,19 @@ giA
 gsn
 gVY
 uGE
-sJj
-pNZ
+big
+vsK
 mSK
 mSK
-cjZ
+fLL
 iTN
 vrI
 xCE
 mSK
-cmO
-kuB
+hAy
+dqG
 etg
-kPE
+pMa
 eUt
 rSo
 aak
@@ -99211,7 +99184,7 @@ ajP
 avs
 avx
 avx
-bGx
+cRm
 avx
 akK
 xFG
@@ -99231,8 +99204,8 @@ rQv
 jJh
 ggI
 vhC
-bvz
-cxi
+aJM
+qTm
 aqB
 ajB
 uYI
@@ -99243,7 +99216,7 @@ lLw
 ydB
 wSH
 wSH
-cAu
+aOd
 kpo
 aaa
 aaa
@@ -99277,27 +99250,27 @@ azQ
 azQ
 aVj
 aWm
-gtn
-aWw
-aAi
-aAi
-azQ
-aAi
-aAi
-aAi
-aAi
-aAi
-aAi
+oEJ
 bJf
-uJd
-uJd
-uJd
-uJd
+aCR
+aCR
+azQ
+aCR
+aCR
+aCR
+aCR
+aCR
+aCR
+aWw
+byn
+byn
+byn
+byn
 bsf
 rdy
 wRO
-wFX
-bWo
+xTF
+bsI
 cXw
 bwM
 nbZ
@@ -99307,18 +99280,18 @@ hyj
 vCl
 uGE
 nAS
-kuB
+dqG
 rql
 mSK
 wVg
-fLL
+elM
 teD
 lPj
 mSK
-rcL
+bWo
 duS
 etg
-kPE
+pMa
 nnH
 rSo
 aak
@@ -99468,7 +99441,7 @@ ajP
 avr
 ajP
 awi
-bGx
+cRm
 avx
 awz
 xFG
@@ -99496,7 +99469,7 @@ gXN
 wbW
 wbW
 wSH
-hFH
+xFs
 aar
 wSH
 wSH
@@ -99533,28 +99506,28 @@ aQa
 aTg
 azQ
 vQJ
+abd
 byn
-uJd
-aWw
+bJf
+abd
 byn
-uJd
-uJd
-uJd
+byn
+byn
 mZH
 wWi
 bgW
 vaz
 mZH
-bJf
-aAi
+aWw
+aCR
 aIp
 lFl
 aCp
 azQ
 bsM
-bLr
-wFX
-bWo
+btP
+xTF
+bsI
 cXx
 bwO
 bwO
@@ -99563,7 +99536,7 @@ bwO
 uGE
 uGE
 uGE
-fXO
+cmO
 nCJ
 llH
 mSK
@@ -99575,7 +99548,7 @@ mSK
 lEg
 sUh
 uGE
-kPE
+pMa
 ntr
 rSo
 aak
@@ -99725,9 +99698,9 @@ ajP
 avr
 ajP
 awj
-awA
 awu
 awA
+awu
 aFg
 fWw
 fWw
@@ -99753,8 +99726,8 @@ wct
 okU
 wbW
 hwe
-hFH
-hFH
+xFs
+xFs
 wSH
 wSH
 wSH
@@ -99790,7 +99763,7 @@ aQa
 aTh
 azQ
 aWl
-byn
+abd
 azQ
 azQ
 aZr
@@ -99809,9 +99782,9 @@ azQ
 azQ
 azQ
 cXr
-bLr
-wFX
-bWo
+btP
+xTF
+bsI
 rSW
 bwO
 xKp
@@ -99821,8 +99794,8 @@ xAQ
 lEg
 lEg
 jBK
-fKe
-pNZ
+fxZ
+vsK
 mSK
 tkg
 kIv
@@ -99832,7 +99805,7 @@ mSK
 fvO
 uGE
 uGE
-kPE
+pMa
 efg
 uGE
 aak
@@ -99857,7 +99830,7 @@ uFJ
 uFJ
 fvH
 uFJ
-qGS
+bmG
 jul
 vhN
 jsN
@@ -99881,17 +99854,17 @@ mRm
 aak
 aak
 xHL
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
+aOd
 xHL
 aak
 aak
@@ -100009,9 +99982,9 @@ trL
 nLb
 cMk
 wbW
-hFH
+xFs
 qMK
-hFH
+xFs
 wXH
 wSH
 wSH
@@ -100047,7 +100020,7 @@ aRn
 aTi
 azQ
 aWl
-byn
+abd
 azQ
 aYc
 aZs
@@ -100066,10 +100039,10 @@ bfE
 bfI
 aXj
 aHf
-bLr
-wFX
-bWo
-bWo
+btP
+xTF
+bsI
+bsI
 plk
 wSZ
 jYD
@@ -100079,7 +100052,7 @@ uGE
 bKp
 efg
 vUi
-kuB
+dqG
 mSK
 mSK
 mSK
@@ -100089,7 +100062,7 @@ mSK
 lEg
 tdd
 uGE
-kPE
+pMa
 rql
 uGE
 aak
@@ -100137,7 +100110,7 @@ aak
 mRm
 aak
 aaa
-cAu
+aOd
 aak
 aaa
 aak
@@ -100149,7 +100122,7 @@ aaa
 aak
 aaa
 aak
-cAu
+aOd
 aak
 aaa
 aaa
@@ -100304,7 +100277,7 @@ aQa
 aQa
 ngq
 aWl
-byn
+abd
 azQ
 aYd
 caX
@@ -100322,11 +100295,11 @@ bnR
 bpq
 bfF
 brX
-bWo
-bLr
-wFX
-bWo
-bWo
+bsI
+btP
+xTF
+bsI
+bsI
 hxr
 tFI
 rAl
@@ -100337,16 +100310,16 @@ eoX
 jSw
 tnO
 pkB
-kuB
-kuB
-pNZ
-kuB
+dqG
+dqG
+vsK
+dqG
 dwB
 uGE
-roC
+hfI
 jKZ
 hLY
-kPE
+pMa
 qBN
 rSo
 aak
@@ -100371,9 +100344,9 @@ xyg
 uPO
 uPO
 uPO
-gii
+btS
 rRm
-qTm
+cwt
 gsl
 iNN
 qBJ
@@ -100394,7 +100367,7 @@ aaa
 mRm
 aak
 aaa
-cAu
+aOd
 aak
 aaa
 aak
@@ -100406,7 +100379,7 @@ aaa
 aak
 aaa
 aak
-cAu
+aOd
 aak
 aaa
 aaa
@@ -100561,7 +100534,7 @@ aSi
 aRn
 azQ
 uZF
-byn
+abd
 azQ
 aYe
 aZs
@@ -100579,11 +100552,11 @@ bnS
 bjy
 bfK
 brX
-bWo
-bLr
-wFX
-bWo
-bWo
+bsI
+btP
+xTF
+bsI
+bsI
 bwR
 rgB
 kcN
@@ -100594,16 +100567,16 @@ uGE
 uGE
 uGE
 uGE
-kuB
+dqG
 dsF
 dmZ
-roC
-roC
+hfI
+hfI
 wWy
-roC
+hfI
 wTj
 hLY
-kPE
+pMa
 qBN
 rSo
 aak
@@ -100628,9 +100601,9 @@ crj
 crj
 crj
 crj
-aSX
+vpk
 rRm
-qTm
+cwt
 iNN
 iNN
 xIT
@@ -100651,7 +100624,7 @@ aaa
 mRm
 aak
 aaa
-cAu
+aOd
 aak
 aaa
 aak
@@ -100663,7 +100636,7 @@ aaa
 aak
 aaa
 aak
-cAu
+aOd
 aak
 aaa
 aaa
@@ -100760,17 +100733,17 @@ xFG
 xFG
 aoe
 iPA
+msu
 oaI
-bWE
-bWE
+oaI
 duF
-cCg
+mhJ
 fyd
-aYz
-aYz
-aYz
+fCF
+fCF
+fCF
 pAZ
-aYz
+fCF
 fyd
 fyd
 jQo
@@ -100780,7 +100753,7 @@ bkM
 dOP
 tVm
 wbW
-hFH
+xFs
 wXH
 wXH
 wSH
@@ -100818,7 +100791,7 @@ aRn
 aQa
 azQ
 aWl
-byn
+abd
 azQ
 aXi
 aZv
@@ -100885,7 +100858,7 @@ ood
 crj
 crj
 rCg
-aSX
+vpk
 rRm
 tQh
 iNN
@@ -100908,9 +100881,9 @@ aaa
 mRm
 aak
 aaa
-cAu
+aOd
 aak
-cAu
+aOd
 cDD
 cFL
 cDD
@@ -100920,7 +100893,7 @@ cFL
 cDD
 cFL
 aak
-cAu
+aOd
 aak
 aaa
 aaa
@@ -101017,13 +100990,13 @@ akK
 xFG
 haH
 jaf
-caP
+eqx
 iET
 aeh
 uKU
 uKU
 uHl
-amw
+vgS
 uKU
 uKU
 uKU
@@ -101075,7 +101048,7 @@ aSA
 aRn
 azQ
 pmu
-byn
+abd
 azQ
 aYf
 caX
@@ -101094,9 +101067,9 @@ bmu
 bfI
 brX
 bsN
-bLr
-wFX
-bWo
+btP
+xTF
+bsI
 bvS
 bwO
 uts
@@ -101117,7 +101090,7 @@ wDx
 gsU
 vwl
 iSZ
-kPE
+pMa
 rql
 uGE
 aak
@@ -101142,7 +101115,7 @@ crj
 crj
 crj
 crj
-crm
+pvk
 gzw
 kym
 jqq
@@ -101165,7 +101138,7 @@ aak
 mRm
 aak
 aak
-cAu
+aOd
 aaa
 llp
 cEN
@@ -101177,7 +101150,7 @@ rxm
 cEN
 vff
 aaa
-cAu
+aOd
 aak
 aak
 aak
@@ -101332,7 +101305,7 @@ azQ
 azQ
 azQ
 aVl
-byn
+abd
 azQ
 aYg
 aZx
@@ -101350,11 +101323,11 @@ bnV
 bjz
 bfJ
 brY
-bVy
-bLr
-wFX
-bWo
-bWo
+cpG
+btP
+xTF
+bsI
+bsI
 bwO
 bwO
 bwO
@@ -101374,7 +101347,7 @@ btG
 dBU
 yky
 gYz
-kPE
+pMa
 efg
 rSo
 aak
@@ -101399,7 +101372,7 @@ crj
 crj
 crj
 crj
-aSX
+vpk
 rRm
 vRW
 kVc
@@ -101422,7 +101395,7 @@ aaa
 mRm
 aak
 aaa
-cAu
+aOd
 aaa
 ioj
 cEN
@@ -101434,7 +101407,7 @@ rxm
 cEN
 lqo
 aaa
-cAu
+aOd
 aak
 aaa
 aaa
@@ -101581,15 +101554,15 @@ aDr
 aDr
 azQ
 azQ
-cAu
-cAu
-cAu
+aOd
+aOd
+aOd
 aak
 aak
 aak
 azQ
 aVl
-byn
+abd
 azQ
 aYh
 aZy
@@ -101597,21 +101570,21 @@ baw
 bbG
 bcH
 bea
-bnW
+bdd
 bgM
 bih
+bdd
 bnW
-bdd
-bdd
+bnW
 juV
 bGn
 bGn
 qFg
-bVy
-bLr
-wFX
-bWo
-bWo
+cpG
+btP
+xTF
+bsI
+bsI
 bwS
 byc
 bzR
@@ -101631,7 +101604,7 @@ vzh
 bsw
 nVB
 iSZ
-kPE
+pMa
 jTm
 rSo
 aak
@@ -101647,17 +101620,17 @@ tnE
 mBw
 crj
 aAO
-aOd
-aSX
-aSX
-aSX
-aSX
-aSX
-aSX
-aSX
-aSX
-aSX
-udi
+omW
+vpk
+vpk
+vpk
+vpk
+vpk
+vpk
+vpk
+vpk
+vpk
+xuU
 gjw
 jZn
 wNm
@@ -101679,7 +101652,7 @@ aaa
 mRm
 aak
 aak
-cAu
+aOd
 aaa
 llp
 cEN
@@ -101691,7 +101664,7 @@ rxm
 cEN
 vff
 aaa
-cAu
+aOd
 aak
 aaa
 aaa
@@ -101846,7 +101819,7 @@ azQ
 azQ
 azQ
 aVm
-byn
+abd
 azQ
 aYn
 aZP
@@ -101864,11 +101837,11 @@ bnX
 bjA
 bfE
 brY
-bVy
-bLr
-wFX
-bWo
-bWo
+cpG
+btP
+xTF
+bsI
+bsI
 bwS
 byd
 bzS
@@ -101888,7 +101861,7 @@ tLr
 gYU
 jDR
 tNG
-kPE
+pMa
 nnH
 rSo
 aak
@@ -101904,7 +101877,7 @@ oHA
 kjx
 gmt
 hVb
-sPl
+omW
 crj
 pDh
 kvX
@@ -101913,7 +101886,7 @@ crj
 crj
 crj
 lPY
-aSX
+vpk
 rRm
 oWx
 iNN
@@ -101936,7 +101909,7 @@ aak
 cXM
 hCP
 ltZ
-cAu
+aOd
 aaa
 ioj
 cEN
@@ -101948,7 +101921,7 @@ rxm
 cEN
 lqo
 aaa
-cAu
+aOd
 aak
 aaa
 aaa
@@ -102097,13 +102070,13 @@ aMu
 azQ
 aaa
 azQ
-aAi
+aCR
 azQ
 aSk
 aTj
-aAi
+aCR
 aVm
-byn
+abd
 azQ
 aYo
 aZT
@@ -102122,9 +102095,9 @@ bmv
 bfF
 brX
 bsN
-bLr
-wFX
-bWo
+btP
+xTF
+bsI
 bvT
 bwS
 bye
@@ -102144,8 +102117,8 @@ tNV
 qDb
 nMg
 oCz
-hfI
-kPE
+roC
+pMa
 tZs
 uGE
 aak
@@ -102165,14 +102138,14 @@ sMD
 fyO
 crj
 crj
-aSX
+vpk
 crj
 crj
 crj
 crj
-aSX
+vpk
 rRm
-qTm
+cwt
 iNN
 iNN
 wNm
@@ -102195,7 +102168,7 @@ bXs
 vBM
 aaa
 aaa
-cAu
+aOd
 cFo
 uVi
 cIw
@@ -102205,7 +102178,7 @@ uVi
 cIw
 bUe
 aaa
-cAu
+aOd
 aak
 aaa
 aaa
@@ -102281,7 +102254,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 uPb
 uPb
 uPb
@@ -102289,8 +102262,8 @@ aaa
 aaa
 uPb
 uPb
-cAu
-cAu
+aOd
+aOd
 uPb
 uPb
 uPb
@@ -102313,8 +102286,8 @@ ffb
 tJQ
 abp
 ahz
-brO
-jzO
+glO
+fny
 xTg
 otF
 eUC
@@ -102354,13 +102327,13 @@ aMu
 azQ
 aak
 azQ
-aAi
+aCR
 azQ
 aSl
 aTk
 aUg
 aVn
-aWw
+bJf
 azQ
 aXj
 aXj
@@ -102378,10 +102351,10 @@ bnZ
 bps
 bfK
 brX
-bWo
-bLr
-wFX
-bWo
+bsI
+btP
+xTF
+bsI
 wGo
 bwT
 qMb
@@ -102422,18 +102395,18 @@ rqO
 mhM
 jGc
 jGc
-agr
+bPY
 jGc
 jGc
 uMv
 jGc
 vXo
 wAP
-qTm
+cwt
 gsl
 iNN
 dxH
-lob
+gZa
 tEJ
 sSt
 iaL
@@ -102452,7 +102425,7 @@ kCU
 vBM
 xHL
 aaa
-cAu
+aOd
 cFp
 qpP
 aak
@@ -102461,7 +102434,7 @@ aak
 wNj
 cLt
 vff
-cAu
+aOd
 xHL
 aak
 iGu
@@ -102539,7 +102512,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 uPb
 uPb
 aaa
@@ -102570,7 +102543,7 @@ ahA
 abp
 abp
 ajp
-brO
+glO
 siz
 tuv
 jTY
@@ -102617,7 +102590,7 @@ azQ
 azQ
 azQ
 aVm
-byn
+abd
 azQ
 aYk
 aZB
@@ -102635,10 +102608,10 @@ boa
 bjy
 bfK
 brX
-bWo
-bLr
-wFX
-bWo
+bsI
+btP
+xTF
+bsI
 bvT
 bwS
 byg
@@ -102672,19 +102645,19 @@ uGE
 myZ
 weM
 tCc
-qTm
+cwt
 rrX
-qTm
+cwt
 iPp
 qDQ
 rxk
 rxk
-aIu
+uBx
 rxk
 rxk
 qDQ
 hAI
-omW
+kMP
 lDu
 cbY
 cbY
@@ -102709,16 +102682,16 @@ bXs
 cXM
 hCP
 aDS
-cAu
-cAu
+aOd
+aOd
 cMj
-cAu
-cAu
-cAu
+aOd
+aOd
+aOd
 cMj
-cAu
-cAu
-cAu
+aOd
+aOd
+aOd
 cyo
 cyo
 cyo
@@ -102868,13 +102841,13 @@ aMv
 azQ
 nNd
 aOK
-aAi
+aCR
 aOK
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
 aWl
-byn
+abd
 azQ
 aYl
 aXj
@@ -102892,11 +102865,11 @@ bob
 bpt
 bfI
 brX
-bWo
-bLr
-wFX
-bWo
-bWo
+bsI
+btP
+xTF
+bsI
+bsI
 bwS
 byh
 kYI
@@ -102917,15 +102890,15 @@ iBV
 cKU
 rjW
 oyA
-hfI
-hfI
+roC
+roC
 uzh
-dqG
-dqG
+kuB
+kuB
 thy
 keF
-umj
-umj
+tzt
+tzt
 nQQ
 nlb
 qFV
@@ -102936,13 +102909,13 @@ xsY
 qDQ
 mBv
 mBv
-xOc
+cDw
 mBv
 mBv
 kyu
-qTm
-omW
-qTm
+cwt
+kMP
+cwt
 ulE
 nTB
 tsu
@@ -103065,7 +103038,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 uPb
 abp
 aAP
@@ -103080,11 +103053,11 @@ rYr
 tcg
 vFP
 vFP
-lgn
+mbf
 aoK
 wET
 kUI
-glO
+brO
 fOi
 tuv
 aoG
@@ -103127,11 +103100,11 @@ aOe
 hsq
 aAQ
 xlx
-aAi
+aCR
 rmD
 aGQ
 aWl
-byn
+abd
 azQ
 aYx
 aZU
@@ -103151,9 +103124,9 @@ bfF
 aXj
 cXs
 aMc
-wFX
-bWo
-bWo
+xTF
+bsI
+bsI
 bwS
 byk
 xVe
@@ -103178,7 +103151,7 @@ uGE
 uGE
 uGE
 uGE
-cEf
+avn
 ipl
 myZ
 myZ
@@ -103193,13 +103166,13 @@ rIW
 qDQ
 lCN
 nCu
-aSX
+vpk
 lAV
 crj
 kyu
-qTm
-omW
-qTm
+cwt
+kMP
+cwt
 ulE
 mqe
 qoh
@@ -103322,27 +103295,27 @@ aaa
 aaa
 aaa
 aaa
-cAu
-cAu
+aOd
+aOd
 abp
 aAS
 aaO
 abp
 abA
-ajI
+arY
 tUf
 xku
-ajI
+arY
 aav
 tUf
-ajI
-ajI
-ajI
+arY
+arY
+arY
 aic
 aim
 hRk
 vrn
-eqr
+ajI
 tUf
 cNa
 cNa
@@ -103388,7 +103361,7 @@ azQ
 aGU
 aGU
 fES
-byn
+abd
 bmV
 bmV
 bmV
@@ -103406,11 +103379,11 @@ aXj
 aXj
 aXj
 aXj
-bWo
-bLr
-wFX
-bWo
-bWo
+bsI
+btP
+xTF
+bsI
+bsI
 uGE
 uGE
 kgg
@@ -103450,7 +103423,7 @@ wrF
 wei
 crj
 nlQ
-cEx
+pwf
 crj
 hrt
 qDQ
@@ -103459,7 +103432,7 @@ qHx
 xKH
 ulE
 ofg
-yci
+aYH
 mke
 tfj
 wTZ
@@ -103586,20 +103559,20 @@ abp
 abp
 abp
 abp
-vgS
+aaB
 oxt
-vgS
+aaB
 rnL
-vgS
+aaB
 teH
-vgS
+aaB
 wMy
 xAK
 aAl
 abp
 abp
 iTd
-amw
+vgS
 qQA
 cNa
 nTK
@@ -103631,19 +103604,19 @@ aDr
 aDr
 azQ
 azQ
-aAi
-aAi
-aAi
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
+aCR
+aCR
+aCR
 azQ
-aAi
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
+aCR
 dPm
-aAi
+aCR
 aVo
 aWq
 aXk
@@ -103665,22 +103638,22 @@ bwL
 bzp
 bvm
 btV
-wFX
-bWo
+xTF
+bsI
 bvS
 uGE
 qHE
 nYX
 qSv
-drN
+tRR
 rex
-drN
+tRR
 mRA
 cxV
 uGE
 cxz
 eII
-tRR
+drN
 fHV
 jsm
 uGE
@@ -103702,12 +103675,12 @@ fOY
 rqA
 ggE
 twq
-eqx
+xnY
 lwm
 nID
 iUB
 iUB
-kxg
+vHl
 dJz
 niA
 coW
@@ -103748,9 +103721,9 @@ qjP
 dum
 cCr
 cyt
-cNS
+cNR
 wIJ
-cNS
+cNR
 tal
 cyo
 aaa
@@ -103843,20 +103816,20 @@ aaa
 aaa
 aaa
 aaa
-vgS
+aaB
 oEn
-vgS
+aaB
 abp
-vgS
+aaB
 oEn
-vgS
+aaB
 abp
 abp
 abp
 abp
 aAl
 cyV
-bsr
+bVy
 xqp
 cNa
 kel
@@ -103884,18 +103857,18 @@ aak
 aDr
 aEg
 aEk
-aAi
-aAi
+aCR
+aCR
 azQ
 aGU
-aAi
+aCR
 azQ
 aIp
 aGU
 rmD
-aAi
+aCR
 oaz
-aAi
+aCR
 aGU
 dop
 qEd
@@ -103909,33 +103882,33 @@ aWs
 aWs
 aWs
 cob
-aWt
-aWt
+cvA
+cvA
 aYI
 aYJ
-aWt
-aWt
+cvA
+cvA
 din
 cGg
-wFX
+xTF
 bwV
 bsi
-wFX
-wFX
-wFX
-wFX
-lpB
+xTF
+xTF
+xTF
+xTF
+tKH
 tsX
-pNZ
-dqG
+vsK
+kuB
 tSJ
-sJj
-arY
+big
+jBB
 nDF
 nYX
-tRR
+drN
 hQe
-tRR
+drN
 uJe
 ntr
 tdd
@@ -103949,7 +103922,7 @@ tLZ
 fxb
 vcU
 uGE
-uBx
+oxL
 sml
 myZ
 sxj
@@ -103959,12 +103932,12 @@ hBH
 fKB
 oil
 ilI
-xnY
-pAM
-bks
-aSX
-bNP
-aSX
+aff
+cVa
+ybs
+vpk
+uDT
+vpk
 crj
 ePq
 kyu
@@ -103998,15 +103971,15 @@ pjB
 mer
 loE
 emQ
-tuE
+ofP
 emQ
 cDI
-wIs
+tpJ
 dJa
 gpN
 cyo
 vnn
-tbf
+cNs
 aou
 sIs
 cyo
@@ -104102,9 +104075,9 @@ aaa
 aaa
 abp
 oJh
-vgS
+aaB
 aak
-vgS
+aaB
 ukf
 abp
 aaa
@@ -104112,7 +104085,7 @@ aak
 aaa
 abp
 aAR
-qtS
+xKR
 siz
 bQN
 wHh
@@ -104124,7 +104097,7 @@ cNa
 cNa
 cNa
 cNa
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -104140,11 +104113,11 @@ aaa
 aak
 aDr
 aEh
-aAi
-aAi
+aCR
+aCR
 aGQ
 azQ
-aAi
+aCR
 qgO
 azQ
 azQ
@@ -104174,14 +104147,14 @@ bjU
 aYy
 bmV
 bsS
-bWo
-bWo
-bWo
-bWo
-bWo
-wFX
-bWo
-bWo
+bsI
+bsI
+bsI
+bsI
+bsI
+xTF
+bsI
+bsI
 uGE
 uGE
 uGE
@@ -104206,7 +104179,7 @@ pGR
 vFh
 urb
 uGE
-cmO
+hAy
 pfD
 myZ
 eJm
@@ -104216,7 +104189,7 @@ vnO
 plv
 ggE
 twq
-eqx
+xnY
 lKR
 qDQ
 uxf
@@ -104255,16 +104228,16 @@ dzt
 mer
 cEV
 cIq
-aKB
+aXu
 cIq
 cEV
 kPC
 ukL
 cCr
 iGF
-cNR
-tbf
-tbf
+bVM
+cNs
+cNs
 tal
 cyo
 aaa
@@ -104369,8 +104342,8 @@ aak
 aaa
 ttX
 aAR
-qtS
-jzO
+xKR
+fny
 adV
 uKf
 yfM
@@ -104381,7 +104354,7 @@ aoO
 wAC
 kec
 fUp
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -104396,13 +104369,13 @@ aak
 aak
 aak
 aDr
-aAi
+aCR
 dop
-aAi
+aCR
 aGR
 azQ
 ovt
-aAi
+aCR
 azQ
 aak
 aak
@@ -104414,9 +104387,9 @@ aak
 aak
 aak
 azQ
-aAi
+aCR
 aVp
-cvA
+aWt
 bmV
 aYp
 aZE
@@ -104436,7 +104409,7 @@ bii
 bii
 bsT
 btX
-wFX
+xTF
 aUO
 nAD
 bwX
@@ -104463,8 +104436,8 @@ sKc
 kok
 urb
 uGE
-cOl
-oQB
+rcL
+kPE
 aWh
 kXG
 hnr
@@ -104520,8 +104493,8 @@ dJa
 cCr
 cyt
 aou
-cNS
-cNS
+cNR
+cNR
 tal
 cyo
 aaa
@@ -104626,8 +104599,8 @@ aak
 aaa
 ttX
 wNp
-qtS
-glO
+xKR
+brO
 lKO
 wHh
 hPe
@@ -104638,7 +104611,7 @@ aoP
 iTz
 vCj
 fUp
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -104655,17 +104628,17 @@ aak
 azQ
 azQ
 azQ
-aAi
+aCR
 azQ
 azQ
-aAi
-aAi
+aCR
+aCR
 azQ
 aak
 aak
 aak
 cDz
-cDA
+cIh
 cJg
 aak
 aak
@@ -104673,13 +104646,13 @@ aak
 azQ
 aUh
 aVp
-cvA
+aWt
 bmV
 aYq
 aZF
 aXm
 bbX
-aYH
+cpn
 aXm
 bfN
 bgP
@@ -104692,9 +104665,9 @@ bpv
 nDG
 bii
 bsU
-bWo
-wFX
-bWo
+bsI
+xTF
+bsI
 bvW
 bwX
 rop
@@ -104720,7 +104693,7 @@ ogs
 kBn
 ruN
 uGE
-arY
+jBB
 jmd
 myZ
 exW
@@ -104741,7 +104714,7 @@ kKH
 tsp
 rzF
 wIX
-rYP
+uzX
 qGG
 qib
 tXX
@@ -104762,7 +104735,7 @@ eyz
 tzV
 cGf
 qmj
-wIs
+tpJ
 czV
 xhp
 cDJ
@@ -104883,7 +104856,7 @@ aak
 aaa
 ttX
 ggh
-xKR
+uJd
 siz
 mxq
 cNa
@@ -104895,7 +104868,7 @@ apb
 ibk
 kuO
 fUp
-cAu
+aOd
 aak
 aak
 aak
@@ -104912,10 +104885,10 @@ aak
 azQ
 aEi
 aEi
-aAi
+aCR
 lFl
 azQ
-aAi
+aCR
 irb
 azQ
 aak
@@ -104930,13 +104903,13 @@ aak
 azQ
 aGU
 aVp
-cvA
+aWt
 bmV
 aYr
 aZG
 baB
 bbP
-aYH
+cpn
 bei
 bfO
 bgQ
@@ -104950,8 +104923,8 @@ bqB
 bsg
 btY
 btY
-wFX
-bWo
+xTF
+bsI
 nAD
 bwX
 bAb
@@ -104996,7 +104969,7 @@ evC
 eid
 pgK
 tsp
-cRF
+rhW
 hAn
 jAW
 iyx
@@ -105019,7 +104992,7 @@ jce
 gnO
 iDa
 uOY
-wIs
+tpJ
 czV
 iSH
 cKF
@@ -105140,7 +105113,7 @@ aak
 aaa
 ttX
 aBD
-qtS
+xKR
 siz
 kwf
 cNa
@@ -105152,7 +105125,7 @@ cNa
 cNa
 cNa
 cNa
-cAu
+aOd
 aaa
 aak
 aaa
@@ -105169,10 +105142,10 @@ azQ
 azQ
 aEj
 aEg
-aAi
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
+aCR
 aGU
 aDr
 aak
@@ -105187,7 +105160,7 @@ aak
 aDr
 aGU
 aVp
-cvA
+aWt
 bmV
 aXm
 aXm
@@ -105201,14 +105174,14 @@ bii
 bii
 bii
 bii
-fPv
+fnt
 bpx
 bqC
 bsb
 btZ
 btZ
-wFX
-bWo
+xTF
+bsI
 nAD
 bwX
 bAb
@@ -105255,7 +105228,7 @@ mJO
 tsp
 oQn
 nuY
-rYP
+uzX
 ygQ
 qib
 mIF
@@ -105272,11 +105245,11 @@ tRu
 gMZ
 cNJ
 jHw
-oei
+hXO
 vYC
 aJA
 qmj
-wIs
+tpJ
 czV
 mbY
 cEp
@@ -105393,7 +105366,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 abp
 abp
 abp
@@ -105426,10 +105399,10 @@ azQ
 azQ
 aEk
 aEk
-aAi
-aAi
+aCR
+aCR
 azQ
-aAi
+aCR
 aJm
 aDr
 cDx
@@ -105450,7 +105423,7 @@ aYs
 aZH
 aXm
 bbR
-aYH
+cpn
 aXm
 bfP
 bgR
@@ -105463,9 +105436,9 @@ bpy
 oEh
 bii
 bsU
-bWo
-wFX
-bWo
+bsI
+xTF
+bsI
 nAD
 bwX
 uIm
@@ -105547,9 +105520,9 @@ cPc
 dJa
 cCr
 cyt
-cNs
-cNs
-cNS
+tbf
+tbf
+cNR
 tal
 cyo
 aaa
@@ -105650,7 +105623,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 kzt
 thb
 aCg
@@ -105683,10 +105656,10 @@ aCO
 azQ
 azQ
 azQ
-aAi
+aCR
 azQ
 azQ
-aAi
+aCR
 aGU
 aDr
 cDz
@@ -105701,13 +105674,13 @@ cJg
 aDr
 aGU
 aVp
-cvA
+aWt
 bmV
 aYt
 aZI
 aXm
 bbS
-aYH
+cpn
 aXm
 bfQ
 bgS
@@ -105719,10 +105692,10 @@ cMJ
 bii
 bii
 bii
-bWo
-bWo
-wFX
-bWo
+bsI
+bsI
+xTF
+bsI
 nAD
 aHj
 lDa
@@ -105748,7 +105721,7 @@ uGE
 uGE
 uGE
 uGE
-cEf
+avn
 kbu
 myZ
 cUh
@@ -105797,7 +105770,7 @@ xip
 ooW
 cEV
 cIq
-aKB
+aXu
 cIq
 cEV
 wkU
@@ -105805,8 +105778,8 @@ wdc
 cCr
 iGF
 wIJ
-cNR
-cNR
+bVM
+bVM
 tal
 cyo
 aaa
@@ -105943,7 +105916,7 @@ aFl
 aFm
 vvT
 azQ
-aAi
+aCR
 aGU
 aDr
 aak
@@ -105958,13 +105931,13 @@ aak
 aDr
 rmD
 aVp
-cvA
+aWt
 bmV
 aYu
 aZJ
 baC
 bbP
-aYH
+cpn
 bej
 bfR
 bgT
@@ -105977,18 +105950,18 @@ bpz
 bqD
 bii
 aJd
-bWo
-wFX
-bWo
+bsI
+xTF
+bsI
 nAD
 bxq
 mCJ
 bAw
-ofP
-ofP
+bAc
+bAc
 bFk
 bNF
-ofP
+bAc
 dYV
 bwW
 bwW
@@ -106001,11 +105974,11 @@ usi
 kfY
 uuX
 uGE
-oBq
+tyl
 iOM
-cmO
+hAy
 scg
-cOl
+rcL
 pEV
 dpQ
 rih
@@ -106033,9 +106006,9 @@ kZb
 dsP
 mcy
 qvc
-hXO
 pyz
-pyz
+nrn
+nrn
 qvc
 bXo
 qVv
@@ -106054,7 +106027,7 @@ xip
 ooW
 cDI
 emQ
-tuE
+ofP
 emQ
 loE
 xIY
@@ -106062,7 +106035,7 @@ drt
 gpN
 cyo
 kkK
-cNS
+cNR
 aou
 nBI
 cyo
@@ -106168,7 +106141,7 @@ nQY
 ahO
 ain
 aiV
-qtS
+xKR
 siz
 mxq
 aoj
@@ -106200,7 +106173,7 @@ aFm
 aGj
 aGT
 azQ
-aAi
+aCR
 rmD
 azQ
 aak
@@ -106215,13 +106188,13 @@ aak
 azQ
 aGU
 aVp
-cvA
+aWt
 bmV
 aXm
 aXm
 aXm
 bbT
-aYH
+cpn
 aXm
 aXm
 aXm
@@ -106234,9 +106207,9 @@ bii
 bii
 bii
 bsX
-bWo
-wFX
-bWo
+bsI
+xTF
+bsI
 bvZ
 bwX
 hHR
@@ -106258,7 +106231,7 @@ dvd
 kfY
 bzq
 uGE
-rcL
+bWo
 ntr
 qCC
 oPI
@@ -106286,13 +106259,13 @@ lkV
 jYp
 nJa
 hIR
+ptU
+ptU
 nmL
-nmL
-cIU
 cxH
-cIU
 nmL
-nmL
+ptU
+ptU
 eey
 bXo
 fOS
@@ -106307,10 +106280,10 @@ qmj
 ofc
 czV
 qgX
-koK
-koK
+caE
+caE
 rfa
-koK
+caE
 uYv
 brm
 vUj
@@ -106318,8 +106291,8 @@ fJM
 nBS
 gQG
 cyt
-cNS
-cNs
+cNR
+tbf
 hQY
 tal
 cyo
@@ -106457,8 +106430,8 @@ azQ
 azQ
 azQ
 azQ
-aAi
-aAi
+aCR
+aCR
 azQ
 aak
 aak
@@ -106472,7 +106445,7 @@ aak
 azQ
 eLa
 aVp
-cvA
+aWt
 bmV
 aYv
 aZK
@@ -106515,7 +106488,7 @@ cNV
 kfY
 nmM
 uGE
-cEf
+avn
 pGR
 ntr
 yfZ
@@ -106546,7 +106519,7 @@ tas
 mtO
 sVZ
 hSW
-rWX
+xxm
 sVZ
 sVZ
 dbi
@@ -106562,8 +106535,8 @@ gHM
 thn
 agv
 ipI
-fde
-fde
+aIu
+aIu
 czV
 czV
 kAQ
@@ -106683,7 +106656,7 @@ aul
 aip
 tje
 aGe
-amw
+vgS
 akL
 aoj
 anE
@@ -106704,24 +106677,24 @@ aaa
 aaa
 azQ
 aAh
-aAi
-aAi
+aCR
+aCR
 aGU
-aAi
+aCR
 hsq
 azQ
-aAi
-aAi
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
+aCR
+aCR
 qhd
 azQ
 aak
 aak
 aak
 cDz
-cDA
+cIh
 cJg
 aak
 aak
@@ -106729,13 +106702,13 @@ aak
 azQ
 aUj
 aVp
-cvA
+aWt
 bmV
 aYw
 aZL
 aXm
 bbX
-aYH
+cpn
 aXm
 bfT
 bgV
@@ -106751,7 +106724,7 @@ bsZ
 bwl
 fxK
 bwl
-cfx
+eHp
 bxb
 byp
 bAf
@@ -106807,7 +106780,7 @@ kSG
 noR
 vXi
 ack
-uWL
+wSB
 jBR
 cVm
 nmD
@@ -106943,7 +106916,7 @@ aHl
 ajR
 faA
 aoj
-ami
+amw
 amT
 oCZ
 oWS
@@ -106961,16 +106934,16 @@ aaa
 aaa
 azQ
 aGQ
-aAi
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
+aCR
 qgO
-aAi
-aAi
+aCR
+aCR
 azQ
 aGU
-aAi
+aCR
 azQ
 azQ
 azQ
@@ -106985,14 +106958,14 @@ azQ
 azQ
 azQ
 azQ
-qxr
+hax
 qad
 bmV
 aYW
 aZM
 baD
 bbP
-aYH
+cpn
 bek
 bfU
 bhl
@@ -107008,7 +106981,7 @@ btE
 bwl
 fxK
 bwl
-cfx
+eHp
 bxc
 vsM
 bAg
@@ -107034,7 +107007,7 @@ uGE
 uGE
 uGE
 uGE
-bqM
+wIs
 uGE
 myZ
 vXx
@@ -107064,14 +107037,14 @@ aJp
 miT
 vma
 kBt
-uWL
+wSB
 jBR
 kdm
 ncI
 ozJ
 bXo
 sAc
-sOT
+oei
 ndQ
 cZj
 cCZ
@@ -107184,9 +107157,9 @@ aak
 acu
 abj
 abF
-ahG
+afi
 acT
-ahG
+afi
 ajm
 aeA
 abj
@@ -107195,12 +107168,12 @@ agz
 krd
 dRQ
 pqP
-caE
+bva
 aHm
 btD
 fib
 anE
-ami
+amw
 bSn
 anU
 aoq
@@ -107227,9 +107200,9 @@ azQ
 azQ
 azQ
 rmD
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
 azQ
 kwM
 aGU
@@ -107242,14 +107215,14 @@ rmD
 aAQ
 loF
 azQ
-qxr
+hax
 oYI
 bmV
 bmV
 bmV
 aXm
 bbV
-aYH
+cpn
 aXm
 aXm
 aXm
@@ -107265,7 +107238,7 @@ cXt
 bwl
 fxK
 bwl
-cfx
+eHp
 bxb
 byr
 byq
@@ -107283,7 +107256,7 @@ cNH
 cNH
 cNH
 cNH
-vpk
+cEf
 eDO
 uGE
 kVm
@@ -107452,12 +107425,12 @@ adA
 ass
 aum
 ais
-caE
+bva
 aHv
 bvg
 fPB
 anE
-xIR
+ami
 jrH
 pnp
 tJU
@@ -107480,41 +107453,41 @@ azQ
 azQ
 azQ
 eLa
-aAi
+aCR
 vbP
 azQ
 aGU
-aAi
+aCR
 aGU
-aAi
+aCR
 azQ
-aAi
+aCR
 ovt
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
 hsq
 aGU
-aAi
-aAi
-aAi
+aCR
+aCR
+aCR
 azQ
-qxr
+hax
 oYI
 aXn
 aYy
 bmV
 ste
 fbw
-aYH
+cpn
 bel
 aXm
 bgX
 bij
 bjK
 blq
-ivj
-ivj
+bNP
+bNP
 bpC
 bqF
 bhf
@@ -107544,7 +107517,7 @@ mwM
 fpR
 uGE
 irD
-bqM
+wIs
 aaa
 xcw
 bXv
@@ -107757,20 +107730,20 @@ aMH
 aMH
 aUt
 aVA
-cvA
-mbf
+aWt
+aXo
 xPt
 bmV
 baF
 bbX
-aYH
+cpn
 bel
 aXm
 bgY
 bik
 bik
 bik
-bHf
+rrb
 bik
 bik
 bqG
@@ -107797,11 +107770,11 @@ bQU
 wPX
 hnV
 cNH
-vpk
+cEf
 iMZ
 uGE
-kPE
-bqM
+pMa
+wIs
 aaa
 phc
 yco
@@ -107841,10 +107814,10 @@ oko
 qwe
 xsj
 fGI
-gQf
+wuL
 qSK
 vZh
-gQf
+wuL
 fBc
 rwX
 fBc
@@ -107968,7 +107941,7 @@ auy
 awC
 ajf
 aLg
-amw
+vgS
 sBP
 aoj
 amm
@@ -107993,29 +107966,29 @@ aaa
 aaa
 aaa
 azQ
-aAi
-btS
-aAi
+aCR
+hJu
+aCR
 azQ
 aGW
 aIp
-aAi
-aAi
+aCR
+aCR
 ovt
-aAi
-aAi
-pMa
-bJf
-bJf
-bJf
+aCR
+aCR
 bqR
-bJf
-bJf
-bJf
+aWw
+aWw
+aWw
+bab
+aWw
+aWw
+aWw
 aUw
 aVH
-aXp
-aXp
+aWH
+aWH
 aYA
 bmV
 baG
@@ -108023,13 +107996,13 @@ bbX
 fvI
 bel
 bfV
-fny
+cpk
 bil
 bjL
 bjO
 bmF
 bik
-bHf
+rrb
 bqH
 bly
 bwl
@@ -108057,8 +108030,8 @@ vVt
 dSA
 fpR
 uGE
-kPE
-bqM
+pMa
+wIs
 aaa
 bXv
 hsj
@@ -108095,13 +108068,13 @@ jnV
 wqm
 vLX
 rxE
-gQf
+wuL
 iHp
 qxm
 jSd
-gQf
-gQf
-gQf
+wuL
+wuL
+wuL
 ncL
 vZh
 jTv
@@ -108217,13 +108190,13 @@ abj
 xyy
 ame
 aeC
-aff
+aeE
 afH
 agF
 ahq
 ahU
 aiu
-caE
+bva
 aMK
 cGG
 wxk
@@ -108272,15 +108245,15 @@ azQ
 aUm
 bmV
 bmV
-aWt
+cvA
 aYB
 bmV
 baH
 bbX
-aYH
+cpn
 bel
 bfV
-ivj
+bNP
 bim
 bjM
 bjR
@@ -108306,7 +108279,7 @@ bIX
 bPJ
 bxa
 kTC
-cOi
+cSf
 bQW
 hnV
 bMj
@@ -108534,10 +108507,10 @@ aYC
 bmV
 baI
 bbY
-aYH
+cpn
 bel
 bfV
-ivj
+bNP
 bil
 bjN
 bjR
@@ -108596,9 +108569,9 @@ huv
 csI
 jXm
 qGh
-rYP
-rYP
-rYP
+uzX
+uzX
+uzX
 gei
 bXq
 vNY
@@ -108739,7 +108712,7 @@ avI
 axN
 ajd
 bkL
-bmK
+dMG
 aCn
 anE
 aAn
@@ -108786,15 +108759,15 @@ aTm
 aUo
 aVt
 bmV
-aWt
+cvA
 aYD
 bmV
 baJ
 bbX
-aYH
+cpn
 bel
 bfV
-nrn
+cNS
 bik
 bik
 bik
@@ -108806,7 +108779,7 @@ bly
 bwl
 bwl
 fxK
-ccu
+caP
 qyu
 bxf
 eoR
@@ -108853,9 +108826,9 @@ csI
 csI
 eJU
 qGh
-rYP
+uzX
 mQG
-rYP
+uzX
 wwr
 bXq
 oqn
@@ -108880,7 +108853,7 @@ wOr
 kHY
 fkK
 fBc
-gQf
+wuL
 sQi
 kHY
 aaa
@@ -108988,7 +108961,7 @@ agt
 adA
 eoZ
 apw
-aff
+aeE
 afK
 aqE
 aht
@@ -108999,7 +108972,7 @@ bmh
 ajU
 akP
 aoj
-ami
+amw
 amY
 qoz
 aoj
@@ -109043,15 +109016,15 @@ aTn
 aUp
 vmY
 bmV
-aWt
+cvA
 aYE
 bmV
 baK
 bbX
-ngT
+fXO
 bmE
-hkC
-ivj
+bzQ
+bNP
 bik
 aYP
 bUO
@@ -109110,13 +109083,13 @@ rLU
 vMw
 mXk
 kxe
-ase
-ase
+vbp
+vbp
 oYF
 pYL
 dPP
 dst
-dAg
+kxg
 ycq
 bXq
 kKB
@@ -109130,13 +109103,13 @@ hAG
 hAG
 hXy
 cCZ
-gQf
+wuL
 qxm
 kHY
 kHY
 kHY
 uje
-gQf
+wuL
 fBc
 ins
 kHY
@@ -109242,10 +109215,10 @@ aaa
 abK
 acf
 acZ
-eXy
+htc
 aed
-aff
-aff
+aeE
+aeE
 aqx
 agF
 ahu
@@ -109300,7 +109273,7 @@ aTo
 aUq
 aVv
 bmV
-aWt
+cvA
 aYF
 aXk
 baL
@@ -109312,10 +109285,10 @@ bhc
 bin
 bjP
 blr
-bmG
+bqM
 cXJ
 bpD
-bmG
+bqM
 bwY
 fxK
 fxK
@@ -109356,7 +109329,7 @@ lQn
 kUm
 fBX
 sIe
-xBJ
+bmK
 kUm
 lYs
 sKH
@@ -109367,13 +109340,13 @@ iVg
 bgN
 pVo
 sFv
-uzX
 rYP
+uzX
 doa
 ifZ
 bXq
 kfL
-gCl
+dAg
 rqG
 nun
 nDq
@@ -109387,7 +109360,7 @@ lHL
 bYv
 qTy
 cCZ
-gQf
+wuL
 dgI
 kHY
 qVV
@@ -109395,7 +109368,7 @@ kHY
 kHY
 rtO
 fsF
-gQf
+wuL
 kHY
 aaa
 aak
@@ -109503,12 +109476,12 @@ adB
 sPm
 ios
 afg
+aqD
 aIR
-avn
-avn
-avn
+aIR
+aIR
 axU
-caE
+bva
 aom
 ajU
 aCn
@@ -109522,16 +109495,16 @@ nXK
 aoS
 jpA
 xgU
-jCl
+avH
 ojt
-jCl
+avH
 fTJ
 fTJ
 lIG
-cCj
-cCj
+mCL
+mCL
 mVI
-cCj
+mCL
 fTJ
 fTJ
 fTJ
@@ -109557,7 +109530,7 @@ aTp
 aUr
 aVw
 bmV
-aWt
+cvA
 aYy
 bmV
 baM
@@ -109574,7 +109547,7 @@ bik
 boi
 bik
 bmJ
-ccu
+caP
 bwl
 fxK
 bwl
@@ -109620,7 +109593,7 @@ jaa
 eJc
 okf
 kbJ
-kMP
+bcJ
 wFI
 fSy
 diU
@@ -109644,7 +109617,7 @@ kNp
 kNp
 nPb
 cCZ
-gQf
+wuL
 ncL
 kHY
 kJa
@@ -109760,28 +109733,28 @@ abM
 mKo
 egr
 afh
-aBi
+rvx
 agH
 ahv
 aqy
 ayF
-caE
+bva
 ajw
 mqs
 awM
 alE
 apI
 afE
-bRh
+oBq
 gxz
 ajV
 alp
 aqH
 alX
 wIx
-avH
+jCl
 rWy
-avH
+jCl
 mjV
 wHn
 jpg
@@ -109814,7 +109787,7 @@ lTv
 bsy
 muW
 bmV
-aWt
+cvA
 aYG
 bmV
 baN
@@ -109827,7 +109800,7 @@ bik
 bik
 blt
 bik
-bHf
+rrb
 bok
 bqN
 bly
@@ -109857,7 +109830,7 @@ pGi
 xEU
 aem
 uGE
-kPE
+pMa
 uGE
 gdf
 lmS
@@ -109874,14 +109847,14 @@ jaa
 jaa
 hMm
 hMm
-kMP
+bcJ
 lML
-kMP
+bcJ
 rLU
 rLU
-kMP
+bcJ
 sZq
-kMP
+bcJ
 rLU
 cCZ
 iDw
@@ -109901,11 +109874,11 @@ caJ
 caI
 ijA
 cCZ
-gQf
+wuL
 ncL
 kHY
 xYm
-gQf
+wuL
 kHY
 kHY
 kHY
@@ -110033,14 +110006,14 @@ qhg
 uWs
 wRt
 xVb
-oxL
+bGx
 xVb
 ezQ
 fIu
 aaD
 awS
 qIB
-oxL
+bGx
 kcy
 xVb
 tZO
@@ -110114,7 +110087,7 @@ nCU
 oEC
 eEJ
 uGE
-kPE
+pMa
 uGE
 xQZ
 lmS
@@ -110161,11 +110134,11 @@ cCZ
 xRm
 fBc
 kHY
-gQf
-gQf
+wuL
+wuL
 qxm
-gQf
-gQf
+wuL
+wuL
 fBc
 kHY
 aaa
@@ -110285,7 +110258,7 @@ hoJ
 hoJ
 hoJ
 aom
-dMG
+anc
 anH
 gPJ
 aoY
@@ -110328,7 +110301,7 @@ aTs
 aUu
 aDc
 bmV
-aWt
+cvA
 gaH
 bmV
 kTS
@@ -110371,7 +110344,7 @@ qKM
 xEU
 lRV
 uGE
-kPE
+pMa
 uGE
 cxv
 oYR
@@ -110398,7 +110371,7 @@ ttI
 ttI
 ttI
 kHY
-gQf
+wuL
 cCZ
 cCZ
 cCZ
@@ -110415,8 +110388,8 @@ cCZ
 cCZ
 cCZ
 cCZ
-gQf
-gQf
+wuL
+wuL
 pSR
 tHp
 gtD
@@ -110542,7 +110515,7 @@ exj
 akV
 ipH
 hSd
-dMG
+anc
 qtc
 gPJ
 apu
@@ -110585,8 +110558,8 @@ fgW
 aUv
 aVy
 bmV
-aWt
-aXo
+cvA
+aYz
 bmV
 baQ
 bcc
@@ -110655,23 +110628,23 @@ caU
 lvI
 ttI
 wjy
-gQf
-gQf
+wuL
+wuL
 heg
 ncL
 ncL
-gQf
-gQf
+wuL
+wuL
 cZv
 vdR
 vcW
-gQf
+wuL
 fBc
-gQf
+wuL
 qSK
-gQf
-gQf
-gQf
+wuL
+wuL
+wuL
 fBc
 kHY
 kHY
@@ -110856,7 +110829,7 @@ bik
 blt
 bik
 bik
-bHf
+rrb
 bBO
 bhf
 btd
@@ -111065,7 +111038,7 @@ aqR
 awX
 eaB
 hRt
-avH
+jCl
 lzO
 aju
 qkB
@@ -111178,14 +111151,14 @@ cWI
 cWI
 cWI
 kHY
-uzr
-uzr
-uzr
+cIU
+cIU
+cIU
 kHY
 kHY
-uzr
-uzr
-uzr
+cIU
+cIU
+cIU
 kHY
 kHY
 aaa
@@ -111314,7 +111287,7 @@ hxN
 hoJ
 amL
 ans
-bRh
+oBq
 aov
 apu
 kQd
@@ -111356,7 +111329,7 @@ aPq
 aPq
 aPq
 aOm
-bzQ
+aLU
 alc
 aXm
 aXm
@@ -111434,7 +111407,7 @@ cWI
 wSV
 mMe
 cWI
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -111579,17 +111552,17 @@ qWW
 aAq
 aAq
 aux
-uza
-uza
+ssn
+ssn
 oJF
-uza
-uza
+ssn
+ssn
 els
-uza
-uza
+ssn
+ssn
 els
-uza
-uza
+ssn
+ssn
 aEc
 aEc
 aEA
@@ -111613,10 +111586,10 @@ alc
 alc
 alc
 aSC
-bzQ
-bzQ
+aLU
+aLU
 aHp
-bzQ
+aLU
 alc
 aqp
 aHw
@@ -111634,7 +111607,7 @@ bwl
 bwl
 fjZ
 bwl
-ccu
+caP
 bwl
 byC
 bwl
@@ -111653,9 +111626,9 @@ bJd
 bJe
 bJe
 gzE
-ajh
-rbo
-rbo
+umj
+ebz
+ebz
 jSU
 xlb
 bJB
@@ -111681,7 +111654,7 @@ pZt
 kgw
 wMG
 kHY
-lXP
+gQf
 cWI
 rfi
 mbx
@@ -111691,7 +111664,7 @@ fWt
 pVi
 gyU
 gEt
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -111812,7 +111785,7 @@ abJ
 aax
 arj
 hyr
-tpJ
+ckO
 fss
 aax
 aax
@@ -111873,16 +111846,16 @@ alc
 alc
 alc
 alc
-bzQ
+aLU
 bcf
-bcJ
-ccu
+alb
+caP
 bwl
 bwl
-ccu
+caP
 bwl
 bwl
-ccu
+caP
 bwl
 bwl
 bqT
@@ -111909,11 +111882,11 @@ bRg
 bJe
 bJB
 bVf
-kff
+kCy
 bXy
 bJB
 bJB
-rkT
+abO
 bJB
 bJB
 bJB
@@ -111934,15 +111907,15 @@ bJB
 teQ
 kHY
 qjY
-gQf
+wuL
 wCE
 uyp
 kHY
-lXP
+gQf
 cWI
 jsW
 eDY
-xFs
+uXW
 cWI
 cWI
 cWI
@@ -112099,20 +112072,20 @@ alc
 axZ
 ayM
 azt
-bzQ
-bzQ
+aLU
+aLU
 pXg
-bzQ
-bzQ
-bzQ
+aLU
+aLU
+aLU
 amx
-bzQ
-bzQ
-bzQ
+aLU
+aLU
+aLU
 aHe
 jWG
-bzQ
-bzQ
+aLU
+aLU
 alc
 alc
 alc
@@ -112132,7 +112105,7 @@ alc
 alc
 diw
 alc
-bcJ
+alb
 bwl
 bwl
 bwl
@@ -112151,7 +112124,7 @@ bxk
 bvs
 daF
 bwl
-ccu
+caP
 bwl
 bwl
 bwl
@@ -112166,42 +112139,42 @@ bJB
 bJe
 bJB
 bJB
-kff
+kCy
 bXy
 bJB
 bJB
-rkT
+abO
 bJB
 lZY
-mok
-ffy
+rbo
+mDp
 fRj
-ffy
-ffy
-ffy
-ffy
-ffy
+mDp
+mDp
+mDp
+mDp
+mDp
 hTY
 joB
-ffy
+mDp
 oZX
 rmk
-rkT
+abO
 bJB
 kKf
 kHY
 sVE
 hBM
-gQf
+wuL
 pwG
 kHY
-lXP
+gQf
 cWI
 hzf
 rBU
 wGX
 mEc
-cAu
+aOd
 aak
 aak
 aak
@@ -112354,7 +112327,7 @@ alc
 alc
 alc
 alc
-bzQ
+aLU
 aqV
 edW
 alc
@@ -112366,7 +112339,7 @@ nHu
 alc
 alc
 alc
-bcJ
+alb
 alc
 alc
 aJU
@@ -112389,13 +112362,13 @@ alc
 alc
 diw
 bcr
-bcJ
+alb
 bwl
 bwl
 bwl
 bwl
 bwl
-ccu
+caP
 bwl
 bwl
 bwl
@@ -112416,19 +112389,19 @@ sSf
 sSf
 sSf
 cOo
-mok
-mok
-mok
-mok
-cpG
+rbo
+rbo
+rbo
+rbo
+cDy
 pCn
 bWt
 lMv
 rpc
-mok
-mok
-ffy
-mok
+rbo
+rbo
+mDp
+rbo
 rHz
 bJB
 cgY
@@ -112439,7 +112412,7 @@ bJB
 bJB
 bJB
 bJB
-kff
+kCy
 bJB
 bJB
 bJB
@@ -112452,7 +112425,7 @@ xBC
 kND
 kui
 kHY
-lXP
+gQf
 cWI
 jEG
 vZo
@@ -112611,7 +112584,7 @@ hVT
 vMW
 ixn
 alc
-bzQ
+aLU
 bbo
 amb
 alc
@@ -112650,7 +112623,7 @@ aqp
 bwl
 bwl
 cXo
-ccu
+caP
 bwl
 bwk
 bwk
@@ -112675,12 +112648,12 @@ lmc
 cXC
 bMM
 bOA
-bPY
+bUa
 icD
-abO
+wIk
 bVD
 bWv
-kff
+kCy
 oiz
 gWa
 gWa
@@ -112696,26 +112669,26 @@ bJB
 xRK
 oUL
 bJB
-kff
+kCy
 bJB
 bJB
-bPY
+bUa
 bJB
 bJB
 nGI
 kHY
 fBs
 sSD
-gQf
+wuL
 xDv
 vJY
-lXP
+gQf
 cWI
 ixm
 dqe
 ucq
 mEc
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -112966,7 +112939,7 @@ kHY
 kHY
 kHY
 kHY
-lXP
+gQf
 cWI
 bSJ
 cWI
@@ -113118,15 +113091,15 @@ jBG
 hNo
 cjt
 vKI
-lhQ
-uwK
-lhQ
+ase
+bgD
+ase
 vKI
 vKI
 jNC
 och
 fMa
-uod
+eTY
 azV
 aAr
 aBa
@@ -113138,20 +113111,20 @@ daf
 aKq
 lGh
 eya
-aKm
+lnI
 dad
 toQ
-mnK
+aKm
 urM
-jUi
-orq
-qlX
+cFl
+hkC
+vCc
 tNj
-ygu
+lob
 gqY
 mkD
-qCq
-qCq
+ygu
+ygu
 oeE
 nHl
 tjT
@@ -113167,8 +113140,8 @@ bhg
 lWq
 bjX
 blC
-mCL
 buB
+cEx
 bpE
 bqW
 bev
@@ -113223,7 +113196,7 @@ cXF
 cDa
 cEq
 kHY
-lXP
+gQf
 qAz
 cIQ
 cJD
@@ -113232,7 +113205,7 @@ pMm
 kHY
 kHY
 kHY
-uzr
+cIU
 kHY
 kHY
 kHY
@@ -113352,25 +113325,25 @@ aaa
 aaa
 aak
 aax
-gZa
+chq
 wHj
 wqt
 hyr
-tpJ
+ckO
 nmz
 hyr
-tpJ
+ckO
 hyr
 tpb
 lNJ
-uwK
-lhQ
+bgD
+ase
 vKI
 vKI
-lhQ
+ase
 pIh
-bTj
-bTj
+ajh
+ajh
 nmz
 kpk
 abM
@@ -113385,8 +113358,8 @@ sFA
 lEV
 orb
 nfY
-wuL
-wuL
+jzO
+jzO
 oUE
 sXN
 lKc
@@ -113424,7 +113397,7 @@ bhh
 pcp
 bjY
 bDP
-pDm
+wlx
 bDP
 bDP
 bqX
@@ -113432,7 +113405,7 @@ blB
 vxy
 bwl
 bwl
-ssn
+ccu
 jtK
 vWD
 byH
@@ -113466,25 +113439,25 @@ ckC
 jEQ
 cmc
 coh
-cpk
-cpk
-cpk
-cpk
-wjS
-cpk
-cpk
-cpk
-cpk
-cpk
-cpk
 lim
+lim
+lim
+lim
+wjS
+lim
+lim
+lim
+lim
+lim
+lim
+orq
 cEr
 hne
-bvL
+yci
 uKz
-btP
-aXu
-bvL
+qCq
+eqr
+yci
 uZG
 hFE
 tBA
@@ -113640,7 +113613,7 @@ oBM
 aax
 nYE
 fqP
-eTY
+uod
 azV
 pBg
 aBc
@@ -113681,7 +113654,7 @@ bhi
 csm
 bDP
 bDP
-pDm
+wlx
 bDP
 bDP
 bsF
@@ -113739,11 +113712,11 @@ cEs
 kHY
 kHY
 kHY
-uzr
-uzr
-uzr
-uzr
-uzr
+cIU
+cIU
+cIU
+cIU
+cIU
 kHY
 kHY
 kHY
@@ -113897,7 +113870,7 @@ xbM
 aax
 fvd
 fqP
-eTY
+uod
 sGL
 sGL
 aKq
@@ -113971,7 +113944,7 @@ bZp
 cau
 tHW
 bJp
-cem
+uwK
 cfE
 bJp
 cim
@@ -114154,12 +114127,12 @@ abM
 aax
 vcS
 fqP
-eTY
+uod
 iEF
 hdW
 aPr
 tMo
-pvk
+eJQ
 wmZ
 aDK
 aEE
@@ -114203,7 +114176,7 @@ blB
 vxy
 bub
 fxK
-nno
+qGS
 bxe
 jgB
 kaW
@@ -114228,7 +114201,7 @@ bXA
 bXA
 bXA
 bJp
-cem
+uwK
 cfE
 bJp
 pie
@@ -114411,12 +114384,12 @@ eQe
 sGL
 xaT
 fqP
-uod
+eTY
 okb
 qer
 aPr
 gOZ
-pvk
+eJQ
 wmZ
 aDL
 aEF
@@ -114425,11 +114398,11 @@ aFD
 kBL
 azU
 azU
-aEO
-anc
-orq
+eBL
+udi
+hkC
 lxB
-qlX
+vCc
 fnc
 azU
 jry
@@ -114460,7 +114433,7 @@ blB
 bwl
 bwl
 jKi
-alb
+cGU
 qpj
 ora
 hky
@@ -114517,7 +114490,7 @@ gNi
 uEv
 ykc
 aaa
-uzr
+cIU
 rbT
 uql
 kHY
@@ -114661,7 +114634,7 @@ tsZ
 abM
 mEo
 qOO
-unw
+iZV
 qWo
 tEO
 xkq
@@ -114682,7 +114655,7 @@ aGP
 azU
 azU
 ntY
-qlX
+vCc
 azU
 nVh
 azU
@@ -114769,15 +114742,15 @@ cVV
 cHW
 wOw
 cVX
-blc
 bkO
+blc
 jVd
 ykc
 aaa
-uzr
+cIU
 efw
 ldT
-uzr
+cIU
 aak
 rkX
 aaa
@@ -114923,8 +114896,8 @@ suT
 nGr
 fRz
 oAm
-bAc
-msu
+wfH
+cOl
 uIt
 azU
 azU
@@ -114939,7 +114912,7 @@ awT
 awT
 frZ
 kGl
-aEO
+eBL
 orJ
 ent
 tzF
@@ -115022,19 +114995,19 @@ cBO
 utQ
 cEw
 qTK
-lim
+orq
 sBl
 hej
 cJI
 bmD
-bkO
+blc
 rwz
 ykc
 aaa
-uzr
+cIU
 rsA
 odN
-uzr
+cIU
 fUu
 aaa
 aaa
@@ -115175,13 +115148,13 @@ abM
 abM
 flE
 qOO
-unw
+iZV
 iyY
 amB
 fRz
 oAm
-wfH
-msu
+koK
+cOl
 kfa
 fTw
 aJn
@@ -115194,7 +115167,7 @@ mqi
 azU
 wNI
 rHD
-orq
+hkC
 doq
 ufr
 azU
@@ -115256,7 +115229,7 @@ ugK
 cam
 hxC
 bJp
-xxm
+ivj
 iAN
 cnv
 cGK
@@ -115283,12 +115256,12 @@ cVV
 cHW
 wOw
 sra
-blc
-blc
-blc
+bkO
+bkO
+bkO
 ykc
 aaa
-uzr
+cIU
 gRu
 fGI
 kHY
@@ -115437,8 +115410,8 @@ kDh
 amB
 fVY
 oAm
-wfH
-msu
+koK
+cOl
 nNU
 azU
 azU
@@ -115451,7 +115424,7 @@ hbj
 azU
 xQm
 rHD
-orq
+hkC
 azU
 azU
 azU
@@ -115475,13 +115448,13 @@ aYK
 aYK
 qUQ
 qaS
-nEX
+erB
 bqf
 sSr
 nCK
 nCK
 ePH
-evs
+crm
 feu
 mUO
 bkc
@@ -115541,11 +115514,11 @@ ykc
 pMF
 cJJ
 mRu
-blc
+bkO
 tnw
 ykc
 aaa
-uzr
+cIU
 gRu
 qAz
 kHY
@@ -115694,8 +115667,8 @@ rpX
 nGr
 fRz
 oAm
-wfH
-msu
+koK
+cOl
 nvp
 azU
 sdt
@@ -115708,7 +115681,7 @@ aJn
 taQ
 wod
 wod
-aEO
+eBL
 azU
 qJi
 psm
@@ -115736,16 +115709,16 @@ jgd
 aYK
 bix
 bkf
-bkg
-bmS
 bDW
+bmS
+bkg
 xoT
 kpp
-bTk
+bse
 bWa
 bwl
 fxK
-ccu
+caP
 vsg
 cNr
 byZ
@@ -115951,9 +115924,9 @@ pkh
 amB
 fRz
 oAm
-wfH
-msu
-uod
+koK
+cOl
+eTY
 awT
 awT
 awT
@@ -115965,7 +115938,7 @@ awT
 awT
 awT
 awT
-anc
+udi
 vHE
 qyG
 hPV
@@ -115992,10 +115965,10 @@ vsa
 lRf
 aYK
 nRH
-bkg
-bkg
-bmT
 bDW
+bDW
+bmT
+bkg
 xoT
 kpp
 tuC
@@ -116003,7 +115976,7 @@ bWa
 bwl
 fxK
 bwl
-bjZ
+lnm
 cNr
 cNr
 cNr
@@ -116209,7 +116182,7 @@ amB
 vSx
 uCT
 rSj
-msu
+cOl
 dey
 apj
 hGY
@@ -116219,7 +116192,7 @@ ful
 spE
 iXT
 wcn
-pwf
+mlo
 gED
 awT
 qvv
@@ -116250,17 +116223,17 @@ ddJ
 aYK
 biz
 mva
-bkg
-bmU
 bDW
+bmU
+bkg
 bpJ
 kpp
-bTk
+bse
 bWa
 bwl
 fxK
 bwl
-eHp
+cfx
 bxm
 byM
 bAx
@@ -116276,8 +116249,8 @@ bOI
 bJp
 bRm
 bSK
-bTG
-oJW
+bVv
+cem
 jJX
 qja
 oFO
@@ -116339,17 +116312,17 @@ aaa
 aaa
 aaR
 aak
-cAu
+aOd
 aak
 aaR
 aaa
 aaa
-cAu
+aOd
 aaa
 aaa
 aaR
 aak
-cAu
+aOd
 aak
 aaR
 aaa
@@ -116466,7 +116439,7 @@ amB
 lqS
 sGL
 ltu
-msu
+cOl
 par
 apj
 oOc
@@ -116479,7 +116452,7 @@ hes
 dUf
 lPD
 awT
-orq
+hkC
 azU
 azU
 azU
@@ -116517,7 +116490,7 @@ bWa
 bwl
 fxK
 bwl
-eHp
+cfx
 crF
 cfy
 cfy
@@ -116534,7 +116507,7 @@ bJp
 bJp
 bJp
 lsM
-oJW
+cem
 jJX
 bXB
 tKt
@@ -116549,7 +116522,7 @@ cjY
 ckM
 cgV
 tDo
-cVa
+xuH
 vTa
 hKX
 tVd
@@ -116601,7 +116574,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -116723,7 +116696,7 @@ amB
 gAL
 sGL
 dDP
-msu
+cOl
 wNc
 wYi
 oOc
@@ -116736,11 +116709,11 @@ eqZ
 lPP
 fgg
 awT
-orq
-orq
+hkC
+hkC
 naR
 azU
-cAu
+aOd
 aak
 aak
 aOn
@@ -116774,11 +116747,11 @@ bwl
 bwl
 fxK
 bwl
-cfx
+eHp
 bxm
 byO
 byN
-rvx
+xIR
 bBY
 bBY
 byN
@@ -116790,8 +116763,8 @@ bOf
 bJp
 bRP
 bSK
-bTG
-oJW
+bVv
+cem
 jJX
 bXC
 niG
@@ -116799,19 +116772,19 @@ can
 cmo
 tIT
 kpu
-xwu
+cyj
 cGF
 cih
-ckO
-ckO
+cjZ
+cjZ
 oNS
 cnx
 hGo
-aXy
-xTF
-cVa
-tKH
-cVa
+oQB
+bTk
+xuH
+cQH
+xuH
 cvz
 pIz
 wAs
@@ -116820,8 +116793,8 @@ cAH
 gIt
 cDu
 vjN
-uDT
-uDT
+jkn
+jkn
 uXv
 deO
 cLf
@@ -116830,10 +116803,10 @@ cBL
 aaa
 aaa
 aaa
-uzr
+cIU
 qoc
 dCB
-uzr
+cIU
 aak
 aaa
 aaa
@@ -116856,11 +116829,11 @@ aaa
 aak
 aak
 aak
-cAu
+aOd
 aak
 fSP
 aak
-cAu
+aOd
 aak
 aak
 aak
@@ -116972,15 +116945,15 @@ anm
 anm
 eBI
 prM
-jkn
+eXy
 cKp
 mRn
 cgl
 eBi
-lhm
+fPv
 oqX
 vDs
-msu
+cOl
 efz
 apj
 dmo
@@ -116997,7 +116970,7 @@ azU
 hkO
 azU
 azU
-cAu
+aOd
 aaa
 aaa
 aOn
@@ -117221,23 +117194,23 @@ uKY
 oxw
 uKY
 uKY
-wPT
+agr
 kjz
-lhm
+fPv
 uAh
 rOi
 wxd
 dvk
-ybs
+fzn
 gHx
 rgs
 vgf
 cgl
 gwr
-lhm
-wfH
-azv
-msu
+fPv
+koK
+psH
+cOl
 iau
 fJX
 eVC
@@ -117254,7 +117227,7 @@ tIH
 kku
 oxj
 aMM
-cAu
+aOd
 aaa
 aaa
 aOn
@@ -117284,15 +117257,15 @@ vPS
 aZO
 qrn
 aYK
-btm
-btm
+buR
+buR
 qLZ
-btm
+buR
 bwq
 bxo
 byQ
 bAy
-ssX
+aEO
 bBZ
 bBZ
 bGF
@@ -117305,7 +117278,7 @@ bxo
 bRp
 bSL
 bJp
-cem
+uwK
 jJX
 jJX
 jJX
@@ -117343,12 +117316,12 @@ dju
 cBL
 aak
 aak
-cAu
+aOd
 kHY
 kHY
 pJk
 kHY
-cAu
+aOd
 aak
 aak
 kpo
@@ -117475,17 +117448,17 @@ aaa
 lhS
 vbd
 pGI
-wTJ
+wPT
 bRv
 dbz
 gZH
 thR
 fQj
-ybs
+fzn
 cGd
 cGd
 cGd
-ybs
+fzn
 kpv
 anm
 anm
@@ -117493,8 +117466,8 @@ hfM
 cKp
 anm
 wYA
-azv
-msu
+psH
+cOl
 ifj
 apj
 hbS
@@ -117511,7 +117484,7 @@ iXK
 kku
 toy
 aMM
-cAu
+aOd
 xMD
 aaa
 aOn
@@ -117530,7 +117503,7 @@ fcp
 lBc
 wBm
 aYK
-bVm
+hNv
 aYK
 aYK
 qAt
@@ -117544,27 +117517,27 @@ dnD
 mzy
 qLZ
 qLZ
-btm
-btm
+buR
+buR
 bxm
 byO
 gnv
-bvH
-bvH
-bvH
-nCF
+gDd
+gDd
+gDd
+nNX
 xfK
 bJs
-nCF
-nCF
+nNX
+nNX
 bOh
 bPB
 bRq
 bSM
 bJp
-cem
-bVv
-cAW
+uwK
+bTG
+cOy
 bVq
 rTq
 opg
@@ -117601,11 +117574,11 @@ kUi
 aaa
 aaa
 aak
-cAu
+aOd
 tGD
 woz
 xva
-cAu
+aOd
 aaa
 aaa
 aak
@@ -117737,13 +117710,13 @@ jNs
 vTg
 nqI
 uQU
-lhm
+fPv
 iGI
 xWv
 xWv
 xWv
-rUk
-jkn
+mWw
+eXy
 kcp
 mWC
 rod
@@ -117757,18 +117730,18 @@ apj
 rjD
 nYj
 mev
-mlo
+sJj
 spE
 iAO
 uMV
-mlo
+sJj
 uqm
 awT
 jDi
 kku
 kIa
 aMM
-cAu
+aOd
 aaa
 aaa
 aOn
@@ -117799,17 +117772,17 @@ aYK
 aYK
 aYK
 btn
-btm
+buR
 qLZ
-btm
-btm
+buR
+buR
 bxm
 byR
 byN
 bCb
 bCb
 bCb
-nNX
+nCF
 bHX
 bJt
 nXp
@@ -117819,7 +117792,7 @@ bxo
 bRR
 bTo
 bJp
-aPB
+bpk
 cfz
 qJs
 nzM
@@ -117858,11 +117831,11 @@ kUi
 aaa
 aaa
 aak
-cAu
+aOd
 krG
-gQf
+wuL
 quV
-cAu
+aOd
 aaa
 aaa
 aak
@@ -118000,15 +117973,15 @@ xWv
 lgG
 tcB
 bQq
-jkn
+eXy
 tzb
 anm
 xjM
 cfC
 cfC
 jyQ
-azv
-msu
+psH
+cOl
 wtg
 apj
 apj
@@ -118025,7 +117998,7 @@ azU
 syw
 azU
 azU
-cAu
+aOd
 aak
 aak
 aOn
@@ -118044,7 +118017,7 @@ eRw
 ndL
 vnv
 aEd
-iJQ
+dEi
 aEd
 jiy
 nHd
@@ -118055,11 +118028,11 @@ rdx
 tgU
 vYA
 bgi
-btm
-btm
+buR
+buR
 jmW
-btm
-btm
+buR
+buR
 bxm
 byS
 byN
@@ -118077,12 +118050,12 @@ bRo
 bJp
 bJp
 gtK
-bTG
-bTG
+bVv
+bVv
 vRn
-bTG
-bTG
-xxm
+bVv
+bVv
+ivj
 jWm
 bJp
 cgV
@@ -118115,11 +118088,11 @@ aak
 aaa
 aaa
 aak
-cAu
+aOd
 krG
-gQf
+wuL
 quV
-cAu
+aOd
 aaa
 aaa
 aak
@@ -118245,29 +118218,29 @@ aaa
 lhS
 jfe
 uKY
-wTJ
+wPT
 pNH
 pJz
 nTw
 mvM
 qXt
 sSk
-rUk
+mWw
 xWv
 xMJ
 hcy
 bQq
-jkn
+eXy
 yhW
 gxD
-vbp
+lxa
 fGH
 fGH
-azv
-azv
-msu
-eTY
-axD
+psH
+psH
+cOl
+uod
+frI
 aaa
 aaa
 aaa
@@ -118312,18 +118285,18 @@ rdx
 tgU
 jrP
 bgi
-btm
-btm
+buR
+buR
 qLZ
-btm
-btm
+buR
+buR
 bxm
 byT
 byN
 bCc
 bCc
 bCc
-nNX
+nCF
 bHY
 bxo
 byN
@@ -118333,13 +118306,13 @@ bPC
 bRs
 bJp
 dHC
-mMt
-xxm
+kRR
+ivj
 iTi
 tLm
 mRY
 fRO
-kRR
+mMt
 bJp
 bJp
 cgV
@@ -118372,11 +118345,11 @@ aak
 aaa
 aaa
 aak
-cAu
+aOd
 krG
-gQf
+wuL
 quV
-cAu
+aOd
 aaa
 aaa
 aak
@@ -118386,7 +118359,7 @@ aaa
 xcV
 aaa
 aaa
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -118501,7 +118474,7 @@ aaa
 aaa
 lhS
 eyn
-qUl
+aQq
 qqX
 pGn
 lqx
@@ -118509,20 +118482,20 @@ fWq
 xiN
 qXt
 mGY
-rUk
-rUk
+mWw
+mWw
 yfy
 rgf
-czy
-jkn
+dPM
+eXy
 cxm
 gxD
 tYj
-vbp
-uRq
+lxa
+cde
 qAA
-psH
-msu
+azv
+cOl
 qLy
 aAd
 aAd
@@ -118549,16 +118522,16 @@ aTG
 pDZ
 uKd
 toY
-qCq
+ygu
 ruP
-bwu
+bvL
 gzq
 aEd
 epG
 vKm
 kkR
 aEd
-elM
+aBi
 aEd
 rdx
 rdx
@@ -118569,18 +118542,18 @@ rdx
 tgU
 eeG
 bgi
-btm
-btm
+buR
+buR
 qLZ
-btm
-btm
+buR
+buR
 bxm
 byR
 byN
 byN
 byN
 byN
-nNX
+nCF
 bHX
 bxm
 bKE
@@ -118590,7 +118563,7 @@ bPD
 bRt
 bJp
 jCJ
-bVv
+bTG
 cfE
 bJp
 bJp
@@ -118629,11 +118602,11 @@ aak
 aaa
 aaa
 aak
-cAu
+aOd
 krG
-gQf
+wuL
 quV
-cAu
+aOd
 aaa
 aaa
 aak
@@ -118643,7 +118616,7 @@ aaa
 aak
 aaa
 aaa
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -118759,27 +118732,27 @@ aaa
 lhS
 tTV
 uKY
-iXh
+kaY
 gKH
 kQs
 cGt
 wyd
 qXt
 lQp
-rUk
+mWw
 xWv
 xMJ
 hwb
 bQq
-jkn
+eXy
 dDc
 gxD
-uRq
+cde
 kYR
 gVf
-azv
-azv
-msu
+psH
+psH
+cOl
 oPD
 aAd
 dfV
@@ -118808,14 +118781,14 @@ aQu
 aQu
 jMH
 aEd
-hIt
+rBn
 qmO
 aEd
 aEd
 aEd
 aEd
 aEd
-iJQ
+dEi
 aEd
 krz
 ozQ
@@ -118827,10 +118800,10 @@ dfl
 kkU
 bgi
 nBH
-btm
+buR
 qLZ
-btm
-btm
+buR
+buR
 bxm
 byS
 vej
@@ -118838,7 +118811,7 @@ bCd
 bCd
 bCd
 bGJ
-nCF
+nNX
 bJu
 bKF
 bMz
@@ -118846,9 +118819,9 @@ bMz
 bPE
 bRu
 bSO
-mMt
-bVv
-bgD
+kRR
+bTG
+cCg
 twK
 bZe
 cao
@@ -118886,11 +118859,11 @@ aak
 aaa
 aaa
 aak
-cAu
+aOd
 krG
-gQf
+wuL
 quV
-cAu
+aOd
 aaa
 aaa
 aak
@@ -119028,19 +119001,19 @@ xWv
 lgG
 rJA
 bQq
-jkn
+eXy
 mgq
 anm
 wlo
 iTX
 iTX
 mlc
-azv
+psH
 xDa
 cUd
 bXt
 mHf
-afi
+ule
 gKb
 iPZ
 uTi
@@ -119066,11 +119039,11 @@ vny
 vny
 vny
 jfu
-lWW
+vTd
 uJf
-brN
-lWW
-brN
+oFR
+vTd
+oFR
 yhi
 qYA
 leM
@@ -119084,10 +119057,10 @@ dsh
 igm
 bzn
 nBH
-buh
+eGq
 qLZ
 bvu
-btm
+buR
 bxm
 byU
 bAA
@@ -119103,15 +119076,15 @@ bJr
 jtD
 byO
 bJp
-oJW
-bTG
+cem
+bVv
 vBS
 cfz
 cfz
 cfz
 voZ
 bJp
-bTG
+bVv
 bWD
 cgX
 aaa
@@ -119143,11 +119116,11 @@ dCa
 aaa
 aaa
 aak
-cAu
+aOd
 vtY
 ltO
 qnz
-cAu
+aOd
 aaa
 aaa
 aak
@@ -119279,12 +119252,12 @@ rXM
 oAS
 fww
 uXd
-lhm
+fPv
 iGI
 xWv
 xWv
 xWv
-rUk
+mWw
 dnp
 foA
 mWC
@@ -119297,7 +119270,7 @@ jKg
 phf
 aAd
 mxo
-hAy
+bjZ
 rUY
 gmN
 nXw
@@ -119341,9 +119314,9 @@ lVZ
 qIa
 bgi
 nBH
-btm
-qBP
-btm
+buR
+mnK
+buR
 bwr
 bxo
 byV
@@ -119361,14 +119334,14 @@ bPD
 bKD
 bJp
 hxc
-bTG
+bVv
 hdg
 fQK
 hdg
 nMy
-bgD
+cCg
 ccC
-bTG
+bVv
 cfI
 cgX
 aaa
@@ -119396,15 +119369,15 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aak
 aak
-cAu
+aOd
 kHY
 kHY
 jux
 kHY
-cAu
+aOd
 aak
 aak
 kpo
@@ -119531,17 +119504,17 @@ aaa
 lhS
 fRX
 qRT
-iXh
+kaY
 eVQ
 tEW
 oRt
 tfW
 tZX
-aSg
+ajG
 txz
 txz
 txz
-aSg
+ajG
 iCb
 anm
 anm
@@ -119550,8 +119523,8 @@ dTV
 anm
 wVJ
 vNV
-msu
-uod
+cOl
+eTY
 aAd
 wvi
 msn
@@ -119563,7 +119536,7 @@ dgy
 rFk
 aAc
 aaa
-aPX
+lqP
 bwG
 aEd
 nqm
@@ -119598,9 +119571,9 @@ jZu
 jnr
 bgi
 btn
-btm
-qBP
-btm
+buR
+mnK
+buR
 bws
 bxo
 bxo
@@ -119653,7 +119626,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -119791,27 +119764,27 @@ uKY
 uKY
 qsx
 uKY
-kCy
+iXh
 yeh
-lhm
+fPv
 xrM
 nRL
 vgs
 eMr
-aSg
+ajG
 oYT
 tRA
 kyw
 wQe
 gwr
-lhm
-wfH
-azv
-msu
+fPv
+koK
+psH
+cOl
 uIt
 aAd
 iPF
-hAy
+bjZ
 vob
 uWc
 uog
@@ -119820,7 +119793,7 @@ dpK
 eIo
 aAc
 aaa
-aPX
+lqP
 xZU
 aEd
 lYe
@@ -119855,9 +119828,9 @@ bgi
 bgi
 bgi
 btq
-btm
-qBP
-btm
+buR
+mnK
+buR
 cXA
 bxo
 byW
@@ -119914,7 +119887,7 @@ aak
 aaa
 aaa
 aaa
-uzr
+cIU
 qoc
 hDr
 kHY
@@ -120061,10 +120034,10 @@ dTV
 mRn
 rRI
 wRY
-lhm
-wfH
-azv
-msu
+fPv
+koK
+psH
+cOl
 dey
 aAd
 gXe
@@ -120077,7 +120050,7 @@ xDt
 aAc
 aAc
 aaa
-aPX
+lqP
 fSz
 aEd
 fYT
@@ -120112,10 +120085,10 @@ uKj
 hty
 wLA
 cXv
-btm
-qBP
-btm
-btm
+buR
+mnK
+buR
+buR
 bxm
 byO
 byN
@@ -120175,7 +120148,7 @@ kHY
 dNj
 rbT
 kHY
-gQf
+wuL
 kHY
 aaa
 yjs
@@ -120186,13 +120159,13 @@ wKY
 oKk
 eWn
 sRZ
-cAu
+aOd
 aaa
 aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aak
 cSW
 cSW
@@ -120206,7 +120179,7 @@ cSW
 cSW
 cSW
 iGu
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -120335,10 +120308,10 @@ mZp
 aAc
 aaa
 aEd
-vCc
+hIt
 aEd
 wND
-hIt
+rBn
 uif
 xuu
 dLe
@@ -120359,9 +120332,9 @@ hDX
 jMl
 uDQ
 pZn
-jQA
-gTG
-tKM
+qkw
+aSF
+cDj
 iiB
 hZQ
 rGU
@@ -120369,10 +120342,10 @@ xBi
 dsw
 wLA
 btr
-btm
-qBP
-btm
-btm
+buR
+mnK
+buR
+buR
 bxm
 byO
 bAC
@@ -120389,12 +120362,12 @@ bPG
 bRw
 aWS
 lET
-byY
+bWG
 wer
 fQK
-bTG
+bVv
 uus
-bgD
+cCg
 ccL
 bJp
 bJp
@@ -120575,11 +120548,11 @@ aaa
 aaa
 iGu
 aaa
-axD
+frI
 yjU
-psH
-msu
-uod
+azv
+cOl
+eTY
 aAd
 xeQ
 oPp
@@ -120616,20 +120589,20 @@ cnU
 bdp
 beK
 csf
-bdG
+aNc
 cWw
 qWN
 rEF
 brw
-niR
+uzr
 ojw
 hTp
 wLA
-btm
-btm
-qBP
-btm
-btm
+buR
+buR
+mnK
+buR
+buR
 bxo
 bzd
 bAS
@@ -120644,12 +120617,12 @@ bKI
 bKI
 bKI
 bKI
-eJQ
+bSQ
 lET
-byY
+bWG
 tKl
 gfZ
-byY
+bWG
 ppG
 dTH
 bIn
@@ -120677,18 +120650,18 @@ ckj
 ikF
 tMM
 tMM
-cOA
+cEX
 hYv
-hax
-hax
-hax
-hax
+uRq
+uRq
+uRq
+uRq
 uSp
 gCM
-cOA
+cEX
 kkE
 vgR
-cOA
+cEX
 hHB
 tRY
 lxh
@@ -120834,8 +120807,8 @@ iGu
 aaa
 gAL
 jrq
-azv
-msu
+psH
+cOl
 uIt
 aAd
 pHF
@@ -120848,22 +120821,22 @@ iUq
 oMB
 aAc
 aaa
-aPX
+lqP
 xZU
 atH
 oNJ
-lWW
+vTd
 koM
 yhi
-lWW
-lWW
+vTd
+vTd
 yhi
-brN
+oFR
 lkQ
 qTr
 qTr
 qTr
-brN
+oFR
 eUa
 nEe
 aEd
@@ -120873,8 +120846,8 @@ qvd
 ncq
 dDG
 csf
-bdG
-cLv
+aNc
+bgs
 bts
 wLA
 wLA
@@ -120882,11 +120855,11 @@ ejE
 rvq
 wLA
 wLA
-btm
-btm
-qBP
-btm
-btm
+buR
+buR
+mnK
+buR
+buR
 bKI
 bKI
 bKI
@@ -120898,15 +120871,15 @@ bKI
 bKI
 bKJ
 cpR
-bSQ
+cxi
 bPH
-byY
 bWG
-lET
 byY
+lET
+bWG
 ebB
 hqW
-byY
+bWG
 wer
 nut
 abP
@@ -120930,7 +120903,7 @@ bTs
 bTs
 bTs
 bTs
-hax
+uRq
 wVf
 uvB
 ftf
@@ -120948,7 +120921,7 @@ cxe
 pXP
 gOT
 cvM
-jBB
+ckk
 ctm
 hOi
 cPJ
@@ -120963,7 +120936,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aaa
 aak
 aaa
@@ -120977,7 +120950,7 @@ aaa
 aaa
 aak
 aaa
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -121091,23 +121064,23 @@ avX
 aaa
 gAL
 cuK
-azv
+psH
 pdD
 nvp
 aAd
 tlM
 wxG
-afi
-afi
+ule
+ule
 cOO
 rbM
 udG
 rtl
 aAc
 aaa
-aPX
+lqP
 wdZ
-elM
+aBi
 eaD
 aEd
 aQK
@@ -121131,44 +121104,44 @@ bDQ
 rYj
 csf
 igg
-aSF
+gTG
 dhb
 dBD
 uRr
-htc
+niR
 neh
 iaF
 wLA
 btt
-btm
-qBP
-btm
+buR
+mnK
+buR
 xFv
 bxy
-byY
-byY
+bWG
+bWG
 bCw
-byY
-byY
-byY
-byY
 bWG
 bWG
 bWG
 bWG
+byY
+byY
+byY
+byY
 bQb
-vTd
-vTd
-vTd
-vTd
-vTd
-vTd
-vTd
-vTd
-vTd
+nno
+nno
+nno
+nno
+nno
+nno
+nno
+nno
+nno
 niQ
-vTd
-vTd
+nno
+nno
 wFe
 ciy
 tFk
@@ -121205,7 +121178,7 @@ ctm
 ctm
 ckj
 qHy
-jBB
+ckk
 ctm
 ouE
 hQN
@@ -121220,7 +121193,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aaa
 aak
 aaa
@@ -121234,7 +121207,7 @@ aaa
 aaa
 aak
 aaa
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -121340,7 +121313,7 @@ aak
 avX
 avX
 jvm
-hNv
+jUi
 ldB
 eMY
 ijX
@@ -121348,9 +121321,9 @@ avX
 sGN
 sGN
 lAx
-azv
-msu
-uod
+psH
+cOl
+eTY
 aAd
 aAd
 aAd
@@ -121362,9 +121335,9 @@ sIW
 imc
 aAc
 aaa
-aPX
+lqP
 qIG
-iJQ
+dEi
 waF
 smd
 aQK
@@ -121389,27 +121362,27 @@ wvg
 lAU
 rli
 bmZ
-tKM
+cDj
 fRf
 rsk
 eYr
 mrk
 lfj
 wLA
-btm
-btm
-qBP
-btm
-btm
+buR
+buR
+mnK
+buR
+buR
 bKI
 bzl
-byY
+bWG
 giN
 ebB
 bSP
 ppG
 bIr
-bWG
+byY
 bLk
 bxI
 bxI
@@ -121451,18 +121424,18 @@ vAr
 ubt
 cnz
 jhC
-mgS
+evm
 caF
 sCl
 jhC
-xuH
+mgS
 vpb
 cnz
 aak
 aak
 ctm
 cvM
-jBB
+ckk
 ckj
 cPq
 fhf
@@ -121600,18 +121573,18 @@ uwP
 ldk
 oZi
 jkz
-hNv
+jUi
 avX
 myQ
 sGN
 qTO
-azv
-msu
+psH
+cOl
 gsR
 awY
 hec
 rhi
-fzn
+fde
 kJt
 aAc
 aAc
@@ -121645,8 +121618,8 @@ csf
 csf
 csf
 nFi
-cLv
-tKM
+bgs
+cDj
 fRf
 rif
 uqp
@@ -121863,7 +121836,7 @@ vBn
 wZZ
 knt
 qQY
-msu
+cOl
 dey
 aAa
 rhd
@@ -121902,8 +121875,8 @@ bdt
 nfv
 qCk
 kZH
-aSF
-tKM
+gTG
+cDj
 iaG
 iaG
 iaG
@@ -121911,9 +121884,9 @@ iaG
 iaG
 tTW
 rnk
-btm
-qBP
-btm
+buR
+mnK
+buR
 bws
 bxt
 mfb
@@ -122119,8 +122092,8 @@ avX
 hks
 sGN
 yaz
-azv
-msu
+psH
+cOl
 par
 gdE
 xfr
@@ -122135,7 +122108,7 @@ vCb
 vCb
 vCb
 vYw
-iJQ
+dEi
 ryS
 aQK
 aMe
@@ -122157,7 +122130,7 @@ eGI
 mIb
 bjc
 kwe
-oFR
+cCy
 cBm
 cBm
 fCC
@@ -122168,10 +122141,10 @@ rMj
 brs
 nty
 qrq
-btm
-qBP
-btm
-btm
+buR
+mnK
+buR
+buR
 cLh
 hUx
 wMn
@@ -122201,7 +122174,7 @@ wUo
 nCT
 vgy
 ecs
-bda
+qvG
 cnz
 tuV
 hyx
@@ -122376,8 +122349,8 @@ avX
 sGN
 sGN
 cRX
-azv
-msu
+psH
+cOl
 wNc
 dIz
 xfr
@@ -122392,7 +122365,7 @@ gsb
 gcp
 vCb
 lLc
-elM
+aBi
 dQt
 aQK
 aMf
@@ -122400,7 +122373,7 @@ aMS
 aNM
 lEw
 aPt
-aNc
+bdG
 xhy
 ovA
 kZC
@@ -122413,7 +122386,7 @@ qTB
 yau
 kxi
 csU
-lxa
+ffy
 bgn
 tTW
 tTW
@@ -122437,7 +122410,7 @@ ydd
 oKd
 upl
 azc
-cfW
+kff
 sNd
 xRi
 mAL
@@ -122460,10 +122433,10 @@ aZl
 frA
 sAK
 eYv
-dEi
+sor
 xgK
 cQs
-dEi
+sor
 cQU
 cut
 cRP
@@ -122474,8 +122447,8 @@ cUf
 cVe
 cVB
 cED
-kaY
 epe
+fGv
 gXR
 ibG
 jjA
@@ -122633,8 +122606,8 @@ avX
 aaa
 gAL
 nJV
-azv
-msu
+psH
+cOl
 xvL
 dIz
 isQ
@@ -122649,7 +122622,7 @@ pEP
 hLe
 vCb
 qNr
-iJQ
+dEi
 yba
 aQK
 aMy
@@ -122657,7 +122630,7 @@ dDA
 aNZ
 aOU
 aLp
-aNc
+bdG
 vRp
 ovA
 eNO
@@ -122670,8 +122643,8 @@ oLo
 jTF
 twB
 gjk
-frI
-tKM
+lgn
+cDj
 blP
 biP
 pDn
@@ -122681,10 +122654,10 @@ pZF
 lpg
 kKA
 blP
-btm
-btm
+buR
+buR
 qLZ
-btm
+buR
 ebH
 cLh
 wyS
@@ -122699,7 +122672,7 @@ xHl
 bze
 noB
 uUG
-bda
+qvG
 xEJ
 lmH
 pmf
@@ -122780,13 +122753,13 @@ aaa
 aaa
 aaa
 aak
-cAu
+aOd
 aak
 aak
 snm
 aak
 aak
-cAu
+aOd
 aak
 aaa
 aaa
@@ -122890,8 +122863,8 @@ aak
 aaa
 gAL
 inl
-azv
-msu
+psH
+cOl
 wNc
 dIz
 isQ
@@ -122906,7 +122879,7 @@ qYL
 kMd
 vCb
 neP
-elM
+aBi
 aEd
 aQK
 aLp
@@ -122927,8 +122900,8 @@ twB
 twB
 twB
 bdv
-frI
-tKM
+lgn
+cDj
 blP
 cWg
 nNH
@@ -122938,10 +122911,10 @@ boD
 bpV
 bru
 tTW
-btm
-btm
+buR
+buR
 qLZ
-btm
+buR
 xox
 bxt
 iCl
@@ -122972,7 +122945,7 @@ lkp
 qwE
 pSh
 jAB
-bda
+qvG
 cnz
 iXW
 nTf
@@ -122988,8 +122961,8 @@ sjU
 sSN
 pzG
 oRq
-xke
-xke
+ntX
+ntX
 mnj
 cnz
 jlj
@@ -123020,8 +122993,8 @@ aak
 aak
 aak
 gPG
-cAu
-cAu
+aOd
+aOd
 bIi
 aaa
 jrL
@@ -123036,18 +123009,18 @@ aak
 aak
 aak
 aak
-cAu
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-cAu
+aOd
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+aOd
 aak
 aak
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -123145,10 +123118,10 @@ aaa
 aaa
 aak
 aaa
-gDd
+axD
 sXS
 kKC
-msu
+cOl
 ifj
 aAa
 okw
@@ -123176,16 +123149,16 @@ bnM
 aSQ
 gLD
 bsO
-cwt
-ptU
+wTJ
+qUl
 gLD
 gLD
 gLD
 xQc
 gLD
 ctZ
-frI
-tKM
+lgn
+cDj
 tTW
 tTW
 tTW
@@ -123196,10 +123169,10 @@ blP
 tTW
 tTW
 cpH
-btm
+buR
 qLZ
-btm
-btm
+buR
+buR
 wEW
 xOi
 stY
@@ -123293,16 +123266,16 @@ aaa
 aaa
 aak
 aaa
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
 aaa
 aak
 aaa
@@ -123405,8 +123378,8 @@ azW
 azW
 azW
 yfU
-msu
-uod
+cOl
+eTY
 gdE
 isQ
 gAa
@@ -123427,7 +123400,7 @@ aMi
 aMV
 aNP
 aOz
-aNc
+bdG
 sAB
 uDg
 baa
@@ -123441,8 +123414,8 @@ ccj
 bqi
 bcy
 cun
-frI
-tKM
+lgn
+cDj
 bhD
 biS
 hqK
@@ -123453,9 +123426,9 @@ pFW
 jyW
 bhD
 btn
-btm
+buR
 qLZ
-btm
+buR
 xNP
 bxt
 ndz
@@ -123470,7 +123443,7 @@ lDt
 bze
 eiR
 vri
-bda
+qvG
 caq
 wdf
 kTA
@@ -123486,7 +123459,7 @@ ceW
 cvH
 pSh
 fLB
-bda
+qvG
 cnz
 jUj
 lSQ
@@ -123499,11 +123472,11 @@ uTa
 eKv
 cnz
 szr
-cJf
+unw
 ubt
 cnz
 szr
-cJf
+unw
 ubt
 cnz
 jwI
@@ -123530,7 +123503,7 @@ aaa
 aaa
 cUC
 aaa
-cAu
+aOd
 aaa
 aak
 bIi
@@ -123549,18 +123522,18 @@ aaa
 aaa
 aaa
 rKs
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
 aak
 aaa
 aaa
@@ -123662,7 +123635,7 @@ eQy
 tkU
 azW
 oyd
-msu
+cOl
 joy
 jwf
 eXt
@@ -123698,8 +123671,8 @@ piO
 piO
 piO
 cuR
-frI
-avz
+lgn
+sPl
 bhG
 cWC
 bkw
@@ -123710,7 +123683,7 @@ cbe
 jXq
 bhD
 esy
-btm
+buR
 qLZ
 bws
 bxr
@@ -123727,7 +123700,7 @@ bIp
 bIp
 xrf
 eOR
-bda
+qvG
 loz
 egf
 sDb
@@ -123743,7 +123716,7 @@ mew
 cvH
 pSh
 jAB
-bda
+qvG
 cnz
 fRC
 lSQ
@@ -123756,11 +123729,11 @@ cSI
 cTr
 cnz
 nhu
-bab
+xwu
 cDq
 cnz
 nhu
-bab
+xwu
 hIF
 cnz
 xjf
@@ -123787,7 +123760,7 @@ aaa
 aaa
 cUC
 aaa
-cAu
+aOd
 aaa
 aak
 bIi
@@ -123797,7 +123770,7 @@ bIi
 ruA
 sUq
 gKv
-aLU
+rYM
 puW
 rQC
 sUq
@@ -123805,19 +123778,19 @@ aaa
 aaa
 aaa
 aaa
-lnm
-lnm
+jQA
+jQA
 doY
 mtC
 uMa
-lnm
+jQA
 gNv
-lnm
+jQA
 xWu
 pwV
 fGG
-lnm
-lnm
+jQA
+jQA
 aak
 aak
 aaa
@@ -123919,7 +123892,7 @@ sNV
 lDA
 myR
 gJq
-msu
+cOl
 faq
 aAa
 nqU
@@ -123934,14 +123907,14 @@ ewz
 uie
 vCb
 gMT
-aaB
+mok
 aEd
 bqm
 aMz
 aNk
 aOb
 aLr
-aNc
+bdG
 tPa
 piO
 piO
@@ -123955,7 +123928,7 @@ cdn
 wBV
 piO
 bdB
-frI
+lgn
 sbw
 bhD
 wmD
@@ -123967,7 +123940,7 @@ bky
 wiK
 bsh
 bsL
-buh
+eGq
 qLZ
 qvL
 bxr
@@ -123987,7 +123960,7 @@ efC
 eNn
 caq
 jVB
-iZV
+bda
 qrL
 wKH
 uHo
@@ -124013,16 +123986,16 @@ uTa
 cTv
 cnz
 vIp
-cJf
+unw
 cDn
 cnz
 vIp
-cJf
+unw
 cDn
 cnz
 jDF
 yjy
-big
+imr
 sCl
 vNa
 yjy
@@ -124062,7 +124035,7 @@ uMJ
 ncz
 ncz
 uMJ
-lnm
+jQA
 cKc
 pkp
 kid
@@ -124073,8 +124046,8 @@ vPV
 uJk
 lkl
 cXT
-lnm
-lnm
+jQA
+jQA
 rKs
 aak
 aaa
@@ -124176,7 +124149,7 @@ rFN
 pnL
 yjq
 iVa
-msu
+cOl
 uIt
 aQK
 aQK
@@ -124198,7 +124171,7 @@ aLr
 aLr
 aLr
 aLr
-bUa
+wZV
 xhy
 piO
 aSM
@@ -124212,7 +124185,7 @@ bac
 bbn
 nRZ
 bdA
-frI
+lgn
 kFt
 nFE
 biV
@@ -124224,8 +124197,8 @@ bky
 lRO
 kAc
 bsL
-btm
-qBP
+buR
+mnK
 gCt
 qNz
 dIC
@@ -124257,7 +124230,7 @@ cvH
 pMp
 pSh
 fLB
-bda
+qvG
 cnz
 jzs
 uSm
@@ -124278,11 +124251,11 @@ cVs
 cnz
 cnz
 jhC
-mgS
+evm
 qFQ
 sCl
 vPH
-mgS
+evm
 pHT
 cnz
 aaa
@@ -124319,7 +124292,7 @@ qIA
 lYA
 qZD
 mKQ
-lnm
+jQA
 yhB
 vRd
 qKr
@@ -124330,9 +124303,9 @@ xNT
 qSN
 qSN
 ijN
-lnm
-lnm
-lnm
+jQA
+jQA
+jQA
 aak
 aaa
 aaa
@@ -124433,7 +124406,7 @@ ssV
 yff
 myR
 gJq
-msu
+cOl
 rWg
 aEd
 ppL
@@ -124448,7 +124421,7 @@ ghk
 jti
 vCb
 nHy
-mhJ
+aXy
 uif
 aEd
 aMl
@@ -124481,8 +124454,8 @@ mLT
 xNO
 kAc
 bsL
-btm
-qBP
+buR
+mnK
 gCt
 cYb
 vmg
@@ -124497,11 +124470,11 @@ fvV
 tNo
 sKj
 vZF
-cIh
+hFH
 nmI
 caq
 kiG
-fnt
+avz
 wOj
 mlh
 uHo
@@ -124514,7 +124487,7 @@ oZk
 siF
 pSh
 jAB
-bda
+qvG
 waP
 waP
 waP
@@ -124522,7 +124495,7 @@ waP
 waP
 waP
 waP
-cAu
+aOd
 aaa
 aaa
 aak
@@ -124566,8 +124539,8 @@ tDf
 vHw
 tet
 jTo
-rBn
-rBn
+kxE
+kxE
 uXL
 vzx
 lKG
@@ -124576,20 +124549,20 @@ gvc
 fqs
 hkJ
 ygV
-lnm
+jQA
 reR
 lHw
 xrh
-lnm
+jQA
 hTQ
-lnm
-lnm
+jQA
+jQA
 eTK
 cer
-lnm
-lnm
-lnm
-lnm
+jQA
+jQA
+jQA
+jQA
 aak
 aaa
 aaa
@@ -124690,7 +124663,7 @@ kwL
 qFZ
 azW
 pDb
-msu
+cOl
 gPn
 aEd
 iBK
@@ -124705,14 +124678,14 @@ lwt
 ngv
 vCb
 csK
-cpn
+aXp
 fxD
 brf
 aMm
 bgr
 bgr
 aOB
-rHh
+qlX
 tPa
 piO
 aSO
@@ -124738,8 +124711,8 @@ mrE
 brx
 kAc
 bsL
-btm
-qBP
+buR
+mnK
 gCt
 jJs
 dJo
@@ -124754,10 +124727,10 @@ uTM
 lLd
 bIq
 pSh
-cDw
-bda
+bwu
+qvG
 loz
-fnt
+avz
 eJY
 wOj
 nRT
@@ -124771,7 +124744,7 @@ oZk
 cww
 pSh
 fLB
-bda
+qvG
 waP
 aaa
 ijt
@@ -124779,39 +124752,39 @@ cqX
 fZI
 cQV
 cRy
-cAu
+aOd
 cSJ
-cyj
+cQO
 cTD
-cyj
-cyj
-cyj
+cQO
+cQO
+cQO
 cTD
-cyj
-cyj
-cyj
+cQO
+cQO
+cQO
 cTD
-cyj
-cyj
-cyj
+cQO
+cQO
+cQO
 cTD
-cyj
-cyj
-cyj
+cQO
+cQO
+cQO
 cTD
-cyj
-cyj
+cQO
+cQO
 nJR
 oON
 wcq
-cQO
-cQO
+uWL
+uWL
 cQB
-cQO
-cQO
+uWL
+uWL
 cQB
-cQO
-cQO
+uWL
+uWL
 cQB
 cQB
 cQB
@@ -124840,13 +124813,13 @@ anJ
 cpT
 hxd
 puH
-lnm
+jQA
 exc
 sGJ
 pgr
-lnm
-lnm
-lnm
+jQA
+jQA
+jQA
 iqq
 aaa
 aaa
@@ -124947,7 +124920,7 @@ iTq
 aXZ
 azW
 sJc
-msu
+cOl
 lYf
 aEd
 oDh
@@ -124962,8 +124935,8 @@ vUr
 vCb
 vCb
 gMT
-rrb
-bwu
+pAM
+bvL
 aLu
 aMn
 aNa
@@ -124995,8 +124968,8 @@ bky
 bry
 bsh
 bsL
-btm
-qBP
+buR
+mnK
 gQe
 bxr
 otq
@@ -125011,12 +124984,12 @@ szH
 tDQ
 bIW
 pSh
-imr
+rkT
 jhB
 caq
 kiG
-fnt
-tyl
+avz
+buT
 dnA
 rzS
 hrs
@@ -125080,30 +125053,30 @@ ugH
 mve
 cfu
 stW
+bDX
 lLx
-bDX
 cqW
-bDX
-bDX
+lLx
+lLx
 aJk
 bAz
 gxM
 cLy
 owq
-lnm
+jQA
 iNU
 jyu
 lRt
-lnm
+jQA
 eGZ
-lnm
-lnm
+jQA
+jQA
 tqa
 lLE
-lnm
-lnm
-lnm
-lnm
+jQA
+jQA
+jQA
+jQA
 aak
 aaa
 aaa
@@ -125204,7 +125177,7 @@ omm
 omm
 fKZ
 sEE
-msu
+cOl
 nHX
 aEd
 aHx
@@ -125220,7 +125193,7 @@ dTc
 dTc
 qZn
 xZU
-vCc
+hIt
 aEd
 aEd
 bdK
@@ -125241,7 +125214,7 @@ piO
 piO
 bdC
 cAF
-cDj
+bhI
 bhD
 bjd
 jgF
@@ -125252,8 +125225,8 @@ jgF
 brE
 bhD
 esy
-btm
-qBP
+buR
+mnK
 bws
 bxr
 bxr
@@ -125322,12 +125295,12 @@ ckj
 ckj
 ckj
 ckj
-cAu
+aOd
 aak
 aak
 aak
 aak
-cAu
+aOd
 aaa
 aaa
 bIi
@@ -125347,7 +125320,7 @@ mwS
 aQn
 fVr
 mKQ
-lnm
+jQA
 bvQ
 myV
 vrp
@@ -125358,9 +125331,9 @@ iZw
 ydo
 ydo
 qdh
-lnm
-lnm
-lnm
+jQA
+jQA
+jQA
 aak
 aaa
 aaa
@@ -125464,27 +125437,27 @@ pPR
 ujS
 wEb
 uJf
-lWW
+vTd
 yhi
 yhi
 gaG
-brN
+oFR
 yhi
-brN
+oFR
 gIm
 dqK
 aNd
 jiT
 tpy
 aEd
-vCc
+hIt
 qLz
 aEd
 fWc
 hBv
 bdK
-bdG
-frI
+aNc
+lgn
 aSd
 bgo
 ejX
@@ -125525,7 +125498,7 @@ ugm
 jhn
 eBR
 lxl
-cDw
+bwu
 ewa
 nup
 nup
@@ -125604,7 +125577,7 @@ lvC
 ncz
 ncz
 uMJ
-lnm
+jQA
 cKc
 cTe
 ard
@@ -125615,8 +125588,8 @@ mxF
 mBK
 wUJ
 sYv
-lnm
-lnm
+jQA
+jQA
 rKs
 aak
 aaa
@@ -125722,8 +125695,8 @@ jyZ
 sLv
 aEd
 aEd
-aPX
-aPX
+lqP
+lqP
 aEd
 aEd
 bwv
@@ -125734,16 +125707,16 @@ kCa
 tef
 aEd
 aEd
-vCc
+hIt
 kGY
 aEd
 aNn
 aTz
 iHB
-qkw
-frI
-cCy
-mJt
+aPB
+lgn
+aSg
+aSX
 cNm
 rtd
 cNm
@@ -125751,10 +125724,10 @@ cNm
 arM
 bZT
 sfA
-ojF
+mJt
 cBm
 cuY
-bgs
+cLv
 bgv
 bhK
 biZ
@@ -125765,10 +125738,10 @@ ucC
 oVC
 brA
 bhK
-btm
-btm
-qBP
-btm
+buR
+buR
+mnK
+buR
 rOX
 xdQ
 jZo
@@ -125808,13 +125781,13 @@ cQS
 cRd
 chn
 cSb
-ckk
+pbj
 cTA
-ckk
+pbj
 cUs
-ckk
+pbj
 cVE
-ckk
+pbj
 eIP
 gdO
 ybn
@@ -125828,7 +125801,7 @@ nsS
 qNA
 qYp
 ybn
-ckk
+pbj
 uoC
 psF
 hYB
@@ -125836,7 +125809,7 @@ cPj
 cPA
 cPR
 ckj
-cAu
+aOd
 aak
 aak
 cQX
@@ -125861,19 +125834,19 @@ xQt
 aaa
 aaa
 aaa
-lnm
-lnm
+jQA
+jQA
 kCv
 xWt
 lRu
-lnm
+jQA
 sCJ
-lnm
+jQA
 axL
 rtq
 fGG
-lnm
-lnm
+jQA
+jQA
 aak
 aak
 aaa
@@ -125974,14 +125947,14 @@ azW
 azW
 azW
 azW
-gDd
-gDd
-gDd
+axD
+axD
+axD
 aEd
 tHU
-cAu
-cAu
-cAu
+aOd
+aOd
+aOd
 aEd
 aEd
 aEd
@@ -126011,8 +125984,8 @@ flj
 aTU
 aTU
 xTe
-bgs
-cDj
+cLv
+bhI
 bhL
 fmY
 bkD
@@ -126022,11 +125995,11 @@ boF
 dnI
 brB
 bhK
-btm
-btm
-qBP
-btm
-btm
+buR
+buR
+mnK
+buR
+buR
 oNO
 rPg
 xgp
@@ -126119,18 +126092,18 @@ aaa
 aaa
 aaa
 rKs
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
 aak
 aaa
 aaa
@@ -126240,7 +126213,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aEd
 aEd
 aEd
@@ -126268,8 +126241,8 @@ gHW
 bbr
 aTU
 cuz
-bgs
-cDj
+cLv
+bhI
 bhK
 oHm
 lid
@@ -126280,10 +126253,10 @@ urB
 qBs
 bhK
 xpL
-btm
-qBP
-btm
-btm
+buR
+mnK
+buR
+buR
 qqB
 gpW
 oyG
@@ -126341,8 +126314,8 @@ ckj
 ckj
 ckj
 ckj
-chq
-chq
+lWW
+lWW
 cOv
 cJd
 ckj
@@ -126377,16 +126350,16 @@ aaa
 aaa
 aak
 aaa
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
 aaa
 aak
 aaa
@@ -126497,7 +126470,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aOq
 aHx
 bhJ
@@ -126506,8 +126479,8 @@ uif
 oQz
 aEd
 xZU
-vCc
-vCc
+hIt
+hIt
 bwG
 xZU
 rml
@@ -126536,11 +126509,11 @@ boJ
 fyz
 brF
 bhK
+btm
 buR
-btm
-qBP
-btm
-btm
+mnK
+buR
+buR
 xdQ
 lcc
 wmP
@@ -126598,13 +126571,13 @@ wph
 ckj
 cOn
 egX
-chq
+lWW
 cQh
 irp
 oPH
 ckj
 dhx
-chq
+lWW
 cPT
 cQh
 ckj
@@ -126618,8 +126591,8 @@ aak
 aak
 aak
 tzh
-cAu
-cAu
+aOd
+aOd
 bIi
 aaa
 sUq
@@ -126634,18 +126607,18 @@ aak
 aak
 aak
 aak
-cAu
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-lnm
-cAu
+aOd
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+jQA
+aOd
 aak
 aak
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -126754,7 +126727,7 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aEd
 aEd
 aEd
@@ -126794,10 +126767,10 @@ bqq
 brG
 bhK
 btx
-btm
-qBP
-btm
-btm
+buR
+mnK
+buR
+buR
 xdQ
 dbp
 dok
@@ -126892,13 +126865,13 @@ aaa
 aaa
 aaa
 aak
-cAu
+aOd
 aak
 aak
 rQo
 aak
 aak
-cAu
+aOd
 aak
 aaa
 aaa
@@ -127027,7 +127000,7 @@ aEd
 aEd
 bkF
 aQZ
-cDj
+bhI
 aTU
 aUk
 buG
@@ -127051,10 +127024,10 @@ evx
 imS
 bhK
 bty
-btm
-qBP
-btm
-btm
+buR
+mnK
+buR
+buR
 kbN
 eBO
 flf
@@ -127067,7 +127040,7 @@ jQD
 bNu
 ubP
 bCB
-cEX
+wFX
 vZD
 gje
 tNR
@@ -127283,8 +127256,8 @@ rrF
 aFd
 jVy
 aPH
-ebz
-cDj
+lpB
+bhI
 aQK
 aQK
 aQK
@@ -127308,10 +127281,10 @@ aQK
 aQK
 aQK
 rPj
-btm
-qBP
-btm
-btm
+buR
+mnK
+buR
+buR
 rND
 nLM
 vqP
@@ -127324,7 +127297,7 @@ yiz
 aNB
 iiK
 iiK
-evm
+bWE
 utO
 fqV
 abu
@@ -127377,9 +127350,9 @@ ckj
 pia
 wWH
 wWH
-fCF
+rUk
 ckj
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -127540,8 +127513,8 @@ aNf
 aNY
 aOF
 aQd
-gTG
-cDj
+aSF
+bhI
 aQK
 xjL
 bah
@@ -127557,7 +127530,7 @@ oFi
 bgy
 bhO
 aEd
-bwu
+bvL
 bmb
 qAH
 onb
@@ -127567,7 +127540,7 @@ oXf
 bWl
 bwC
 buW
-btm
+buR
 rOX
 xdQ
 waQ
@@ -127814,17 +127787,17 @@ oFi
 gGW
 lNg
 aEd
-bwu
+bvL
 bmc
 aEd
 aEd
 aEd
 aEd
 aEd
-agl
-btm
+brN
+buR
 buX
-btm
+buR
 kZt
 xdQ
 qCF
@@ -127863,7 +127836,7 @@ ktu
 uaP
 bYN
 gRX
-cSf
+cSr
 cSS
 cTB
 cTL
@@ -127893,7 +127866,7 @@ nmp
 itn
 fnV
 cQw
-fCF
+rUk
 aaa
 aaa
 aaa
@@ -128044,7 +128017,7 @@ aLE
 aNb
 aFd
 aPs
-kxE
+aVk
 aKS
 aJO
 nSd
@@ -128071,14 +128044,14 @@ wGd
 cjT
 bhQ
 aEd
-bwu
+bvL
 bmd
 aEd
 boK
 bpX
 brH
 eKq
-cOy
+uza
 btU
 bIQ
 btU
@@ -128319,7 +128292,7 @@ aVe
 aWa
 cVn
 aXP
-aPX
+lqP
 xHt
 vnF
 aEd
@@ -128328,18 +128301,18 @@ bjv
 vRl
 pUf
 aEd
-bwu
+bvL
 bme
 aEd
 boL
 bpY
 brI
 otW
+btm
 buR
-btm
-bva
-btm
-btm
+lQN
+buR
+buR
 dGR
 bFH
 oaj
@@ -128355,7 +128328,7 @@ hnB
 mLv
 bFH
 xwG
-hJu
+evs
 bJT
 bJT
 bJT
@@ -128402,10 +128375,10 @@ tCh
 cPs
 dsx
 pia
-rYM
+tuE
 hOM
-rYM
-rYM
+tuE
+tuE
 cQw
 cSh
 aaa
@@ -128576,7 +128549,7 @@ yjC
 exy
 aRf
 aXQ
-aPX
+lqP
 xHt
 pgc
 aEd
@@ -128592,11 +128565,11 @@ boM
 cXK
 brJ
 bsk
-lQN
 qBP
+mnK
 cec
-btm
-btm
+buR
+buR
 nvH
 bFH
 quF
@@ -128634,7 +128607,7 @@ wAz
 xaK
 aak
 xaK
-cSf
+cSr
 cxf
 xaK
 cTP
@@ -128645,7 +128618,7 @@ xaK
 aak
 aak
 aak
-cAu
+aOd
 aak
 aak
 aaa
@@ -128833,15 +128806,15 @@ aRf
 fmJ
 aRf
 aXR
-aPX
+lqP
 bap
 qYs
-brN
-brN
-brN
+oFR
+oFR
+oFR
 qYs
 bhX
-brN
+oFR
 upg
 mAV
 aEd
@@ -128849,11 +128822,11 @@ boN
 bqa
 tRh
 eKq
+btm
 buR
-btm
 gzW
-btm
-btm
+buR
+buR
 dAW
 bFH
 qSg
@@ -128902,8 +128875,8 @@ xaK
 aaa
 aaa
 aaa
-cAu
-cAu
+aOd
+aOd
 aak
 aak
 uxu
@@ -128921,7 +128894,7 @@ pCD
 pCD
 xiR
 ckj
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -129092,14 +129065,14 @@ pDE
 opG
 aQK
 aQK
-aPX
-uYl
-aPX
-aPX
-aPX
-aQK
-aQK
 lqP
+uYl
+lqP
+lqP
+lqP
+aQK
+aQK
+xke
 aQK
 aQK
 bsl
@@ -129107,10 +129080,10 @@ lko
 brI
 eKq
 qLc
-btm
-bva
-btm
-btm
+buR
+lQN
+buR
+buR
 bwt
 bFH
 cJZ
@@ -129126,7 +129099,7 @@ qIx
 fVC
 bFH
 dbT
-hJu
+evs
 poi
 bJT
 bJT
@@ -129363,11 +129336,11 @@ uIB
 nzp
 oaL
 jpf
+iJQ
 noW
-lCH
 hQC
-btm
-btm
+buR
+buR
 bwr
 bxD
 bxD
@@ -129429,7 +129402,7 @@ ckj
 ckj
 ckj
 ckj
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -129621,10 +129594,10 @@ kEc
 nJv
 tLs
 nBo
-btm
+buR
 gzW
-qBP
-qBP
+mnK
+mnK
 pQx
 bJT
 bBg
@@ -129878,14 +129851,14 @@ puX
 lnp
 guH
 nBo
-eGq
+aKB
 tuZ
 ikI
-noW
+iJQ
 fkH
 sAV
 mTm
-hJu
+evs
 bJT
 fje
 eLr
@@ -129931,13 +129904,13 @@ rMV
 aaa
 aaa
 aaa
-cAu
+aOd
 aak
 cUW
 xHL
 aak
 aak
-cAu
+aOd
 aaa
 aaR
 aaa
@@ -130134,11 +130107,11 @@ tum
 eHD
 sJz
 otW
+btm
 buR
-btm
-bva
-btm
-btm
+lQN
+buR
+buR
 rmt
 bJT
 rUr
@@ -130176,7 +130149,7 @@ cQG
 xaK
 xaK
 xaK
-cSf
+cSr
 cSY
 cRA
 mJe
@@ -130188,7 +130161,7 @@ rMV
 cCd
 cCd
 cCd
-cGU
+cAR
 aaa
 aaa
 aaa
@@ -130391,18 +130364,18 @@ rGN
 tBp
 nfd
 eKq
-agl
+brN
 bul
 gzW
 bvI
-btm
+buR
 pVz
 bJT
 oQT
 eAX
 bJT
 lGN
-tzt
+wUA
 bIw
 bJT
 xwH
@@ -130431,8 +130404,8 @@ bTe
 cPO
 nAC
 cPO
-aJM
-aJM
+cfW
+cfW
 cSl
 cSZ
 cSZ
@@ -130445,7 +130418,7 @@ cCe
 xkb
 hUM
 cXU
-cAR
+sOT
 aaa
 aaa
 aaa
@@ -130648,7 +130621,7 @@ lmv
 lmv
 lmv
 pzw
-bhI
+ahG
 btF
 bvc
 btF
@@ -130686,10 +130659,10 @@ bYN
 bYN
 scz
 cPP
-cQH
-cQH
+czy
+czy
 cRk
-cSr
+cRF
 ozT
 cTa
 bsA
@@ -130702,7 +130675,7 @@ rMV
 cCd
 cCd
 cCd
-cAR
+sOT
 aaa
 aaa
 aaa
@@ -130903,7 +130876,7 @@ bsp
 btB
 oZu
 vXK
-eLL
+cek
 tSE
 bst
 jfH
@@ -130926,9 +130899,9 @@ aPa
 xcv
 bJT
 bUu
-aQq
+cAW
 tNk
-ajG
+bLr
 oUs
 qUJ
 dbT
@@ -130941,7 +130914,7 @@ xaK
 ces
 bCG
 cDr
-cQH
+czy
 cPS
 xaK
 xaK
@@ -130959,13 +130932,13 @@ rMV
 aaa
 aaa
 aaa
-cAR
+sOT
 aak
 aak
-cAu
+aOd
 aak
 aak
-cAu
+aOd
 aaa
 aaR
 aaa
@@ -131156,15 +131129,15 @@ wxQ
 aOG
 aaa
 aaa
-eLL
+cek
 fYD
 ijT
 giD
 pcZ
 bOn
 aFQ
-wlx
-wSB
+bvz
+cGI
 bvx
 bvx
 bvx
@@ -131183,9 +131156,9 @@ tOS
 mtm
 bJT
 tBu
-xuU
-wUA
-wUA
+vgE
+ssX
+ssX
 imM
 gZi
 iJu
@@ -131216,7 +131189,7 @@ aaa
 aaa
 aaa
 aaa
-cAR
+sOT
 aaa
 aaa
 aaa
@@ -131417,11 +131390,11 @@ bsp
 mIM
 giY
 ibh
-eLL
+cek
 tSE
 bst
 jfH
-erB
+bsr
 jfH
 jfH
 jfH
@@ -131473,7 +131446,7 @@ aaa
 aaa
 aaa
 aaa
-cGU
+cAR
 aaa
 aaa
 aaa
@@ -131671,14 +131644,14 @@ aOG
 aDH
 aDH
 bsp
-cek
+pDm
 ppp
-cek
+pDm
 lmv
 phy
 bst
 jfH
-erB
+bsr
 bvy
 jfH
 jfH
@@ -131687,7 +131660,7 @@ bBi
 jfH
 bEm
 bJT
-vgE
+lXP
 bIz
 sWt
 fuy
@@ -131730,7 +131703,7 @@ czG
 czG
 czG
 aaa
-cGU
+cAR
 aaa
 czG
 czG
@@ -131931,11 +131904,11 @@ bsp
 bnE
 giY
 bol
-eLL
+cek
 bOn
 cGH
 jfH
-erB
+bsr
 jfH
 jfH
 jfH
@@ -131963,7 +131936,7 @@ pwa
 mid
 bxD
 jug
-nDi
+oJW
 vIk
 txJ
 aeN
@@ -131981,19 +131954,19 @@ xaK
 aaa
 aaR
 aak
+sOT
+sOT
+sOT
+sOT
+sOT
 cAR
 cAR
 cAR
-cAR
-cAR
-cGU
-cGU
-cGU
-cAR
-cAR
-cAR
-cAR
-cAR
+sOT
+sOT
+sOT
+sOT
+sOT
 aak
 aaR
 aaa
@@ -132184,20 +132157,20 @@ wxQ
 aOG
 aak
 aak
-eLL
+cek
 bnF
 giY
 bqj
 brP
 bOo
-cGI
-erB
-erB
-wlx
-wlx
-wlx
-wlx
-wlx
+cDB
+bsr
+bsr
+bvz
+bvz
+bvz
+bvz
+bvz
 bCP
 bEo
 bxD
@@ -132220,7 +132193,7 @@ rMU
 uuK
 bxD
 wud
-cde
+nDi
 ceR
 psW
 wRs
@@ -132244,7 +132217,7 @@ czG
 czG
 czG
 aaa
-cGU
+cAR
 aaa
 czG
 czG
@@ -132445,7 +132418,7 @@ bsp
 bnQ
 boW
 bzC
-eLL
+cek
 bOn
 btH
 bvh
@@ -132495,19 +132468,19 @@ xaK
 aaa
 oCj
 aaa
-aeE
-ule
-ule
-ule
-ule
+lCH
+xBJ
+xBJ
+xBJ
+xBJ
 aaa
 iGq
 aaa
-ule
-ule
-ule
-ule
-aeE
+xBJ
+xBJ
+xBJ
+xBJ
+lCH
 aaa
 aaR
 aaa
@@ -132700,9 +132673,9 @@ aak
 aak
 bsp
 bsp
-cek
+pDm
 bql
-cek
+pDm
 bss
 boU
 bmm
@@ -132957,9 +132930,9 @@ aaa
 aaa
 aaa
 aaa
-cek
+pDm
 pXq
-cek
+pDm
 bHT
 boU
 aaa
@@ -133009,19 +132982,19 @@ xaK
 aaa
 aaR
 aak
+sOT
 cAR
-cGU
+sOT
 cAR
-cGU
-cGU
+cAR
 iGq
 lya
-cGU
+cAR
+sOT
+sOT
 cAR
 cAR
-cGU
-cGU
-cGU
+cAR
 aak
 aaR
 aaa
@@ -133214,9 +133187,9 @@ aaa
 aaa
 aaa
 aaa
-cek
+pDm
 tbN
-cek
+pDm
 jfH
 boU
 aaa
@@ -133228,9 +133201,9 @@ boU
 jfH
 boU
 aak
-cAu
-cAu
-cAu
+aOd
+aOd
+aOd
 aak
 aak
 aaa
@@ -133471,9 +133444,9 @@ aaa
 aaa
 aaa
 aaa
-cek
+pDm
 bqn
-cek
+pDm
 bxF
 boU
 aak
@@ -133523,19 +133496,19 @@ aak
 aak
 oCj
 aaa
-aeE
-ule
-ule
-ule
-ule
+lCH
+xBJ
+xBJ
+xBJ
+xBJ
 aaa
 iGq
 aaa
-ule
-ule
-ule
-ule
-aeE
+xBJ
+xBJ
+xBJ
+xBJ
+lCH
 aaa
 aaR
 aaa
@@ -134037,19 +134010,19 @@ aaa
 aaa
 aaR
 aak
+sOT
+sOT
+sOT
+sOT
+sOT
 cAR
-cAR
-cAR
-cAR
-cAR
-cGU
 iGq
-cGU
 cAR
-cAR
-cAR
-cAR
-cAR
+sOT
+sOT
+sOT
+sOT
+sOT
 aak
 oCj
 aaa
@@ -134300,7 +134273,7 @@ czG
 czG
 czG
 aaa
-cAR
+sOT
 aaa
 czG
 czG
@@ -134557,7 +134530,7 @@ aaa
 aaa
 aaa
 aaa
-cAR
+sOT
 aaa
 aaa
 aaa
@@ -135071,7 +135044,7 @@ aaa
 aaa
 wAa
 aaa
-cAu
+aOd
 aaa
 aak
 aaa
@@ -135322,19 +135295,19 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aak
 aak
 aaR
 aak
 aaa
-cAu
+aOd
 aaa
 aak
 aaR
 aak
 aak
-cAu
+aOd
 aaa
 aaa
 aaa
@@ -135821,9 +135794,9 @@ aaa
 aaa
 aaa
 aaa
-cAu
+aOd
 aak
-cAu
+aOd
 aaa
 aaa
 aaa

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -20358,13 +20358,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cer" = (
+/obj/machinery/status_display/ai/directional/south,
+/obj/structure/cable/layer3,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/status_display/ai/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "ces" = (
@@ -29935,19 +29938,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "exc" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/stack/cable_coil,
-/obj/item/t_scanner{
-	pixel_x = 7
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
-/obj/item/multitool{
-	pixel_x = -5;
-	pixel_y = -2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
 "exj" = (
 /obj/structure/rack,
@@ -31086,6 +31081,9 @@
 "eTK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
@@ -47872,22 +47870,24 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "lLE" = (
+/obj/machinery/flasher/directional/south{
+	id = "AI";
+	pixel_x = -10
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "AI Sat - Chamber South";
+	network = list("minisat")
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/flasher/directional/south{
-	id = "AI";
-	pixel_x = -10
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/directional/south{
-	c_tag = "AI Sat - Chamber South";
-	network = list("minisat")
-	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "lLI" = (
@@ -56700,11 +56700,20 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "pgr" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/stack/cable_coil,
+/obj/item/t_scanner{
+	pixel_x = 7
+	},
+/obj/item/multitool{
+	pixel_x = -5;
+	pixel_y = -2
 	},
 /obj/structure/sign/warning/electric_shock/directional/south,
-/turf/open/floor/circuit/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "pgy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -62274,6 +62283,12 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"rqr" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "rqA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -65381,10 +65396,15 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
+/obj/structure/cable/multilayer/connected,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/terminal,
-/obj/structure/cable/multilayer/connected,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "sGL" = (
@@ -67193,6 +67213,10 @@
 "tqa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
@@ -125391,7 +125415,7 @@ ouP
 wFV
 iZw
 ydo
-ydo
+rqr
 qdh
 jQA
 jQA

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -41326,6 +41326,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "iZy" = (
@@ -47886,6 +47887,7 @@
 	c_tag = "AI Sat - Chamber South";
 	network = list("minisat")
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "lLI" = (
@@ -75150,6 +75152,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "wFX" = (
@@ -78690,6 +78693,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "ydu" = (


### PR DESCRIPTION
## About The Pull Request

Redoes the entire wiring of heliostation. The stated goal is to replace the current design with a circular design. 
The station's wiring runs from engineering clock-wise arounds the station, with branches inside each department to reach every APC in them but with hardly any redundancies or cross-department bridges, with the exception of cargo and engi which link back up at the end of the powernet's journey.

This simplifies the powernet, making it easier to follow the trail of wires through maints, while retaining some robustness for the powernet, since you must cut a wire on both sides of a section of wiring to cut power to it.

`As of the latest commit`: Adds electrical danger signs accompanied by maintenance tunnel signs to locations where a wire runs through a maints entrance. This will hopefully make it easier to find and follow the power network when performing repairs.
## Why It's Good For The Game

This makes it simpler to fix broken wires, since the zone in which a wire has been cut can be pinpointed more accurately based on the areas that have become unpowered.
Engineers can always add bypasses and bridges if they so wish, and the circular shape of the circuit facilitates this innitiative.

Also closes #923
## Changelog
:cl:
bal : Re-does Heliostation's wiring to make it circular.
/:cl:
