### PR TITLE
 Posession now does revive the dead and turns them into temporary vassals

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
@@ -25,7 +25,7 @@
  * conversion_target - Person being vassalized
  */
 /datum/antagonist/bloodsucker/proc/can_make_vassal(mob/living/conversion_target)
-	if(!iscarbon(conversion_target) || conversion_target.stat > UNCONSCIOUS)
+	if(!iscarbon(conversion_target))
 		return FALSE
 	// No Mind!
 	if(!conversion_target.mind)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -274,7 +274,7 @@
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = user.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	if(target.stat > UNCONSCIOUS)
 		balloon_alert(user, "too badly injured!")
-		return TRUE
+		return FALSE
 
 	if(IS_VASSAL(target))
 		var/datum/antagonist/vassal/vassaldatum = target.mind.has_antag_datum(/datum/antagonist/vassal)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -272,6 +272,10 @@
  */
 /obj/structure/bloodsucker/vassalrack/proc/torture_victim(mob/living/user, mob/living/target)
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = user.mind.has_antag_datum(/datum/antagonist/bloodsucker)
+	if(target.stat > UNCONSCIOUS)
+		balloon_alert(user, "too badly injured!")
+		return TRUE
+
 	if(IS_VASSAL(target))
 		var/datum/antagonist/vassal/vassaldatum = target.mind.has_antag_datum(/datum/antagonist/vassal)
 		if(!vassaldatum.master.broke_masquerade)


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.
There's nothing else player facing (other than a balloon alert), but code-wise `can_make_vassal()` will now succeed even if the target is in hardcrit or worse. That check is now specific to the persuassion rack which is (currently) the only other way for someone to become a vassal.
## Why It's Good For The Game

It's a bugfix.

## Changelog
:cl:
fix: Posession now revives those who are dead or in hard crit and turns them into temporary vassals
qol: Added a balloon alert that indicates when someone cannot be tortured in a persuasion rack due to being dead or in hard crit.
/:cl:
