### PR TITLE
Frenzied torpor

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -10,7 +10,7 @@
 	if(!owner)
 		INVOKE_ASYNC(src, PROC_REF(HandleDeath))
 		return
-	if(HAS_TRAIT(owner.current, TRAIT_NODEATH))
+	if(HAS_TRAIT(owner.current, TRAIT_NODEATH) || bloodsucker_blood_volume == 0)
 		check_end_torpor()
 	// Deduct Blood
 	if(owner.current.stat == CONSCIOUS && !HAS_TRAIT(owner.current, TRAIT_IMMOBILIZED) && !HAS_TRAIT(owner.current, TRAIT_NODEATH))

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -204,7 +204,6 @@
 	// Temporary Death? Convert to Torpor.
 	if(HAS_TRAIT(owner.current, TRAIT_NODEATH))
 		return
-	to_chat(owner.current, span_danger("Your immortal body will not yet relinquish your soul to the abyss. You enter Torpor."))
 	check_begin_torpor(TRUE)
 
 /datum/antagonist/bloodsucker/proc/HandleStarving() // I am thirsty for blood!

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
@@ -113,11 +113,18 @@
  * - Sol being over, dealt with by /sunlight/process() [bloodsucker_daylight.dm]
 */
 /datum/antagonist/bloodsucker/proc/check_begin_torpor(SkipChecks = FALSE)
+	var/mob/living/carbon/user = owner.current
+	/// Prevent Torpor whilst frenzied
+	var/datum/antagonist/bloodsucker/bloodsuckerdatum = IS_BLOODSUCKER(user)
+	if(bloodsuckerdatum.frenzied || (IS_DEAD_OR_INCAP(user) && bloodsuckerdatum.bloodsucker_blood_volume == 0))
+		to_chat(user, span_userdanger("Your frenzy prevents you from entering torpor!"))
+		return
 	/// Are we entering Torpor via Sol/Death? Then entering it isnt optional!
 	if(SkipChecks)
+		to_chat(dead_bloodsucker, span_danger("Your immortal body will not yet relinquish your soul to the abyss. You enter Torpor."))
 		torpor_begin()
 		return
-	var/mob/living/carbon/user = owner.current
+
 	var/total_brute = user.getBruteLoss_nonProsthetic()
 	var/total_burn = user.getFireLoss_nonProsthetic()
 	var/total_damage = total_brute + total_burn

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
@@ -121,7 +121,7 @@
 		return
 	/// Are we entering Torpor via Sol/Death? Then entering it isnt optional!
 	if(SkipChecks)
-		to_chat(dead_bloodsucker, span_danger("Your immortal body will not yet relinquish your soul to the abyss. You enter Torpor."))
+		to_chat(user, span_danger("Your immortal body will not yet relinquish your soul to the abyss. You enter Torpor."))
 		torpor_begin()
 		return
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
@@ -114,9 +114,8 @@
 */
 /datum/antagonist/bloodsucker/proc/check_begin_torpor(SkipChecks = FALSE)
 	var/mob/living/carbon/user = owner.current
-	/// Prevent Torpor whilst frenzied
-	var/datum/antagonist/bloodsucker/bloodsuckerdatum = IS_BLOODSUCKER(user)
-	if(bloodsuckerdatum.frenzied || (IS_DEAD_OR_INCAP(user) && bloodsuckerdatum.bloodsucker_blood_volume == 0))
+	/// Prevent Torpor whilst frenzied.
+	if(frenzied || (IS_DEAD_OR_INCAP(user) && bloodsucker_blood_volume == 0))
 		to_chat(user, span_userdanger("Your frenzy prevents you from entering torpor!"))
 		return
 	/// Are we entering Torpor via Sol/Death? Then entering it isnt optional!

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
@@ -124,7 +124,6 @@
 		to_chat(user, span_danger("Your immortal body will not yet relinquish your soul to the abyss. You enter Torpor."))
 		torpor_begin()
 		return
-
 	var/total_brute = user.getBruteLoss_nonProsthetic()
 	var/total_burn = user.getFireLoss_nonProsthetic()
 	var/total_damage = total_brute + total_burn


### PR DESCRIPTION

## About The Pull Request
Change torpor mechanic to be blocked if user is frenzied (or is dead and has 0 blood). Am open to input
## Why It's Good For The Game
Prevents torpor loop whilst technically unable to recover.
## Changelog
:cl:
fix: torpor healing and dying loop closed
/:cl:
