### PR TITLE
Makes all blood updates go through AddBloodVolume

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
@@ -14,8 +14,9 @@
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = IS_BLOODSUCKER(exposed_mob)
 	if(!bloodsuckerdatum)
 		return ..()
-	bloodsuckerdatum.bloodsucker_blood_volume = min(bloodsuckerdatum.bloodsucker_blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM)
-
+	var/blood_to_add = min(bloodsuckerdatum.bloodsucker_blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM)
+    if((blood_to_add - bloodsuckerdatum.bloodsucker_blood_volume) > 0)
+        bloodsuckerdatum.AddBloodVolume(blood_to_add - bloodsuckerdatum.bloodsucker_blood_volume)
 
 /mob/living/carbon/transfer_blood_to(atom/movable/AM, amount, forced)
 	. = ..()
@@ -25,7 +26,7 @@
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	if(!bloodsuckerdatum)
 		return
-	bloodsuckerdatum.bloodsucker_blood_volume -= amount
+	bloodsuckerdatum.AddBloodVolume(-amount)
 
 /// Prevents using a Memento Mori
 /obj/item/clothing/neck/necklace/memento_mori/memento(mob/living/carbon/human/user)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
@@ -14,9 +14,7 @@
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = IS_BLOODSUCKER(exposed_mob)
 	if(!bloodsuckerdatum)
 		return ..()
-	var/blood_to_add = min(bloodsuckerdatum.bloodsucker_blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM)
-	if((blood_to_add - bloodsuckerdatum.bloodsucker_blood_volume) > 0)
-		bloodsuckerdatum.AddBloodVolume(blood_to_add - bloodsuckerdatum.bloodsucker_blood_volume)
+	bloodsuckerdatum.AddBloodVolume(round(reac_volume, 0.1))
 
 /mob/living/carbon/transfer_blood_to(atom/movable/AM, amount, forced)
 	. = ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_integration.dm
@@ -15,8 +15,8 @@
 	if(!bloodsuckerdatum)
 		return ..()
 	var/blood_to_add = min(bloodsuckerdatum.bloodsucker_blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM)
-    if((blood_to_add - bloodsuckerdatum.bloodsucker_blood_volume) > 0)
-        bloodsuckerdatum.AddBloodVolume(blood_to_add - bloodsuckerdatum.bloodsucker_blood_volume)
+	if((blood_to_add - bloodsuckerdatum.bloodsucker_blood_volume) > 0)
+		bloodsuckerdatum.AddBloodVolume(blood_to_add - bloodsuckerdatum.bloodsucker_blood_volume)
 
 /mob/living/carbon/transfer_blood_to(atom/movable/AM, amount, forced)
 	. = ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/_clan.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/_clan.dm
@@ -255,7 +255,7 @@
 	if(QDELETED(src) || QDELETED(bloodsuckerdatum.owner.current) || QDELETED(vassaldatum.owner.current))
 		return FALSE
 	vassaldatum.make_special(vassal_response)
-	bloodsuckerdatum.bloodsucker_blood_volume -= 150
+	bloodsuckerdatum.AddBloodVolume(-150)
 	return TRUE
 
 /**

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
@@ -164,7 +164,7 @@
 	// Bloodsuckers in a Frenzy don't have enough Blood to pay it, so just don't.
 	if(bloodsuckerdatum_power.frenzied)
 		return
-	bloodsuckerdatum.AddBloodVolume(bloodcost)
+	bloodsuckerdatum_power.AddBloodVolume(bloodcost)
 	bloodsuckerdatum_power.update_hud()
 
 /datum/action/cooldown/bloodsucker/proc/ActivatePower(trigger_flags)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
@@ -164,7 +164,7 @@
 	// Bloodsuckers in a Frenzy don't have enough Blood to pay it, so just don't.
 	if(bloodsuckerdatum_power.frenzied)
 		return
-	bloodsuckerdatum_power.bloodsucker_blood_volume -= bloodcost
+	bloodsuckerdatum.AddBloodVolume(bloodcost)
 	bloodsuckerdatum_power.update_hud()
 
 /datum/action/cooldown/bloodsucker/proc/ActivatePower(trigger_flags)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
@@ -164,7 +164,7 @@
 	// Bloodsuckers in a Frenzy don't have enough Blood to pay it, so just don't.
 	if(bloodsuckerdatum_power.frenzied)
 		return
-	bloodsuckerdatum_power.AddBloodVolume(bloodcost)
+	bloodsuckerdatum_power.AddBloodVolume(-bloodcost)
 	bloodsuckerdatum_power.update_hud()
 
 /datum/action/cooldown/bloodsucker/proc/ActivatePower(trigger_flags)


### PR DESCRIPTION

## About The Pull Request

Updates all blood updates for bloodsuckers go through AddBloodVolume()
## Why It's Good For The Game

Consistency is king.
## Changelog
:cl:
refactor: Removes blood updates that directly manipulate bloodsucker_blood_volume and forces them to use AddBloodVolume instead.
/:cl:
