### PR TITLE
Adds a second fulp Deathmatch arena

### DIFF
--- a/fulp_modules/mapping/deathmatch/code/deathmatch_loadouts.dm
+++ b/fulp_modules/mapping/deathmatch/code/deathmatch_loadouts.dm
@@ -26,6 +26,6 @@
 	head = /obj/item/clothing/head/costume/powdered_wig
 	r_hand = /obj/item/melee/sabre
 	
-	granted_spells = (
+	granted_spells = list(
 		/datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/two,
 		)

--- a/fulp_modules/mapping/deathmatch/code/deathmatch_loadouts.dm
+++ b/fulp_modules/mapping/deathmatch/code/deathmatch_loadouts.dm
@@ -7,3 +7,12 @@
 	shoes = /obj/item/clothing/shoes/sandal
 	r_hand = /obj/item/knife/combat
 	l_hand = /obj/item/shield/buckler
+
+/datum/outfit/deathmatch_loadout/beeftide
+	name = "Deathmatch: Beeftide"
+	display_name = "Beeftide"
+	desc = "Nice to meat you."
+	uniform = /obj/item/clothing/under/bodysash
+	suit = /obj/item/clothing/suit/hooded/onesie/beefman
+	r_hand = /obj/item/gun/magic/hook
+	l_pocket = /obj/item/reagent_containers/hypospray/medipen/methamphetamine

--- a/fulp_modules/mapping/deathmatch/code/deathmatch_loadouts.dm
+++ b/fulp_modules/mapping/deathmatch/code/deathmatch_loadouts.dm
@@ -25,7 +25,7 @@
 	suit = /obj/item/clothing/suit/costume_2021/alucard_suit
 	head = /obj/item/clothing/head/costume/powdered_wig
 	r_hand = /obj/item/melee/sabre
-
-/datum/outfit/deathmatch_loadout/masquerader(mob/living/carbon/human/equipped_on, visualsOnly=FALSE)
-	var/datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/two/battlers_key = new(equipped_on.mind || equipped_on)
-	battlers_key.Grant(equipped_on)
+	
+	granted_spells = (
+		/datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/two,
+		)

--- a/fulp_modules/mapping/deathmatch/code/deathmatch_loadouts.dm
+++ b/fulp_modules/mapping/deathmatch/code/deathmatch_loadouts.dm
@@ -16,3 +16,16 @@
 	suit = /obj/item/clothing/suit/hooded/onesie/beefman
 	r_hand = /obj/item/gun/magic/hook
 	l_pocket = /obj/item/reagent_containers/hypospray/medipen/methamphetamine
+
+/datum/outfit/deathmatch_loadout/masquerader
+	name = "Deathmatch: Masquerader"
+	display_name = "Masquerader"
+	desc = "Worth the stakes."
+	uniform = /obj/item/clothing/under/costume/draculass
+	suit = /obj/item/clothing/suit/costume_2021/alucard_suit
+	head = /obj/item/clothing/head/costume/powdered_wig
+	r_hand = /obj/item/melee/sabre
+
+/datum/outfit/deathmatch_loadout/masquerader(mob/living/carbon/human/equipped_on, visualsOnly=FALSE)
+	var/datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/two/battlers_key = new(equipped_on.mind || equipped_on)
+	battlers_key.Grant(equipped_on)

--- a/fulp_modules/mapping/deathmatch/code/deathmatch_maps.dm
+++ b/fulp_modules/mapping/deathmatch/code/deathmatch_maps.dm
@@ -1,7 +1,7 @@
 /datum/lazy_template/deathmatch/fulp
 	map_dir = "fulp_modules/mapping/deathmatch/maps"
 
-/datum/lazy_template/deathmatch/pandamonium
+/datum/lazy_template/deathmatch/fulp/pandamonium
 	name = "Pandamonium"
 	desc = "Release the beast in the panda way!"
 	max_players = 16
@@ -12,7 +12,7 @@
 	map_name = "pandamonium"
 	key = "pandamonium"
 
-/datum/lazy_template/deathmatch/heliocentric
+/datum/lazy_template/deathmatch/fulp/heliocentric
 	name = "Heliocentric"
 	desc = "Nostalgic five-tile wide hallways."
 	max_players = 15

--- a/fulp_modules/mapping/deathmatch/code/deathmatch_maps.dm
+++ b/fulp_modules/mapping/deathmatch/code/deathmatch_maps.dm
@@ -18,6 +18,7 @@
 	allowed_loadouts = list(
 		/datum/outfit/deathmatch_loadout/assistant,
 		/datum/outfit/deathmatch_loadout/beeftide,
+		/datum/outfit/deathmatch_loadout/masquerader,
 		/datum/outfit/deathmatch_loadout/naked,
 	)
 	map_name = "heliocentric"

--- a/fulp_modules/mapping/deathmatch/code/deathmatch_maps.dm
+++ b/fulp_modules/mapping/deathmatch/code/deathmatch_maps.dm
@@ -1,8 +1,6 @@
-/datum/lazy_template/deathmatch/fulp
-	map_dir = "fulp_modules/mapping/deathmatch/maps"
-
-/datum/lazy_template/deathmatch/fulp/pandamonium
+/datum/lazy_template/deathmatch/pandamonium
 	name = "Pandamonium"
+	map_dir = "fulp_modules/mapping/deathmatch/maps"
 	desc = "Release the beast in the panda way!"
 	max_players = 16
 	allowed_loadouts = list(
@@ -12,8 +10,9 @@
 	map_name = "pandamonium"
 	key = "pandamonium"
 
-/datum/lazy_template/deathmatch/fulp/heliocentric
+/datum/lazy_template/deathmatch/heliocentric
 	name = "Heliocentric"
+	map_dir = "fulp_modules/mapping/deathmatch/maps"
 	desc = "Nostalgic five-tile wide hallways."
 	max_players = 15
 	allowed_loadouts = list(

--- a/fulp_modules/mapping/deathmatch/code/deathmatch_maps.dm
+++ b/fulp_modules/mapping/deathmatch/code/deathmatch_maps.dm
@@ -18,6 +18,7 @@
 	max_players = 15
 	allowed_loadouts = list(
 		/datum/outfit/deathmatch_loadout/assistant,
+		/datum/outfit/deathmatch_loadout/beeftide,
 		/datum/outfit/deathmatch_loadout/naked,
 	)
 	map_name = "heliocentric"

--- a/fulp_modules/mapping/deathmatch/code/deathmatch_maps.dm
+++ b/fulp_modules/mapping/deathmatch/code/deathmatch_maps.dm
@@ -1,6 +1,8 @@
+/datum/lazy_template/deathmatch/fulp
+	map_dir = "fulp_modules/mapping/deathmatch/maps"
+
 /datum/lazy_template/deathmatch/pandamonium
 	name = "Pandamonium"
-	map_dir = "fulp_modules/mapping/deathmatch/maps"
 	desc = "Release the beast in the panda way!"
 	max_players = 16
 	allowed_loadouts = list(
@@ -9,3 +11,14 @@
 	)
 	map_name = "pandamonium"
 	key = "pandamonium"
+
+/datum/lazy_template/deathmatch/heliocentric
+	name = "Heliocentric"
+	desc = "Nostalgic five-tile wide hallways."
+	max_players = 15
+	allowed_loadouts = list(
+		/datum/outfit/deathmatch_loadout/assistant,
+		/datum/outfit/deathmatch_loadout/naked,
+	)
+	map_name = "heliocentric"
+	key = "heliocentric"

--- a/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
+++ b/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
@@ -28,11 +28,6 @@
 /obj/structure/holosign/barrier,
 /turf/open/indestructible,
 /area/deathmatch/fullbright)
-"aZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/floor,
-/turf/open/indestructible,
-/area/deathmatch/fullbright)
 "ba" = (
 /obj/machinery/oven/range,
 /turf/open/indestructible/kitchen,
@@ -170,7 +165,6 @@
 /area/deathmatch/fullbright)
 "er" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/light/floor,
 /turf/open/indestructible/dark,
 /area/deathmatch/fullbright)
 "es" = (
@@ -266,10 +260,6 @@
 /area/deathmatch/fullbright)
 "hP" = (
 /obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/deathmatch/fullbright)
