### PR TITLE
Turf click redirection for beefman tears, 1 extra range to interact with them, screentips and shoter balloon alerts

### DIFF
--- a/fulp_modules/features/species/beefmen/phobetor_trauma.dm
+++ b/fulp_modules/features/species/beefmen/phobetor_trauma.dm
@@ -162,6 +162,9 @@
 	. = ..()
 	created_on = world.time
 
+	AddElement(/datum/element/contextual_screentip_bare_hands, lmb_text = "Jump into the tear")
+	AddComponent(/datum/component/redirect_attack_hand_from_turf)
+
 /obj/effect/client_image_holder/phobetor/Destroy()
 	if(linked_to)
 		linked_to.linked_to = null
@@ -202,23 +205,22 @@
 	if(user != seer || !linked_to)
 		return
 	if(!active)
-		user.balloon_alert(user, "Your connection to [src] is too faint to pass through it.")
+		user.balloon_alert(user, "the tear is too faint!")
 		return
-	if(user.loc != src.loc)
-		user.balloon_alert(user, "Step into the Tear before using it.")
+	if(!in_range(usr, src))
 		return
 	for(var/obj/item/implant/tracking/imp in user.implants)
 		if(imp)
-			user.balloon_alert(user, "[imp] gives you the sense that you're being watched.")
+			user.balloon_alert(user, "something is watching you from inside!")
 			return
 	// Is this, or linked, stream being watched?
 	if(check_location_seen(user, get_turf(user)))
-		user.balloon_alert(user, "Not while you're being watched.")
+		user.balloon_alert(user, "not while you're being watched!")
 		return
 	if(check_location_seen(user, get_turf(linked_to)))
-		user.balloon_alert(user, "Your destination is being watched.")
+		user.balloon_alert(user, "the other side is being watched!")
 		return
-	user.balloon_alert(user, "You slip unseen through [src].")
+	user.balloon_alert(user, "slip into the tear")
 
 	var/mob/living/carbon/carbon_user = user
 	var/user_sanity = user.mob_mood.sanity


### PR DESCRIPTION
## About The Pull Request
Some QoL to Beefman

You can now teleport when you are 1 tile away from the tear, instead of being forced to be on top of it.
You will click the tear if you click the floor turf it is on, just like how airlocks work, no more pixel hunting.
Screentips.
And reworked some balloon alerts that were too long.
## Why It's Good For The Game
Random QoLs while I was making sure my Fulp branch was setup correctly again.
## Changelog
:cl: Guillaume Prata
qol: Clicking on the floor turf under a tear will move your click into the tear, easier teleports with no pixel hunting.
balance: Beefman can teleport using tears when they are 1 tile away from it instead of needing to be on top.
/:cl:
