### PR TITLE
admins get a tgui list instead of radial for clans

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
@@ -27,7 +27,11 @@
 		option.info = "[initial(all_clans.name)] - [span_boldnotice(initial(all_clans.join_description))]"
 		radial_display[initial(all_clans.name)] = option
 
-	var/chosen_clan = show_radial_menu(person_selecting, owner.current, radial_display)
+	var/chosen_clan
+	if(person_selecting)
+		chosen_clan = tgui_input_list(person_selecting, "What Clan should [owner.current] be?", "Clan Selection", options)
+	else
+		chosen_clan = show_radial_menu(person_selecting, owner.current, radial_display)
 	chosen_clan = options[chosen_clan]
 	if(QDELETED(src) || QDELETED(owner.current))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

Admins choosing a clan for bloodsuckers through their traitor panel now gets a tgui list rather than a radial one, so they don't have to be physically near or observing the player they're editing.

## Why It's Good For The Game

admins can fix bloodsuckers without having to wonder why they just get the message saying they are "too far" because they were still in-game.
