### PR TITLE
removes some copy paste from mentor stuff

### DIFF
--- a/fulp_modules/features/mentors/mentor.dm
+++ b/fulp_modules/features/mentors/mentor.dm
@@ -12,15 +12,21 @@ GLOBAL_PROTECT(mentor_href_token)
 	var/target
 	/// href token for Mentor commands, uses the same token used by Admins.
 	var/href_token
+	///The mob currently being followed with mfollow.
 	var/mob/following
 	/// Are we a Contributor?
 	var/is_contributor = FALSE
+	///List of all contributors for special MSAY text.
+	var/static/list/contributor_list = world.file2list("[global.config.directory]/mentors.txt")
 
 /datum/mentors/New(ckey)
 	if(!ckey)
 		QDEL_IN(src, 0)
 		throw EXCEPTION("Mentor datum created without a ckey")
 		return
+	link_mentor_datum(ckey)
+
+/datum/mentors/proc/link_mentor_datum(ckey)
 	target = ckey(ckey)
 	name = "[ckey]'s mentor datum"
 	href_token = GenerateToken()
@@ -31,19 +37,8 @@ GLOBAL_PROTECT(mentor_href_token)
 		owner.mentor_datum = src
 		owner.add_mentor_verbs()
 		GLOB.mentors += owner
-
-/datum/mentors/proc/CheckMentorHREF(href, href_list)
-	var/auth = href_list["mentor_token"]
-	. = auth && (auth == href_token || auth == GLOB.mentor_href_token)
-	if(.)
-		return
-	var/msg = !auth ? "no" : "a bad"
-	message_admins("[key_name_admin(usr)] clicked an href with [msg] authorization key!")
-	if(CONFIG_GET(flag/debug_admin_hrefs))
-		message_admins("Debug mode enabled, call not blocked. Please ask your coders to review this round's logs.")
-		log_world("UAH: [href]")
-		return TRUE
-	log_admin_private("[key_name(usr)] clicked an href with [msg] authorization key! [href]")
+	if(ckey in contributor_list)
+		is_contributor = TRUE
 
 /proc/RawMentorHrefToken(forceGlobal = FALSE)
 	var/tok = GLOB.mentor_href_token
@@ -61,6 +56,7 @@ GLOBAL_PROTECT(mentor_href_token)
 /proc/MentorHrefToken(forceGlobal = FALSE)
 	return "mentor_token=[RawMentorHrefToken(forceGlobal)]"
 
+///Loads all mentors from the mentors.txt file, setting admins as mentors as well.
 /proc/load_mentors()
 	GLOB.mentor_datums.Cut()
 	for(var/client/mentor_clients in GLOB.mentors)
@@ -75,7 +71,9 @@ GLOBAL_PROTECT(mentor_href_token)
 			continue
 		new /datum/mentors(line)
 	for(var/client/admin in GLOB.admins)
-		admin.mentor_datum_set()
+		//not a mentor, let's add them.
+		if(!GLOB.mentor_datums[admin.ckey])
+			new /datum/mentors(admin.ckey)
 
 /client/proc/reload_mentors()
 	set name = "Reload Mentors"

--- a/fulp_modules/features/mentors/mentor_clientprocs.dm
+++ b/fulp_modules/features/mentors/mentor_clientprocs.dm
@@ -9,11 +9,6 @@
 
 // Overwrites /client/Topic to return for mentor client procs
 /client/Topic(href, href_list, hsrc)
-	if(mentor_client_procs(href_list))
-		return
-	return ..()
-
-/client/proc/mentor_client_procs(href_list)
 	if(href_list["mentor_msg"])
 		cmd_mentor_pm(href_list["mentor_msg"],null)
 		return TRUE
@@ -21,28 +16,19 @@
 	/// Mentor Follow
 	if(href_list["mentor_follow"])
 		var/mob/living/followed_guy = locate(href_list["mentor_follow"])
-
 		if(istype(followed_guy))
 			mentor_follow(followed_guy)
 		return TRUE
-
+	return ..()
 
 /client/proc/mentor_datum_set()
 	mentor_datum = GLOB.mentor_datums[ckey]
-	/// Admin with no mentor datum? let's fix that
-	if(!mentor_datum && check_rights_for(src, R_ADMIN, 0))
-		new /datum/mentors(ckey)
 	if(mentor_datum)
-		GLOB.mentors |= src
-		mentor_datum.owner = src
-		add_mentor_verbs()
-		var/list/cdatums = list()
-		for(var/coder in world.file2list("[global.config.directory]/contributors.txt"))
-			cdatums += ckey(coder)
-		if(ckey in cdatums)
-			mentor_datum.is_contributor = TRUE
+		mentor_datum.link_mentor_datum(ckey)
+	else if(holder)
+		new /datum/mentors(ckey)
 
 ///Verifies if the client is considered a Mentor, AKA has a Mentor datum or is an Admin.
 /client/proc/is_mentor()
-	if(mentor_datum || check_rights_for(src, R_ADMIN, 0))
+	if(mentor_datum || holder)
 		return TRUE

--- a/fulp_modules/features/mentors/mentorpm.dm
+++ b/fulp_modules/features/mentors/mentorpm.dm
@@ -54,7 +54,7 @@
 	log_mentor("Mentor PM: [key_name(src)]->[key_name(chosen_client)]: [msg]")
 
 	msg = emoji_parse(msg)
-	chosen_client << 'sound/items/bikehorn.ogg'
+	SEND_SOUND(chosen_client, 'sound/items/bikehorn.ogg')
 	if(chosen_client.is_mentor())
 		if(is_mentor())
 			/// Both are Mentors

--- a/fulp_modules/features/mentors/mentorsay.dm
+++ b/fulp_modules/features/mentors/mentorsay.dm
@@ -28,7 +28,7 @@
 		msg = "<b><font color = #A097FE><span class='prefix'>HOP:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message linkify'>[msg]</span></font></b>"
 	else if(mentor_datum?.is_contributor)
 		msg = "<b><font color = #16abf9><span class='prefix'>CONTRIB:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message linkify'>[msg]</span></font></b>"
-	else if(check_rights_for(src, R_ADMIN, 0))
+	else if(holder)
 		msg = "<b><font color = #8A2BE2><span class='prefix'>STAFF:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message linkify'>[msg]</span></font></b>"
 	else
 		msg = "<b><font color = #E236D8><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message linkify'>[msg]</span></font></b>"


### PR DESCRIPTION
## About The Pull Request

removes checking for R_ADMIN and replaces it with having a holder, there were only 2 args on the proc and we provided 3 which was a little fucked and probably best to replace it.
I cut down on copy paste to give the mentor datum and it now has its own proc to set up the mentor verbs and such which is pretty cool so hopefully roundstart and latejoin mentors get the same abilities

## Why It's Good For The Game

I am still trying to fix inconsistencies with the mentor panel, the last PR made it work some of the time but runtimes are not helping me figure out why the rest isn't working, though apparently it's reportedly not working for admins, so I thought best next step would be to make mentors and admins more consistent and make sure they always are the same level.