### PR TITLE
prison bot rebalance

### DIFF
--- a/fulp_modules/features/prison/prison_kitchen/food_overwrites.dm
+++ b/fulp_modules/features/prison/prison_kitchen/food_overwrites.dm
@@ -5,14 +5,15 @@
 /obj/item/food/friedegg
 	venue_value = FOOD_PRICE_TRASH
 
+/obj/item/food/butterdog
+	venue_value = FOOD_PRICE_CHEAP
+
 /**
  * Lizard food
  */
-/obj/item/food/grown/korta_nut
-	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/black_eggs
-	venue_value = FOOD_PRICE_TRASH
+	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/lizard_dumplings
 	venue_value = FOOD_PRICE_CHEAP
@@ -21,18 +22,21 @@
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/patzikula
-	venue_value = FOOD_PRICE_CHEAP
+	venue_value = FOOD_PRICE_NORMAL
 
 /obj/item/food/nectar_larvae
-	venue_value = FOOD_PRICE_NORMAL
+	venue_value = FOOD_PRICE_EXOTIC
+
+/obj/item/food/tiziran_sausage
+	venue_value = FOOD_PRICE_EXOTIC
 
 /**
  * Rat food
  */
-/obj/item/food/cheese
+/obj/item/food/cheese/wedge
 	venue_value = FOOD_PRICE_TRASH
 
-/obj/item/food/grilled_cheese_sandwich
+/obj/item/food/sandwich/cheese/grilled
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/cheese/wheel

--- a/fulp_modules/features/prison/prison_kitchen/prison_bots/head_of_security_bot.dm
+++ b/fulp_modules/features/prison/prison_kitchen/prison_bots/head_of_security_bot.dm
@@ -14,7 +14,7 @@
 			/obj/item/food/donut/plain = 6,
 			/obj/item/food/burger/superbite = 6,
 			/obj/item/food/pizza/vegetable = 5,
-			/obj/item/food/grilled_cheese_sandwich = 5,
+			/obj/item/food/sandwich/cheese/grilled = 5,
 			/obj/item/food/pancakes = 5,
 			/obj/item/food/spaghetti/butternoodles = 4,
 			/obj/item/food/meatbun = 4,

--- a/fulp_modules/features/prison/prison_kitchen/prison_bots/lizard_bot.dm
+++ b/fulp_modules/features/prison/prison_kitchen/prison_bots/lizard_bot.dm
@@ -10,14 +10,14 @@
 	self_defense_line = "I al oh se ahoah!"
 	orderable_objects = list(
 		VENUE_RESTAURANT = list(
-			/obj/item/food/grown/korta_nut = 5,
-			/obj/item/food/black_eggs = 4,
-			/obj/item/food/lizard_dumplings = 4,
+			/obj/item/food/black_eggs = 5,
+			/obj/item/food/lizard_dumplings = 5,
 			/obj/item/food/breadslice/root = 4,
 			/obj/item/food/bread/root = 3,
 			/obj/item/food/sauerkraut = 3,
 			/obj/item/food/patzikula = 3,
 			/obj/item/food/nectar_larvae = 2,
+			/obj/item/food/tiziran_sausage = 2,
 		),
 	)
 	found_seat_lines = list(

--- a/fulp_modules/features/prison/prison_kitchen/prison_bots/prisoner_bot.dm
+++ b/fulp_modules/features/prison/prison_kitchen/prison_bots/prisoner_bot.dm
@@ -15,7 +15,7 @@
 			/datum/reagent/consumable/nutriment/soup/hotchili = 3,
 			/obj/item/food/nugget = 4,
 			/datum/reagent/consumable/nutriment/soup/miso = 4,
-			/obj/item/food/grilled_cheese_sandwich = 3,
+			/obj/item/food/sandwich/cheese/grilled = 3,
 			/obj/item/food/spaghetti/boiledspaghetti = 3,
 			/obj/item/food/eggsausage = 3,
 			/obj/item/food/burger/plain = 1,

--- a/fulp_modules/features/prison/prison_kitchen/prison_bots/rat_bot.dm
+++ b/fulp_modules/features/prison/prison_kitchen/prison_bots/rat_bot.dm
@@ -9,9 +9,9 @@
 	self_defense_line = "Squeak!!"
 	orderable_objects = list(
 		VENUE_RESTAURANT = list(
-			/obj/item/food/cheese/wedge = 10,
-			/obj/item/food/grilled_cheese_sandwich = 8,
-			/obj/item/food/burger/cheese = 5,
+			/obj/item/food/cheese/wedge = 5,
+			/obj/item/food/sandwich/cheese/grilled = 5,
+			/obj/item/food/burger/cheese = 4,
 			/obj/item/food/sandwich/cheese = 4,
 			/obj/item/food/cheesyfries = 4,
 			/obj/item/food/cheese/wheel = 3,

--- a/fulp_modules/features/prison/prison_kitchen/prison_bots/warden_bot.dm
+++ b/fulp_modules/features/prison/prison_kitchen/prison_bots/warden_bot.dm
@@ -12,7 +12,8 @@
 	orderable_objects = list(
 		VENUE_RESTAURANT = list(
 			/obj/item/food/donut/plain = 8,
-			/obj/item/food/poutine = 6,
+			/obj/item/food/butterdog = 6,
+			/obj/item/food/poutine = 4,
 			/obj/item/food/pie/applepie = 4,
 			/obj/item/food/burger/cheese = 4,
 			/obj/item/food/eggsausage = 3,


### PR DESCRIPTION

## About The Pull Request

So anyway I was minding my business in helio perma when this occured
![image](https://github.com/fulpstation/fulpstation/assets/25415050/57e629fe-aaaa-4383-bed2-90c082dc1f6f)

Naturally I was shaken to my core, trying to regain composure I quickly opened the coding program of my choice and fixed the paths for the grilled cheese sandwich as well as the one of the cheese wedge.
It turns out redefining the items to add extra venue prices kind of screws us in the long term when the typepath changes and we inevitably dont get notified

i also modified a few values mostly related to how soup got refactored to add extra steps and how korta is more easily orderable


## Why It's Good For The Game
## Changelog
:cl:
fix: fixed bad perma prison bot orders
/:cl:
