### PR TITLE
Adds Reload Mentors as an admin verb

### DIFF
--- a/fulp_modules/Z_edits/fulp_verbs.dm
+++ b/fulp_modules/Z_edits/fulp_verbs.dm
@@ -1,6 +1,6 @@
 /world/AVerbsDefault()
-	var/list/verbs = ..()
-	verbs.Add(
+	var/list/admin_verbs = ..()
+	admin_verbs.Add(
 		/client/proc/reload_mentors,
 	)
-	return list
+	return admin_verbs

--- a/fulp_modules/Z_edits/fulp_verbs.dm
+++ b/fulp_modules/Z_edits/fulp_verbs.dm
@@ -1,0 +1,6 @@
+/world/AVerbsDefault()
+	var/list/verbs = ..()
+	verbs.Add(
+		/client/proc/reload_mentors,
+	)
+	return list

--- a/fulp_modules/features/mentors/mentor.dm
+++ b/fulp_modules/features/mentors/mentor.dm
@@ -74,4 +74,20 @@ GLOBAL_PROTECT(mentor_href_token)
 		if(findtextEx(line, "#", 1, 2))
 			continue
 		new /datum/mentors(line)
+	for(var/client/admin in GLOB.admins)
+		admin.mentor_datum_set()
 
+/client/proc/reload_mentors()
+	set name = "Reload Mentors"
+	set category = "Mentor"
+
+	if(!src.holder)
+		return
+
+	var/confirm = tgui_alert(usr, "Are you sure you want to reload all mentors?", "Confirm", list("Yes", "No"))
+	if(confirm != "Yes")
+		return
+
+	load_mentors()
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Reload All Mentors") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
+	message_admins("[key_name_admin(usr)] manually reloaded mentors")

--- a/fulp_modules/features/mentors/mentor_clientprocs.dm
+++ b/fulp_modules/features/mentors/mentor_clientprocs.dm
@@ -27,7 +27,7 @@
 		return TRUE
 
 
-/client/proc/mentor_datum_set(admin)
+/client/proc/mentor_datum_set()
 	mentor_datum = GLOB.mentor_datums[ckey]
 	/// Admin with no mentor datum? let's fix that
 	if(!mentor_datum && check_rights_for(src, R_ADMIN,0))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5931,6 +5931,7 @@
 #include "fulp_modules\Z_edits\christmas.dm"
 #include "fulp_modules\Z_edits\felinid_edit.dm"
 #include "fulp_modules\Z_edits\fulp_bans.dm"
+#include "fulp_modules\Z_edits\fulp_verbs.dm"
 #include "fulp_modules\Z_edits\job_edits.dm"
 #include "fulp_modules\Z_edits\nightmare_edit.dm"
 #include "fulp_modules\Z_edits\upstream_bot.dm"


### PR DESCRIPTION

## About The Pull Request

- What it says on the tin. Basically a copypaste from `reload_admins()` but calling `load_mentors()` instead. Should be noted that, while it requires admin permissions, I've placed it in the mentor tab for convenience.
 - Added a block to `load_mentors()` to ensure admins whose ckey may not be in the mentor list are also considered when reloading. This may not be entirely desireable, as it's a situation that shouldn't happen, but we already do it in mentor_datum_set(), so it's mainly for consistency.
- Removed the seemingly useless parameter from `mentor_datum_set()`. What's that thing for?

This required a new Z-Edit, found in `fulp_verbs.dm` to add the verb into the `AVerbsDefault`, since it's a protected list.
## Why It's Good For The Game

Requested by an admin.
## Changelog
:cl:
fix: load_mentors() now correctly loads admins as mentors, even if their ckey isn't in the mentor list
admin: added a reload_mentors(), analogous to reload_admins()
/:cl:
