### PR TITLE
Allows normal tongues to speak Space Russian

### DIFF
--- a/fulp_modules/Z_edits/fulp_languages.dm
+++ b/fulp_modules/Z_edits/fulp_languages.dm
@@ -1,0 +1,3 @@
+// Allows all tongues to speak our languages
+/obj/item/organ/internal/tongue/get_possible_languages()
+	return ..() + /datum/language/russian

--- a/fulp_modules/features/species/beefmen/russian.dm
+++ b/fulp_modules/features/species/beefmen/russian.dm
@@ -35,6 +35,3 @@
 	disliked_foodtypes = VEGETABLES | FRUIT | CLOTH
 	liked_foodtypes = RAW | MEAT | FRIED
 	toxic_foodtypes = DAIRY | PINEAPPLE
-
-/obj/item/organ/internal/tongue/beefman/get_possible_languages()
-	return ..() + /datum/language/russian

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5931,6 +5931,7 @@
 #include "fulp_modules\Z_edits\christmas.dm"
 #include "fulp_modules\Z_edits\felinid_edit.dm"
 #include "fulp_modules\Z_edits\fulp_bans.dm"
+#include "fulp_modules\Z_edits\fulp_languages.dm"
 #include "fulp_modules\Z_edits\job_edits.dm"
 #include "fulp_modules\Z_edits\nightmare_edit.dm"
 #include "fulp_modules\Z_edits\upstream_bot.dm"


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. Recently re-reported, apparently it had been brought up before but I forgot to actually make the PR.
Oopsie.

Downside is that it requires a new Z-edit. Gave it its own file in case we ever do more stuff with languages in the future.
## Why It's Good For The Game

Primarily for the sake of compatibility with the bilingual quirk, since no other ways to learn space russian come to mind.
## Changelog
:cl:
fix: humanoids who know Space Russian can now speak it without having a beefman tongue
/:cl:
