### PR TITLE
Lowers job positions across the board

### DIFF
--- a/fulp_modules/Z_edits/job_edits.dm
+++ b/fulp_modules/Z_edits/job_edits.dm
@@ -25,34 +25,32 @@
 	exp_requirements = 180
 
 /datum/job/atmospheric_technician
-	total_positions = 6
-	spawn_positions = 2
 	exp_requirements = 300
 
 /** Science */
 /datum/job/scientist
-	total_positions = 7
+	total_positions = 6
 	spawn_positions = 3
 	exp_requirements = 180
 
 /datum/job/roboticist
-	total_positions = 5
+	total_positions = 3
 	spawn_positions = 2
 	exp_requirements = 180
 
 /datum/job/geneticist
-	total_positions = 4
+	total_positions = 3
 	spawn_positions = 2
 	exp_requirements = 180
 
 /** Medical */
 /datum/job/doctor
-	total_positions = 12
+	total_positions = 8
 	spawn_positions = 6
 	exp_requirements = 180
 
 /datum/job/paramedic
-	total_positions = 4
+	total_positions = 2
 	spawn_positions = 2
 	exp_requirements = 180
 
@@ -74,7 +72,7 @@
 	exp_requirements = 300
 
 /datum/job/shaft_miner
-	total_positions = 8
+	total_positions = 5
 	spawn_positions = 3
 	exp_requirements = 180
 	exp_required_type = EXP_TYPE_CREW
@@ -85,7 +83,7 @@
 	spawn_positions = 2
 
 /datum/job/botanist
-	total_positions = 5
+	total_positions = 3
 	spawn_positions = 3
 
 /datum/job/cook


### PR DESCRIPTION
## About The Pull Request

We have tg edits to increase the number of job positions and it's been useful when we were in highpop, but with our current pop it seems more like a bunch of people can be crowded into one job, which essentially forces all players to rush whenever there's something to do before one of their coworkers takes up all the job content, while other departments get ignored completely. The only department I can think of where it's nice to have as many players possible in it is Security, which is why it isn't touched by this PR.

In general :tm: there's more job positions than TG and in general :tm: job positions that are fit for "beginners" aren't affected much (engineers, doctors) This was meant to target jobs that have a bunch of job positions, so jobs like Clown and such that we gave a second job position are left untouched. You can see files changed for all the information, but these are total job positions edited:

Shaft miners 8 -> 5 (Each map has 3 closets for miners, the rest has to use their ticket for a conscription kit)
Scientists 7 -> 6
Roboticist 5 -> 3
Geneticist 4 -> 3 (there's usually 3 consoles in every map, so the fourth guy can't really do anything without researching tech and building their own machines anyway)
Doctor 12 -> 8
Paramedic 4 -> 2
Atmos techs 5 -> 2
Botanists are 5 -> 3

## Why It's Good For The Game

We're no longer hitting 120 pop and keeping the job positions the same as before seems to be making the issue of departmentless players more prevalent, especially in lowpop. Hopefully this can be a minor help to that.
