### PR TITLE
Icebox service changes

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -122,10 +122,10 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/tile/red/full,
+/obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red/full,
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
 "acE" = (
@@ -262,7 +262,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/structure/chair{
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_large,
@@ -1087,7 +1087,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "asJ" = (
-/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
@@ -1876,14 +1875,16 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aEU" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/kitchen/diagonal,
-/area/station/service/kitchen)
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/effect/turf_decal/tile/red/full,
+/obj/structure/table/wood,
+/turf/open/floor/iron/large,
+/area/station/service/kitchen/diner)
 "aFg" = (
 /obj/machinery/button/door/directional/east{
 	id = "lawyer_blast";
@@ -2016,9 +2017,6 @@
 /area/station/command/meeting_room)
 "aHZ" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
@@ -3068,6 +3066,7 @@
 "aWS" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets/donkpocketberry,
+/obj/item/aquarium_kit,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "aWV" = (
@@ -3614,6 +3613,8 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/south,
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/toy,
 /turf/open/floor/iron/half{
 	dir = 1
 	},
@@ -4546,13 +4547,14 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Service Diner North"
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/chair/sofa/corp/left{
+	dir = 4;
+	pixel_x = -4
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
 "bts" = (
@@ -14397,15 +14399,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
-"enG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/computer/department_orders/service{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/service)
 "enI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Tool Storage Maintenance"
@@ -17636,9 +17629,10 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "fqc" = (
-/obj/structure/table,
 /obj/item/clothing/mask/cigarette/cigar,
 /obj/effect/turf_decal/tile/red/full,
+/obj/structure/table/wood,
+/obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
 "fqv" = (
@@ -19286,9 +19280,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/table,
 /obj/item/clothing/head/fedora,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/table/wood,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
 "fRP" = (
@@ -20214,10 +20208,11 @@
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
 "ggD" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red/full,
+/obj/structure/chair/sofa/corp/right{
+	dir = 4;
+	pixel_x = -4
+	},
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
 "ggG" = (
@@ -21669,6 +21664,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Service Botany - Upper North"
 	},
+/obj/item/book/manual/hydroponics_pod_people,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "gER" = (
@@ -21907,11 +21903,11 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
 	pixel_y = 8
 	},
 /obj/structure/sign/poster/random/directional/north,
+/obj/structure/table/wood,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
 "gHS" = (
@@ -24591,11 +24587,11 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/structure/sign/poster/random/directional/north,
 /obj/effect/turf_decal/tile/red/full,
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
 "hBd" = (
@@ -27791,7 +27787,6 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/structure/table,
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = -3
 	},
@@ -27799,6 +27794,7 @@
 	pixel_x = 3
 	},
 /obj/effect/turf_decal/tile/red/full,
+/obj/structure/table/wood,
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
 "iAO" = (
@@ -30631,10 +30627,8 @@
 /area/station/hallway/primary/central)
 "jwv" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/item/holosign_creator/robot_seat/restaurant,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "jwx" = (
@@ -31119,12 +31113,19 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "jFA" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Service Hall"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/iron/textured_half,
 /area/station/hallway/secondary/service)
 "jFR" = (
 /obj/effect/turf_decal/stripes/line{
@@ -31749,9 +31750,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/modular_computer/preset/cargochat/service{
-	dir = 4
-	},
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "jPc" = (
@@ -31841,10 +31840,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "jQo" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/machinery/grill,
-/turf/open/floor/iron/kitchen/diagonal,
-/area/station/service/kitchen)
+/obj/effect/landmark/start/assistant,
+/turf/closed/wall,
+/area/station/commons/dorms)
 "jQt" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
@@ -32723,6 +32721,7 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/duct,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "keu" = (
@@ -32887,8 +32886,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/chair,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/landmark/start/assistant,
+/obj/structure/chair/comfy/black,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
 "kfZ" = (
@@ -34079,12 +34079,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "kvs" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
 	},
-/turf/open/floor/iron/kitchen/diagonal,
-/area/station/service/kitchen)
+/obj/effect/spawner/random/entertainment/arcade,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "kvu" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "IsolationCell";
@@ -36119,10 +36120,10 @@
 /turf/closed/wall,
 /area/mine/production)
 "kZz" = (
-/obj/machinery/computer/order_console/cook{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/computer/department_orders/service{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -37548,7 +37549,6 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "lxf" = (
-/obj/structure/table,
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = -3
 	},
@@ -37556,6 +37556,8 @@
 	pixel_x = 3
 	},
 /obj/effect/turf_decal/tile/red/full,
+/obj/structure/table/wood,
+/obj/structure/table/wood,
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
 "lxn" = (
@@ -38609,6 +38611,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/window/left/directional/east,
 /obj/structure/sign/warning/gas_mask/directional/north,
+/obj/machinery/vending/wardrobe/chef_wardrobe{
+	pixel_x = -2
+	},
 /turf/open/floor/plating/snowed/coldroom,
 /area/station/service/kitchen/coldroom)
 "lOz" = (
@@ -40037,18 +40042,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "mnj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Service Hall"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/service/general,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
 /turf/open/floor/iron/textured_half,
 /area/station/hallway/secondary/service)
 "mnu" = (
@@ -47669,8 +47662,9 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Service Hallway - Upper West"
 	},
-/obj/structure/table,
-/obj/item/aquarium_kit,
+/obj/machinery/modular_computer/preset/cargochat/service{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "oBs" = (
@@ -50487,11 +50481,12 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/newscaster/directional/north,
 /obj/effect/landmark/start/hangover,
+/obj/structure/chair/sofa/corp/left{
+	dir = 4;
+	pixel_x = -4
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
 "ptx" = (
@@ -50820,11 +50815,11 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/structure/chair,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Service Diner South"
 	},
+/obj/structure/chair/comfy/black,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
 "pxu" = (
@@ -52892,8 +52887,9 @@
 "qfe" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/item/book/manual/chef_recipes,
-/obj/item/holosign_creator/robot_seat/restaurant,
+/obj/machinery/processor{
+	pixel_y = 6
+	},
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "qfh" = (
@@ -56315,13 +56311,13 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/structure/table,
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = -3
 	},
 /obj/item/reagent_containers/condiment/peppermill{
 	pixel_x = 3
 	},
+/obj/structure/table/wood,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
 "rgi" = (
@@ -56396,7 +56392,6 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
 "rhh" = (
-/obj/machinery/biogenerator,
 /obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
@@ -56404,6 +56399,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/table/glass,
+/obj/item/watertank,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rhi" = (
@@ -57361,6 +57358,11 @@
 /obj/structure/sign/warning/electric_shock,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"rxS" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/biogenerator,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "rxW" = (
 /turf/closed/mineral/random/snow,
 /area/icemoon/underground/unexplored/rivers)
@@ -61636,12 +61638,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "sMb" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/machinery/processor{
-	pixel_y = 6
-	},
 /obj/machinery/light/directional/east,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/obj/item/book/manual/chef_recipes,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "sMg" = (
@@ -64055,9 +64056,6 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "tCs" = (
-/obj/structure/table,
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/item/watertank,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "tCu" = (
@@ -66540,10 +66538,10 @@
 "uqB" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/machinery/vending/wardrobe/chef_wardrobe{
-	pixel_x = -2
-	},
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/computer/order_console/cook{
+	dir = 1
+	},
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "uqG" = (
@@ -68590,11 +68588,11 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red/full,
 /obj/machinery/light/directional/west,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
 "vbd" = (
@@ -69198,9 +69196,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/structure/chair,
 /obj/effect/turf_decal/tile/red/full,
 /obj/structure/sign/poster/random/directional/west,
+/obj/structure/chair/comfy/black,
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
 "vlI" = (
@@ -70883,9 +70881,6 @@
 /area/station/service/chapel/office)
 "vMq" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/holopad,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
@@ -73693,6 +73688,7 @@
 	pixel_y = 32
 	},
 /obj/structure/table,
+/obj/item/storage/toolbox/fishing,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "wEh" = (
@@ -74020,7 +74016,7 @@
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
@@ -75256,9 +75252,6 @@
 /area/station/service/bar/atrium)
 "xbn" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
@@ -75962,7 +75955,7 @@
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
 "xlv" = (
-/obj/structure/chair{
+/obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_large,
@@ -241143,7 +241136,7 @@ xkp
 ygB
 ygB
 qBd
-ygB
+jQo
 ygB
 lOz
 ygB
@@ -245009,7 +245002,7 @@ tCs
 exw
 exw
 exw
-exw
+rxS
 glQ
 bMu
 exw
@@ -245265,9 +245258,9 @@ hvr
 exw
 exw
 jPa
-enG
 mdZ
 vlI
+nHa
 nHa
 izC
 hwM
@@ -245522,8 +245515,8 @@ xFA
 aTV
 rQt
 tGZ
-tGZ
 tqZ
+mnj
 mrF
 iFc
 bJA
@@ -246037,7 +246030,7 @@ kQX
 tGZ
 oBp
 mdZ
-mdZ
+kvs
 dqd
 bfZ
 izC
@@ -248868,7 +248861,7 @@ ggD
 ifg
 qZB
 gtw
-jQo
+xHi
 vMq
 eUw
 jZt
@@ -249121,7 +249114,7 @@ rrx
 nIr
 mdZ
 fRJ
-lxf
+aEU
 son
 qZB
 gtw
@@ -249383,7 +249376,7 @@ iXH
 qZB
 oEh
 kpf
-kvs
+gtw
 qfe
 ecZ
 fkk
@@ -249640,7 +249633,7 @@ son
 skp
 eDx
 fkk
-aEU
+fMP
 fMP
 fMP
 oyV


### PR DESCRIPTION

## About The Pull Request

Tried to fix icebox's cursed service using my 1000+ hours RPG maker experience

## Why It's Good For The Game

Icebox station's service department is currently in a state where a HOP, engineering, or skeleton crew access is required to bring it in line in terms of convenience, usability and efficiency with the other stations on rotation.

Cook is a role often recommended to beginners, this is a beginner server, and Icebox's kitchen breaks many conventions other stations teach you.

## Changelog

**Service** **Hall**:
* Botany counter (Bar entrance to Service Hall connector) expanded.
* Bio Generator no longer requires full Hydroponics access.
* A Fishing toolbox spawns next to the Aquarium Kit.

**Kitchen**:
* Moved the Produce Orders Console into the kitchen, Chef-Drobe moved to cold room.
* Updated from obsolete kitchen equipment.
* Moved disposal unit and adjusted disposal pipes accordingly. Previously it would intercept food thrown onto the counter.
* Improved diner décor (subjective).
* Added an assistant start to the diner.
* Added a random lighter spawn next to the lone cigar.
## Screenshots
![dreamseeker_NFfwwV5WTv](https://github.com/fulpstation/fulpstation/assets/157846764/9c2dcb4b-a5fc-44e4-912e-824515e3d5a4)
![dreamseeker_Ln2Txr26Hn](https://github.com/fulpstation/fulpstation/assets/157846764/147cbc96-493c-4447-a261-ac41cf72e49a)
![dreamseeker_lsnIQ7KZ4b](https://github.com/fulpstation/fulpstation/assets/157846764/c7d57ff8-fff5-4f0c-81b7-edcf267f9fc2)
