### PR TITLE
Syndicate Engineers & The Prototype Station

### DIFF
--- a/fulp_modules/_defines/fulp_defines.dm
+++ b/fulp_modules/_defines/fulp_defines.dm
@@ -51,3 +51,6 @@
 
 ///Define for the 'Rabbits' Faction.
 #define FACTION_RABBITS "rabbits"
+
+//Define for the Syndicate Engineer Ruin, used in 'syndicate_engineer.dm"
+#define ROLE_SYNDICATE_ENGINEER "Syndicate Engineer"

--- a/fulp_modules/mapping/areas/areas.dm
+++ b/fulp_modules/mapping/areas/areas.dm
@@ -67,3 +67,53 @@
 /area/ruin/space/has_grav/powered/beef/atmos
 	name = "beef station atmos"
 	icon_state = "beef_station_atmos"
+
+
+
+
+/area/ruin/has_grav/prototype
+	requires_power = TRUE
+	outdoors = FALSE
+	power_light = FALSE
+	power_equip = FALSE
+	power_environ = FALSE
+
+/area/ruin/has_grav/prototype/Captain
+	name = "Prototype Captain's quarter"
+	icon_state = "blue"
+
+/area/ruin/has_grav/prototype/arrivals
+	name = "Prototype Arrivals"
+	icon_state = "hallP"
+
+/area/ruin/has_grav/prototype/hallway
+	name = "Prototype Main Hallway"
+	icon_state = "hallS"
+
+/area/ruin/has_grav/prototype/medsci
+	name = "Prototype Med-Sci"
+	icon_state = "green"
+
+/area/ruin/has_grav/prototype/botany
+	name = "Prototype Botany"
+	icon_state = "garden"
+
+/area/ruin/has_grav/prototype/engineering
+	name = "Prototype Engineering"
+	icon_state = "engi_storage"
+
+/area/ruin/has_grav/prototype/solars
+	name = "Prototype Solars"
+	icon_state = "engi_storage"
+
+/area/ruin/has_grav/prototype/kitchen
+	name = "Prototype Kitchen"
+	icon_state = "kitchen"
+
+/area/ruin/has_grav/prototype/brig
+	name = "Prototype Brig"
+	icon_state = "maint_brig"
+
+/area/ruin/has_grav/prototype/dorms
+	name = "Prototype Dormitories"
+	icon_state = "dorms"

--- a/fulp_modules/mapping/areas/areas.dm
+++ b/fulp_modules/mapping/areas/areas.dm
@@ -80,40 +80,50 @@
 
 /area/ruin/has_grav/prototype/Captain
 	name = "Prototype Captain's quarter"
-	icon_state = "blue"
+	icon = 'icons/area/areas_station.dmi'
+	icon_state = "captain"
 
 /area/ruin/has_grav/prototype/arrivals
 	name = "Prototype Arrivals"
-	icon_state = "hallP"
+	icon = 'icons/area/areas_station.dmi'
+	icon_state = "entry"
 
 /area/ruin/has_grav/prototype/hallway
 	name = "Prototype Main Hallway"
-	icon_state = "hallS"
+	icon = 'icons/area/areas_station.dmi'
+	icon_state = "hall"
 
 /area/ruin/has_grav/prototype/medsci
 	name = "Prototype Med-Sci"
-	icon_state = "green"
+	icon = 'icons/area/areas_station.dmi'
+	icon_state = "medbay"
 
 /area/ruin/has_grav/prototype/botany
 	name = "Prototype Botany"
-	icon_state = "garden"
+	icon = 'icons/area/areas_station.dmi'
+	icon_state = "hydro"
 
 /area/ruin/has_grav/prototype/engineering
 	name = "Prototype Engineering"
-	icon_state = "engi_storage"
+	icon = 'icons/area/areas_station.dmi'
+	icon_state = "engie"
 
 /area/ruin/has_grav/prototype/solars
 	name = "Prototype Solars"
-	icon_state = "engi_storage"
+	icon = 'icons/area/areas_station.dmi'
+	icon_state = "panels"
 
 /area/ruin/has_grav/prototype/kitchen
 	name = "Prototype Kitchen"
+	icon = 'icons/area/areas_station.dmi'
 	icon_state = "kitchen"
 
 /area/ruin/has_grav/prototype/brig
 	name = "Prototype Brig"
-	icon_state = "maint_brig"
+	icon = 'icons/area/areas_station.dmi'
+	icon_state = "brig"
 
 /area/ruin/has_grav/prototype/dorms
 	name = "Prototype Dormitories"
+	icon = 'icons/area/areas_station.dmi'
 	icon_state = "dorms"

--- a/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
+++ b/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
@@ -90,11 +90,13 @@
 	pixel_y = 4;
 	pixel_x = -2
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
 /turf/open/floor/iron/smooth/airless,
 /area/ruin/has_grav/prototype/brig)
 "au" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/survival,
 /obj/item/reagent_containers/hypospray/medipen/survival,
 /turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/has_grav/prototype/brig)
@@ -249,6 +251,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/has_grav/prototype/brig)
 "aQ" = (
@@ -271,7 +275,9 @@
 	req_access = null
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/has_grav/prototype/brig)
 "aT" = (
@@ -418,6 +424,9 @@
 	},
 /obj/effect/decal/cleanable/vomit/old,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth/airless,
 /area/ruin/has_grav/prototype/brig)
 "bt" = (
@@ -1066,6 +1075,8 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/smooth/airless,
 /area/ruin/has_grav/prototype/brig)
 "dL" = (
@@ -1107,6 +1118,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker/airless,
 /area/ruin/has_grav/prototype/arrivals)
 "dR" = (
@@ -1600,7 +1612,6 @@
 /area/ruin/has_grav/prototype/engineering)
 "fD" = (
 /obj/effect/gibspawner/human,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/suit/space/syndicate/black/red,
 /obj/item/clothing/head/helmet/space/syndicate/black/red,
 /obj/structure/lattice,
@@ -1617,12 +1628,10 @@
 /turf/open/floor/iron/airless,
 /area/ruin/has_grav/prototype/botany)
 "fF" = (
-/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/checker/airless,
-/area/ruin/has_grav/prototype/arrivals)
+/obj/item/t_scanner,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
 "fG" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	icon_state = "blood1";
@@ -1630,6 +1639,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/airless,
 /area/ruin/has_grav/prototype/arrivals)
 "fH" = (
@@ -1865,7 +1875,7 @@
 /area/ruin/has_grav/prototype/hallway)
 "iC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
+/obj/structure/firelock_frame,
 /turf/open/floor/plating/airless,
 /area/ruin/has_grav/prototype/hallway)
 "iI" = (
@@ -1910,10 +1920,8 @@
 /turf/open/floor/plating,
 /area/ruin/has_grav/prototype/botany)
 "mK" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/item/electronics/firelock,
 /turf/open/floor/plating/airless,
 /area/ruin/has_grav/prototype/botany)
 "ng" = (
@@ -2037,7 +2045,9 @@
 /area/ruin/has_grav/prototype/hallway)
 "Cz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/has_grav/prototype/brig)
 "DP" = (
@@ -2131,7 +2141,7 @@
 /area/ruin/has_grav/prototype/medsci)
 "Oo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
@@ -2142,6 +2152,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker/airless,
 /area/ruin/has_grav/prototype/arrivals)
 "OI" = (
@@ -2169,7 +2180,7 @@
 "Pf" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/checker/airless,
@@ -2232,7 +2243,8 @@
 /area/ruin/has_grav/prototype/engineering)
 "Rw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/has_grav/prototype/brig)
 "St" = (
@@ -2313,22 +2325,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/airless,
 /area/ruin/has_grav/prototype/dorms)
+"Wp" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
+/obj/item/toy/plush/shrimp,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/dorms)
 "WB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker/airless,
 /area/ruin/has_grav/prototype/arrivals)
 "WO" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/built{
-	icon_state = "bulb-empty";
-	dir = 1
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
-/obj/item/toy/plush/shrimp,
-/turf/open/floor/wood/airless,
-/area/ruin/has_grav/prototype/dorms)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/arrivals)
 "XU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -2550,12 +2568,12 @@ gC
 fr
 dT
 be
-fF
+Ys
 dP
 OD
 OD
 wx
-fl
+WO
 fl
 fG
 dr
@@ -2788,7 +2806,7 @@ fx
 cH
 bB
 ab
-WO
+dx
 Tf
 ex
 Kf
@@ -2822,7 +2840,7 @@ fz
 bB
 cH
 ab
-dy
+Wp
 eO
 ab
 dY
@@ -2849,7 +2867,7 @@ aa
 aa
 ak
 av
-aQ
+Rw
 bv
 bV
 dC
@@ -3371,7 +3389,7 @@ eo
 PN
 kg
 NW
-fj
+fF
 kg
 cs
 wz

--- a/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
+++ b/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
@@ -1953,6 +1953,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/has_grav/prototype/medsci)
+"qk" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/closet/crate/solarpanel_small,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/solars)
 "qs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3243,7 +3248,7 @@ eh
 eh
 bA
 eh
-eh
+qk
 dl
 bC
 "}

--- a/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
+++ b/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
@@ -1028,15 +1028,11 @@
 /area/ruin/has_grav/prototype/botany)
 "dH" = (
 /obj/structure/cable,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/iron/airless,
 /area/ruin/has_grav/prototype/engineering)
 "dI" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wallframe/apc{

--- a/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
+++ b/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
@@ -1,0 +1,3589 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ab" = (
+/turf/closed/wall,
+/area/ruin/has_grav/prototype/dorms)
+"ac" = (
+/obj/structure/girder/displaced,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/medsci)
+"ad" = (
+/turf/closed/wall,
+/area/ruin/has_grav/prototype/medsci)
+"ae" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"af" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"ag" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/mob_spawn/ghost_role/human/syndicate_engineer{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/space/has_grav/powered)
+"ah" = (
+/obj/effect/mob_spawn/ghost_role/human/syndicate_engineer{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/space/has_grav/powered)
+"ai" = (
+/turf/closed/wall,
+/area/ruin/has_grav/prototype/brig)
+"aj" = (
+/turf/closed/wall/r_wall,
+/area/ruin/has_grav/prototype/brig)
+"ak" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/brig)
+"al" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"am" = (
+/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"an" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"ao" = (
+/turf/closed/wall/r_wall,
+/area/ruin/has_grav/prototype/Captain)
+"ap" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/Captain)
+"aq" = (
+/turf/closed/wall,
+/area/ruin/has_grav/prototype/kitchen)
+"ar" = (
+/turf/closed/wall,
+/area/ruin/has_grav/prototype/hallway)
+"as" = (
+/obj/effect/spawner/random/structure/crate_abandoned,
+/turf/template_noop,
+/area/template_noop)
+"at" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/reagent_containers/pill/maintenance,
+/obj/item/paper/crumpled/fluff{
+	pixel_y = 4;
+	pixel_x = -2
+	},
+/turf/open/floor/iron/smooth/airless,
+/area/ruin/has_grav/prototype/brig)
+"au" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/survival,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/ruin/has_grav/prototype/brig)
+"av" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/disabler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/ruin/has_grav/prototype/brig)
+"aw" = (
+/obj/structure/table/reinforced,
+/obj/item/poster/random_official,
+/obj/item/poster/random_official,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/ruin/has_grav/prototype/brig)
+"ax" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/light{
+	icon_state = "tube";
+	dir = 8
+	},
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"ay" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"az" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/item/clothing/head/beret/centcom_formal,
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag{
+	pixel_y = -8
+	},
+/obj/item/ammo_casing/c45/spent{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"aA" = (
+/obj/structure/safe,
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"aB" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/fruit_bowl{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"aC" = (
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"aD" = (
+/obj/machinery/vending/boozeomat/all_access,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"aF" = (
+/obj/machinery/door/airlock{
+	name = "Shower"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/showroomfloor/airless,
+/area/ruin/has_grav/prototype/hallway)
+"aG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"aI" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/light/small/built{
+	icon_state = "bulb-empty";
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor/airless,
+/area/ruin/has_grav/prototype/hallway)
+"aJ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	icon_state = "sink_alt";
+	pixel_x = -10
+	},
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"aK" = (
+/turf/template_noop,
+/area/ruin/has_grav/prototype/medsci)
+"aL" = (
+/obj/machinery/airalarm/directional/east{
+	req_access = null
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/medsci)
+"aM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/molten_object/large,
+/obj/item/circuitboard/computer/operating,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"aN" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth/airless,
+/area/ruin/has_grav/prototype/brig)
+"aO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/secure/gear{
+	anchored = 1;
+	name = "mining gear crate";
+	req_access_txt = "0"
+	},
+/obj/item/lazarus_injector,
+/obj/item/mining_scanner,
+/obj/item/storage/bag/ore,
+/obj/item/circuitboard/machine/ore_redemption,
+/obj/item/circuitboard/machine/ore_silo,
+/obj/item/pickaxe/drill,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"aP" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison cell"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/ruin/has_grav/prototype/brig)
+"aQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/ruin/has_grav/prototype/brig)
+"aR" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/can/food{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"aS" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/south{
+	req_access = null
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/ruin/has_grav/prototype/brig)
+"aT" = (
+/obj/structure/closet/syndicate,
+/obj/item/melee/baton,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/restraints/handcuffs,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/has_grav/prototype/brig)
+"aU" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"aV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/hallway)
+"aW" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"aX" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	layer = 3
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"aZ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"ba" = (
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"bb" = (
+/obj/structure/table,
+/obj/machinery/airalarm/directional/west{
+	req_access = null
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kitchen/tongs,
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"bd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"be" = (
+/turf/closed/wall,
+/area/ruin/has_grav/prototype/arrivals)
+"bf" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/drip{
+	icon_state = "u_guilty_l"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"bh" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/botany)
+"bi" = (
+/turf/closed/wall,
+/area/ruin/has_grav/prototype/engineering)
+"bj" = (
+/turf/closed/wall/r_wall,
+/area/ruin/has_grav/prototype/engineering)
+"bk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/arrivals)
+"bl" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"bo" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/medkit,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/medsci)
+"bp" = (
+/obj/structure/cable,
+/obj/structure/closet/crate/medical,
+/obj/item/defibrillator/loaded,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment,
+/obj/item/stack/medical/ointment,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/circuitboard/machine/chem_dispenser,
+/obj/item/circuitboard/machine/chem_master,
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/medsci)
+"bq" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"br" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/syringe{
+	layer = 3.01
+	},
+/turf/open/floor/iron/smooth/airless,
+/area/ruin/has_grav/prototype/brig)
+"bs" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth/airless,
+/area/ruin/has_grav/prototype/brig)
+"bt" = (
+/obj/structure/door_assembly,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"bu" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Shuttle door";
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered)
+"bv" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/ruin/has_grav/prototype/brig)
+"bw" = (
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"bx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/stockparts/basic{
+	pixel_x = 7;
+	pixel_y = -10
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"bz" = (
+/obj/machinery/airalarm/directional/west{
+	req_access = null
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/rank/centcom/commander,
+/obj/item/clothing/suit/armor/vest{
+	layer = 2.9
+	},
+/obj/item/clothing/shoes/combat{
+	layer = 2.9
+	},
+/obj/structure/closet/cabinet,
+/obj/item/clothing/glasses/hud/security/sunglasses/eyepatch,
+/obj/item/reagent_containers/cup/glass/bottle/champagne/cursed,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"bA" = (
+/obj/structure/lattice/catwalk,
+/mob/living/basic/carp,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/solars)
+"bB" = (
+/turf/template_noop,
+/area/ruin/has_grav/prototype/hallway)
+"bC" = (
+/obj/item/solar_assembly,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/solars)
+"bD" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/solars)
+"bE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west{
+	req_access = null
+	},
+/obj/structure/closet/crate/hydroponics,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/shovel/spade,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/storage/bag/plants/portaseeder,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"bF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 8;
+	frequency = 1442;
+	id_tag = "syndie_lavaland_n2_out";
+	internal_pressure_bound = 5066;
+	name = "Air Out"
+	},
+/turf/open/floor/engine/air,
+/area/ruin/has_grav/prototype/engineering)
+"bG" = (
+/turf/open/floor/engine/air,
+/area/ruin/has_grav/prototype/engineering)
+"bH" = (
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/solars)
+"bI" = (
+/obj/item/clothing/glasses/science,
+/turf/template_noop,
+/area/template_noop)
+"bJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"bM" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
+	},
+/turf/open/floor/engine/air,
+/area/ruin/has_grav/prototype/engineering)
+"bN" = (
+/obj/machinery/door/airlock/research{
+	name = "MedSci Department"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"bO" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"bP" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"bQ" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"bR" = (
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/grass,
+/area/ruin/has_grav/prototype/arrivals)
+"bS" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/science,
+/obj/item/circuitboard/machine/protolathe,
+/obj/item/storage/box/beakers,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"bT" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"bU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"bV" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Brig"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/brig)
+"bW" = (
+/obj/machinery/door/airlock{
+	name = "Toilet"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/showroomfloor/airless,
+/area/ruin/has_grav/prototype/hallway)
+"bX" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small/built{
+	icon_state = "bulb-empty";
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor/airless,
+/area/ruin/has_grav/prototype/hallway)
+"bY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 8;
+	frequency = 1442;
+	id_tag = "syndie_lavaland_o2_out";
+	internal_pressure_bound = 5066;
+	name = "Oxygen Out"
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/has_grav/prototype/engineering)
+"bZ" = (
+/turf/open/floor/engine/o2,
+/area/ruin/has_grav/prototype/engineering)
+"ca" = (
+/obj/effect/decal/cleanable/blood/drip{
+	icon_state = "gib5-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/basic/carp/mega,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cc" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cd" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cf" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/ammo_casing/spent{
+	pixel_x = 3;
+	pixel_y = -6
+	},
+/obj/item/ammo_casing/spent{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"ch" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/has_grav/prototype/engineering)
+"ck" = (
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/botany)
+"cl" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"cm" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cn" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cq" = (
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/botany)
+"cr" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"cs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"ct" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cv" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/engineering)
+"cw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 8;
+	frequency = 1442;
+	id_tag = "syndie_lavaland_n2_out";
+	internal_pressure_bound = 5066;
+	name = "Nitrogen Out"
+	},
+/turf/open/floor/engine/n2,
+/area/ruin/has_grav/prototype/engineering)
+"cx" = (
+/turf/open/floor/engine/n2,
+/area/ruin/has_grav/prototype/engineering)
+"cy" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "blood1";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cz" = (
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"cC" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
+	},
+/turf/open/floor/engine/n2,
+/area/ruin/has_grav/prototype/engineering)
+"cD" = (
+/obj/structure/chair,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/engineering)
+"cG" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/arrivals)
+"cH" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/hallway)
+"cI" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"cJ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/engineering)
+"cK" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/arrivals)
+"cL" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/arrivals)
+"cO" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cP" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cR" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/light/built{
+	icon_state = "tube-empty";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/hallway)
+"cS" = (
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"cT" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/engineering)
+"cU" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/dorms)
+"cV" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/botany)
+"cW" = (
+/turf/template_noop,
+/area/ruin/has_grav/prototype/dorms)
+"cX" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/botany)
+"cZ" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/botany)
+"da" = (
+/obj/item/stack/cable_coil/five,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"db" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/botany)
+"dc" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"de" = (
+/turf/template_noop,
+/area/ruin/has_grav/prototype/botany)
+"df" = (
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/botany)
+"dg" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"dh" = (
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"di" = (
+/obj/structure/table_frame/wood,
+/obj/machinery/light/small/built,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"dj" = (
+/obj/structure/grille/broken,
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/botany)
+"dk" = (
+/obj/structure/closet/crate/engineering{
+	name = "Electric Supplies"
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west{
+	req_access = null
+	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/inducer{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/apc,
+/obj/item/electronics/apc,
+/obj/item/electronics/apc,
+/obj/item/electronics/firelock,
+/obj/item/electronics/firelock,
+/obj/item/electronics/firelock,
+/obj/item/electronics/firealarm,
+/obj/item/electronics/firealarm,
+/obj/item/electronics/firealarm,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/engineering)
+"dl" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/solars)
+"dm" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"dn" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"do" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/botany)
+"dr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"dv" = (
+/obj/machinery/vending/cigarette/syndicate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"dw" = (
+/obj/item/stack/sheet/rglass,
+/turf/template_noop,
+/area/template_noop)
+"dx" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/built{
+	icon_state = "bulb-empty";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/dorms)
+"dy" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/dorms)
+"dA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/biogenerator,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"dC" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"dD" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/template_noop,
+/area/ruin/has_grav/prototype/medsci)
+"dE" = (
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light/small{
+	icon_state = "bulb";
+	dir = 8
+	},
+/obj/structure/closet/crate/solarpanel_medium,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"dF" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"dG" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"dH" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/engineering)
+"dI" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wallframe/apc{
+	pixel_y = 6
+	},
+/obj/item/electronics/apc{
+	pixel_x = -2;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"dJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/build{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/cyan/hidden{
+	dir = 4
+	},
+/obj/structure/closet/crate/secure/plasma{
+	locked = 0
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 50
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/engineering)
+"dK" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth/airless,
+/area/ruin/has_grav/prototype/brig)
+"dL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"dM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to Distro"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"dN" = (
+/obj/effect/decal/cleanable/blood/drip{
+	icon_state = "u_guilty_l"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"dO" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"dP" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/drip{
+	icon_state = "u_guilty_l"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"dR" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"dS" = (
+/obj/item/wallframe/apc,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/hallway)
+"dT" = (
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/hallway)
+"dU" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "blood1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/hallway)
+"dV" = (
+/obj/item/stack/cable_coil/five,
+/obj/machinery/airalarm/directional/north{
+	req_access = null
+	},
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/hallway)
+"dW" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"dX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/engineering)
+"dY" = (
+/obj/machinery/airalarm/directional/north{
+	req_access = null
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"ea" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/botany)
+"eb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/botany)
+"ec" = (
+/obj/machinery/airalarm/directional/east{
+	req_access = null
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"ee" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"eg" = (
+/obj/structure/cable,
+/obj/item/wallframe/apc,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"eh" = (
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/solars)
+"ei" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/space/has_grav/powered)
+"ej" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered)
+"ek" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/powered)
+"el" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/engineering)
+"em" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"eo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"ep" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"er" = (
+/obj/machinery/door/airlock{
+	name = "Cabin 1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/dorms)
+"es" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"et" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"ev" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"ex" = (
+/obj/machinery/door/airlock{
+	name = "Cabin 2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/dorms)
+"ey" = (
+/obj/machinery/door/airlock{
+	name = "Cabin 3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/dorms)
+"ez" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "blood1";
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"eA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"eB" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "blood1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"eE" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "blood1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"eF" = (
+/obj/machinery/hydroponics/constructable{
+	anchored = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/botany)
+"eG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"eH" = (
+/obj/structure/lattice,
+/obj/item/clothing/glasses/science,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/medsci)
+"eJ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"eK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/dorms)
+"eL" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/atropine{
+	pixel_y = 10
+	},
+/obj/item/storage/medkit,
+/turf/open/floor/pod/dark,
+/area/ruin/space/has_grav/powered)
+"eM" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/command{
+	name = "Captain's Office";
+	req_access_txt = "20"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"eO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/dorms)
+"eP" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/seeds/random{
+	pixel_x = 6
+	},
+/obj/item/seeds/random,
+/obj/item/seeds/random{
+	pixel_x = -6
+	},
+/obj/structure/window/spawner/directional/south,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"eQ" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/window/spawner/directional/south,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"eR" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"eS" = (
+/obj/machinery/door/window{
+	name = "Botany"
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"eT" = (
+/obj/machinery/vending/hydronutrients,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/spawner/directional/south,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"eU" = (
+/obj/structure/closet/crate/engineering{
+	name = "Construction Supplies"
+	},
+/obj/structure/cable,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/rglass{
+	amount = 50
+	},
+/obj/item/pipe_dispenser,
+/obj/item/construction/rcd/loaded,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/glass/fifty{
+	layer = 2.99
+	},
+/obj/item/stack/sheet/glass/fifty{
+	layer = 2.99
+	},
+/obj/item/stack/sheet/glass/fifty{
+	layer = 2.99
+	},
+/obj/item/stack/rods/fifty{
+	layer = 2.99
+	},
+/obj/item/stack/rods/fifty{
+	layer = 2.99
+	},
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/engineering)
+"eV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"eZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"fa" = (
+/obj/structure/sign/departments/engineering{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"fc" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/dorms)
+"fd" = (
+/obj/machinery/vending/hydroseeds,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/spawner/directional/south,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"fe" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitories"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"ff" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/public/glass{
+	name = "Botany"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/dorms)
+"fh" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/engineering)
+"fj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"fk" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/engineering)
+"fl" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"fm" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"fn" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"fo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"fp" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gib2-old"
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gibmid3"
+	},
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/hallway)
+"fr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/hallway)
+"fs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/engineering)
+"fv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/built{
+	icon_state = "tube-empty";
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"fw" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/ruin/space/has_grav/powered)
+"fx" = (
+/obj/machinery/light/built{
+	icon_state = "tube-empty";
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"fy" = (
+/turf/open/floor/pod/dark,
+/area/ruin/space/has_grav/powered)
+"fz" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"fA" = (
+/obj/structure/closet/crate/engineering,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/gold{
+	amount = 5
+	},
+/obj/item/stack/sheet/mineral/silver{
+	amount = 5
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/engineering)
+"fC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "N2 to Airmix"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"fD" = (
+/obj/effect/gibspawner/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/space/syndicate/black/red,
+/obj/item/clothing/head/helmet/space/syndicate/black/red,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/arrivals)
+"fE" = (
+/obj/structure/cable,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"fF" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"fG" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "blood1";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"fH" = (
+/obj/item/stack/cable_coil/five,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"fK" = (
+/obj/effect/decal/remains/human,
+/obj/effect/gibspawner/human,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"fM" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"fO" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"fP" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/engineering)
+"fR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/stockparts/basic{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/machinery/light/built{
+	icon_state = "tube-empty";
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"fS" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/engine/o2,
+/area/ruin/has_grav/prototype/engineering)
+"fT" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"fU" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/engine/n2,
+/area/ruin/has_grav/prototype/engineering)
+"fV" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/ruin/has_grav/prototype/engineering)
+"fW" = (
+/obj/item/mop/advanced,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/dorms)
+"fY" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/medsci)
+"fZ" = (
+/obj/item/shard,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/medsci)
+"ga" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"gb" = (
+/obj/structure/lattice,
+/obj/structure/girder/displaced,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/medsci)
+"gc" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"gd" = (
+/obj/structure/table/optable,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"ge" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/Captain)
+"gf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/plasteel{
+	amount = 2
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"gi" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"gl" = (
+/obj/machinery/light/small/built,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/dorms)
+"gp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"gr" = (
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/structure/rack,
+/turf/open/floor/pod/dark,
+/area/ruin/space/has_grav/powered)
+"gs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"gu" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/botany)
+"gv" = (
+/obj/machinery/light/built{
+	icon_state = "tube-empty";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/botany)
+"gx" = (
+/obj/structure/grille/broken,
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/botany)
+"gz" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/machinery/light{
+	icon_state = "tube";
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"gA" = (
+/obj/structure/sign/departments/evac,
+/turf/closed/wall,
+/area/ruin/has_grav/prototype/arrivals)
+"gB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"gC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/departments/medbay/alt{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"gD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/departments/science/alt{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"gF" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"gG" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"gH" = (
+/obj/machinery/light/small/built,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"gO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"hs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/machine,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"ii" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/built,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"iC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"iI" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "blood1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/hallway)
+"jO" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"kg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"kA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"ls" = (
+/obj/structure/window/spawner/directional/north,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/botany)
+"mK" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/botany)
+"ng" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/pistachios,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"nq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/reagent_containers/medigel/aiuri{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"nJ" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"nT" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"ph" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"qs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"sZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"tK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/botany)
+"tY" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"uT" = (
+/obj/item/shard,
+/turf/template_noop,
+/area/template_noop)
+"vZ" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kitchen/fork/plastic,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"wx" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"wz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/engineering)
+"xY" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"zF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"AJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wallframe/firealarm{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"AT" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "blood1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"Cz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/ruin/has_grav/prototype/brig)
+"DP" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"DY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "O2 to Airmix"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"Et" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/hallway)
+"Gh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"Gz" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"Il" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"Jb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"Kf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"Kh" = (
+/obj/item/food/syndicake{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/space/has_grav/powered)
+"MG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"MJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"Nx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"NW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"Oh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/medigel/libital{
+	pixel_y = 7;
+	pixel_x = -6
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"Oo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"OD" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"OI" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wallframe/apc,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"OL" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kitchen/rollingpin,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"ON" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/knife/kitchen,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"Pf" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"Pl" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/engineering)
+"Pp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/spawner/directional/north,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"Pr" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"Pz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/botany)
+"PM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wallframe/firealarm{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"PN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"PU" = (
+/obj/structure/lattice,
+/obj/structure/firelock_frame,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/dorms)
+"QE" = (
+/obj/item/wallframe/firealarm{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/hallway)
+"Ra" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/engineering)
+"Rw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/ruin/has_grav/prototype/brig)
+"St" = (
+/obj/item/wallframe/firealarm{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"SF" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wallframe/apc,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"Tf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/dorms)
+"Tj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria/airless,
+/area/ruin/has_grav/prototype/kitchen)
+"Ud" = (
+/obj/item/electronics/firelock,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"Ue" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/dorms)
+"Ug" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"Ux" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"Vr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"Vs" = (
+/obj/structure/lattice,
+/mob/living/basic/carp,
+/turf/template_noop,
+/area/ruin/has_grav/prototype/botany)
+"Vv" = (
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 1;
+	name = "Waste to Filter"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"VR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/has_grav/prototype/hallway)
+"Wh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/dorms)
+"WB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"WO" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/built{
+	icon_state = "bulb-empty";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
+/obj/item/toy/plush/shrimp,
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/dorms)
+"XU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"Ys" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/checker/airless,
+/area/ruin/has_grav/prototype/arrivals)
+"YZ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stack/sheet/plasteel{
+	amount = 2
+	},
+/turf/open/floor/wood/airless,
+/area/ruin/has_grav/prototype/Captain)
+"Zd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/has_grav/prototype/hallway)
+"ZG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/engineering)
+"ZK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/has_grav/prototype/medsci)
+"ZP" = (
+/mob/living/basic/carp,
+/turf/template_noop,
+/area/template_noop)
+
+(1,1,1) = {"
+aa
+aa
+aa
+ac
+gc
+ad
+ad
+aV
+aV
+aV
+be
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+aa
+ac
+aK
+gd
+ph
+ad
+cc
+ct
+ct
+be
+XU
+dr
+es
+es
+es
+es
+es
+dr
+bk
+bk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(3,1,1) = {"
+bI
+aa
+aK
+fZ
+fY
+aM
+ad
+bU
+bU
+bU
+be
+PM
+dN
+dr
+dr
+dr
+dr
+dr
+gO
+dr
+bk
+aa
+aa
+aa
+ei
+ej
+ej
+ei
+aa
+aa
+aa
+aa
+"}
+(4,1,1) = {"
+ZP
+as
+aK
+fY
+an
+nq
+ad
+gD
+bU
+Ug
+be
+dr
+WB
+et
+et
+et
+et
+et
+Ys
+dr
+bk
+bk
+bk
+Il
+ei
+eL
+gr
+ei
+aa
+aa
+aa
+aa
+"}
+(5,1,1) = {"
+aa
+aa
+dD
+fY
+ae
+ZK
+bN
+cd
+cd
+cd
+dg
+Gz
+dO
+be
+bR
+be
+bR
+gA
+ev
+fM
+cG
+cK
+cL
+cz
+bu
+fy
+fy
+ej
+aa
+aa
+aa
+aa
+"}
+(6,1,1) = {"
+aa
+aa
+eH
+ga
+MG
+hs
+ad
+gC
+fr
+dT
+be
+fF
+dP
+OD
+OD
+wx
+fl
+fl
+fG
+dr
+bk
+bk
+bk
+Il
+ej
+fy
+Kh
+ej
+aa
+aa
+aa
+aa
+"}
+(7,1,1) = {"
+aa
+aa
+gb
+al
+Oh
+bq
+ad
+cR
+fr
+dT
+be
+dr
+Pf
+dR
+eJ
+fm
+eZ
+fD
+Oo
+eZ
+bk
+aa
+aa
+aa
+ek
+ag
+ah
+ek
+aa
+aa
+aa
+aa
+"}
+(8,1,1) = {"
+aa
+aa
+ad
+am
+eA
+bo
+ad
+dS
+iI
+dT
+be
+dv
+OI
+ec
+eZ
+nT
+eZ
+eZ
+gi
+dr
+bk
+aa
+aa
+aa
+ek
+ek
+ek
+ek
+aa
+aa
+aa
+aa
+"}
+(9,1,1) = {"
+aa
+aa
+ad
+ad
+aL
+bp
+ad
+dV
+Zd
+fp
+be
+be
+be
+be
+be
+fe
+be
+be
+be
+be
+be
+aa
+aa
+aa
+fw
+aa
+aa
+fw
+aa
+aa
+aa
+aa
+"}
+(10,1,1) = {"
+aa
+aa
+ai
+aj
+aj
+aj
+aj
+bU
+dU
+cS
+ab
+dx
+Tf
+er
+Ue
+Wh
+dh
+bt
+fK
+di
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(11,1,1) = {"
+aa
+aa
+aj
+aj
+aN
+br
+aj
+bU
+qs
+cS
+ab
+dy
+eO
+ab
+dh
+eV
+dh
+ab
+Ud
+cU
+cW
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(12,1,1) = {"
+aa
+aa
+aj
+at
+dK
+bs
+aj
+dW
+AT
+cH
+ab
+ab
+ab
+ab
+dh
+Vr
+gl
+ab
+cU
+cW
+cW
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(13,1,1) = {"
+aa
+aa
+aj
+aj
+aP
+aj
+aj
+fx
+cH
+bB
+ab
+WO
+Tf
+ex
+Kf
+da
+cU
+PU
+fW
+cW
+cW
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(14,1,1) = {"
+aa
+aa
+ak
+au
+Rw
+aS
+aj
+fz
+bB
+cH
+ab
+dy
+eO
+ab
+dY
+cU
+cU
+cU
+cU
+cU
+cU
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(15,1,1) = {"
+aa
+aa
+ak
+av
+aQ
+bv
+bV
+dC
+cH
+cH
+ab
+ab
+ab
+ab
+eg
+cU
+gH
+ab
+cU
+cW
+cW
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(16,1,1) = {"
+aa
+aa
+ak
+aw
+Cz
+aQ
+aj
+cS
+ez
+cS
+ab
+dx
+Tf
+ey
+Ue
+Vr
+Jb
+bt
+dh
+cU
+cW
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(17,1,1) = {"
+aa
+aa
+aj
+aj
+aT
+aT
+aj
+cS
+eB
+cS
+ab
+dy
+eO
+ab
+eK
+fc
+dh
+ab
+ep
+Jb
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(18,1,1) = {"
+aa
+aa
+ao
+ao
+ao
+ao
+ao
+fH
+eE
+QE
+ab
+ab
+ab
+ab
+ab
+ff
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(19,1,1) = {"
+aa
+aa
+ap
+ax
+SF
+bz
+ao
+gF
+cy
+bU
+do
+dA
+bE
+fn
+eP
+tY
+Pp
+AJ
+cq
+cX
+cZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(20,1,1) = {"
+aa
+aa
+ap
+cg
+aU
+cg
+ge
+gf
+cy
+bU
+dj
+gp
+Pz
+fn
+eQ
+tY
+Pp
+cq
+tK
+ck
+gx
+aa
+dw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(21,1,1) = {"
+aa
+aa
+ap
+aO
+YZ
+bJ
+ge
+bU
+cy
+bU
+gu
+dF
+ea
+tY
+eS
+tY
+mK
+cq
+cV
+de
+de
+aa
+aa
+aa
+bC
+eh
+bH
+aa
+bC
+eh
+bD
+aa
+"}
+(22,1,1) = {"
+aa
+aa
+ap
+az
+aZ
+aZ
+eM
+cf
+cy
+bU
+do
+gp
+eb
+eF
+eT
+tY
+df
+Vs
+cV
+de
+cZ
+aa
+aa
+dw
+bD
+eh
+bH
+aa
+bH
+eh
+bD
+aa
+"}
+(23,1,1) = {"
+aa
+aa
+ap
+cg
+MJ
+ay
+ao
+gB
+cd
+cn
+bh
+dG
+fv
+eG
+fd
+fE
+ls
+ck
+gv
+cq
+db
+aa
+aa
+aa
+bD
+eh
+bH
+aa
+bD
+dl
+bC
+aa
+"}
+(24,1,1) = {"
+aa
+aa
+ap
+aA
+ba
+bO
+ao
+cm
+cd
+ii
+bi
+bi
+bi
+bi
+bi
+fP
+bi
+bi
+bi
+bi
+bi
+aa
+aa
+aa
+bH
+eh
+bH
+aa
+bH
+eh
+bH
+aa
+"}
+(25,1,1) = {"
+aa
+aa
+ao
+ao
+ao
+ao
+ao
+gG
+Et
+iC
+bi
+dH
+dk
+eU
+fA
+fh
+bi
+cr
+dE
+ee
+bi
+aa
+aa
+aa
+bH
+eh
+bH
+aa
+bC
+eh
+bH
+aa
+"}
+(26,1,1) = {"
+aa
+aa
+aq
+af
+aJ
+bb
+bQ
+bU
+cd
+cO
+bi
+dI
+fs
+Ra
+Vv
+Gh
+cl
+eR
+bw
+eR
+cI
+dl
+dl
+eh
+eh
+eh
+eh
+bA
+eh
+eh
+dl
+bC
+"}
+(27,1,1) = {"
+aa
+aa
+aq
+aB
+Pr
+zF
+bQ
+bU
+cD
+ng
+bi
+dJ
+el
+DP
+cT
+fa
+bi
+bi
+bi
+bi
+bi
+aa
+aa
+aa
+bH
+eh
+bH
+aa
+bD
+eh
+bH
+aa
+"}
+(28,1,1) = {"
+aa
+aa
+aq
+aC
+aR
+bd
+bP
+bU
+cD
+vZ
+bi
+dX
+kA
+cT
+cT
+bw
+fo
+gz
+fT
+cE
+aa
+aa
+aa
+aa
+bC
+eh
+bH
+aa
+bD
+eh
+bH
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+aq
+aD
+aW
+Tj
+OL
+bU
+cD
+cP
+bi
+ZG
+cT
+cT
+em
+Nx
+Nx
+fj
+fj
+cE
+aa
+aa
+aa
+aa
+bH
+eh
+bD
+aa
+bH
+dl
+bH
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+dm
+ON
+aX
+nJ
+jO
+bU
+cd
+dc
+bi
+St
+eo
+PN
+kg
+NW
+fj
+kg
+cs
+wz
+cJ
+aa
+aa
+aa
+bH
+eh
+bC
+aa
+bH
+dl
+bH
+aa
+"}
+(31,1,1) = {"
+aa
+aa
+cH
+aG
+bf
+bT
+fO
+cd
+cd
+bU
+bi
+dL
+Nx
+fj
+fj
+fj
+fj
+Nx
+gs
+cE
+aa
+aa
+aa
+aa
+bH
+eh
+bH
+aa
+bC
+eh
+bH
+aa
+"}
+(32,1,1) = {"
+aa
+uT
+dn
+bx
+bl
+ca
+cb
+bU
+VR
+bU
+bi
+dM
+sZ
+fj
+DY
+fj
+fj
+fC
+Ux
+cE
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(33,1,1) = {"
+aa
+aa
+xY
+aG
+bS
+bU
+fR
+bU
+bU
+bU
+bj
+Pl
+fk
+bj
+fk
+cv
+bj
+fk
+cv
+bj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(34,1,1) = {"
+aa
+aa
+ar
+aF
+ar
+aF
+ar
+bW
+ar
+bW
+bj
+bF
+bM
+bj
+bY
+ch
+bj
+cw
+cC
+bj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(35,1,1) = {"
+aa
+aa
+ar
+aI
+ar
+aI
+ar
+bX
+ar
+bX
+bj
+bG
+fV
+bj
+bZ
+fS
+bj
+cx
+fU
+bj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(36,1,1) = {"
+aa
+aa
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}

--- a/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
+++ b/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
@@ -1889,10 +1889,10 @@
 /area/ruin/has_grav/prototype/kitchen)
 "kg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/has_grav/prototype/engineering)
 "kA" = (

--- a/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
+++ b/fulp_modules/mapping/ruins/space/syndicate_engineer.dmm
@@ -1334,7 +1334,7 @@
 /obj/item/reagent_containers/hypospray/medipen/atropine{
 	pixel_y = 10
 	},
-/obj/item/storage/medkit,
+/obj/item/storage/medkit/advanced,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered)
 "eM" = (

--- a/fulp_modules/mapping/ruins/space/syndicate_engineer/syndicate_engineer.dm
+++ b/fulp_modules/mapping/ruins/space/syndicate_engineer/syndicate_engineer.dm
@@ -3,6 +3,7 @@
 	id = "prototype"
 	description = "Apparently one of the first stations built by Nanotrasen. Slated for reclaimation by the Syndicate."
 	suffix = "syndicate_engineer.dmm"
+	always_place = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/syndicate_engineer
 	name = "Syndicate Engineer Corps"

--- a/fulp_modules/mapping/ruins/space/syndicate_engineer/syndicate_engineer.dm
+++ b/fulp_modules/mapping/ruins/space/syndicate_engineer/syndicate_engineer.dm
@@ -3,6 +3,7 @@
 	id = "prototype"
 	description = "Apparently one of the first stations built by Nanotrasen. Slated for reclaimation by the Syndicate."
 	suffix = "syndicate_engineer.dmm"
+	always_place = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/syndicate_engineer
 	name = "Syndicate Engineer Corps"
@@ -15,6 +16,11 @@
 	important_text = "Leaving the station is forbidden."
 	spawner_job_path = /datum/job/syndicate_engineer
 	outfit = /datum/outfit/syndicate_engineer
+
+/obj/effect/mob_spawn/ghost_role/human/syndicate_engineer/special(mob/living/new_spawn)
+	. = ..()
+	to_chat(new_spawn, "<b>You have been implanted with a bomb that will detonate if you stray too far from the station. Glory to the Syndicate.</b>")
+	new_spawn.AddComponent(/datum/component/stationstuck, PUNISHMENT_GIB, "You have left the vicinity of the Prototype Station. Your bomb implant has been triggered.")
 
 /datum/job/syndicate_engineer
 	title = ROLE_SYNDICATE_ENGINEER
@@ -31,7 +37,7 @@
 	back = /obj/item/storage/backpack
 	belt = /obj/item/storage/belt/utility/chief/full
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/double
-	internals_slot = ITEM_SLOT_DEX_STORAGE//SLOT_R_STORE
+	internals_slot = ITEM_SLOT_DEX_STORAGE // SLOT_R_STORE
 	id = /obj/item/card/id/advanced/chameleon
 	implants = list(/obj/item/implant/weapons_auth)
 	backpack_contents = list(/obj/item/storage/box/survival/syndie=1,\
@@ -44,6 +50,8 @@
 /obj/effect/mob_spawn/human/syndicate_engineer/Destroy()
 	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))
 	return ..()
+
+// We're giving them a special solar panel crate because the budget one doesn't have enough panels-- and I don't want to place 20 crates.
 
 /obj/structure/closet/crate/solarpanel_medium
 	name = "solar panel crate"

--- a/fulp_modules/mapping/ruins/space/syndicate_engineer/syndicate_engineer.dm
+++ b/fulp_modules/mapping/ruins/space/syndicate_engineer/syndicate_engineer.dm
@@ -1,0 +1,60 @@
+/datum/map_template/ruin/space/fulp/prototype
+	name = "Prototype Station"
+	id = "prototype"
+	description = "Apparently one of the first stations built by Nanotrasen. Slated for reclaimation by the Syndicate."
+	suffix = "syndicate_engineer.dmm"
+	always_place = TRUE
+
+/obj/effect/mob_spawn/ghost_role/human/syndicate_engineer
+	name = "Syndicate Engineer Corps"
+	desc = "A cryogenics pod, storing someone to be awakened later. Best to leave it alone."
+	prompt_name = "Syndicate engineer"
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper_s"
+	you_are_text = "You are a Syndicate Engineer, tasked by your superiors to repair a derelict station."
+	flavour_text = "You must ensure that the station can support human life. You're pretty sure nobody will disturb you here, yet you can't shake the feeling this job will be like no other."
+	important_text = "Leaving the station is forbidden."
+	spawner_job_path = /datum/job/syndicate_engineer
+	outfit = /datum/outfit/syndicate_engineer
+
+/datum/job/syndicate_engineer
+	title = ROLE_SYNDICATE_ENGINEER
+
+/datum/outfit/syndicate_engineer
+	name = "Syndicate Engineer"
+	head = /obj/item/clothing/head/helmet/space/syndicate/black/engie
+	mask = /obj/item/clothing/mask/breath
+	uniform = /obj/item/clothing/under/syndicate
+	suit = /obj/item/clothing/suit/space/syndicate/black/engie
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/combat
+	ears = /obj/item/radio/headset/syndicate/alt
+	back = /obj/item/storage/backpack
+	belt = /obj/item/storage/belt/utility/chief/full
+	r_pocket = /obj/item/tank/internals/emergency_oxygen/double
+	internals_slot = ITEM_SLOT_DEX_STORAGE//SLOT_R_STORE
+	id = /obj/item/card/id/advanced/chameleon
+	implants = list(/obj/item/implant/weapons_auth)
+	backpack_contents = list(/obj/item/storage/box/survival/syndie=1,\
+		/obj/item/tank/jetpack/oxygen/harness=1,\
+		/obj/item/gun/ballistic/automatic/pistol)
+
+/datum/outfit/syndicate_engineer/post_equip(mob/living/carbon/human/H)
+	H.faction |= ROLE_SYNDICATE
+
+/obj/effect/mob_spawn/human/syndicate_engineer/Destroy()
+	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))
+	return ..()
+
+/obj/structure/closet/crate/solarpanel_medium
+	name = "solar panel crate"
+	icon_state = "engi_e_crate"
+
+/obj/structure/closet/crate/solarpanel_medium/PopulateContents()
+	..()
+	for(var/i in 1 to 33)
+		new /obj/item/solar_assembly(src)
+	new /obj/item/electronics/tracker(src)
+	new /obj/item/stack/cable_coil(src)
+	new /obj/item/circuitboard/computer/solar_control(src)
+	new /obj/item/paper/guides/jobs/engi/solars(src)

--- a/fulp_modules/mapping/ruins/space/syndicate_engineer/syndicate_engineer.dm
+++ b/fulp_modules/mapping/ruins/space/syndicate_engineer/syndicate_engineer.dm
@@ -51,7 +51,7 @@
 
 /obj/structure/closet/crate/solarpanel_medium/PopulateContents()
 	..()
-	for(var/i in 1 to 33)
+	for(var/i in 1 to 26)
 		new /obj/item/solar_assembly(src)
 	new /obj/item/electronics/tracker(src)
 	new /obj/item/stack/cable_coil(src)

--- a/fulp_modules/mapping/ruins/space/syndicate_engineer/syndicate_engineer.dm
+++ b/fulp_modules/mapping/ruins/space/syndicate_engineer/syndicate_engineer.dm
@@ -3,7 +3,6 @@
 	id = "prototype"
 	description = "Apparently one of the first stations built by Nanotrasen. Slated for reclaimation by the Syndicate."
 	suffix = "syndicate_engineer.dmm"
-	always_place = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/syndicate_engineer
 	name = "Syndicate Engineer Corps"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6258,6 +6258,7 @@
 #include "fulp_modules\mapping\ruins\icemoon\beefman_cytology\beefcyto_spawner.dm"
 #include "fulp_modules\mapping\ruins\lavaland\exiled_ruins\exiled_ruins.dm"
 #include "fulp_modules\mapping\ruins\space\beefman_station\beefman_station.dm"
+#include "fulp_modules\mapping\ruins\space\syndicate_engineer\syndicate_engineer.dm"
 #include "fulp_modules\mapping\shuttles\map_templates.dm"
 #include "fulp_modules\mapping\station_objects\decals.dm"
 #include "fulp_modules\mapping\station_objects\fluff.dm"


### PR DESCRIPTION
## About The Pull Request

It's exactly as it says on the tin-- Syndicate Engineers are back!

![0-added](https://github.com/fulpstation/fulpstation/assets/76599451/fe58854c-e1c5-43b9-9475-215bc801d2b4)
(MDB render is a bit fucky but rest assured I fully tested it)
## Why It's Good For The Game

FulpStation is a beginner server, so having a space ruin dedicated to teaching new players the basics of engineering is... well, natural.
## Changelog
:cl:
add: Syndicate Engineer Ghost Role
add: Prototype Station Space Ruin
/:cl:
