### PR TITLE
Re-adds the option to toggle antag tips

### DIFF
--- a/fulp_modules/tg_edits.md
+++ b/fulp_modules/tg_edits.md
@@ -40,4 +40,4 @@
 - tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/ghostinfiltrator.ts
 - tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/monsterhunter.ts
 - tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/vampiricaccident.ts
-- tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/antag_tips.tsx
+- tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/antag_tips.tsx

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/antag_tips.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/antag_tips.tsx
@@ -1,0 +1,9 @@
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const antag_tips: FeatureToggle = {
+  name: 'Antagonist tips',
+  category: 'GAMEPLAY',
+  description:
+    'Gives a basic explanation on how to play an antagonist upon obtaining one.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. We lost the TGUI file in a TGU, so players weren't able to change the setting.
Also moved it to the `game_preferences` folder rather than the `character_preferences` one (not sure why we kept it there) and updated the `tg_edits.md` file accordingly.
## Why It's Good For The Game

Bug fix
## Changelog
:cl:
fix: Antag tips can once again be toggled on and off in the "Gameplay" section of game preferences.
/:cl:
