### PR TITLE
Code cleanup on halloween gifts and beacons

### DIFF
--- a/fulp_modules/features/halloween/_code.dm
+++ b/fulp_modules/features/halloween/_code.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_EMPTY_TYPED(halloween_gifts, /obj/item/storage/box/halloween)
 /proc/populate_halloween_gifts()
 	var/list/valid_gifts = subtypesof(/obj/item/storage/box/halloween)
 	for(var/obj/item/storage/box/halloween/halloween_box as anything in valid_gifts)
-		if(!initial(halloween_boxes.theme_name))
+		if(!initial(halloween_box.theme_name))
 			valid_gifts -= halloween_box
 
 	GLOB.halloween_gifts = valid_gifts

--- a/fulp_modules/features/halloween/_code.dm
+++ b/fulp_modules/features/halloween/_code.dm
@@ -1,4 +1,4 @@
-GLOBAL_LIST_EMPTY(halloween_gifts)
+GLOBAL_LIST_EMPTY_TYPED(halloween_gifts, /obj/item/storage/box/halloween)
 
 /proc/populate_halloween_gifts()
 	var/list/valid_gifts = subtypesof(/obj/item/storage/box/halloween)

--- a/fulp_modules/features/halloween/_code.dm
+++ b/fulp_modules/features/halloween/_code.dm
@@ -115,6 +115,4 @@ GLOBAL_LIST_EMPTY_TYPED(halloween_gifts, /obj/item/storage/box/halloween)
 	if(!GLOB.halloween_gifts.len)
 		populate_halloween_gifts()
 
-	var/gift_type = pick(GLOB.halloween_gifts)
-
-	return gift_type
+	return pick(GLOB.halloween_gifts)

--- a/fulp_modules/features/halloween/_code.dm
+++ b/fulp_modules/features/halloween/_code.dm
@@ -1,3 +1,13 @@
+GLOBAL_LIST_EMPTY(halloween_gifts)
+
+/proc/populate_halloween_gifts()
+	var/list/valid_gifts = subtypesof(/obj/item/storage/box/halloween)
+	for(var/obj/item/storage/box/halloween/halloween_box as anything in valid_gifts)
+		if(!initial(halloween_boxes.theme_name))
+			valid_gifts -= halloween_box
+
+	GLOB.halloween_gifts = valid_gifts
+
 /**
  * Choice beacon
  * Purchased at Cargo, allows you to order any Costume you want
@@ -9,12 +19,15 @@
 	icon_state = "gangtool-white"
 
 /obj/item/choice_beacon/halloween/generate_display_names()
-	var/list/halloween_costumes = list()
-	for(var/generated_options in subtypesof(/obj/item/storage/box/halloween))
-		var/obj/item/storage/box/halloween/halloween_boxes = generated_options
-		if(!(initial(halloween_boxes.theme_name)))
-			continue
-		halloween_costumes[initial(halloween_boxes.theme_name)] = halloween_boxes
+	var/static/list/halloween_costumes
+	if(!halloween_costumes)
+		if(!GLOB.halloween_gifts.len)
+			populate_halloween_gifts()
+
+		halloween_costumes = list()
+		for(var/obj/item/storage/box/halloween/halloween_boxes as anything in GLOB.halloween_gifts)
+			halloween_costumes[initial(halloween_boxes.theme_name)] = halloween_boxes
+
 	return halloween_costumes
 
 /obj/item/choice_beacon/halloween/spawn_option(obj/choice, mob/living/gifted_person)
@@ -24,9 +37,12 @@
 /// Debug delivery beacon with unlimited uses
 /obj/item/choice_beacon/halloween/debug
 	name = "debug halloween delivery beacon"
-	desc = "Summon up to 100 boxes of halloween costumes to help you get spooky."
+	desc = "A wonder of bluespace technology, capable of warping in an unlimited amount halloween costumes to help you get spooky."
 	uses = 100
 
+/obj/item/choice_beacon/halloween/debug/consume_use(obj/choice_path, mob/living/user)
+	uses++
+	return ..()
 
 /**
  * Storage box code
@@ -96,14 +112,9 @@
 	item.add_fingerprint(user)
 
 /obj/item/halloween_gift/proc/get_gift_type()
-	if(!GLOB.possible_gifts.len)
-		var/list/gift_types_list = subtypesof(/obj/item/storage/box/halloween)
-		for(var/generated_options in gift_types_list)
-			var/obj/item/item = generated_options
-			if((!initial(item.icon_state)) || (!initial(item.inhand_icon_state)) || (initial(item.item_flags) & ABSTRACT))
-				gift_types_list -= generated_options
-		GLOB.possible_gifts = gift_types_list
+	if(!GLOB.halloween_gifts.len)
+		populate_halloween_gifts()
 
-	var/gift_type = pick(GLOB.possible_gifts)
+	var/gift_type = pick(GLOB.halloween_gifts)
 
 	return gift_type


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes  #1068.
Cleans up the procs for halloween beacons and gifts to remove useless checks on one hand and redundant work on the other.
The only other player-facing change is that the debug beacon is actually unlimited now, previously it was false advertisement.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix and code improvement.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Halloween gifts can no longer be empty due to choosing a box prototype
fix: The debug halloween beacon has actually unlimited uses now.
code: Removes useless checks and redundant loops from the code for halloween gifts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
