### PR TITLE
Fulpstation specific maps syndicate docking ports addition.

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -77956,7 +77956,9 @@
 /turf/open/floor/wood,
 /area/station/maintenance/aft/lesser)
 "xBJ" = (
-/obj/structure/cable,
+/obj/docking_port/stationary/syndicate/northwest{
+	dir = 8
+	},
 /turf/open/space/basic,
 /area/space)
 "xCv" = (
@@ -87919,7 +87921,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+xBJ
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -46650,6 +46650,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"snj" = (
+/obj/docking_port/stationary/syndicate/northwest{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "snD" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
@@ -62736,7 +62742,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+snj
 aaa
 aaa
 aaa

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -49016,6 +49016,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
+"qtR" = (
+/obj/docking_port/stationary/syndicate/northwest{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "qtW" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -78573,7 +78579,7 @@ iQW
 iQW
 iQW
 iQW
-iQW
+qtR
 iQW
 iQW
 iQW


### PR DESCRIPTION
Adds syndicate docking ports to Pubbystation, Heliostation and Selenestation. These are named Northwest under the docking_port/syndicate
## About The Pull Request

Adds syndicate docking ports to Pubbystation, Heliostation and Selenestation. These are named Northwest under the docking_port/syndicate
## Why It's Good For The Game

It should be possible to do your final.
## Changelog

Adds syndicate docking ports to Selenestation, Pubbystation and Heliostation.
:cl: fix 
/:cl: fix
