### PR TITLE
adds 2023 to the halloween beacon

### DIFF
--- a/fulp_modules/features/halloween/_code.dm
+++ b/fulp_modules/features/halloween/_code.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_EMPTY_TYPED(halloween_gifts, /obj/item/storage/box/halloween)
 /obj/item/storage/box/halloween/edition_22
 	year = 2022
 
-/obj/item/storage/box/halloween/edition_22
+/obj/item/storage/box/halloween/edition_23
 	year = 2023
 
 /**

--- a/fulp_modules/features/halloween/_code.dm
+++ b/fulp_modules/features/halloween/_code.dm
@@ -83,6 +83,9 @@ GLOBAL_LIST_EMPTY_TYPED(halloween_gifts, /obj/item/storage/box/halloween)
 /obj/item/storage/box/halloween/edition_22
 	year = 2022
 
+/obj/item/storage/box/halloween/edition_22
+	year = 2023
+
 /**
  * Gift code
  */

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6158,6 +6158,7 @@
 #include "fulp_modules\features\halloween\2021\costumes.dm"
 #include "fulp_modules\features\halloween\2021\costumes_gags.dm"
 #include "fulp_modules\features\halloween\2022\costumes.dm"
+#include "fulp_modules\features\halloween\2023\costumes.dm"
 #include "fulp_modules\features\jobs\inventories.dm"
 #include "fulp_modules\features\jobs\job_integration.dm"
 #include "fulp_modules\features\lisa\joelgun.dm"


### PR DESCRIPTION
i messed up and forgot to add this code
## About The Pull Request
I apparently missed the vital code to make it spawnable outside of admin spawns so now the 2023 costume can spawn
## Why It's Good For The Game

it fix mistake :)
## Changelog
so when adding 2023 to the beacons i forgot to add the code to make it spawn in beacons the costume is now no longer admin spawn only
:cl:

code: adds the missing code to make it spawn in halloween beacons (whoopsie)

:cl:
