### PR TITLE
Added bitrunner order console to helio

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -66974,6 +66974,7 @@
 /area/station/service/cafeteria)
 "tfy" = (
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/computer/order_console/bitrunning,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "tfS" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -26530,10 +26530,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"clF" = (
-/obj/effect/spawner/random/maintenance,
-/turf/closed/mineral/random/low_chance,
-/area/centcom/asteroid/nearstation/bomb_site)
 "clG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -96734,7 +96730,7 @@ ckK
 ckK
 ckK
 ckK
-clF
+ckK
 cju
 cju
 ckK


### PR DESCRIPTION
## About The Pull Request
When I ported the helio rewire over to the tgu i forgot to add the bitrunner vendor.
Also removes a maints item spawner from inside the rocks in pubby's bomb test site that caused tests to fail beause of RNG.
## Why It's Good For The Game
Bitrunners like to be able to order stuff ig
## Changelog
:cl:
fix: Fixes Heliostation not having a bitrunning order console
/:cl:
