### PR TITLE
Adds bigger art canvases to fulp maps

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -17699,6 +17699,9 @@
 	pixel_x = 32
 	},
 /obj/machinery/light/directional/east,
+/obj/item/canvas/fortyfive_twentyseven,
+/obj/item/canvas/fortyfive_twentyseven,
+/obj/item/canvas/fortyfive_twentyseven,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bHf" = (
@@ -62369,6 +62372,16 @@
 /obj/machinery/mineral/stacking_unit_console,
 /turf/closed/wall,
 /area/station/maintenance/disposal)
+"rlS" = (
+/obj/structure/table/glass,
+/obj/structure/sign/painting/library{
+	pixel_x = 32
+	},
+/obj/item/canvas/thirtysix_twentyfour,
+/obj/item/canvas/thirtysix_twentyfour,
+/obj/item/canvas/thirtysix_twentyfour,
+/turf/open/floor/wood,
+/area/station/service/library)
 "rlX" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -121146,7 +121159,7 @@ bzd
 bAS
 bCo
 bDO
-bFw
+rlS
 bGS
 bFw
 bKI

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -17076,9 +17076,6 @@
 /area/station/service/cafeteria)
 "bCo" = (
 /obj/structure/table/glass,
-/obj/structure/sign/painting/library{
-	pixel_x = 32
-	},
 /obj/item/canvas/twentythree_nineteen,
 /obj/item/canvas/twentythree_nineteen,
 /obj/item/canvas/twentythree_nineteen,
@@ -17258,12 +17255,12 @@
 	c_tag = "Library Gallery";
 	name = "Gallery Camera"
 	},
-/obj/structure/sign/painting/library{
-	pixel_x = 32
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_twentythree,
+/obj/structure/sign/painting/large/library{
+	dir = 4
 	},
-/obj/item/canvas/twentythree_twentythree,
-/obj/item/canvas/twentythree_twentythree,
-/obj/item/canvas/twentythree_twentythree,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bDP" = (
@@ -17695,13 +17692,13 @@
 /area/station/hallway/primary/central)
 "bGS" = (
 /obj/structure/table/glass,
-/obj/structure/sign/painting/library{
-	pixel_x = 32
-	},
 /obj/machinery/light/directional/east,
 /obj/item/canvas/fortyfive_twentyseven,
 /obj/item/canvas/fortyfive_twentyseven,
 /obj/item/canvas/fortyfive_twentyseven,
+/obj/structure/sign/painting/large/library{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/service/library)
 "bHf" = (
@@ -62374,9 +62371,6 @@
 /area/station/maintenance/disposal)
 "rlS" = (
 /obj/structure/table/glass,
-/obj/structure/sign/painting/library{
-	pixel_x = 32
-	},
 /obj/item/canvas/thirtysix_twentyfour,
 /obj/item/canvas/thirtysix_twentyfour,
 /obj/item/canvas/thirtysix_twentyfour,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -10350,6 +10350,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/item/canvas/twentyfour_twentyfour,
+/obj/item/canvas/thirtysix_twentyfour,
+/obj/item/canvas/fortyfive_twentyseven,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "aOu" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -50896,6 +50896,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"vJu" = (
+/obj/structure/sign/painting/large/library{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/library/artgallery)
 "vJD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
@@ -72878,8 +72884,8 @@ whJ
 ebp
 wJL
 mFu
-wJL
 roy
+vJu
 whJ
 whJ
 whJ

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -4977,6 +4977,8 @@
 	c_tag = "Service - Art Gallery";
 	network = list("ss13","service")
 	},
+/obj/structure/table/wood/fancy/green,
+/obj/item/canvas/thirtysix_twentyfour,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
 "bGI" = (
@@ -13391,6 +13393,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/table/wood/fancy/green,
+/obj/item/canvas/fortyfive_twentyseven,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
 "evR" = (
@@ -39388,6 +39392,8 @@
 /obj/structure/sign/painting/library{
 	pixel_x = 32
 	},
+/obj/structure/table/wood/fancy/green,
+/obj/item/canvas/thirtysix_twentyfour,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
 "mXH" = (
@@ -70814,6 +70820,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/table/wood/fancy/green,
+/obj/item/canvas/fortyfive_twentyseven,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
 "xIE" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -21868,9 +21868,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "hnB" = (
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
 /obj/structure/displaycase/trophy,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
@@ -57737,6 +57734,12 @@
 "tmO" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
+"tmR" = (
+/obj/structure/displaycase/trophy,
+/obj/machinery/light/directional/south,
+/obj/structure/sign/painting/large/library,
+/turf/open/floor/carpet/royalblue,
+/area/station/service/library/artgallery)
 "tmT" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/camera/directional/north{
@@ -60724,6 +60727,11 @@
 "uol" = (
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/hop)
+"uox" = (
+/obj/structure/displaycase/trophy,
+/obj/structure/sign/painting/large/library,
+/turf/open/floor/carpet/royalblue,
+/area/station/service/library/artgallery)
 "uoJ" = (
 /obj/machinery/airlock_sensor/incinerator_atmos{
 	pixel_x = 24
@@ -69704,9 +69712,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "xpb" = (
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
 /obj/structure/displaycase/trophy,
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/royalblue,
@@ -103069,7 +103074,7 @@ fug
 jqS
 nPk
 dNU
-xpb
+tmR
 wGC
 oCM
 wai
@@ -103840,7 +103845,7 @@ tGo
 tGo
 jHD
 rAQ
-hnB
+uox
 wGC
 wPs
 wai


### PR DESCRIPTION
## About The Pull Request
Helio, Pubby, and Selene are currently missing the bigger canvases. Well, no more! On Pubby and Helio I just put them on the tables that were already there, but for Selene I had to add a couple of extra ones on the sides. Nothing crazy though. Also replaces some of the small frames with the big ones, so there's a place to mount the new canvases.

Selene
![image](https://github.com/fulpstation/fulpstation/assets/42454181/4a415161-3221-4713-bcf2-9d7bfa09e1ee)
Pubby
![image](https://github.com/fulpstation/fulpstation/assets/42454181/3f2f5230-16df-4729-9722-5ab291d14d5a)
Helio
![image](https://github.com/fulpstation/fulpstation/assets/42454181/6b99527a-cd51-40f9-894a-5f48a0d7b72c)
## Why It's Good For The Game
Art is good, bigger art means bigger good.
## Changelog
:cl:
add: NT has finally begun stocking the art rooms of their stations with larger canvases!
/:cl:
