### PR TITLE
Makes some minor additions to detective offices on helio and selene (NOTICE BOARDS :D) 

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -4881,10 +4881,20 @@
 /area/space/nearstation)
 "aDK" = (
 /obj/structure/table/wood,
-/obj/item/toy/figure/detective,
 /obj/item/hand_labeler{
 	pixel_x = -5;
 	pixel_y = -8
+	},
+/obj/item/toy/figure/detective{
+	pixel_x = -10;
+	pixel_y = 3
+	},
+/obj/item/paper_bin/carbon{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = 6
 	},
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
@@ -5263,6 +5273,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "aFC" = (
@@ -19612,8 +19623,8 @@
 	dir = 1
 	},
 /obj/machinery/computer/monitor{
-	name = "backup power monitoring console";
-	dir = 1
+	dir = 1;
+	name = "backup power monitoring console"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -43488,8 +43499,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/power/terminal{
-	dir = 1;
-	cable_layer = 1
+	cable_layer = 1;
+	dir = 1
 	},
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
@@ -50064,6 +50075,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
+/obj/structure/filingcabinet/security,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "mAG" = (
@@ -58182,8 +58194,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/terminal{
-	dir = 1;
-	cable_layer = 1
+	cable_layer = 1;
+	dir = 1
 	},
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
@@ -77962,6 +77974,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/structure/noticeboard/directional/east,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "xGm" = (
@@ -78420,7 +78433,10 @@
 /obj/machinery/computer/records/security{
 	dir = 8
 	},
-/obj/machinery/newscaster/directional/east,
+/obj/machinery/requests_console/directional/east{
+	department = "Detective's Office";
+	name = "Detective's Requests Console"
+	},
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "xPt" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -55908,6 +55908,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/detective,
+/obj/structure/noticeboard/directional/east,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "sHD" = (
@@ -61278,6 +61279,10 @@
 /area/station/maintenance/department/engine)
 "uzk" = (
 /obj/machinery/light/directional/east,
+/obj/machinery/requests_console/directional/east{
+	department = "Detective's Office";
+	name = "Detective's Requests Console"
+	},
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "uzp" = (


### PR DESCRIPTION
## About The Pull Request
adds:
 request consoles 
notice boards
paper bin on helio
filing cabinet on helio

## Why It's Good For The Game
these things were missing on fulp maps.
the notice boards are a cool addition I think 
## Changelog
:cl:
add: notice boards on fulp maps' detective offices
fix: adds a few missing objects and items in det office
/:cl:
