### PR TITLE
Fixes recycler direction on Helio

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -38242,7 +38242,9 @@
 	dir = 4;
 	id = "garbage"
 	},
-/obj/machinery/recycler,
+/obj/machinery/recycler{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -38243,7 +38243,7 @@
 	id = "garbage"
 	},
 /obj/machinery/recycler{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{


### PR DESCRIPTION

## About The Pull Request
Recycler on helio was facing the wrong way, now it's not.
## Why It's Good For The Game
Makes the recycler face the right way
## Changelog
:cl:
fix: Helio's recycler now faces the right way
/:cl:
