### PR TITLE
add pixel offsets so the collision makes sense

### DIFF
--- a/fulp_modules/mapping/station_objects/trees.dm
+++ b/fulp_modules/mapping/station_objects/trees.dm
@@ -3,3 +3,5 @@
 	desc = "A cherry tree that has been bio-engineered to keep its pink flowers year-round."
 	icon = 'fulp_modules/mapping/icons/cherry.dmi'
 	icon_state = "cherry"
+	pixel_x = -68
+	pixel_y = -20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pixel offset cherry tree. Any maps that use it might want to check that the positioning still makes sense!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #893
![dreamseeker_HYoXcx5LuQ](https://github.com/fulpstation/fulpstation/assets/27014495/1e3934a3-9121-42aa-ad24-4c10f452e8f9)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
image: cherry tree now has appropriate collision
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
