### PR TITLE
Fixes vassals keeping abilities post-BS death

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/_clan.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/_clan.dm
@@ -262,6 +262,6 @@
  * bloodsuckerdatum - antagonist datum of the Bloodsucker who turned them into a Vassal.
  * vassaldatum - the antagonist datum of the Vassal being offered up.
  */
-/datum/bloodsucker_clan/proc/on_favorite_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/vassaldatum)
+/datum/bloodsucker_clan/proc/on_favorite_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/favorite/vassaldatum)
 	SIGNAL_HANDLER
 	vassaldatum.BuyPower(new /datum/action/cooldown/bloodsucker/targeted/brawn)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_malkavian.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_malkavian.dm
@@ -43,7 +43,7 @@
 	var/message = pick(strings("malkavian_revelations.json", "revelations", "fulp_modules/strings/bloodsuckers"))
 	INVOKE_ASYNC(bloodsuckerdatum.owner.current, /atom/movable/proc/say, message, , , , , , CLAN_MALKAVIAN)
 
-/datum/bloodsucker_clan/malkavian/on_favorite_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/vassaldatum)
+/datum/bloodsucker_clan/malkavian/on_favorite_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/favorite/vassaldatum)
 	var/mob/living/carbon/carbonowner = vassaldatum.owner.current
 	if(istype(carbonowner))
 		carbonowner.gain_trauma(/datum/brain_trauma/mild/hallucinations, TRAUMA_RESILIENCE_ABSOLUTE)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_nosferatu.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_nosferatu.dm
@@ -32,7 +32,7 @@
 	if(!HAS_TRAIT(bloodsuckerdatum.owner.current, TRAIT_NOBLOOD))
 		bloodsuckerdatum.owner.current.blood_volume = BLOOD_VOLUME_SURVIVE
 
-/datum/bloodsucker_clan/nosferatu/on_favorite_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/vassaldatum)
+/datum/bloodsucker_clan/nosferatu/on_favorite_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/favorite/vassaldatum)
 	vassaldatum.owner.current.add_traits(list(TRAIT_VENTCRAWLER_NUDE, TRAIT_DISFIGURED), BLOODSUCKER_TRAIT)
 	to_chat(vassaldatum.owner.current, span_notice("Additionally, you can now ventcrawl while naked, and are permanently disfigured."))
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_tremere.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_tremere.dm
@@ -72,9 +72,9 @@
 
 	finalize_spend_rank(bloodsuckerdatum, cost_rank, blood_cost)
 
-/datum/bloodsucker_clan/tremere/on_favorite_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/vassaldatum)
-	var/datum/action/cooldown/spell/shapeshift/bat/batform = new(vassaldatum.owner || vassaldatum.owner.current)
-	batform.Grant(vassaldatum.owner.current)
+/datum/bloodsucker_clan/tremere/on_favorite_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/favorite/vassaldatum)
+	vassaldatum.batform = new(vassaldatum.owner || vassaldatum.owner.current)
+	vassaldatum.batform.Grant(vassaldatum.owner.current)
 
 /datum/bloodsucker_clan/tremere/on_vassal_made(datum/antagonist/bloodsucker/source, mob/living/user, mob/living/target)
 	. = ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
@@ -118,8 +118,8 @@
 	to_chat(bloodsuckerdatum.owner.current, span_danger("You don't have any levels or enough Blood to Rank [vassaldatum.owner.current] up with."))
 	return TRUE
 
-/datum/bloodsucker_clan/ventrue/on_favorite_vassal(datum/source, datum/antagonist/vassal/vassaldatum, mob/living/bloodsucker)
-	to_chat(bloodsucker, span_announce("* Bloodsucker Tip: You can now upgrade your Favorite Vassal by buckling them onto a Candelabrum!"))
+/datum/bloodsucker_clan/ventrue/on_favorite_vassal(datum/source, datum/antagonist/vassal/favorite/vassaldatum)
+	to_chat(source, span_announce("* Bloodsucker Tip: You can now upgrade your Favorite Vassal by buckling them onto a Candelabrum!"))
 	vassaldatum.BuyPower(new /datum/action/cooldown/bloodsucker/distress)
 
 #undef BLOODSUCKER_BLOOD_RANKUP_COST

--- a/fulp_modules/features/antagonists/bloodsuckers/code/vassal/types/favorite_vassal.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/vassal/types/favorite_vassal.dm
@@ -11,12 +11,22 @@
 	vassal_description = "The Favorite Vassal gets unique abilities over other Vassals depending on your Clan \
 		and becomes completely immune to Mindshields. If part of Ventrue, this is the Vassal you will rank up."
 
+	///The batform that some Favorite vassals get given by their Bloodsucker.
+	var/datum/action/cooldown/spell/shapeshift/bat/batform
 	///Bloodsucker levels, but for Vassals, used by Ventrue.
 	var/vassal_level
 
 /datum/antagonist/vassal/favorite/on_gain()
 	. = ..()
 	SEND_SIGNAL(master, BLOODSUCKER_MAKE_FAVORITE, src)
+
+/datum/antagonist/vassal/favorite/on_removal()
+	. = ..()
+	if(batform)
+		QDEL_NULL(batform)
+	var/mob/living/carbon/carbonowner = owner.current
+	carbonowner.cure_trauma_type(/datum/brain_trauma/mild/hallucinations, TRAUMA_RESILIENCE_ABSOLUTE)
+	carbonowner.cure_trauma_type(/datum/brain_trauma/special/bluespace_prophet/phobetor, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /datum/antagonist/vassal/favorite/pre_mindshield(mob/implanter, mob/living/mob_override)
 	return COMPONENT_MINDSHIELD_RESISTED


### PR DESCRIPTION
## About The Pull Request

Fixes Tremere and Malkavian Favorite Vassals from keeping their traumas and batform after their Bloodsucker reached Final Death.

## Why It's Good For The Game

fix