### PR TITLE
Fix gnomed

### DIFF
--- a/fulp_modules/features/halloween/2020/costumes.dm
+++ b/fulp_modules/features/halloween/2020/costumes.dm
@@ -405,7 +405,7 @@
 	illustration = "pumpkin"
 	costume_contents = list(
 		/obj/item/clothing/under/costume_2020/gnome,
-		/obj/item/clothing/head/costume_2020/gnomed,
+		/obj/item/clothing/head/costume_2020/gnome/gnomed,
 		/obj/item/clothing/suit/costume_2020/gnome,
 		/obj/item/clothing/shoes/costume_2020/gnome,
 	)

--- a/fulp_modules/features/halloween/2020/costumes.dm
+++ b/fulp_modules/features/halloween/2020/costumes.dm
@@ -404,7 +404,7 @@
 /obj/item/storage/box/halloween/special/gnomed
 	illustration = "pumpkin"
 	costume_contents = list(
-		/obj/item/clothing/under/costume_2020/gnome,
+		/obj/item/clothing/under/costume_2020/gnomed,
 		/obj/item/clothing/head/costume_2020/gnome,
 		/obj/item/clothing/suit/costume_2020/gnome,
 		/obj/item/clothing/shoes/costume_2020/gnome,

--- a/fulp_modules/features/halloween/2020/costumes.dm
+++ b/fulp_modules/features/halloween/2020/costumes.dm
@@ -404,8 +404,8 @@
 /obj/item/storage/box/halloween/special/gnomed
 	illustration = "pumpkin"
 	costume_contents = list(
-		/obj/item/clothing/under/costume_2020/gnomed,
-		/obj/item/clothing/head/costume_2020/gnome,
+		/obj/item/clothing/under/costume_2020/gnome,
+		/obj/item/clothing/head/costume_2020/gnomed,
 		/obj/item/clothing/suit/costume_2020/gnome,
 		/obj/item/clothing/shoes/costume_2020/gnome,
 	)


### PR DESCRIPTION

## About The Pull Request
The halloween costume box had the wrong gnome hat.
## Why It's Good For The Game
I used to gnome people with the box and couldn't because it was bugged, now I can gnome people again!
## Changelog
:cl: Guillaume Prata
fix: The gnomed halloween box spawns the correct gnome hat now.
/:cl:
