### PR TITLE
Handful of Bloodsucker fixes

### DIFF
--- a/fulp_modules/_defines/bloodsuckers.dm
+++ b/fulp_modules/_defines/bloodsuckers.dm
@@ -52,6 +52,7 @@
 #define CLAN_VENTRUE "Ventrue Clan"
 #define CLAN_MALKAVIAN "Malkavian Clan"
 #define CLAN_TZIMISCE "Tzimisce Clan"
+#define CLAN_VASSAL "your Master"
 
 #define TREMERE_VASSAL "tremere_vassal"
 #define FAVORITE_VASSAL "favorite_vassal"

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_moodlets.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_moodlets.dm
@@ -1,51 +1,51 @@
 /datum/mood_event/drankblood
-	description = "<span class='nicegreen'>I have fed greedly from that which nourishes me.</span>\n"
+	description = "<span class='nicegreen'>I have fed greedly from that which nourishes me.</span>"
 	mood_change = 10
 	timeout = 8 MINUTES
 
 /datum/mood_event/drankblood_bad
-	description = "<span class='boldwarning'>I drank the blood of a lesser creature. Disgusting.</span>\n"
+	description = "<span class='boldwarning'>I drank the blood of a lesser creature. Disgusting.</span>"
 	mood_change = -4
 	timeout = 3 MINUTES
 
 /datum/mood_event/drankblood_dead
-	description = "<span class='boldwarning'>I drank dead blood. I am better than this.</span>\n"
+	description = "<span class='boldwarning'>I drank dead blood. I am better than this.</span>"
 	mood_change = -7
 	timeout = 8 MINUTES
 
 /datum/mood_event/drankblood_synth
-	description = "<span class='boldwarning'>I drank synthetic blood. What is wrong with me?</span>\n"
+	description = "<span class='boldwarning'>I drank synthetic blood. What is wrong with me?</span>"
 	mood_change = -7
 	timeout = 8 MINUTES
 
 /datum/mood_event/drankkilled
-	description = "<span class='boldwarning'>I fed off of a dead person. I feel... less human.</span>\n"
+	description = "<span class='boldwarning'>I fed off of a dead person. I feel... less human.</span>"
 	mood_change = -15
 	timeout = 10 MINUTES
 
 /datum/mood_event/madevamp
-	description = "<span class='boldwarning'>A mortal has reached an apotheosis- undeath- by my own hand.</span>\n"
+	description = "<span class='boldwarning'>A mortal has reached an apotheosis- undeath- by my own hand.</span>"
 	mood_change = 15
-	timeout = 20 MINUTES
+	timeout = 5 MINUTES
 
 /datum/mood_event/coffinsleep
-	description = "<span class='nicegreen'>I slept in a coffin during the day. I feel whole again.</span>\n"
+	description = "<span class='nicegreen'>I slept in a coffin during the day. I feel whole again.</span>"
 	mood_change = 10
 	timeout = 6 MINUTES
 
 /datum/mood_event/daylight_1
-	description = "<span class='boldwarning'>I slept poorly in a makeshift coffin during the day.</span>\n"
+	description = "<span class='boldwarning'>I slept poorly in a makeshift coffin during the day.</span>"
 	mood_change = -3
 	timeout = 6 MINUTES
 
 /datum/mood_event/daylight_2
-	description = "<span class='boldwarning'>I have been scorched by the unforgiving rays of the sun.</span>\n"
+	description = "<span class='boldwarning'>I have been scorched by the unforgiving rays of the sun.</span>"
 	mood_change = -6
 	timeout = 6 MINUTES
 
 ///Candelabrum's mood event to non Bloodsucker/Vassals
 /datum/mood_event/vampcandle
-	description = "<span class='boldwarning'>Something is making your mind feel... loose.</span>\n"
+	description = "<span class='boldwarning'>Something is making your mind feel... loose.</span>"
 	mood_change = -15
 	timeout = 5 MINUTES
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_vassal.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_vassal.dm
@@ -1,0 +1,18 @@
+/**
+ * Vassal Clan
+ *
+ * Automatically assigned to Vassals who become Bloodsuckers mid-round.
+ * We can't level ourselves up or interact with our own Vassals.
+ */
+/datum/bloodsucker_clan/vassal
+	name = CLAN_VASSAL
+	description = "As a Vassal, you are too young to enter a Clan of your own. \n\
+		Continue to help your Master advance in their aspirations."
+	joinable_clan = FALSE
+	blood_drink_type = BLOODSUCKER_DRINK_SNOBBY //You drink the same as your Master.
+
+/datum/bloodsucker_clan/vassal/spend_rank(datum/antagonist/bloodsucker/source, mob/living/carbon/target, cost_rank = TRUE, blood_cost)
+	return FALSE
+
+/datum/bloodsucker_clan/vassal/interact_with_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/favorite/vassaldatum)
+	return FALSE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
@@ -132,7 +132,7 @@
  */
 /datum/objective/ventrue_clan_objective
 	name = "embrace"
-	explanation_text = "Use the Candelabrum to Rank your Favorite Vassal up enough to become a Bloodsucker and keep them alive until the end."
+	explanation_text = "Use the Persuasion Rack to Rank your Favorite Vassal up enough to become a Bloodsucker and keep them alive until the end."
 	martyr_compatible = TRUE
 
 /datum/objective/ventrue_clan_objective/check_completion()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
@@ -24,13 +24,19 @@
 			return ..()
 		return FALSE
 	var/datum/antagonist/vassal/favorite/vassaldatum = target.mind.has_antag_datum(/datum/antagonist/vassal/favorite)
+	var/datum/antagonist/bloodsucker/vassal_bloodsuker_datum = target.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	if(!vassaldatum)
 		return FALSE
 	// Purchase Power Prompt
 	var/list/options = list()
 	for(var/datum/action/cooldown/bloodsucker/power as anything in bloodsuckerdatum.all_bloodsucker_powers)
-		if(initial(power.purchase_flags) & VASSAL_CAN_BUY && !(locate(power) in vassaldatum.powers))
-			options[initial(power.name)] = power
+		if(!(initial(power.purchase_flags) & VASSAL_CAN_BUY))
+			continue
+		if(locate(power) in vassaldatum.powers)
+			continue
+		if(vassal_bloodsuker_datum && (locate(power) in vassal_bloodsuker_datum.powers))
+			continue
+		options[initial(power.name)] = power
 
 	if(options.len < 1)
 		to_chat(bloodsuckerdatum.owner.current, span_notice("You grow more ancient by the night!"))
@@ -75,11 +81,16 @@
 			target.add_traits(list(TRAIT_NOHARDCRIT, TRAIT_HARDLY_WOUNDED), BLOODSUCKER_TRAIT)
 			to_chat(target, span_notice("You feel yourself able to take cuts and stabbings like it's nothing."))
 		if(6 to INFINITY)
-			if(!target.mind.has_antag_datum(/datum/antagonist/bloodsucker))
+			if(!vassal_bloodsuker_datum)
+				if(vassaldatum.info_button_ref)
+					QDEL_NULL(vassaldatum.info_button_ref)
+				vassal_bloodsuker_datum = target.mind.add_antag_datum(/datum/antagonist/bloodsucker)
+				vassal_bloodsuker_datum.my_clan = new /datum/bloodsucker_clan/vassal(src)
+
 				to_chat(target, span_notice("You feel your heart stop pumping for the last time as you begin to thirst for blood, you feel... dead."))
-				target.mind.add_antag_datum(/datum/antagonist/bloodsucker)
 				bloodsuckerdatum.owner.current.add_mood_event("madevamp", /datum/mood_event/madevamp)
-			vassaldatum.set_vassal_level(target)
+
+			vassaldatum.set_vassal_level(vassal_bloodsuker_datum)
 
 	finalize_spend_rank(bloodsuckerdatum, cost_rank, blood_cost)
 	vassaldatum.LevelUpPowers()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
@@ -72,7 +72,7 @@
 	pay_cost()
 	ActivatePower(trigger_flags)
 	if(!(power_flags & BP_AM_TOGGLE) || !active)
-		StartCooldown()
+		DeactivatePower()
 	return TRUE
 
 /datum/action/cooldown/bloodsucker/proc/can_pay_cost()
@@ -128,9 +128,14 @@
 		to_chat(user, span_warning("Not while you're incapacitated!"))
 		return FALSE
 	// Constant Cost (out of blood)
-	if(constant_bloodcost > 0 && bloodsuckerdatum_power?.bloodsucker_blood_volume <= 0)
-		to_chat(user, span_warning("You don't have the blood to upkeep [src]."))
-		return FALSE
+	if(constant_bloodcost > 0)
+		if(bloodsuckerdatum_power)
+			if(bloodsuckerdatum_power.bloodsucker_blood_volume <= 0)
+				to_chat(user, span_warning("You don't have the blood to upkeep [src]."))
+				return FALSE
+			else if(user.blood_volume <= 0)
+				to_chat(user, span_warning("You don't have the blood to upkeep [src]."))
+				return FALSE
 	return TRUE
 
 /// NOTE: With this formula, you'll hit half cooldown at level 8 for that power.

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/veil.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/veil.dm
@@ -8,7 +8,7 @@
 		Clothes, gear, and Security/Medical HUD status is kept the same while this power is active."
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_IN_FRENZY
-	purchase_flags = BLOODSUCKER_DEFAULT_POWER|VASSAL_CAN_BUY
+	purchase_flags = BLOODSUCKER_DEFAULT_POWER
 	bloodcost = 15
 	constant_bloodcost = 0.1
 	cooldown_time = 10 SECONDS

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_coffin.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_coffin.dm
@@ -42,6 +42,7 @@
 	name = "black coffin"
 	desc = "For those departed who are not so dear."
 	icon_state = "coffin"
+	base_icon_state = "coffin"
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/vamp_obj.dmi'
 	open_sound = 'fulp_modules/features/antagonists/bloodsuckers/sounds/coffin_open.ogg'
 	close_sound = 'fulp_modules/features/antagonists/bloodsuckers/sounds/coffin_close.ogg'
@@ -64,6 +65,7 @@
 	name = "secure coffin"
 	desc = "For those too scared of having their place of rest disturbed."
 	icon_state = "securecoffin"
+	base_icon_state = "securecoffin"
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/vamp_obj.dmi'
 	open_sound = 'fulp_modules/features/antagonists/bloodsuckers/sounds/coffin_open.ogg'
 	close_sound = 'fulp_modules/features/antagonists/bloodsuckers/sounds/coffin_close.ogg'
@@ -86,6 +88,7 @@
 	name = "meat coffin"
 	desc = "When you're ready to meat your maker, the steaks can never be too high."
 	icon_state = "meatcoffin"
+	base_icon_state = "meatcoffin"
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/vamp_obj.dmi'
 	resistance_flags = FIRE_PROOF
 	open_sound = 'sound/effects/footstep/slime1.ogg'
@@ -108,6 +111,7 @@
 	name = "metal coffin"
 	desc = "A big metal sardine can inside of another big metal sardine can, in space."
 	icon_state = "metalcoffin"
+	base_icon_state = "metalcoffin"
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/vamp_obj.dmi'
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 	open_sound = 'sound/effects/pressureplate.ogg'

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -124,8 +124,12 @@
 		They usually ensure that victims are handcuffed, to prevent them from running away.\n\
 		Their rituals take time, allowing us to disrupt it."
 
+#ifdef BLOODSUCKER_TESTING
+	var/convert_progress = 1
+#else
 	/// Resets on each new character to be added to the chair. Some effects should lower it...
 	var/convert_progress = 3
+#endif
 	/// Mindshielded and Antagonists willingly have to accept you as their Master.
 	var/disloyalty_confirm = FALSE
 	/// Prevents popup spam.
@@ -195,7 +199,7 @@
 	density = TRUE
 
 	// Set up Torture stuff now
-	convert_progress = 3
+	convert_progress = initial(convert_progress)
 	disloyalty_confirm = FALSE
 	disloyalty_offered = FALSE
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -422,7 +422,6 @@
 	light_power = 3
 	light_range = 0 // to 2
 	density = FALSE
-	can_buckle = TRUE
 	anchored = FALSE
 	ghost_desc = "This is a magical candle which drains at the sanity of non Bloodsuckers and Vassals.\n\
 		Vassals can turn the candle on manually, while Bloodsuckers can do it from a distance."
@@ -474,6 +473,7 @@
 
 /obj/structure/bloodsucker/candelabrum/process()
 	if(!lit)
+		STOP_PROCESSING(SSobj, src)
 		return
 	for(var/mob/living/carbon/nearly_people in viewers(7, src))
 		/// We dont want Bloodsuckers or Vassals affected by this

--- a/fulp_modules/features/antagonists/bloodsuckers/code/vassal/types/favorite_vassal.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/vassal/types/favorite_vassal.dm
@@ -21,6 +21,10 @@
 /datum/antagonist/vassal/favorite/pre_mindshield(mob/implanter, mob/living/mob_override)
 	return COMPONENT_MINDSHIELD_RESISTED
 
-///Set the Vassal's rank to their Bloodsucker level
-/datum/antagonist/vassal/favorite/proc/set_vassal_level(mob/living/carbon/human/target)
-	master.bloodsucker_level = vassal_level
+///Set the Vassal's rank to their Bloodsucker level, and transfer all abilities to the Bloodsucker level.
+/datum/antagonist/vassal/favorite/proc/set_vassal_level(datum/antagonist/bloodsucker/vassal_bloodsucker_datum)
+	for(var/datum/action/cooldown/bloodsucker/bloodsucker_powers as anything in powers)
+		powers -= bloodsucker_powers
+		vassal_bloodsucker_datum.powers += bloodsucker_powers
+		bloodsucker_powers.bloodsuckerdatum_power = vassal_bloodsucker_datum
+	vassal_bloodsucker_datum.bloodsucker_level = vassal_level

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6000,6 +6000,7 @@
 #include "fulp_modules\features\antagonists\bloodsuckers\code\clans\clan_malkavian.dm"
 #include "fulp_modules\features\antagonists\bloodsuckers\code\clans\clan_nosferatu.dm"
 #include "fulp_modules\features\antagonists\bloodsuckers\code\clans\clan_tremere.dm"
+#include "fulp_modules\features\antagonists\bloodsuckers\code\clans\clan_vassal.dm"
 #include "fulp_modules\features\antagonists\bloodsuckers\code\clans\clan_ventrue.dm"
 #include "fulp_modules\features\antagonists\bloodsuckers\code\powers\_powers.dm"
 #include "fulp_modules\features\antagonists\bloodsuckers\code\powers\cloak.dm"


### PR DESCRIPTION
## About The Pull Request

- Favorite Vassals who become a Bloodsucker can no longer join a Clan, they are still apart of their Master and way too young to do their own stuff.
- I also removed their Vassal antag button once they become a Bloodsucker because it makes the action button list feel way too cluttered.
- I also fixed abilities like Distress not be active upon using it (and waiting the cooldown).
- Favorite Vassal abilities pre-bloodsucker now work and use blood.
- Favorite Vassal abilities pre-bloodsucker now properly set your new bloodsucker status to take your bloodsucker blood instead.
- Favorite Vassals post-bloodsucker cannot make favorite/revenge vassals.
- Bloodsucker moods no longer have a bunch of newlines
- Making a new bloodsucker no longer punishes for 20 fucking minutes.
- Custom coffins now have their proper respective icons.
- You can't buckle people to candelabrum anymore
- Ventrue's objective now says you need to use persuasion rack instead of candelabrum

## Why It's Good For The Game

Bugs and inconsistencies being patched is pretty awesome i think.

## Changelog