-"hQ" = (
-/obj/machinery/light/floor,
 /turf/open/floor/wood,
 /area/deathmatch/fullbright)
 "hR" = (
@@ -572,7 +562,6 @@
 /area/deathmatch/fullbright)
 "ve" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light/floor,
 /turf/open/indestructible/dark/smooth_large,
 /area/deathmatch/fullbright)
 "vj" = (
@@ -614,11 +603,6 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/deathmatch_player_spawn,
-/obj/effect/light_emitter{
-	light_color = "#DEEFFF";
-	set_cap = 2;
-	set_luminosity = 2
-	},
 /turf/open/indestructible,
 /area/deathmatch/fullbright)
 "wl" = (
@@ -698,10 +682,6 @@
 /obj/machinery/door/poddoor/shutters/indestructible,
 /turf/open/indestructible/large,
 /area/deathmatch/fullbright)
-"yW" = (
-/obj/machinery/light/floor,
-/turf/open/indestructible/white/smooth_large,
-/area/deathmatch/fullbright)
 "zx" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -768,6 +748,7 @@
 /area/deathmatch/fullbright)
 "Ca" = (
 /obj/effect/decal/cleanable/blood/old,
+/obj/structure/closet/crate/coffin/blackcoffin,
 /turf/open/indestructible/plating,
 /area/deathmatch/fullbright)
 "Cl" = (
@@ -962,10 +943,6 @@
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/item/shard,
 /turf/open/floor/grass,
-/area/deathmatch/fullbright)
-"IP" = (
-/obj/machinery/light/floor,
-/turf/open/indestructible,
 /area/deathmatch/fullbright)
 "IW" = (
 /obj/structure/tank_holder/extinguisher,
@@ -1216,10 +1193,6 @@
 	dir = 6
 	},
 /turf/open/floor/wood,
-/area/deathmatch/fullbright)
-"Re" = (
-/obj/machinery/light/floor,
-/turf/open/indestructible/dark/smooth_large,
 /area/deathmatch/fullbright)
 "Rf" = (
 /obj/effect/turf_decal/tile/red/full,
@@ -1561,7 +1534,7 @@ ER
 Ko
 hg
 hP
-hQ
+Uc
 Uc
 Uc
 mK
@@ -1665,7 +1638,7 @@ kg
 HM
 kg
 vV
-Re
+Aa
 uJ
 uJ
 ve
@@ -1860,7 +1833,7 @@ Ni
 Ni
 Ni
 Lu
-IP
+Lu
 Lu
 hj
 EN
@@ -1874,7 +1847,7 @@ pw
 EN
 Lu
 Lu
-IP
+Lu
 Lu
 Lu
 Pl
@@ -2077,7 +2050,7 @@ Nc
 vV
 zI
 dB
-IP
+Lu
 wG
 sO
 Ap
@@ -2116,7 +2089,7 @@ Va
 xE
 vV
 es
-aZ
+hq
 Fa
 ng
 vV
@@ -2171,7 +2144,7 @@ Lu
 pC
 YQ
 kg
-yW
+lF
 Va
 cJ
 vV

--- a/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
+++ b/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
@@ -490,9 +490,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/deathmatch)
-"qx" = (
-/turf/open/floor/glass/reinforced/plasma,
-/area/deathmatch)
 "qB" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -2295,7 +2292,7 @@ Lt
 vV
 nu
 dB
-qx
+Lu
 pC
 YQ
 vV

--- a/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
+++ b/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
@@ -696,6 +696,11 @@
 	},
 /turf/open/indestructible/white/smooth_large,
 /area/deathmatch)
+"yr" = (
+/obj/machinery/griddle,
+/obj/item/food/grown/sunflower,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
 "yv" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
 	dir = 4
@@ -1574,7 +1579,7 @@ UB
 Cl
 FI
 kg
-ba
+yr
 AY
 Mt
 vV

--- a/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
+++ b/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
@@ -1,0 +1,2336 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/structure/broken_flooring/pile/directional/west,
+/turf/open/indestructible/plating,
+/area/deathmatch)
+"al" = (
+/obj/structure/table/reinforced,
+/obj/item/dnainjector/blindmut{
+	pixel_y = 4
+	},
+/obj/item/dnainjector/blindmut{
+	pixel_y = 8
+	},
+/obj/item/dnainjector/blindmut,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"aM" = (
+/obj/structure/barricade/security,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"aP" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/obj/structure/holosign/barrier,
+/turf/open/indestructible,
+/area/deathmatch)
+"aZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/indestructible,
+/area/deathmatch)
+"ba" = (
+/obj/machinery/oven/range,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"bx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/deathmatch)
+"bI" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"cq" = (
+/obj/structure/sign/map/fulp/helio/right{
+	pixel_y = 32
+	},
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"cz" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible,
+/area/deathmatch)
+"cD" = (
+/obj/structure/reflector/double/mapping{
+	dir = 9
+	},
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"cF" = (
+/obj/structure/table/glass,
+/obj/item/gun/ballistic/revolver/c38,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"cG" = (
+/obj/structure/sign/directions/security{
+	dir = 4;
+	pixel_y = 30
+	},
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = 36
+	},
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"cJ" = (
+/obj/machinery/destructive_scanner,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"cR" = (
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/structure/holosign/barrier,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"cY" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/glass/bottle/molotov{
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/glass/bottle/molotov{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/cup/glass/bottle/molotov{
+	pixel_x = -7
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/indestructible,
+/area/deathmatch)
+"dd" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"dv" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/deathmatch_player_spawn,
+/turf/open/indestructible,
+/area/deathmatch)
+"dw" = (
+/obj/machinery/conveyor/auto{
+	dir = 8
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"dx" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/indestructible/white,
+/area/deathmatch)
+"dB" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"dJ" = (
+/turf/open/indestructible/plating,
+/area/deathmatch)
+"dN" = (
+/obj/structure/rack,
+/obj/item/slimecross/burning/gold,
+/obj/item/reagent_containers/syringe/plasma,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"dO" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/deathmatch)
+"ec" = (
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"ee" = (
+/obj/structure/table/glass,
+/obj/item/storage/medkit/brute,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"eg" = (
+/obj/structure/barricade/security,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"er" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/light/floor,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"es" = (
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/obj/structure/ore_box,
+/turf/open/indestructible,
+/area/deathmatch)
+"eA" = (
+/obj/item/throwing_star,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"eC" = (
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"eT" = (
+/obj/item/gun/energy/beam_rifle,
+/obj/structure/rack,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"fj" = (
+/obj/structure/barricade/security,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"fE" = (
+/obj/machinery/computer{
+	dir = 8
+	},
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"fJ" = (
+/obj/effect/turf_decal/tile/green/full,
+/obj/structure/sign/directions/engineering{
+	dir = 4;
+	pixel_y = -25
+	},
+/turf/open/indestructible/large,
+/area/deathmatch)
+"gb" = (
+/obj/structure/table/wood,
+/obj/item/gavelblock,
+/obj/item/gavelhammer,
+/turf/open/floor/wood,
+/area/deathmatch)
+"ge" = (
+/obj/structure/mystery_box/tdome,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/light_emitter{
+	light_color = "#DEEFFF";
+	set_cap = 2;
+	set_luminosity = 2
+	},
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"hb" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/deathmatch)
+"hg" = (
+/obj/structure/chair,
+/turf/open/floor/wood,
+/area/deathmatch)
+"hi" = (
+/obj/structure/chair{
+	dir = 4;
+	name = "Prosecution"
+	},
+/turf/open/floor/wood,
+/area/deathmatch)
+"hj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/deathmatch_player_spawn,
+/obj/effect/light_emitter{
+	light_color = "#DEEFFF";
+	set_cap = 2;
+	set_luminosity = 2
+	},
+/turf/open/floor/iron,
+/area/deathmatch)
+"hq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible,
+/area/deathmatch)
+"hw" = (
+/obj/structure/table/reinforced,
+/obj/item/broken_bottle,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/indestructible,
+/area/deathmatch)
+"hP" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/deathmatch)
+"hQ" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood,
+/area/deathmatch)
+"hR" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible,
+/area/deathmatch)
+"in" = (
+/obj/item/grenade/frag,
+/obj/structure/broken_flooring/corner/directional/south,
+/turf/open/indestructible/plating,
+/area/deathmatch)
+"iB" = (
+/obj/item/shard,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"iO" = (
+/obj/machinery/door/airlock/medical/glass,
+/turf/open/indestructible,
+/area/deathmatch)
+"js" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"jA" = (
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/obj/structure/ore_box,
+/turf/open/indestructible,
+/area/deathmatch)
+"jE" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/sign/map/fulp/helio/right{
+	pixel_y = 32
+	},
+/turf/open/indestructible/large,
+/area/deathmatch)
+"jM" = (
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"jS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/landmark/deathmatch_player_spawn,
+/turf/open/floor/wood,
+/area/deathmatch)
+"kc" = (
+/obj/machinery/door/airlock/science/glass,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"kg" = (
+/obj/effect/spawner/structure/window,
+/turf/open/indestructible/plating,
+/area/deathmatch)
+"kR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"kS" = (
+/obj/structure/flora/bush/leafy,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/machinery/deployable_turret,
+/turf/open/floor/grass,
+/area/deathmatch)
+"lp" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible,
+/area/deathmatch)
+"lB" = (
+/obj/machinery/door/poddoor/shutters/indestructible{
+	dir = 4
+	},
+/turf/open/indestructible/white,
+/area/deathmatch)
+"lF" = (
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"md" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"mz" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"mF" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"mI" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/apron/chef,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"mK" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/deathmatch)
+"mN" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/deathmatch)
+"ne" = (
+/obj/structure/table/glass,
+/obj/item/circular_saw,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"ng" = (
+/obj/machinery/conveyor/auto{
+	dir = 8
+	},
+/obj/structure/ore_box,
+/turf/open/indestructible,
+/area/deathmatch)
+"nt" = (
+/obj/effect/decal/cleanable/ants,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"nu" = (
+/obj/structure/tank_holder/extinguisher,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"nU" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"or" = (
+/obj/effect/spawner/random/trash/soap,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"os" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"oz" = (
+/obj/structure/reflector/double/mapping{
+	dir = 10
+	},
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"oB" = (
+/obj/machinery/conveyor/auto{
+	dir = 6
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"oS" = (
+/obj/machinery/conveyor/auto{
+	dir = 6
+	},
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"oX" = (
+/obj/structure/mystery_box/tdome,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/indestructible,
+/area/deathmatch)
+"pl" = (
+/obj/effect/turf_decal/tile/red/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"pm" = (
+/obj/machinery/door/airlock/engineering/glass,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"pr" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/obj/effect/landmark/deathmatch_player_spawn,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"pw" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/deathmatch)
+"pC" = (
+/obj/effect/turf_decal/tile/purple,
+/turf/open/indestructible,
+/area/deathmatch)
+"qk" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/deathmatch)
+"qx" = (
+/turf/open/floor/glass/reinforced/plasma,
+/area/deathmatch)
+"qB" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"qM" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/deathmatch)
+"rA" = (
+/obj/structure/rack,
+/obj/item/slimecross/burning/blue,
+/obj/item/reagent_containers/syringe/plasma,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"rD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"rJ" = (
+/obj/structure/rack,
+/obj/item/slimecross/burning/darkblue,
+/obj/item/reagent_containers/syringe/plasma,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"rT" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/indestructible,
+/area/deathmatch)
+"sr" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"sB" = (
+/obj/structure/table/glass,
+/obj/item/storage/medkit/toxin,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"sO" = (
+/obj/effect/turf_decal/tile/purple/full,
+/obj/effect/turf_decal/bot,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"tm" = (
+/obj/machinery/conveyor/auto{
+	dir = 5
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"tv" = (
+/turf/open/indestructible/white,
+/area/deathmatch)
+"tU" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/indestructible,
+/area/deathmatch)
+"tW" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"ue" = (
+/obj/effect/turf_decal/tile/dark_blue/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"uA" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"uJ" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/deathmatch)
+"ve" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/floor,
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"vj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/deathmatch)
+"vk" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/landmark/deathmatch_player_spawn,
+/obj/effect/light_emitter{
+	light_color = "#DEEFFF";
+	set_cap = 2;
+	set_luminosity = 2
+	},
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"vq" = (
+/obj/structure/closet/crate/large,
+/obj/item/throwing_star,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible,
+/area/deathmatch)
+"vz" = (
+/obj/effect/landmark/deathmatch_player_spawn,
+/obj/effect/light_emitter{
+	light_color = "#DEEFFF";
+	set_cap = 2;
+	set_luminosity = 2
+	},
+/turf/open/indestructible/white,
+/area/deathmatch)
+"vD" = (
+/obj/structure/tank_holder/extinguisher,
+/obj/effect/turf_decal/tile/green/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"vV" = (
+/turf/closed/indestructible/reinforced,
+/area/deathmatch)
+"vW" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/deathmatch_player_spawn,
+/obj/effect/light_emitter{
+	light_color = "#DEEFFF";
+	set_cap = 2;
+	set_luminosity = 2
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"wl" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/indestructible,
+/area/deathmatch)
+"wo" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/indestructible,
+/area/deathmatch)
+"wG" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/item/broken_bottle,
+/turf/open/indestructible,
+/area/deathmatch)
+"wI" = (
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
+/area/deathmatch)
+"xa" = (
+/obj/item/toy/plush/lizard_plushie/green,
+/turf/open/indestructible/plating,
+/area/deathmatch)
+"xb" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"xf" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_x = -1;
+	pixel_y = 25
+	},
+/turf/open/indestructible/large,
+/area/deathmatch)
+"xE" = (
+/obj/item/gun/ballistic/rifle/rebarxbow/syndie,
+/obj/structure/table/reinforced,
+/obj/item/throwing_star,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"xT" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/deathmatch)
+"ym" = (
+/obj/structure/sign/map/fulp/helio/left{
+	pixel_y = 32
+	},
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"yv" = (
+/obj/machinery/door/poddoor/shutters/indestructible{
+	dir = 4
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"yy" = (
+/obj/machinery/door/poddoor/shutters/indestructible,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"yW" = (
+/obj/machinery/light/floor,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"zx" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"zI" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/sign/map/fulp/helio/left{
+	pixel_y = 32
+	},
+/turf/open/indestructible/large,
+/area/deathmatch)
+"Aa" = (
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"Ah" = (
+/obj/effect/turf_decal/tile/purple/full,
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	pixel_x = -1
+	},
+/turf/open/indestructible/large,
+/area/deathmatch)
+"Ap" = (
+/obj/structure/table/reinforced,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"AF" = (
+/obj/item/gun/syringe/dna,
+/obj/structure/table/reinforced,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"AY" = (
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"Bl" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"Bz" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"BL" = (
+/obj/machinery/conveyor/auto{
+	dir = 10
+	},
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"BX" = (
+/obj/structure/table/glass,
+/obj/item/throwing_star,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"BZ" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/deathmatch)
+"Ca" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/plating,
+/area/deathmatch)
+"Cl" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"Cm" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible,
+/area/deathmatch)
+"CE" = (
+/obj/structure/table/wood,
+/obj/item/chair{
+	name = "Defense"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/deathmatch)
+"CL" = (
+/obj/structure/rack,
+/obj/item/grenade/frag/mega,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"CR" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/deathmatch)
+"Dm" = (
+/obj/structure/plasticflaps,
+/turf/open/indestructible,
+/area/deathmatch)
+"Ey" = (
+/obj/structure/mystery_box/tdome,
+/obj/effect/turf_decal/stripes/white/full,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"EJ" = (
+/obj/structure/table/glass,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"EK" = (
+/obj/machinery/stasis{
+	dir = 4
+	},
+/turf/open/indestructible/white,
+/area/deathmatch)
+"EN" = (
+/turf/open/floor/iron,
+/area/deathmatch)
+"EQ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible,
+/area/deathmatch)
+"ER" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"ET" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/deathmatch)
+"EY" = (
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/obj/item/throwing_star,
+/turf/open/indestructible,
+/area/deathmatch)
+"Fa" = (
+/obj/structure/closet/crate/large,
+/turf/open/indestructible,
+/area/deathmatch)
+"Fd" = (
+/obj/structure/table/reinforced,
+/obj/item/food/grown/firelemon,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"Fj" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"Fv" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood,
+/area/deathmatch)
+"Fw" = (
+/obj/structure/table/glass,
+/obj/item/throwing_star,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"FI" = (
+/obj/effect/turf_decal/tile/green/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"FJ" = (
+/obj/machinery/door/poddoor/shutters/indestructible{
+	dir = 4
+	},
+/turf/open/indestructible/large,
+/area/deathmatch)
+"FZ" = (
+/turf/open/indestructible/large,
+/area/deathmatch)
+"Gs" = (
+/obj/machinery/door/airlock/medical/glass,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"GA" = (
+/obj/item/book/granter/martial/cqc,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"GZ" = (
+/obj/machinery/door/poddoor/shutters/indestructible{
+	dir = 8
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"Hj" = (
+/obj/structure/closet/secure_closet,
+/obj/item/gun/ballistic/revolver/c38,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"Ho" = (
+/obj/machinery/power/emitter/energycannon{
+	dir = 8
+	},
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"Hq" = (
+/obj/structure/closet/abductor,
+/obj/effect/mob_spawn/corpse/human/abductor,
+/obj/item/weldingtool/abductor,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"HB" = (
+/obj/effect/turf_decal/tile/green/full,
+/obj/effect/decal/cleanable/ants,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"HM" = (
+/obj/structure/table/reinforced,
+/obj/item/knife/kitchen,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"Ie" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/deathmatch)
+"Ii" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 8
+	},
+/turf/open/indestructible/white,
+/area/deathmatch)
+"Io" = (
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"IC" = (
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	dir = 1
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"IK" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/item/shard,
+/turf/open/floor/grass,
+/area/deathmatch)
+"IP" = (
+/obj/machinery/light/floor,
+/turf/open/indestructible,
+/area/deathmatch)
+"IW" = (
+/obj/structure/tank_holder/extinguisher,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"Jf" = (
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/deathmatch)
+"Jg" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"Jp" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"Jr" = (
+/obj/machinery/door/poddoor/shutters/indestructible{
+	dir = 8
+	},
+/turf/open/indestructible/large,
+/area/deathmatch)
+"JI" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/deathmatch)
+"JY" = (
+/obj/structure/bookcase,
+/turf/open/floor/wood,
+/area/deathmatch)
+"Ko" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"Kq" = (
+/obj/machinery/door/poddoor/shutters/indestructible,
+/turf/open/indestructible,
+/area/deathmatch)
+"Kr" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/clothing/accessory/lawyers_badge,
+/turf/open/floor/wood,
+/area/deathmatch)
+"Ku" = (
+/obj/machinery/conveyor/auto{
+	dir = 9
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"KE" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/indestructible,
+/area/deathmatch)
+"KT" = (
+/obj/machinery/conveyor/auto,
+/turf/open/indestructible,
+/area/deathmatch)
+"KU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/deathmatch)
+"Ld" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/deathmatch_player_spawn,
+/obj/effect/light_emitter{
+	light_color = "#DEEFFF";
+	set_cap = 2;
+	set_luminosity = 2
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"Lh" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/turf/open/floor/iron,
+/area/deathmatch)
+"Li" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/landmark/deathmatch_player_spawn,
+/obj/effect/light_emitter{
+	light_color = "#DEEFFF";
+	set_cap = 2;
+	set_luminosity = 2
+	},
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"Lt" = (
+/obj/structure/table/glass,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"Lu" = (
+/turf/open/indestructible,
+/area/deathmatch)
+"Lx" = (
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"LE" = (
+/obj/structure/table,
+/obj/item/pizzabox/bomb/armed,
+/obj/item/gun/ballistic/rifle/boltaction/surplus,
+/turf/open/indestructible,
+/area/deathmatch)
+"Mt" = (
+/obj/machinery/deepfryer,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"MI" = (
+/obj/machinery/conveyor/auto,
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"MN" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/deathmatch)
+"MS" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"MX" = (
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"MZ" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/indestructible/white,
+/area/deathmatch)
+"Na" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/c4,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"Nc" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"Nd" = (
+/obj/effect/landmark/deathmatch_player_spawn,
+/obj/effect/light_emitter{
+	light_color = "#DEEFFF";
+	set_cap = 2;
+	set_luminosity = 2
+	},
+/turf/open/floor/wood,
+/area/deathmatch)
+"Ni" = (
+/obj/structure/barricade/security,
+/turf/open/indestructible,
+/area/deathmatch)
+"NA" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/deathmatch)
+"NL" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/deathmatch)
+"Og" = (
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/deathmatch)
+"Oj" = (
+/obj/machinery/conveyor/auto{
+	dir = 5
+	},
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"Ov" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"OU" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/mine/shrapnel,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"Pl" = (
+/obj/structure/mystery_box/tdome,
+/obj/effect/turf_decal/stripes/white/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"Po" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"Pt" = (
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/deathmatch)
+"Pv" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"PX" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"Qb" = (
+/obj/structure/table/reinforced,
+/obj/item/dnainjector/hulkmut,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"Qk" = (
+/obj/structure/table/wood,
+/obj/item/clothing/under/rank/civilian/lawyer/blue,
+/turf/open/floor/wood,
+/area/deathmatch)
+"QA" = (
+/obj/structure/flora/bush/leafy,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/deathmatch)
+"Ra" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/deathmatch)
+"Re" = (
+/obj/machinery/light/floor,
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"Rf" = (
+/obj/effect/turf_decal/tile/red/full,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"Ri" = (
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible,
+/area/deathmatch)
+"Rm" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/soap,
+/turf/open/indestructible,
+/area/deathmatch)
+"Rx" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"RM" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_y = 36
+	},
+/turf/open/indestructible/large,
+/area/deathmatch)
+"RW" = (
+/obj/structure/broken_flooring/pile/directional/east,
+/turf/open/indestructible/plating,
+/area/deathmatch)
+"Sr" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/item/broken_bottle,
+/turf/open/indestructible,
+/area/deathmatch)
+"SC" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/deathmatch)
+"TD" = (
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/mini,
+/obj/effect/turf_decal/tile/red/fourcorners,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"TG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/deathmatch_player_spawn,
+/turf/open/indestructible,
+/area/deathmatch)
+"TR" = (
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"Uc" = (
+/turf/open/floor/wood,
+/area/deathmatch)
+"Ut" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"UB" = (
+/obj/structure/mystery_box/tdome,
+/obj/effect/turf_decal/stripes/white/full,
+/obj/effect/light_emitter{
+	light_color = "#DEEFFF";
+	set_cap = 2;
+	set_luminosity = 2
+	},
+/turf/open/indestructible/large,
+/area/deathmatch)
+"UQ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/deathmatch)
+"UY" = (
+/obj/structure/table/glass,
+/obj/item/storage/medkit/fire,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"Va" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"Vb" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/structure/sign/directions/supply{
+	pixel_x = 30
+	},
+/turf/open/indestructible/large,
+/area/deathmatch)
+"Vv" = (
+/obj/structure/closet/secure_closet/freezer/fridge/all_access,
+/obj/item/food/pie/cream,
+/obj/item/food/pie/cream,
+/obj/item/food/pie/cream,
+/turf/open/indestructible/kitchen,
+/area/deathmatch)
+"VG" = (
+/obj/structure/table/wood,
+/obj/item/gun/ballistic/rifle/sniper_rifle,
+/turf/open/floor/wood,
+/area/deathmatch)
+"VQ" = (
+/obj/effect/turf_decal/tile/brown,
+/turf/open/indestructible,
+/area/deathmatch)
+"Wi" = (
+/obj/structure/table/wood,
+/obj/item/melee/chainofcommand,
+/turf/open/floor/wood,
+/area/deathmatch)
+"Wj" = (
+/obj/machinery/conveyor/auto{
+	dir = 10
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"Wm" = (
+/obj/structure/mystery_box/tdome,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"Ww" = (
+/obj/structure/hedge,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"WA" = (
+/obj/machinery/door/poddoor/shutters/indestructible{
+	dir = 1
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"WL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"WS" = (
+/obj/item/storage/medkit/tactical/premium,
+/turf/open/indestructible/white,
+/area/deathmatch)
+"Xt" = (
+/obj/effect/landmark/deathmatch_player_spawn,
+/obj/machinery/light/floor,
+/turf/open/indestructible,
+/area/deathmatch)
+"Xv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/indestructible,
+/area/deathmatch)
+"Xy" = (
+/obj/effect/turf_decal/tile/red/fourcorners,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"XB" = (
+/obj/machinery/power/supermatter_crystal/shard/hugbox{
+	anchored = 0
+	},
+/obj/machinery/conveyor/auto{
+	dir = 9
+	},
+/turf/open/indestructible/dark/smooth_large,
+/area/deathmatch)
+"YC" = (
+/obj/effect/turf_decal/tile/purple/full,
+/obj/effect/turf_decal/delivery,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"YM" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible,
+/area/deathmatch)
+"YQ" = (
+/obj/effect/turf_decal/tile/purple/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"YX" = (
+/obj/structure/rack,
+/obj/item/slimecross/burning/green,
+/obj/item/reagent_containers/syringe/plasma,
+/turf/open/indestructible/white/smooth_large,
+/area/deathmatch)
+"Zh" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"Zq" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/deathmatch)
+"Zr" = (
+/obj/structure/closet/secure_closet,
+/obj/item/shield/riot,
+/obj/effect/turf_decal/tile/red/fourcorners,
+/turf/open/indestructible/dark,
+/area/deathmatch)
+"Zv" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/obj/item/broken_bottle,
+/turf/open/indestructible,
+/area/deathmatch)
+"Zy" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible,
+/area/deathmatch)
+"ZM" = (
+/obj/structure/barricade/security,
+/obj/effect/turf_decal/tile/red/full,
+/turf/open/indestructible/large,
+/area/deathmatch)
+"ZS" = (
+/obj/machinery/stasis,
+/turf/open/indestructible/white,
+/area/deathmatch)
+
+(1,1,1) = {"
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+FJ
+yv
+yv
+yv
+FJ
+vV
+vV
+lB
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+"}
+(2,1,1) = {"
+vV
+ge
+Ut
+bI
+qB
+md
+vV
+Uc
+Uc
+vj
+jS
+hi
+vV
+MS
+IC
+Lu
+Cl
+vD
+kg
+ba
+GA
+Mt
+vV
+ec
+CL
+eT
+ec
+vV
+"}
+(3,1,1) = {"
+vV
+dd
+ec
+kg
+eg
+ER
+vV
+Uc
+gb
+Uc
+CE
+Ra
+kg
+lF
+IC
+UB
+Cl
+FI
+kg
+ba
+AY
+Mt
+vV
+ec
+Aa
+Aa
+ec
+vV
+"}
+(4,1,1) = {"
+vV
+vV
+vV
+vV
+uA
+ER
+Ko
+hg
+hP
+hQ
+Uc
+Uc
+mK
+lF
+Ri
+Lu
+Cl
+FI
+Fd
+AY
+rD
+AY
+Ov
+Oj
+MX
+MX
+XB
+vV
+"}
+(5,1,1) = {"
+vV
+Hj
+xb
+bI
+Fj
+eA
+vV
+Uc
+Wi
+Uc
+mN
+SC
+kg
+lF
+IC
+Lu
+Cl
+HB
+mI
+AY
+AY
+Jg
+Ov
+oS
+MI
+MI
+BL
+vV
+"}
+(6,1,1) = {"
+vV
+vk
+ec
+kg
+Rx
+fj
+vV
+Uc
+Uc
+vj
+KU
+Uc
+vV
+lF
+IC
+cz
+Sr
+FI
+kg
+Vv
+rD
+nt
+vV
+oz
+uJ
+uJ
+Aa
+vV
+"}
+(7,1,1) = {"
+vV
+vV
+vV
+vV
+Rx
+zx
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+lF
+IC
+IP
+EQ
+FI
+vV
+kg
+HM
+kg
+vV
+Re
+uJ
+uJ
+ve
+vV
+"}
+(8,1,1) = {"
+vV
+TD
+Ut
+Ut
+Fj
+ER
+Xy
+vV
+JY
+Uc
+Fv
+MN
+vV
+ym
+IC
+Lu
+Cl
+FI
+vV
+YM
+vW
+oX
+vV
+Po
+uJ
+uJ
+Aa
+vV
+"}
+(9,1,1) = {"
+vV
+vV
+Pv
+kg
+Pv
+vV
+Xy
+NL
+Uc
+Nd
+Kr
+VG
+vV
+cq
+Pt
+EN
+UQ
+FI
+wo
+rT
+wl
+Cm
+wo
+Aa
+uJ
+uJ
+cD
+vV
+"}
+(10,1,1) = {"
+xa
+vV
+er
+kg
+er
+vV
+Zr
+vV
+Qk
+Uc
+Uc
+dO
+vV
+lF
+Pt
+EN
+UQ
+FI
+vV
+hw
+KE
+cY
+vV
+Bl
+uJ
+uJ
+Ho
+vV
+"}
+(11,1,1) = {"
+vV
+vV
+Pv
+kg
+Pv
+vV
+vV
+vV
+kg
+kg
+kg
+vV
+vV
+cG
+Pt
+Jf
+UQ
+fJ
+vV
+kg
+kg
+kg
+vV
+vV
+pm
+pm
+vV
+vV
+"}
+(12,1,1) = {"
+yy
+pl
+pl
+pl
+pl
+pl
+ZM
+Rf
+pl
+pl
+pl
+pl
+pl
+EN
+FZ
+Og
+FZ
+EN
+TR
+TR
+TR
+TR
+TR
+or
+TR
+TR
+IW
+WA
+"}
+(13,1,1) = {"
+Kq
+Xv
+Xv
+Ld
+Xv
+hR
+aM
+Xv
+Xv
+Rm
+bx
+bx
+bx
+FZ
+Ww
+IK
+Ww
+FZ
+EN
+Ie
+sr
+sr
+sr
+sr
+sr
+sr
+dv
+WA
+"}
+(14,1,1) = {"
+Kq
+Pl
+Lu
+Ni
+Ni
+Ni
+Ni
+Lu
+IP
+Lu
+hj
+EN
+xT
+qM
+QA
+kS
+hb
+Zq
+pw
+EN
+Lu
+Lu
+IP
+Lu
+Lu
+Pl
+Lu
+WA
+"}
+(15,1,1) = {"
+Kq
+tW
+tW
+tW
+aP
+tW
+tW
+tW
+Zv
+tW
+BZ
+BZ
+BZ
+FZ
+Ww
+ET
+Ww
+iB
+EN
+qk
+VQ
+VQ
+VQ
+VQ
+VQ
+VQ
+VQ
+WA
+"}
+(16,1,1) = {"
+yy
+ue
+ue
+ue
+cR
+ue
+ue
+ue
+ue
+ue
+ue
+ue
+ue
+EN
+FZ
+NA
+FZ
+EN
+Vb
+jM
+jM
+jM
+Zh
+Zh
+jM
+jM
+jM
+WA
+"}
+(17,1,1) = {"
+vV
+vV
+Gs
+Gs
+vV
+vV
+vV
+vV
+vV
+Gs
+Gs
+vV
+vV
+RM
+CR
+Lh
+JI
+YQ
+vV
+kg
+kc
+kg
+vV
+vV
+Dm
+Dm
+vV
+vV
+"}
+(18,1,1) = {"
+vV
+dx
+MZ
+dx
+dx
+Lt
+WS
+Lt
+dx
+dx
+dx
+tv
+vV
+Lx
+CR
+EN
+wI
+YQ
+vV
+rA
+Va
+dN
+vV
+tm
+jA
+jA
+Ku
+vV
+"}
+(19,1,1) = {"
+vV
+MS
+Io
+MS
+lF
+Lt
+tv
+ne
+Io
+Io
+EJ
+Nc
+Gs
+Lx
+dB
+Lu
+pC
+YQ
+vV
+rJ
+Va
+YX
+vV
+eC
+vq
+Lu
+dw
+vV
+"}
+(20,1,1) = {"
+vV
+lF
+WL
+Io
+vV
+vV
+tv
+tv
+vV
+mz
+EJ
+Nc
+Gs
+Lx
+lp
+Lu
+pC
+YC
+Qb
+WL
+Va
+Hq
+vV
+eC
+Fa
+LE
+dw
+vV
+"}
+(21,1,1) = {"
+vV
+lF
+vV
+vz
+tv
+EK
+Lt
+tv
+EK
+nU
+Fw
+Nc
+vV
+zI
+dB
+IP
+wG
+sO
+Ap
+Jp
+PX
+lF
+vV
+EY
+os
+hq
+ng
+vV
+"}
+(22,1,1) = {"
+vV
+lF
+tv
+BX
+Io
+mF
+OU
+mF
+tv
+tv
+vV
+tv
+vV
+jE
+dB
+Lu
+pC
+Ah
+vV
+MS
+Va
+xE
+vV
+es
+aZ
+Fa
+ng
+vV
+"}
+(23,1,1) = {"
+vV
+MS
+tv
+ne
+Io
+Io
+Io
+Io
+tv
+tv
+vV
+kR
+vV
+Lx
+dB
+Xt
+Zy
+YQ
+vV
+Wm
+Bz
+Na
+vV
+es
+TG
+Fa
+dw
+vV
+"}
+(24,1,1) = {"
+vV
+MS
+vV
+nU
+nU
+ZS
+nU
+tv
+ZS
+tv
+lF
+js
+vV
+xf
+dB
+Lu
+pC
+YQ
+kg
+yW
+Va
+cJ
+vV
+oB
+KT
+KT
+Wj
+vV
+"}
+(25,1,1) = {"
+vV
+lF
+lF
+mz
+vV
+vV
+Lt
+Lt
+vV
+mz
+MS
+Nc
+iO
+Lx
+dB
+Pl
+pC
+YQ
+kc
+lF
+PX
+MS
+vV
+vV
+Dm
+Dm
+vV
+vV
+"}
+(26,1,1) = {"
+vV
+vV
+Io
+lF
+lF
+tv
+tv
+tv
+mF
+Li
+EJ
+Nc
+iO
+Lx
+dB
+Lu
+pC
+YQ
+kg
+al
+Ii
+pr
+kc
+RW
+dJ
+aa
+tU
+vV
+"}
+(27,1,1) = {"
+vV
+Ey
+MS
+vV
+ee
+sB
+UY
+tv
+tv
+Lt
+cF
+Lt
+vV
+nu
+dB
+qx
+pC
+YQ
+vV
+AF
+fE
+fE
+vV
+Ca
+dJ
+in
+tU
+vV
+"}
+(28,1,1) = {"
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+Jr
+GZ
+GZ
+GZ
+Jr
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+vV
+"}

--- a/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
+++ b/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
@@ -61,7 +61,7 @@
 /turf/open/indestructible,
 /area/deathmatch/fullbright)
 "cD" = (
-/obj/structure/reflector/double/mapping{
+/obj/structure/reflector/box/mapping{
 	dir = 9
 	},
 /turf/open/indestructible/dark/smooth_large,
@@ -427,7 +427,7 @@
 /turf/open/indestructible,
 /area/deathmatch/fullbright)
 "oz" = (
-/obj/structure/reflector/double/mapping{
+/obj/structure/reflector/box/mapping{
 	dir = 10
 	},
 /turf/open/indestructible/dark/smooth_large,
@@ -600,11 +600,6 @@
 /area/deathmatch/fullbright)
 "vz" = (
 /obj/effect/landmark/deathmatch_player_spawn,
-/obj/effect/light_emitter{
-	light_color = "#DEEFFF";
-	set_cap = 2;
-	set_luminosity = 2
-	},
 /turf/open/indestructible/white,
 /area/deathmatch/fullbright)
 "vD" = (
@@ -1053,11 +1048,6 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/deathmatch_player_spawn,
-/obj/effect/light_emitter{
-	light_color = "#DEEFFF";
-	set_cap = 2;
-	set_luminosity = 2
-	},
 /turf/open/indestructible,
 /area/deathmatch/fullbright)
 "Lh" = (
@@ -1071,11 +1061,6 @@
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/landmark/deathmatch_player_spawn,
-/obj/effect/light_emitter{
-	light_color = "#DEEFFF";
-	set_cap = 2;
-	set_luminosity = 2
-	},
 /turf/open/indestructible/white/smooth_large,
 /area/deathmatch/fullbright)
 "Lt" = (
@@ -1137,11 +1122,6 @@
 /area/deathmatch/fullbright)
 "Nd" = (
 /obj/effect/landmark/deathmatch_player_spawn,
-/obj/effect/light_emitter{
-	light_color = "#DEEFFF";
-	set_cap = 2;
-	set_luminosity = 2
-	},
 /turf/open/floor/wood,
 /area/deathmatch/fullbright)
 "Ni" = (
@@ -1317,16 +1297,6 @@
 	dir = 8
 	},
 /turf/open/indestructible/dark,
-/area/deathmatch/fullbright)
-"UB" = (
-/obj/structure/mystery_box/tdome,
-/obj/effect/turf_decal/stripes/white/full,
-/obj/effect/light_emitter{
-	light_color = "#DEEFFF";
-	set_cap = 2;
-	set_luminosity = 2
-	},
-/turf/open/indestructible/large,
 /area/deathmatch/fullbright)
 "UQ" = (
 /obj/effect/turf_decal/tile/green{
@@ -1567,7 +1537,7 @@ Ra
 kg
 lF
 IC
-UB
+Pl
 Cl
 FI
 kg

--- a/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
+++ b/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
@@ -2,7 +2,7 @@
 "aa" = (
 /obj/structure/broken_flooring/pile/directional/west,
 /turf/open/indestructible/plating,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "al" = (
 /obj/structure/table/reinforced,
 /obj/item/dnainjector/blindmut{
@@ -13,64 +13,64 @@
 	},
 /obj/item/dnainjector/blindmut,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "aM" = (
 /obj/structure/barricade/security,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "aP" = (
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
 	},
 /obj/structure/holosign/barrier,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "aZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/floor,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ba" = (
 /obj/machinery/oven/range,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "bx" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "bI" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "cq" = (
 /obj/structure/sign/map/fulp/helio/right{
 	pixel_y = 32
 	},
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "cz" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "cD" = (
 /obj/structure/reflector/double/mapping{
 	dir = 9
 	},
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "cF" = (
 /obj/structure/table/glass,
 /obj/item/gun/ballistic/revolver/c38,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "cG" = (
 /obj/structure/sign/directions/security{
 	dir = 4;
@@ -81,16 +81,16 @@
 	pixel_y = 36
 	},
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "cJ" = (
 /obj/machinery/destructive_scanner,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "cR" = (
 /obj/effect/turf_decal/tile/dark_blue/full,
 /obj/structure/holosign/barrier,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "cY" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/glass/bottle/molotov{
@@ -104,14 +104,14 @@
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "dd" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "dv" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -119,94 +119,94 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/deathmatch_player_spawn,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "dw" = (
 /obj/machinery/conveyor/auto{
 	dir = 8
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "dx" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "dB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "dJ" = (
 /turf/open/indestructible/plating,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "dN" = (
 /obj/structure/rack,
 /obj/item/slimecross/burning/gold,
 /obj/item/reagent_containers/syringe/plasma,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "dO" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ec" = (
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ee" = (
 /obj/structure/table/glass,
 /obj/item/storage/medkit/brute,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "eg" = (
 /obj/structure/barricade/security,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "er" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/machinery/light/floor,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "es" = (
 /obj/machinery/conveyor/auto{
 	dir = 4
 	},
 /obj/structure/ore_box,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "eA" = (
 /obj/item/throwing_star,
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "eC" = (
 /obj/machinery/conveyor/auto{
 	dir = 4
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "eT" = (
 /obj/item/gun/energy/beam_rifle,
 /obj/structure/rack,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "fj" = (
 /obj/structure/barricade/security,
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "fE" = (
 /obj/machinery/computer{
 	dir = 8
 	},
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "fJ" = (
 /obj/effect/turf_decal/tile/green/full,
 /obj/structure/sign/directions/engineering{
@@ -214,13 +214,13 @@
 	pixel_y = -25
 	},
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "gb" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
 /obj/item/gavelhammer,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ge" = (
 /obj/structure/mystery_box/tdome,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -232,236 +232,231 @@
 	set_luminosity = 2
 	},
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "hb" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "hg" = (
 /obj/structure/chair,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "hi" = (
 /obj/structure/chair{
 	dir = 4;
 	name = "Prosecution"
 	},
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "hj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/deathmatch_player_spawn,
-/obj/effect/light_emitter{
-	light_color = "#DEEFFF";
-	set_cap = 2;
-	set_luminosity = 2
-	},
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "hq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "hw" = (
 /obj/structure/table/reinforced,
 /obj/item/broken_bottle,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "hP" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "hQ" = (
 /obj/machinery/light/floor,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "hR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "in" = (
 /obj/item/grenade/frag,
 /obj/structure/broken_flooring/corner/directional/south,
 /turf/open/indestructible/plating,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "iB" = (
 /obj/item/shard,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "iO" = (
 /obj/machinery/door/airlock/medical/glass,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "js" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "jA" = (
 /obj/machinery/conveyor/auto{
 	dir = 1
 	},
 /obj/structure/ore_box,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "jE" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/structure/sign/map/fulp/helio/right{
 	pixel_y = 32
 	},
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "jM" = (
 /obj/effect/turf_decal/tile/brown/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "jS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/effect/landmark/deathmatch_player_spawn,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "kc" = (
 /obj/machinery/door/airlock/science/glass,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "kg" = (
 /obj/effect/spawner/structure/window,
 /turf/open/indestructible/plating,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "kR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "kS" = (
 /obj/structure/flora/bush/leafy,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/machinery/deployable_turret,
 /turf/open/floor/grass,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "lp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "lB" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
 	dir = 4
 	},
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "lF" = (
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "md" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "mz" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "mF" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "mI" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/apron/chef,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "mK" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "mN" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ne" = (
 /obj/structure/table/glass,
 /obj/item/circular_saw,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ng" = (
 /obj/machinery/conveyor/auto{
 	dir = 8
 	},
 /obj/structure/ore_box,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "nt" = (
 /obj/effect/decal/cleanable/ants,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "nu" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "nU" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "or" = (
 /obj/effect/spawner/random/trash/soap,
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "os" = (
 /obj/structure/chair/plastic{
 	dir = 4
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "oz" = (
 /obj/structure/reflector/double/mapping{
 	dir = 10
 	},
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "oB" = (
 /obj/machinery/conveyor/auto{
 	dir = 6
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "oS" = (
 /obj/machinery/conveyor/auto{
 	dir = 6
 	},
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "oX" = (
 /obj/structure/mystery_box/tdome,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "pl" = (
 /obj/effect/turf_decal/tile/red/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "pm" = (
 /obj/machinery/door/airlock/engineering/glass,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "pr" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
@@ -471,7 +466,7 @@
 	},
 /obj/effect/landmark/deathmatch_player_spawn,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "pw" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -480,23 +475,23 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "pC" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "qk" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "qB" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "qM" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -506,84 +501,84 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "rA" = (
 /obj/structure/rack,
 /obj/item/slimecross/burning/blue,
 /obj/item/reagent_containers/syringe/plasma,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "rD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "rJ" = (
 /obj/structure/rack,
 /obj/item/slimecross/burning/darkblue,
 /obj/item/reagent_containers/syringe/plasma,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "rT" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "sr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "sB" = (
 /obj/structure/table/glass,
 /obj/item/storage/medkit/toxin,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "sO" = (
 /obj/effect/turf_decal/tile/purple/full,
 /obj/effect/turf_decal/bot,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "tm" = (
 /obj/machinery/conveyor/auto{
 	dir = 5
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "tv" = (
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "tU" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "tW" = (
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ue" = (
 /obj/effect/turf_decal/tile/dark_blue/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "uA" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "uJ" = (
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ve" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/floor,
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "vj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "vk" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -596,13 +591,13 @@
 	set_luminosity = 2
 	},
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "vq" = (
 /obj/structure/closet/crate/large,
 /obj/item/throwing_star,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "vz" = (
 /obj/effect/landmark/deathmatch_player_spawn,
 /obj/effect/light_emitter{
@@ -611,15 +606,15 @@
 	set_luminosity = 2
 	},
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "vD" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "vV" = (
 /turf/closed/indestructible/reinforced,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "vW" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -630,39 +625,39 @@
 	set_luminosity = 2
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "wl" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "wo" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "wG" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/item/broken_bottle,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "wI" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "xa" = (
 /obj/item/toy/plush/lizard_plushie/green,
 /turf/open/indestructible/plating,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "xb" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "xf" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/structure/sign/directions/evac{
@@ -671,13 +666,13 @@
 	pixel_y = 25
 	},
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "xE" = (
 /obj/item/gun/ballistic/rifle/rebarxbow/syndie,
 /obj/structure/table/reinforced,
 /obj/item/throwing_star,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "xT" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -686,47 +681,47 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ym" = (
 /obj/structure/sign/map/fulp/helio/left{
 	pixel_y = 32
 	},
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "yr" = (
 /obj/machinery/griddle,
 /obj/item/food/grown/sunflower,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "yv" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
 	dir = 4
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "yy" = (
 /obj/machinery/door/poddoor/shutters/indestructible,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "yW" = (
 /obj/machinery/light/floor,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "zx" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "zI" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/structure/sign/map/fulp/helio/left{
 	pixel_y = 32
 	},
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Aa" = (
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ah" = (
 /obj/effect/turf_decal/tile/purple/full,
 /obj/effect/turf_decal/loading_area{
@@ -734,23 +729,23 @@
 	pixel_x = -1
 	},
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ap" = (
 /obj/structure/table/reinforced,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "AF" = (
 /obj/item/gun/syringe/dna,
 /obj/structure/table/reinforced,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "AY" = (
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Bl" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Bz" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/purple/line{
@@ -758,39 +753,39 @@
 	},
 /obj/effect/turf_decal/trimline/purple/line,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "BL" = (
 /obj/machinery/conveyor/auto{
 	dir = 10
 	},
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "BX" = (
 /obj/structure/table/glass,
 /obj/item/throwing_star,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "BZ" = (
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ca" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/plating,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Cl" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Cm" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "CE" = (
 /obj/structure/table/wood,
 /obj/item/chair{
@@ -800,114 +795,114 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "CL" = (
 /obj/structure/rack,
 /obj/item/grenade/frag/mega,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "CR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Dm" = (
 /obj/structure/plasticflaps,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ey" = (
 /obj/structure/mystery_box/tdome,
 /obj/effect/turf_decal/stripes/white/full,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "EJ" = (
 /obj/structure/table/glass,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "EK" = (
 /obj/machinery/stasis{
 	dir = 4
 	},
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "EN" = (
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "EQ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ER" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ET" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "EY" = (
 /obj/machinery/conveyor/auto{
 	dir = 4
 	},
 /obj/item/throwing_star,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Fa" = (
 /obj/structure/closet/crate/large,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Fd" = (
 /obj/structure/table/reinforced,
 /obj/item/food/grown/firelemon,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Fj" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Fv" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Fw" = (
 /obj/structure/table/glass,
 /obj/item/throwing_star,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "FI" = (
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "FJ" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
 	dir = 4
 	},
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "FZ" = (
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Gs" = (
 /obj/machinery/door/airlock/medical/glass,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "GA" = (
 /obj/item/book/granter/martial/cqc,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "GZ" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
 	dir = 8
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Hj" = (
 /obj/structure/closet/secure_closet,
 /obj/item/gun/ballistic/revolver/c38,
@@ -915,35 +910,35 @@
 	dir = 1
 	},
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ho" = (
 /obj/machinery/power/emitter/energycannon{
 	dir = 8
 	},
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Hq" = (
 /obj/structure/closet/abductor,
 /obj/effect/mob_spawn/corpse/human/abductor,
 /obj/item/weldingtool/abductor,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "HB" = (
 /obj/effect/turf_decal/tile/green/full,
 /obj/effect/decal/cleanable/ants,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "HM" = (
 /obj/structure/table/reinforced,
 /obj/item/knife/kitchen,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ie" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ii" = (
 /obj/structure/chair{
 	dir = 4
@@ -955,103 +950,103 @@
 	dir = 8
 	},
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Io" = (
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "IC" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255;
 	dir = 1
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "IK" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/item/shard,
 /turf/open/floor/grass,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "IP" = (
 /obj/machinery/light/floor,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "IW" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Jf" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Jg" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Jp" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Jr" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
 	dir = 8
 	},
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "JI" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "JY" = (
 /obj/structure/bookcase,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ko" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Kq" = (
 /obj/machinery/door/poddoor/shutters/indestructible,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Kr" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/clothing/accessory/lawyers_badge,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ku" = (
 /obj/machinery/conveyor/auto{
 	dir = 9
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "KE" = (
 /obj/structure/table/reinforced,
 /obj/item/lighter,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "KT" = (
 /obj/machinery/conveyor/auto,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "KU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ld" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -1064,14 +1059,14 @@
 	set_luminosity = 2
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Lh" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Li" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/decal/cleanable/blood/old,
@@ -1082,64 +1077,64 @@
 	set_luminosity = 2
 	},
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Lt" = (
 /obj/structure/table/glass,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Lu" = (
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Lx" = (
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "LE" = (
 /obj/structure/table,
 /obj/item/pizzabox/bomb/armed,
 /obj/item/gun/ballistic/rifle/boltaction/surplus,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Mt" = (
 /obj/machinery/deepfryer,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "MI" = (
 /obj/machinery/conveyor/auto,
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "MN" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "MS" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "MX" = (
 /obj/machinery/conveyor/auto{
 	dir = 1
 	},
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "MZ" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Na" = (
 /obj/structure/table/reinforced,
 /obj/item/grenade/c4,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Nc" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Nd" = (
 /obj/effect/landmark/deathmatch_player_spawn,
 /obj/effect/light_emitter{
@@ -1148,11 +1143,11 @@
 	set_luminosity = 2
 	},
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ni" = (
 /obj/structure/barricade/security,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "NA" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -1160,14 +1155,14 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "NL" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Og" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -1175,43 +1170,43 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Oj" = (
 /obj/machinery/conveyor/auto{
 	dir = 5
 	},
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ov" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "OU" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/mine/shrapnel,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Pl" = (
 /obj/structure/mystery_box/tdome,
 /obj/effect/turf_decal/stripes/white/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Po" = (
 /obj/structure/tank_holder/extinguisher,
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Pt" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255;
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Pv" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "PX" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
@@ -1219,38 +1214,38 @@
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Qb" = (
 /obj/structure/table/reinforced,
 /obj/item/dnainjector/hulkmut,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Qk" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/rank/civilian/lawyer/blue,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "QA" = (
 /obj/structure/flora/bush/leafy,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ra" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Re" = (
 /obj/machinery/light/floor,
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Rf" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ri" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255;
@@ -1258,21 +1253,21 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Rm" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/spawner/random/trash/soap,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Rx" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "RM" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/structure/sign/directions/medical{
@@ -1280,49 +1275,49 @@
 	pixel_y = 36
 	},
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "RW" = (
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/open/indestructible/plating,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Sr" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /obj/item/broken_bottle,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "SC" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "TD" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/mini,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "TG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/deathmatch_player_spawn,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "TR" = (
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Uc" = (
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ut" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "UB" = (
 /obj/structure/mystery_box/tdome,
 /obj/effect/turf_decal/stripes/white/full,
@@ -1332,96 +1327,96 @@
 	set_luminosity = 2
 	},
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "UQ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "UY" = (
 /obj/structure/table/glass,
 /obj/item/storage/medkit/fire,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Va" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Vb" = (
 /obj/effect/turf_decal/tile/brown/full,
 /obj/structure/sign/directions/supply{
 	pixel_x = 30
 	},
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Vv" = (
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /obj/item/food/pie/cream,
 /obj/item/food/pie/cream,
 /obj/item/food/pie/cream,
 /turf/open/indestructible/kitchen,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "VG" = (
 /obj/structure/table/wood,
 /obj/item/gun/ballistic/rifle/sniper_rifle,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "VQ" = (
 /obj/effect/turf_decal/tile/brown,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Wi" = (
 /obj/structure/table/wood,
 /obj/item/melee/chainofcommand,
 /turf/open/floor/wood,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Wj" = (
 /obj/machinery/conveyor/auto{
 	dir = 10
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Wm" = (
 /obj/structure/mystery_box/tdome,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Ww" = (
 /obj/structure/hedge,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "WA" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
 	dir = 1
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "WL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "WS" = (
 /obj/item/storage/medkit/tactical/premium,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Xt" = (
 /obj/effect/landmark/deathmatch_player_spawn,
 /obj/machinery/light/floor,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Xv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Xy" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "XB" = (
 /obj/machinery/power/supermatter_crystal/shard/hugbox{
 	anchored = 0
@@ -1430,34 +1425,34 @@
 	dir = 9
 	},
 /turf/open/indestructible/dark/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "YC" = (
 /obj/effect/turf_decal/tile/purple/full,
 /obj/effect/turf_decal/delivery,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "YM" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "YQ" = (
 /obj/effect/turf_decal/tile/purple/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "YX" = (
 /obj/structure/rack,
 /obj/item/slimecross/burning/green,
 /obj/item/reagent_containers/syringe/plasma,
 /turf/open/indestructible/white/smooth_large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Zh" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Zq" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -1467,34 +1462,34 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Zr" = (
 /obj/structure/closet/secure_closet,
 /obj/item/shield/riot,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/indestructible/dark,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Zv" = (
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
 	},
 /obj/item/broken_bottle,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "Zy" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ZM" = (
 /obj/structure/barricade/security,
 /obj/effect/turf_decal/tile/red/full,
 /turf/open/indestructible/large,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 "ZS" = (
 /obj/machinery/stasis,
 /turf/open/indestructible/white,
-/area/deathmatch)
+/area/deathmatch/fullbright)
 
 (1,1,1) = {"
 vV
@@ -1692,7 +1687,7 @@ vV
 vV
 lF
 IC
-IP
+Lu
 EQ
 FI
 vV

--- a/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
+++ b/fulp_modules/mapping/deathmatch/maps/heliocentric.dmm
@@ -1305,7 +1305,7 @@
 /area/deathmatch/fullbright)
 "VG" = (
 /obj/structure/table/wood,
-/obj/item/gun/ballistic/rifle/sniper_rifle,
+/obj/item/minigunpack,
 /turf/open/floor/wood,
 /area/deathmatch/fullbright)
 "VQ" = (


### PR DESCRIPTION
## About The Pull Request

Adds the Heliocentric arena, based on a somewhat popular station map.
![image](https://github.com/fulpstation/fulpstation/assets/25415050/356382f6-87c3-4374-bc0f-af3fb376026d)

Beeftide
![image](https://github.com/fulpstation/fulpstation/assets/25415050/ed2ba25c-ba39-42c6-88c9-f40599300834)

Masquerader
![image](https://github.com/fulpstation/fulpstation/assets/25415050/139eba6e-2b0b-4a17-a338-44fcdfaa95fd)



## Why It's Good For The Game

No sunflower was harmed in the making

## Changelog
:cl:
add: Heliocentric, DM map.
/:cl:
