### PR TITLE
Frenzy exit amount now respects humanity level

### DIFF
--- a/fulp_modules/_defines/bloodsuckers.dm
+++ b/fulp_modules/_defines/bloodsuckers.dm
@@ -14,9 +14,9 @@
 /// Cost to convert someone after successful torture, in blood
 #define TORTURE_CONVERSION_COST 50
 /// Once blood is this low, will enter Frenzy
-#define FRENZY_THRESHOLD_ENTER 25
-/// Once blood is this high, will exit Frenzy
-#define FRENZY_THRESHOLD_EXIT 250
+#define FRENZY_MINIMUM_THRESHOLD_ENTER 25
+///Amount of blood on TOP of your frenzy limit you need to EXIT frenzy.
+#define FRENZY_EXTRA_BLOOD_NEEDED 50
 
 /**
  * Vassal defines

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -46,7 +46,7 @@
 	///How many Masquerade Infractions do we have?
 	var/masquerade_infractions = 0
 	///Blood required to enter Frenzy
-	var/frenzy_threshold = FRENZY_THRESHOLD_ENTER
+	var/frenzy_threshold = FRENZY_MINIMUM_THRESHOLD_ENTER
 	///If we are currently in a Frenzy
 	var/frenzied = FALSE
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -46,7 +46,8 @@
 		to_chat(owner.current, span_warning("You hit the maximum amount of lost Humanty, you are far from Human."))
 		return
 	humanity_lost += value
-	to_chat(owner.current, span_warning("You feel as if you lost some of your humanity, you will now enter Frenzy at [FRENZY_THRESHOLD_ENTER + (humanity_lost * 10)] Blood."))
+	frenzy_threshold = (FRENZY_MINIMUM_THRESHOLD_ENTER + humanity_lost * 10)
+	to_chat(owner.current, span_warning("You feel as if you lost some of your humanity, you will now enter Frenzy at [frenzy_threshold] Blood."))
 
 /// mult: SILENT feed is 1/3 the amount
 /datum/antagonist/bloodsucker/proc/handle_feeding(mob/living/carbon/target, mult=1, power_level)
@@ -214,7 +215,7 @@
 //	handled in bloodsucker_integration.dm
 
 	// BLOOD_VOLUME_EXIT: [250] - Exit Frenzy (If in one) This is high because we want enough to kill the poor soul they feed off of.
-	if(bloodsucker_blood_volume >= FRENZY_THRESHOLD_EXIT && frenzied)
+	if(bloodsucker_blood_volume >= (frenzy_threshold + FRENZY_EXTRA_BLOOD_NEEDED) && frenzied)
 		owner.current.remove_status_effect(/datum/status_effect/frenzy)
 	// BLOOD_VOLUME_BAD: [224] - Jitter
 	if(bloodsucker_blood_volume < BLOOD_VOLUME_BAD && prob(0.5) && !HAS_TRAIT(owner.current, TRAIT_NODEATH) && !HAS_TRAIT(owner.current, TRAIT_MASQUERADE))
@@ -224,7 +225,7 @@
 		owner.current.set_eye_blur_if_lower((8 - 8 * (bloodsucker_blood_volume / BLOOD_VOLUME_BAD))*2 SECONDS)
 
 	// The more blood, the better the Regeneration, get too low blood, and you enter Frenzy.
-	if(bloodsucker_blood_volume < (FRENZY_THRESHOLD_ENTER + (humanity_lost * 10)) && !frenzied)
+	if(bloodsucker_blood_volume < frenzy_threshold && !frenzied)
 		owner.current.apply_status_effect(/datum/status_effect/frenzy)
 	else if(bloodsucker_blood_volume < BLOOD_VOLUME_BAD)
 		additional_regen = 0.1


### PR DESCRIPTION
## About The Pull Request

Before:
Amount of blood to enter Frenzy increases when you lose humanity
Exiting frenzy requires 250 blood

Now:
Amount of blood to enter Frenzy increases when you lose humanity
Exiting frenzy requires the amount of blood to enter frenzy+50u extra

## Why It's Good For The Game

If you lose enough humanity I think bloodsuckers can get into a state where they endlessly enter and exit frenzy, this should fix that in a way that makes humanity a little more scary.