### PR TITLE
Gives Heliostation, Selene and Pubby's morgues coroner surgery trays

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -48996,7 +48996,7 @@
 /area/station/science/robotics/lab)
 "mfv" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray/full/morgue,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mfJ" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -49213,8 +49213,8 @@
 "uly" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced,
-/obj/item/surgery_tray/full,
 /obj/machinery/newscaster/directional/west,
+/obj/item/surgery_tray/full/morgue,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "ulV" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -38361,7 +38361,7 @@
 /area/station/maintenance/department/medical)
 "mGU" = (
 /obj/structure/table/reinforced,
-/obj/item/surgery_tray/full,
+/obj/item/surgery_tray/full/morgue,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mGV" = (


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. They were either normal surgery duffels or normal trays, which don't have the cruel tools coroners should have access to.

Thanks to Nintyuk for pointing this out in the forums.
## Why It's Good For The Game

Gives coroners the tools they should have roundstart.
## Changelog
:cl:
fix: morgues on fulp maps now have coroner surgery trays, with their cruel surgery tools
/:cl:
