### PR TITLE
Selene Medbay Rework

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -5574,7 +5574,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/effect/turf_decal/tile/green/diagonal_edge,
-/obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -6058,7 +6057,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
@@ -7849,7 +7847,6 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/engineering/gravity_generator)
 "cOq" = (
-/obj/machinery/duct,
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 5
@@ -10894,7 +10891,6 @@
 "dUx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /obj/effect/mapping_helpers/mail_sorting/service/hydroponics,
 /obj/structure/disposalpipe/sorting/mail/flip,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -14427,7 +14423,6 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 8
 	},
-/obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
@@ -16552,7 +16547,6 @@
 "fYc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/botanist,
-/obj/machinery/light/directional/north,
 /obj/structure/sink/kitchen/directional/south{
 	name = "utility sink"
 	},
@@ -18623,7 +18617,6 @@
 "gOb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -19913,6 +19906,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "hnc" = (
@@ -32584,7 +32578,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
@@ -35124,7 +35117,6 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/cmo)
 "mIB" = (
-/obj/machinery/duct,
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 9
@@ -39972,7 +39964,6 @@
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "oyj" = (
@@ -43641,7 +43632,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -44918,7 +44908,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos/storage/gas)
 "qqM" = (
-/obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/line{
@@ -46442,6 +46431,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/hand_labeler,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "qXm" = (
@@ -49337,7 +49327,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -57167,8 +57156,8 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "uWt" = (
@@ -58981,7 +58970,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "vGN" = (
-/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/green/half/contrasted,
@@ -60659,6 +60647,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "wqC" = (
@@ -63186,7 +63175,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
 "xjk" = (
-/obj/machinery/duct,
+/obj/machinery/smartfridge/chemistry{
+	name = "smart chemical and blood storage"
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "xjw" = (
@@ -65450,7 +65441,6 @@
 /area/station/medical/morgue)
 "yas" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 9
@@ -92228,7 +92218,7 @@ eDI
 glm
 dLY
 mMM
-xjk
+xFE
 xFE
 xFE
 hjt
@@ -93258,7 +93248,7 @@ lGr
 hZp
 wZi
 qXa
-wZi
+xjk
 hZp
 eGf
 hZp

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -391,8 +391,11 @@
 /area/station/security/checkpoint/science)
 "agF" = (
 /obj/structure/closet/wardrobe/pjs,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "agG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -865,15 +868,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"aoO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "aoU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1107,12 +1101,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "atf" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 1
 	},
-/obj/structure/curtain,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "atl" = (
@@ -1988,6 +1983,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"aJM" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "aKf" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Xenobiology Maintenance"
@@ -2248,6 +2252,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -4318,6 +4325,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/medical/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bAJ" = (
@@ -4425,8 +4433,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bCg" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 4
 	},
@@ -4620,6 +4626,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"bGd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/cryo)
 "bGi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -4678,6 +4690,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"bHl" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "bHm" = (
 /obj/machinery/light/broken/directional/east,
 /turf/open/floor/iron,
@@ -5821,7 +5839,16 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "cbF" = (
-/obj/machinery/airalarm/directional/south,
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/medical{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/medical/half,
+/obj/structure/curtain,
 /obj/effect/turf_decal/tile/medical/anticorner{
 	dir = 8
 	},
@@ -6092,13 +6119,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"cic" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "cit" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock"
@@ -6264,6 +6284,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
+"cmr" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "cmy" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/central)
@@ -6841,8 +6871,9 @@
 "cwx" = (
 /obj/machinery/iv_drip,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "cwA" = (
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
 /turf/open/floor/iron,
@@ -7277,6 +7308,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"cDL" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "cDO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
@@ -7980,6 +8017,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
+"cSG" = (
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "cSI" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/iron/dark/smooth_large,
@@ -8045,9 +8094,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/primary/port)
 "cTF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/space/basic,
-/area/space)
+/obj/vehicle/ridden/wheelchair{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/coldroom)
 "cTO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -8455,11 +8506,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
-"daz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/cryo)
 "daB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8507,6 +8553,9 @@
 	},
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "daZ" = (
@@ -9460,9 +9509,12 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "duU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/medical{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 8
 	},
@@ -9644,8 +9696,9 @@
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "dyU" = (
-/turf/closed/wall,
-/area/station/medical/storage)
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "dzb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -9690,24 +9743,19 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
 "dzN" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/pharmacy)
 "dzW" = (
 /obj/structure/training_machine,
 /obj/item/target,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "dAi" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/light/directional/south,
-/obj/machinery/status_display/evac/directional/south,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/medical/half,
-/obj/structure/curtain,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "dAj" = (
@@ -10102,6 +10150,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
+"dHN" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "dHU" = (
 /obj/structure/window/reinforced/spawner/directional/east{
 	layer = 2.9
@@ -11249,8 +11301,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "ecY" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "edq" = (
@@ -12021,6 +12074,9 @@
 /area/station/science/ordnance)
 "etD" = (
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "etK" = (
@@ -12663,10 +12719,16 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"eFp" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "eFB" = (
 /obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "eFG" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/mixed,
@@ -12811,6 +12873,15 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"eIK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "eIM" = (
 /mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/carpet/neon/simple/black/nodots,
@@ -13582,13 +13653,16 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "eXk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/west,
-/obj/effect/turf_decal/tile/medical/anticorner{
+/obj/structure/bed{
 	dir = 1
 	},
+/obj/item/bedsheet/medical{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/medical/half{
+	dir = 1
+	},
+/obj/structure/curtain,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "eXr" = (
@@ -14540,6 +14614,9 @@
 	req_access = list("pharmacy")
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fox" = (
@@ -14693,7 +14770,7 @@
 /area/station/maintenance/department/science)
 "frd" = (
 /turf/open/floor/iron/freezer,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "fre" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment{
@@ -15123,6 +15200,12 @@
 /obj/structure/sign/warning/vacuum/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"fyD" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "fzk" = (
 /obj/structure/sign/departments/xenobio/directional/south,
 /turf/open/floor/iron/white,
@@ -15296,9 +15379,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "fEj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
@@ -15755,11 +15839,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fKY" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/coldroom)
 "fLg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -16403,6 +16484,7 @@
 "fXU" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "fXZ" = (
@@ -16601,6 +16683,7 @@
 	c_tag = "Medical - Pharmacy";
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "gbJ" = (
@@ -16976,6 +17059,18 @@
 	dir = 8
 	},
 /area/station/tcommsat/computer)
+"giZ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "gju" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/armory/laser_gun,
@@ -17636,6 +17731,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"gxW" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/medical/medbay)
 "gyc" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -17796,6 +17897,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"gBA" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "gBC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18329,12 +18440,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"gKL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "gKT" = (
 /obj/structure/chair/plastic{
 	dir = 1
@@ -19355,6 +19460,7 @@
 	pixel_x = 7;
 	pixel_y = -1
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "hfo" = (
@@ -19581,11 +19687,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"hkE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "hlb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -19853,6 +19954,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "hpb" = (
@@ -20038,6 +20142,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/lockers)
+"htl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/mid_joiner,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/cryo)
 "htr" = (
 /obj/item/stock_parts/cell/high,
 /obj/structure/chair/office/light{
@@ -20245,6 +20355,14 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
+"hxP" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "hxX" = (
 /obj/machinery/door/airlock{
 	name = "Art Storage Room"
@@ -20408,14 +20526,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"hCD" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "hCG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -20687,6 +20797,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"hIv" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/medbay/central)
 "hIw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20957,6 +21073,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"hMR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "hMT" = (
 /obj/structure/mineral_door/paperframe,
 /turf/open/floor/wood,
@@ -21297,6 +21419,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"hSn" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "hSG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -22058,16 +22186,6 @@
 /obj/effect/turf_decal/tile/prison,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
-"iio" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "iiw" = (
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/east,
@@ -22105,8 +22223,11 @@
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "iiY" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/engine,
@@ -22883,12 +23004,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"ixM" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_edge,
-/area/station/medical/medbay)
 "iyg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23339,15 +23454,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "iGY" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/coldroom)
 "iHd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
 	dir = 4
@@ -23752,6 +23864,9 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/status_display/evac/directional/east,
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "iNU" = (
@@ -25378,19 +25493,6 @@
 /obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"jtf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "jtt" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -26605,6 +26707,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "jPF" = (
@@ -29139,6 +29242,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "kGb" = (
@@ -29592,6 +29698,14 @@
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/glass/reinforced,
 /area/station/service/cafeteria)
+"kPx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/cryo)
 "kPy" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -29622,18 +29736,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"kQj" = (
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line,
-/turf/open/floor/iron/white/textured_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "kQV" = (
 /obj/effect/turf_decal/tile/command/half{
 	dir = 8
@@ -30493,8 +30595,9 @@
 	name = "Medbay Cold Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "liD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -31511,16 +31614,6 @@
 /obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"lBs" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "lBt" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/window/left/directional/north{
@@ -32078,11 +32171,11 @@
 "lKW" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/iron/freezer,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "lKY" = (
 /obj/effect/spawner/structure/window/ice,
 /turf/open/floor/plating,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "lLj" = (
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/machinery/camera/directional/east{
@@ -34042,6 +34135,13 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"mrk" = (
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/coldroom)
 "mrm" = (
 /obj/structure/chair{
 	dir = 1;
@@ -35654,15 +35754,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"mVk" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "mVA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -35777,18 +35868,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
-"mXL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "mXM" = (
 /obj/structure/railing{
 	dir = 1
@@ -36025,8 +36104,9 @@
 /turf/open/floor/iron/white,
 /area/station/science)
 "nbZ" = (
-/turf/open/floor/plating,
-/area/station/medical/paramedic)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/coldroom)
 "ncc" = (
 /obj/effect/turf_decal/tile/security/half{
 	dir = 8
@@ -36525,8 +36605,11 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/item/tank/internals/plasmaman/full,
 /obj/structure/closet/crate/secure/plasma,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "nlL" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Containment Pen #8";
@@ -37174,7 +37257,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/freezer,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "nvF" = (
 /obj/machinery/rnd/server/master,
 /obj/machinery/camera/directional/south{
@@ -37617,10 +37700,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"nFZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "nGa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38678,8 +38757,11 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "obr" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
@@ -39768,12 +39850,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"owJ" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/medbay/central)
 "owL" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet,
@@ -41103,6 +41179,15 @@
 "oYJ" = (
 /turf/closed/wall,
 /area/station/science/genetics)
+"oYU" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "oYY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41620,11 +41705,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
-"pip" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "pis" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -42567,6 +42647,9 @@
 /obj/item/radio/headset/headset_med,
 /obj/item/storage/box/syringes,
 /obj/item/radio/headset/headset_med,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "pAp" = (
@@ -42923,8 +43006,11 @@
 /area/station/science/explab)
 "pGr" = (
 /obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "pGv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43104,6 +43190,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"pKH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/medbay)
 "pKQ" = (
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
@@ -43159,12 +43254,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"pMY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "pMZ" = (
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/spawner/random/structure/crate,
@@ -43538,6 +43627,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"pTr" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "pTt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -44413,15 +44512,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"qjt" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "qju" = (
 /obj/structure/table,
 /obj/item/food/badrecipe/moldy,
@@ -44965,6 +45055,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
+"qtZ" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "quh" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -47999,6 +48098,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"rEB" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "rEP" = (
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
@@ -48270,6 +48379,15 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"rJg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "rJm" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/structure/cable,
@@ -48642,11 +48760,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "rQV" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/turf/closed/wall,
+/area/station/medical/coldroom)
 "rRr" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/effect/turf_decal/tile/science/anticorner{
@@ -48810,6 +48925,19 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
+"rUM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "rUO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49444,6 +49572,9 @@
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "sgd" = (
@@ -50506,15 +50637,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet/purple,
 /area/station/service/lawoffice)
-"syG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "syU" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -50887,13 +51009,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "sGl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/freezer,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "sGu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -51961,15 +52086,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"tfa" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "tfe" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plating,
@@ -52485,7 +52601,9 @@
 	},
 /area/station/engineering/lobby)
 "tnA" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "tnF" = (
@@ -53094,6 +53212,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
+"tyc" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "tyd" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/south{
@@ -53379,6 +53504,11 @@
 /obj/effect/spawner/random/clothing/gloves,
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
+"tDG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "tDH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -53543,7 +53673,7 @@
 	},
 /obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "tHl" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
@@ -56907,6 +57037,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "uVb" = (
@@ -57242,6 +57375,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /obj/effect/turf_decal/tile/security/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "vaY" = (
@@ -59847,6 +59981,7 @@
 /obj/effect/turf_decal/tile/security/anticorner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "wcT" = (
@@ -60213,6 +60348,9 @@
 /area/station/cargo/miningdock)
 "wki" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "wkm" = (
@@ -60342,6 +60480,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
+"woj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "wom" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60829,6 +60973,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/turf_decal/trimline/blue/mid_joiner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/cryo)
 "wxt" = (
@@ -61048,6 +61195,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"wBe" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "wBH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/engineering{
@@ -61808,6 +61964,13 @@
 /obj/structure/sign/warning/vacuum/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"wPu" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "wPB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62359,7 +62522,7 @@
 "wZh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "wZi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -62840,11 +63003,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "xgZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/medical/half{
 	dir = 8
@@ -63194,6 +63352,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xlX" = (
@@ -63321,15 +63482,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"xno" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/medbay)
 "xnz" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -63932,10 +64084,10 @@
 /area/station/security/brig)
 "xzB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/coldroom)
 "xzG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -65326,11 +65478,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ybQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/pharmacy)
 "ybS" = (
 /obj/item/toy/plush/fly,
 /turf/open/floor/plating,
@@ -104860,7 +105010,7 @@ ycg
 ycg
 hTl
 lQH
-nbZ
+ygs
 ycg
 hlt
 wrl
@@ -105397,7 +105547,7 @@ tbg
 vmp
 vmp
 jFr
-hCD
+hxP
 fNJ
 sIZ
 uaz
@@ -105662,7 +105812,7 @@ foA
 oNI
 grY
 wki
-cUe
+dyU
 pAg
 wzS
 jCH
@@ -105901,8 +106051,8 @@ rXy
 wCc
 lHq
 bpn
-ybQ
-ybQ
+cDL
+cDL
 lOs
 mhn
 mhn
@@ -105916,10 +106066,10 @@ fNJ
 sIZ
 oqz
 kFY
-cUe
-cUe
+dzN
+dzN
 xlW
-cUe
+ybQ
 wzS
 wzS
 jCH
@@ -106163,7 +106313,7 @@ ydb
 rvE
 mhn
 tqs
-mXL
+giZ
 mEF
 oPS
 eZZ
@@ -106420,7 +106570,7 @@ tlE
 bAn
 uxN
 mwm
-mXL
+giZ
 mEF
 rbr
 jUP
@@ -106431,7 +106581,7 @@ sIZ
 oqz
 jdu
 etQ
-sGj
+cmr
 mBv
 hfm
 lkG
@@ -106672,14 +106822,14 @@ rXy
 wCc
 rmc
 eTq
-ixM
-ixM
+gxW
+gxW
 tlI
 mhn
 mwm
-mXL
+giZ
 mEF
-qjt
+wBe
 jps
 uxN
 ykY
@@ -106688,7 +106838,7 @@ sIZ
 iVJ
 qrU
 oNI
-sGj
+cmr
 cUe
 gbD
 hVO
@@ -106925,21 +107075,21 @@ tVA
 lAW
 bmk
 aAq
-rXy
+oYU
 ezN
-rQV
+bHl
 hey
-gKL
-gKL
+hMR
+hMR
 ych
 mhn
 wTX
-mVk
+aJM
 srj
 jCv
 tTz
 viM
-iio
+pTr
 fNJ
 sIZ
 nPY
@@ -107186,7 +107336,7 @@ rXy
 kna
 lFw
 cXM
-aoO
+eIK
 xgs
 mmE
 bzD
@@ -107197,7 +107347,7 @@ oot
 xDS
 aXc
 nSF
-xno
+pKH
 sIZ
 xaG
 xaG
@@ -107441,19 +107591,19 @@ ndu
 ndu
 rXy
 urd
-xzB
+fyD
 tQz
 eEN
 kEU
 tQz
 mhn
 mHg
-tfa
+qtZ
 tdW
 lgz
 mEF
 viM
-lBs
+rEB
 uTT
 pis
 pXI
@@ -107696,7 +107846,7 @@ ttg
 ttg
 kqZ
 seR
-dzN
+wPu
 psk
 tQz
 tQz
@@ -107704,13 +107854,13 @@ uyD
 osE
 mOg
 mhn
-owJ
-kQj
+hIv
+cSG
 sgo
 lgz
 rld
 mhn
-cic
+tyc
 brb
 qXX
 xBU
@@ -107967,7 +108117,7 @@ jqn
 auJ
 sIQ
 mhn
-cic
+tyc
 brb
 dGh
 xBU
@@ -108208,10 +108358,10 @@ ycg
 ycg
 pGr
 iiW
-pGr
-dyU
-rXy
 iGY
+rQV
+rXy
+gBA
 vtH
 rtJ
 laH
@@ -108220,7 +108370,7 @@ gdX
 oOD
 wKX
 meO
-daz
+bGd
 wwY
 hmE
 oOD
@@ -108463,12 +108613,12 @@ ycg
 nvA
 nvA
 lKY
-pGr
-iiW
+mrk
+cTF
 cwx
-dyU
+rQV
 mDN
-iGY
+gBA
 vtH
 nBJ
 pOF
@@ -108478,12 +108628,12 @@ oOD
 ouv
 iku
 jrh
-wwY
+htl
 oqS
 haw
-cic
+tyc
 sWZ
-nFZ
+dHN
 upW
 oGR
 vrV
@@ -108720,9 +108870,9 @@ qcC
 wZh
 frd
 lik
-vrV
-vrV
-vrV
+xzB
+fKY
+nbZ
 tGS
 rXy
 ufi
@@ -108734,13 +108884,13 @@ jLF
 oOD
 qYr
 meO
-daz
-wwY
+kPx
+htl
 gHL
 haw
 xXk
-syG
-nFZ
+rJg
+dHN
 upW
 ddv
 dVd
@@ -108977,10 +109127,10 @@ ycg
 sGl
 lKW
 lKY
-vrV
-vrV
+xzB
+fKY
 eFB
-dyU
+rQV
 rXy
 psk
 tQz
@@ -109237,7 +109387,7 @@ ycg
 obq
 agF
 nlD
-dyU
+rQV
 cbH
 slT
 rcT
@@ -109254,11 +109404,11 @@ aqv
 ymc
 ncF
 aNn
-hkE
+eFp
 upW
 uYA
 vrV
-pip
+tDG
 vrV
 cBc
 xaG
@@ -109493,9 +109643,9 @@ ygs
 ycg
 ycg
 ycg
-dyU
-dyU
-fKY
+rQV
+rQV
+hSn
 wNj
 thQ
 wNj
@@ -109507,16 +109657,16 @@ wFB
 wNj
 wNj
 bJM
-ybQ
+cDL
 fnA
-ybQ
+cDL
 clV
 bRO
 upW
 wyW
 vrV
-pip
-pMY
+tDG
+woj
 nxI
 xaG
 hpm
@@ -110787,7 +110937,7 @@ yee
 jnY
 hTZ
 wCg
-jtf
+rUM
 ouL
 rJm
 wmv
@@ -112320,7 +112470,7 @@ iQW
 iQW
 iQW
 iQW
-cTF
+iQW
 iQW
 iQW
 nit
@@ -112577,7 +112727,7 @@ iQW
 iQW
 iQW
 iQW
-cTF
+iQW
 iQW
 iQW
 nit
@@ -112834,7 +112984,7 @@ iQW
 iQW
 iQW
 iQW
-cTF
+iQW
 iQW
 iQW
 nit
@@ -113091,7 +113241,7 @@ iQW
 iQW
 iQW
 iQW
-cTF
+iQW
 iQW
 iQW
 iQW
@@ -113348,7 +113498,7 @@ iQW
 iQW
 iQW
 iQW
-cTF
+iQW
 iQW
 iQW
 iQW
@@ -113605,7 +113755,7 @@ iQW
 iQW
 iQW
 iQW
-cTF
+iQW
 iQW
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -461,6 +461,11 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"aid" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "aif" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -1622,13 +1627,6 @@
 	dir = 8
 	},
 /area/station/security/brig)
-"aBL" = (
-/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "aBO" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 8
@@ -2731,6 +2729,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
+"aWU" = (
+/obj/structure/window/spawner/directional/east,
+/mob/living/basic/rabbit,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "aWX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3877,12 +3881,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"btH" = (
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "buj" = (
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
@@ -4636,6 +4634,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"bGa" = (
+/obj/machinery/plumbing/synthesizer,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "bGi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -4951,6 +4956,12 @@
 /obj/effect/turf_decal/tile/medical,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"bLv" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "bLO" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
@@ -6264,6 +6275,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"cll" = (
+/obj/effect/turf_decal/trimline/yellow,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "clr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "departureslock";
@@ -6343,6 +6358,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
+"cmT" = (
+/obj/structure/window/spawner/directional/north,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "cnd" = (
 /obj/effect/turf_decal/tile/command/half{
 	dir = 8
@@ -7875,6 +7895,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"cPG" = (
+/obj/machinery/plumbing/synthesizer,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "cPL" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/camera/directional/west{
@@ -9354,12 +9379,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/command)
-"dsv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "dsx" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron,
@@ -9652,6 +9671,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/ordnance)
+"dwv" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/north,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/loom,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "dwC" = (
 /obj/structure/table,
 /obj/item/food/boiledrice,
@@ -9831,6 +9859,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"dAN" = (
+/obj/machinery/plumbing/synthesizer,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "dAU" = (
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = -2;
@@ -9882,6 +9917,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/sepia,
 /area/station/maintenance/starboard/fore)
+"dCn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "dCo" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -10463,11 +10506,6 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"dMA" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "dMI" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
@@ -10503,12 +10541,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
-"dNm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "dNs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/command/half,
@@ -11063,10 +11095,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
-"dXw" = (
-/obj/effect/turf_decal/trimline/yellow,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "dXy" = (
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -15245,6 +15273,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "fzP" = (
@@ -16355,11 +16386,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
-"fUx" = (
-/obj/structure/window/spawner/directional/north,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
 "fUy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -16950,6 +16976,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
+"ghb" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ghh" = (
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/iron/grimy,
@@ -17004,10 +17036,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"ghX" = (
-/obj/effect/turf_decal/trimline/blue,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "gia" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/computer/camera_advanced/xenobio{
@@ -17024,12 +17052,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/ai_monitored/security/armory)
-"gid" = (
-/obj/structure/window/spawner/directional/east,
-/mob/living/basic/rabbit,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
 "gif" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -17099,12 +17121,6 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
-"gjF" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "gkh" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -18283,12 +18299,6 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
-"gIq" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "gIr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19002,6 +19012,12 @@
 /obj/effect/mapping_helpers/damaged_window,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"gVs" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "gVu" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -19689,6 +19705,13 @@
 	},
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
+"hjt" = (
+/obj/machinery/door/window/left/directional/north{
+	name = "rabbitry";
+	req_one_access = list("hydroponics")
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "hjD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20169,10 +20192,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/lockers)
-"htk" = (
-/obj/machinery/plumbing/reaction_chamber,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "htl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/trimline/blue/line,
@@ -20464,6 +20483,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"hzO" = (
+/obj/machinery/plumbing/reaction_chamber,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "hAg" = (
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
@@ -20570,14 +20593,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
-"hCI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "hCY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21593,6 +21608,15 @@
 "hVO" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/chemistry)
+"hVQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "hWj" = (
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 1
@@ -21627,6 +21651,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"hXi" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "hXE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23000,6 +23031,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"ixq" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ixr" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -23242,6 +23277,13 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/carpet/neon/simple/black/nodots,
 /area/station/service/bar)
+"iBw" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "iBL" = (
 /obj/structure/table/wood/fancy,
 /obj/item/toy/figure/wizard,
@@ -24683,14 +24725,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"jdb" = (
-/obj/structure/window/spawner/directional/north,
-/obj/structure/window/spawner/directional/east,
-/obj/structure/cat_house{
-	name = "rabbit hutch"
-	},
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
 "jdm" = (
 /obj/effect/spawner/random/maintenance/three,
 /obj/structure/rack,
@@ -25629,6 +25663,13 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/station/maintenance/department/medical/plasmaman)
+"juX" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "juZ" = (
 /obj/machinery/button/door/directional/west{
 	id = "detprivacy";
@@ -26777,15 +26818,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"jQp" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/window/spawner/directional/north,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/loom,
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
 "jQv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -31095,15 +31127,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"lsg" = (
-/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "lsh" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -31269,12 +31292,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
-"lvm" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "lvn" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1
@@ -35059,13 +35076,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/science)
-"mHs" = (
-/obj/machinery/plumbing/output,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "mHD" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -35120,9 +35130,6 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/station/service/hydroponics)
-"mIH" = (
-/turf/open/floor/grass,
 /area/station/service/hydroponics)
 "mIL" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -38789,6 +38796,12 @@
 /obj/effect/spawner/random/armory/disablers,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"oaD" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "oaI" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -39264,13 +39277,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"okI" = (
-/obj/machinery/duct,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "okO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/herringbone,
@@ -39643,13 +39649,6 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/medical/cryo)
-"oqV" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "oqY" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/duct,
@@ -39834,6 +39833,10 @@
 /obj/machinery/camera/directional/north,
 /turf/open/floor/iron/textured,
 /area/station/medical/cryo)
+"ouJ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ouL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -41640,13 +41643,6 @@
 "pfG" = (
 /turf/closed/wall,
 /area/station/cargo/sorting)
-"pfJ" = (
-/obj/machinery/plumbing/synthesizer,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "pgF" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
@@ -44850,6 +44846,15 @@
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"qpz" = (
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qpP" = (
 /obj/structure/sign/warning/fire,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
@@ -44915,7 +44920,10 @@
 "qqM" = (
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "qqN" = (
@@ -45341,6 +45349,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"qAd" = (
+/obj/structure/window/spawner/directional/north,
+/obj/structure/window/spawner/directional/east,
+/obj/structure/cat_house{
+	name = "rabbit hutch"
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "qAe" = (
 /obj/machinery/nanite_chamber,
 /obj/item/radio/intercom/directional/south,
@@ -46212,6 +46228,13 @@
 /mob/living/simple_animal/bot/secbot/beepsky/officer,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"qTc" = (
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qTg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -46285,10 +46308,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard)
-"qUk" = (
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "qUt" = (
 /obj/structure/rack,
 /obj/item/shard,
@@ -49324,13 +49343,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"scE" = (
-/obj/machinery/duct,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "scO" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners{
 	dir = 1
@@ -50162,13 +50174,6 @@
 /obj/effect/turf_decal/tile/dark,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"sqP" = (
-/obj/machinery/plumbing/synthesizer,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "sqQ" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Kitchen";
@@ -51455,11 +51460,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"sRA" = (
-/obj/machinery/plumbing/synthesizer,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "sRI" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing"
@@ -51946,6 +51946,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"tcH" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "tcI" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/vendor,
@@ -52823,10 +52829,6 @@
 /obj/item/clothing/head/cowboy,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"tqU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "tqZ" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
@@ -53658,6 +53660,10 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
+"tFE" = (
+/obj/effect/turf_decal/trimline/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "tFH" = (
 /obj/effect/turf_decal/tile/security/half{
 	dir = 1
@@ -55773,12 +55779,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
-"uuA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "uuB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56058,6 +56058,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/plasmaman)
+"uBu" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "uBv" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/disposal/bin,
@@ -56395,13 +56401,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/construction)
-"uIv" = (
-/obj/machinery/door/window/left/directional/north{
-	name = "rabbitry";
-	req_one_access = list("hydroponics")
-	},
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
 "uID" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -56681,6 +56680,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/office)
+"uNZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "uOg" = (
 /turf/closed/wall,
 /area/station/maintenance/fore)
@@ -58028,6 +58033,12 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"vmO" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "vmT" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/showroomfloor,
@@ -58661,6 +58672,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"vzR" = (
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "vzX" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -58838,6 +58852,11 @@
 /obj/effect/turf_decal/tile/prison,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
+"vED" = (
+/obj/structure/window/spawner/directional/west,
+/mob/living/basic/rabbit,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "vEF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59189,11 +59208,6 @@
 	dir = 8
 	},
 /area/station/security/brig/entrance)
-"vLW" = (
-/obj/structure/window/spawner/directional/west,
-/mob/living/basic/rabbit,
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
 "vMb" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -60742,12 +60756,6 @@
 /obj/effect/turf_decal/tile/prison,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
-"wsh" = (
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "wsj" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -62330,6 +62338,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
+"wUF" = (
+/obj/machinery/plumbing/output,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "wUV" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/camera{
@@ -64246,15 +64261,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"xCn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "xCv" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -91709,10 +91715,10 @@ uYK
 uYK
 fYc
 mIB
-btH
-oqV
-jQp
-vLW
+vmO
+hXi
+dwv
+vED
 wZi
 plo
 gXu
@@ -91966,9 +91972,9 @@ hZp
 hmX
 rGK
 cOq
-wsh
+bLv
 xaT
-fUx
+cmT
 rui
 wZi
 jcx
@@ -92225,8 +92231,8 @@ mMM
 xjk
 xFE
 xFE
-uIv
-mIH
+hjt
+vzR
 wZi
 iuq
 iIx
@@ -92481,9 +92487,9 @@ okq
 oVP
 yas
 cXY
-oqV
-fUx
-mIH
+hXi
+cmT
+vzR
 wZi
 jcx
 oPu
@@ -92739,8 +92745,8 @@ gOb
 qqM
 fzw
 xaT
-jdb
-gid
+qAd
+aWU
 wZi
 jcx
 iIx
@@ -105348,9 +105354,9 @@ pAD
 pOG
 vZP
 xJX
-gjF
-scE
-sqP
+oaD
+iBw
+bGa
 hVO
 dyo
 mFP
@@ -105603,11 +105609,11 @@ ptu
 jlb
 ptu
 ptu
-tqU
-mHs
-htk
-qUk
-sRA
+ouJ
+wUF
+hzO
+ixq
+cPG
 hVO
 fxI
 tsJ
@@ -105860,11 +105866,11 @@ ptu
 jlb
 ptu
 ptu
-tqU
-lvm
+ouJ
+uBu
 xEW
-okI
-pfJ
+juX
+dAN
 hVO
 jBM
 joq
@@ -106117,7 +106123,7 @@ vpa
 dAC
 qFr
 ptu
-dsv
+ghb
 pOG
 pOG
 pOG
@@ -106374,11 +106380,11 @@ srC
 hCz
 iYy
 wfR
-uuA
+uNZ
 iYy
 ptu
 ptu
-tqU
+ouJ
 xaG
 wuw
 xaG
@@ -106631,11 +106637,11 @@ tAW
 rEP
 ptu
 ptu
-lsg
+qpz
 iYy
 ptu
 ptu
-tqU
+ouJ
 xaG
 gzg
 xaG
@@ -106886,10 +106892,10 @@ hVO
 ijY
 rlq
 jCH
-ghX
-aBL
-dXw
-xCn
+tFE
+qTc
+cll
+hVQ
 oen
 mmB
 yjZ
@@ -107145,7 +107151,7 @@ iiY
 jCH
 ptu
 ptu
-lsg
+qpz
 dMp
 ptu
 ptu
@@ -107402,11 +107408,11 @@ lUO
 jCH
 ptu
 ptu
-lsg
+qpz
 dMp
 ptu
 ptu
-tqU
+ouJ
 xaG
 bAs
 xaG
@@ -107657,13 +107663,13 @@ hVO
 hVO
 coA
 qZE
-ghX
-aBL
-dXw
-hCI
-ghX
+tFE
+qTc
+cll
+dCn
+tFE
 ptu
-tqU
+ouJ
 xaG
 ksz
 xaG
@@ -107916,11 +107922,11 @@ wmI
 ptu
 ptu
 ptu
-lsg
+qpz
 tCK
 ptu
 ptu
-dMA
+aid
 xaG
 wuw
 mdT
@@ -108173,11 +108179,11 @@ jCH
 ptu
 ptu
 ptu
-ghX
+tFE
 ptu
 ptu
 ptu
-tqU
+ouJ
 xaG
 hqe
 lMo
@@ -108434,7 +108440,7 @@ tAW
 tAW
 tAW
 rEP
-tqU
+ouJ
 xaG
 bNa
 lMo
@@ -108674,7 +108680,7 @@ sWZ
 eNU
 upW
 oGR
-dNm
+gVs
 aoU
 fdN
 xaG
@@ -109445,7 +109451,7 @@ aNn
 uGN
 upW
 uYA
-dNm
+gVs
 haI
 vrV
 cBc
@@ -109702,7 +109708,7 @@ clV
 bRO
 upW
 wyW
-gIq
+tcH
 haI
 fqV
 nxI

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -389,6 +389,10 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
+"agF" = (
+/obj/structure/closet/wardrobe/pjs,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "agG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -728,13 +732,8 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "ane" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -961,9 +960,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "aqv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "aqD" = (
 /obj/effect/turf_decal/tile/security/opposingcorners,
 /obj/machinery/computer/shuttle/labor/selene{
@@ -1107,8 +1110,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "atl" = (
-/turf/closed/wall,
-/area/station/medical/storage)
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/medical/medbay)
 "atn" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -1134,11 +1140,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "atB" = (
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/medbay/central)
 "atD" = (
 /obj/machinery/vending/assist,
 /obj/machinery/camera/directional/south{
@@ -1186,7 +1191,13 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "auJ" = (
-/obj/machinery/duct,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/door/window/left/directional/east{
+	name = "Cryogenics";
+	req_access = list("medical")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "auV" = (
@@ -2097,13 +2108,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "aNn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -2190,9 +2197,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aPe" = (
-/obj/effect/turf_decal/tile/medical/half,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/cryo)
 "aPm" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig"
@@ -2229,9 +2237,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -2302,13 +2307,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "aQv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
+/obj/machinery/door/airlock/public/glass{
+	name = "Medbay"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/lobby)
 "aQw" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
@@ -2410,8 +2414,7 @@
 "aSi" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "aSl" = (
 /obj/structure/cable,
@@ -2542,9 +2545,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "aUZ" = (
@@ -2695,13 +2695,6 @@
 /obj/effect/turf_decal/tile/medical/anticorner,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"aWT" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/break_room)
 "aWX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2713,7 +2706,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aXh" = (
@@ -2733,9 +2725,6 @@
 /area/station/security/mechbay)
 "aXr" = (
 /obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "aXA" = (
@@ -3115,9 +3104,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "bfx" = (
@@ -3271,13 +3257,6 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"bja" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "bjj" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel Hall"
@@ -3461,11 +3440,10 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "blX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
 	},
-/turf/open/floor/circuit/telecomms,
-/area/station/science/xenobiology)
+/area/station/maintenance/starboard/fore)
 "bmc" = (
 /obj/structure/transit_tube/diagonal,
 /turf/open/space/basic,
@@ -3617,6 +3595,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bpT" = (
@@ -4013,11 +3992,6 @@
 	},
 /turf/open/floor/eighties,
 /area/station/maintenance/starboard/fore)
-"bwn" = (
-/obj/structure/filingcabinet,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/wood,
-/area/station/medical/psychology)
 "bws" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -4081,6 +4055,12 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"bxz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/grille/broken,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "bxB" = (
 /obj/structure/chair{
 	dir = 8
@@ -4207,13 +4187,10 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "bzD" = (
+/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/medbay/central)
 "bzG" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -4261,12 +4238,14 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "bAn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/obj/structure/chair/sofa/left{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/obj/effect/turf_decal/tile/blue/half,
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/medical/medbay)
 "bAs" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/decoration/glowstick,
@@ -4279,8 +4258,7 @@
 /area/station/maintenance/starboard)
 "bAt" = (
 /mob/living/basic/bot/medbot,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "bAu" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -4288,13 +4266,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bAC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
+/obj/machinery/door/airlock/medical/glass{
+	name = "Cryogenics"
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/medical/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bAJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -4537,7 +4514,6 @@
 /turf/open/floor/iron/terracotta,
 /area/station/maintenance/starboard/aft)
 "bEQ" = (
-/obj/effect/turf_decal/tile/medical/half,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4724,9 +4700,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -4792,18 +4765,6 @@
 /obj/structure/reflector/single,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"bJM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "bJP" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/directional/south{
@@ -5125,8 +5086,13 @@
 /area/station/maintenance/disposal)
 "bPs" = (
 /obj/structure/table,
-/obj/item/clipboard,
-/obj/effect/turf_decal/tile/medical/fourcorners,
+/obj/item/clipboard{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/cup/glass/mug/tea{
+	pixel_x = -7;
+	pixel_y = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bPJ" = (
@@ -5192,13 +5158,6 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
-"bRf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
 "bRi" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -5238,7 +5197,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bRS" = (
@@ -5644,11 +5602,9 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "bYx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/plasmaman)
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "bYI" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/structure/cable,
@@ -5769,9 +5725,6 @@
 "cba" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /mob/living/basic/bot/cleanbot/medbay,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "cbe" = (
@@ -5790,17 +5743,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "cbH" = (
-/obj/machinery/stasis{
-	dir = 1
-	},
-/obj/machinery/defibrillator_mount{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
+/obj/machinery/camera/directional/north{
+	c_tag = "Medical - Central Hall NE";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay)
 "cbK" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/rec)
@@ -6159,8 +6107,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "ckF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -6216,22 +6163,12 @@
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "clV" = (
-/obj/structure/chair/sofa/left/brown{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
-"cmr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
+/area/station/medical/medbay)
 "cmy" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/central)
@@ -6353,9 +6290,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "cov" = (
-/obj/structure/window/spawner/directional/east,
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "cow" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -6730,11 +6666,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/fore)
-"cvb" = (
-/obj/machinery/iv_drip,
-/obj/structure/window/spawner/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/medical/medbay)
 "cvc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
 	dir = 1
@@ -6810,13 +6741,9 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "cwx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/darkbrown{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/obj/machinery/iv_drip,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "cwA" = (
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
@@ -7095,9 +7022,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/button/door/directional/south{
 	id = "engsm";
 	name = "Radiation Chamber Shutters";
@@ -7404,9 +7329,9 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cGi" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/tile/medical/fourcorners,
+/obj/machinery/computer/records/medical{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "cGn" = (
@@ -7601,12 +7526,6 @@
 /obj/effect/turf_decal/siding/grey/corner,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"cJD" = (
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "cKE" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
@@ -7669,9 +7588,6 @@
 "cLQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
@@ -8028,18 +7944,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/primary/port)
 "cTF" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Medical - Cryogenics";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/space/basic,
+/area/space)
 "cTO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -8298,9 +8205,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "cXM" = (
-/obj/effect/spawner/structure/window,
+/obj/machinery/camera/directional/east{
+	c_tag = "Medical - Central Hall NW";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "cXX" = (
 /obj/structure/chair/stool/directional/north,
@@ -8485,9 +8398,6 @@
 	},
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "daZ" = (
@@ -8664,7 +8574,6 @@
 	department = "medbay lobby";
 	name = "Medbay Lobby Requests Console"
 	},
-/obj/effect/turf_decal/tile/medical/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "dep" = (
@@ -8684,7 +8593,6 @@
 /obj/structure/table,
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/cell_charger,
-/obj/effect/turf_decal/tile/medical/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "deK" = (
@@ -8866,11 +8774,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "djl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/machinery/vending/drugs,
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_corner,
 /area/station/medical/medbay)
 "djo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -9274,16 +9183,6 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
-"dsW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "dsX" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -9403,7 +9302,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "duL" = (
@@ -9618,10 +9516,6 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/station/maintenance/department/medical/plasmaman)
-"dyU" = (
-/obj/effect/turf_decal/tile/medical,
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "dzb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -9665,12 +9559,6 @@
 /mob/living/basic/cow,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
-"dzN" = (
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "dzW" = (
 /obj/structure/training_machine,
 /obj/item/target,
@@ -9808,9 +9696,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "dDq" = (
@@ -9945,12 +9830,12 @@
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "dFE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
+/obj/machinery/camera/directional/east{
+	c_tag = "Medical - Psychology";
+	network = list("ss13","medbay")
 	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "dFF" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #5";
@@ -9984,7 +9869,6 @@
 /area/station/maintenance/department/engine)
 "dGh" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "dGi" = (
@@ -10059,7 +9943,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "dHz" = (
-/obj/structure/grille/broken,
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "dHI" = (
@@ -10255,9 +10141,6 @@
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "dKU" = (
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/mail_sorting/medbay/general,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
@@ -10295,9 +10178,6 @@
 /obj/structure/table,
 /obj/item/newspaper,
 /obj/item/toy/figure/md,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
-	},
 /obj/item/toy/figure/paramedic,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
@@ -10897,9 +10777,6 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Medical - Surgery";
 	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
@@ -11649,6 +11526,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"elj" = (
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "elm" = (
 /obj/machinery/door/airlock/virology{
 	name = "Virology Quarters B"
@@ -11985,9 +11869,6 @@
 /area/station/science/ordnance)
 "etD" = (
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "etK" = (
@@ -11995,7 +11876,6 @@
 /obj/machinery/microwave{
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/tile/medical/anticorner,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "etQ" = (
@@ -12307,9 +12187,6 @@
 /area/station/maintenance/department/engine)
 "ezs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ezt" = (
@@ -12331,18 +12208,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"ezN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "ezO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 5
@@ -12402,10 +12267,8 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/science)
 "eAc" = (
-/obj/structure/cable,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/break_room)
 "eAv" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
@@ -12614,12 +12477,14 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "eEN" = (
-/obj/machinery/cryo_cell,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id = "psych_shutters";
+	name = "Psychology Privacy Shutters"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/turf/open/floor/plating,
+/area/station/medical/psychology)
 "eEX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12632,15 +12497,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "eFB" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Medical - Stasis Room";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "eFG" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/mixed,
@@ -13200,8 +13059,7 @@
 "eQV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "eRa" = (
 /obj/structure/chair{
@@ -13311,6 +13169,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"eTq" = (
+/obj/machinery/vending/medical{
+	pixel_x = -2
+	},
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 8
+	},
+/area/station/medical/medbay)
 "eTt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -13476,13 +13345,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"eWk" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "eWq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -13658,7 +13520,6 @@
 	network = list("ss13","medbay")
 	},
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "eZY" = (
@@ -13669,16 +13530,12 @@
 /turf/open/floor/carpet,
 /area/station/maintenance/fore)
 "eZZ" = (
-/obj/structure/table/glass,
+/obj/machinery/stasis{
+	dir = 1
+	},
 /obj/machinery/light_switch/directional/west,
-/obj/structure/cable,
-/obj/item/clothing/under/misc/pj/blue,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/storage/box,
-/obj/item/blood_filter,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
+/obj/machinery/defibrillator_mount{
+	pixel_y = -32
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -14287,9 +14144,6 @@
 	pixel_y = 10
 	},
 /obj/machinery/light_switch/directional/west,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "flb" = (
@@ -14378,7 +14232,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "fmm" = (
@@ -14436,13 +14289,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
-"fnA" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "fnF" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/status_display/evac/directional/west,
@@ -14504,9 +14350,6 @@
 	req_access = list("pharmacy")
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fox" = (
@@ -14609,13 +14452,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"fpY" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "fqa" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -14659,13 +14495,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "frd" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/vending/drugs,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/department/medical)
 "fre" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment{
@@ -14706,9 +14537,6 @@
 /obj/item/surgery_tray/full,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "frE" = (
@@ -14969,14 +14797,13 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "fvn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/tile/medical/anticorner,
+/obj/machinery/disposal/delivery_chute{
+	dir = 8
 	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/maintenance/starboard)
 "fvq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
@@ -15194,8 +15021,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "fBM" = (
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "fBS" = (
 /obj/structure/cable,
@@ -15467,7 +15293,6 @@
 /obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -15727,20 +15552,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"fKY" = (
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
-"fLg" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "fLh" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
@@ -16226,9 +16037,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/engineering/half,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "fUM" = (
@@ -16378,12 +16187,6 @@
 "fXU" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/loading_area/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "fXZ" = (
@@ -16451,9 +16254,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2
@@ -16582,7 +16382,6 @@
 	c_tag = "Medical - Pharmacy";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "gbJ" = (
@@ -16737,13 +16536,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gdX" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/cryo)
+/obj/structure/table/wood,
+/obj/item/toy/plush/moth,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "gdZ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -16983,9 +16779,6 @@
 /area/station/cargo/miningdock)
 "glc" = (
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "glk" = (
@@ -17171,16 +16964,6 @@
 /obj/item/book/manual/wiki/ordnance,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"gpw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "gpB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/engineering/half,
@@ -17421,16 +17204,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"gtN" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "gtR" = (
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 8
@@ -17609,7 +17382,6 @@
 "gxL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -17623,13 +17395,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"gyc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "gyr" = (
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/plating,
@@ -17899,12 +17664,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"gEi" = (
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "gEs" = (
 /obj/item/kirbyplants/random,
 /obj/structure/disposalpipe/segment{
@@ -18041,8 +17800,7 @@
 "gHh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "gHm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18082,15 +17840,15 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "gHL" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/textured,
 /area/station/medical/cryo)
 "gHT" = (
 /obj/structure/window/reinforced/spawner/directional/east{
@@ -18372,13 +18130,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"gLv" = (
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/obj/effect/turf_decal/tile/medical/anticorner,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "gLz" = (
 /obj/machinery/modular_computer/preset/curator,
 /obj/structure/sign/poster/official/soft_cap_pop_art/directional/north,
@@ -18891,15 +18642,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"gWb" = (
-/obj/machinery/vending/medical{
-	pixel_x = -2
-	},
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "gWf" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
@@ -19079,9 +18821,6 @@
 "gYX" = (
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "gYZ" = (
@@ -19298,6 +19037,10 @@
 /obj/machinery/air_sensor/mix_tank,
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
+"hey" = (
+/obj/structure/window/spawner/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "heF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19324,14 +19067,10 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "hfh" = (
 /obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "hfm" = (
 /obj/machinery/chem_mass_spec,
-/obj/effect/turf_decal/tile/medical/half,
 /obj/item/toy/figure/chemist{
 	pixel_x = 7;
 	pixel_y = -1
@@ -19690,13 +19429,16 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "hmE" = (
-/obj/structure/table/glass,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/firealarm/directional/south,
-/obj/item/defibrillator,
-/obj/effect/turf_decal/tile/medical/anticorner,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron/textured,
+/area/station/medical/cryo)
 "hmK" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -19826,9 +19568,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "hpb" = (
@@ -20001,9 +19740,6 @@
 /area/station/maintenance/starboard)
 "hta" = (
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "htf" = (
@@ -20017,11 +19753,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/lockers)
-"htl" = (
-/obj/machinery/iv_drip,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/medical/medbay)
 "htr" = (
 /obj/item/stock_parts/cell/high,
 /obj/structure/chair/office/light{
@@ -20349,12 +20080,6 @@
 "hAJ" = (
 /turf/closed/wall,
 /area/station/security/processing)
-"hAQ" = (
-/obj/effect/turf_decal/loading_area/red{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "hBb" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -20370,16 +20095,6 @@
 /obj/effect/turf_decal/tile/medical,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"hBN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "hCg" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -20676,13 +20391,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"hIw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "hIz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21261,7 +20969,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical,
+/obj/machinery/requests_console/directional/east{
+	department = "Medbay";
+	name = "Medbay RC"
+	},
+/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "hSa" = (
@@ -21561,15 +21273,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"iai" = (
-/obj/structure/cable,
-/obj/structure/sign/departments/medbay/directional/north,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "iam" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
@@ -22047,9 +21750,6 @@
 "iiw" = (
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "iiO" = (
@@ -22080,16 +21780,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "iiW" = (
-/obj/structure/closet/secure_closet/psychology,
-/obj/machinery/camera/directional/west{
-	c_tag = "Medical - Psychology";
-	network = list("ss13","medbay")
+/obj/vehicle/ridden/wheelchair{
+	dir = 4
 	},
-/obj/item/toy/figure/psychologist{
-	pixel_x = 4;
-	pixel_y = 16
-	},
-/turf/open/floor/wood,
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "iiY" = (
 /obj/effect/landmark/start/chemist,
@@ -22180,9 +21874,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "iku" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/dark,
-/area/station/medical/medbay)
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/textured,
+/area/station/medical/cryo)
 "ikA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22295,11 +21997,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "imL" = (
-/obj/structure/cable,
-/obj/structure/sign/departments/exam_room/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
+/obj/structure/sign/poster/official/cleanliness/directional/north,
+/obj/effect/turf_decal/tile/medical/half{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/maintenance/department/medical/plasmaman)
 "imX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -22708,12 +22411,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood,
 /obj/item/clipboard,
-/obj/item/reagent_containers/cup/glass/mug/tea,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "iuP" = (
 /obj/effect/turf_decal/tile/command/anticorner{
@@ -23258,12 +22959,15 @@
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "iFv" = (
-/obj/structure/sign/poster/official/cleanliness/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
+/obj/item/toy/katana,
+/obj/item/toy/figure/ninja{
+	pixel_x = -8;
+	pixel_y = 6
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
+/area/station/maintenance/starboard/fore)
 "iFE" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -23308,7 +23012,6 @@
 /area/station/maintenance/starboard/fore)
 "iGY" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "iHd" = (
@@ -23349,9 +23052,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "iHD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -23422,6 +23123,11 @@
 	},
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/fore)
+"iJh" = (
+/obj/structure/cable,
+/obj/structure/sign/departments/medbay/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "iJp" = (
 /obj/machinery/requests_console/directional/south{
 	department = "Virology";
@@ -23490,8 +23196,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood,
 /obj/item/paper_bin,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "iKA" = (
 /obj/effect/spawner/random/structure/grille,
@@ -23710,7 +23415,6 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/status_display/evac/directional/east,
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/medical/anticorner,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "iNU" = (
@@ -24734,8 +24438,7 @@
 /obj/structure/cable,
 /obj/structure/table/wood,
 /obj/item/book/bible,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "jhT" = (
 /obj/machinery/status_display/evac/directional/north,
@@ -25033,7 +24736,6 @@
 	network = list("ss13","medbay")
 	},
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "jnZ" = (
@@ -25123,11 +24825,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"jps" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "jpu" = (
 /obj/machinery/shower/directional/south,
 /obj/structure/curtain,
@@ -25163,9 +24860,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "jpQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jqb" = (
@@ -25199,6 +24894,14 @@
 /obj/effect/turf_decal/tile/command/anticorner,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
+"jqn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/window/right/directional/east{
+	name = "Cryogenics";
+	req_access = list("medical")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "jqM" = (
 /obj/structure/sign/warning/cold_temp/directional/south,
 /turf/open/floor/iron/white,
@@ -25219,7 +24922,10 @@
 /area/station/service/library/artgallery)
 "jrh" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/cryo)
 "jrL" = (
 /obj/structure/bed,
@@ -25396,9 +25102,6 @@
 "jum" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "jut" = (
@@ -25700,7 +25403,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "jAZ" = (
@@ -25767,7 +25469,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jCx" = (
@@ -25916,9 +25617,6 @@
 "jFr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "jFD" = (
@@ -26254,12 +25952,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "jLF" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
-/obj/machinery/photocopier,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/structure/chair/sofa/right/brown{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "jLO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26537,7 +26236,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -26624,9 +26322,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
 "jRK" = (
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/white,
@@ -26727,12 +26422,12 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"jTp" = (
-/obj/effect/turf_decal/tile/medical/anticorner{
+"jTn" = (
+/obj/structure/chair/sofa/left/brown{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "jTq" = (
 /turf/open/floor/plating,
 /area/station/hallway/primary/fore)
@@ -26817,10 +26512,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "jUP" = (
-/obj/structure/table/glass,
-/obj/structure/cable,
 /obj/item/book/manual/wiki/medicine,
-/obj/effect/turf_decal/tile/medical/half,
 /obj/item/toy/plush/lizard_plushie,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -27245,12 +26937,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/hallway/primary/port)
-"kdG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "kdY" = (
 /obj/structure/cable,
 /obj/structure/sign/nanotrasen{
@@ -27905,10 +27591,13 @@
 /area/station/hallway/primary/fore)
 "kna" = (
 /obj/structure/cable,
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/tile/medical/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay)
 "knd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -27949,11 +27638,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"knL" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "knM" = (
 /obj/structure/sign/warning/secure_area/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -28342,6 +28026,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/command/storage/eva)
+"kuP" = (
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
+/area/station/maintenance/starboard/fore)
 "kuT" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -28974,14 +28664,18 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
 "kEU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/machinery/door/airlock/medical{
+	name = "Psychology"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "kEV" = (
 /turf/closed/wall,
 /area/station/cargo/storage)
@@ -29052,9 +28746,6 @@
 /turf/open/floor/iron/white,
 /area/station/science)
 "kFY" = (
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -29542,12 +29233,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"kQg" = (
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "kQV" = (
 /obj/effect/turf_decal/tile/command/half{
 	dir = 8
@@ -29677,9 +29362,6 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "kTp" = (
@@ -29870,8 +29552,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "kXJ" = (
 /obj/structure/cable,
@@ -29921,9 +29602,7 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "kYN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical,
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "kYR" = (
@@ -30297,9 +29976,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "lgz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -30406,25 +30083,18 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "lik" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
-/obj/machinery/fax{
-	fax_name = "Medical";
-	name = "Medical Fax Machine"
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Cold Room"
 	},
-/obj/structure/table/glass,
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/maintenance/department/medical)
 "liD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
-"liH" = (
-/obj/effect/turf_decal/tile/medical/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "liI" = (
 /obj/effect/turf_decal/tile/medical/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -30739,10 +30409,6 @@
 /obj/effect/turf_decal/tile/command/anticorner,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"lpf" = (
-/obj/effect/turf_decal/tile/medical/anticorner,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "lpr" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -30841,13 +30507,6 @@
 /obj/item/food/fishmeat/carp,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard)
-"lrC" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "lrF" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
@@ -30963,7 +30622,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ltC" = (
-/obj/effect/turf_decal/tile/medical/half,
 /obj/structure/disposalpipe/junction{
 	dir = 2
 	},
@@ -31053,14 +30711,21 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "lvf" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/effect/turf_decal/tile/medical/half{
+/obj/machinery/button/door/directional/south{
+	id = "psych_shutters";
+	name = "Shutter Control";
+	pixel_x = -4;
+	req_access = list("psychology")
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/cryo)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "lvn" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1
@@ -31632,9 +31297,6 @@
 "lEW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -31671,29 +31333,11 @@
 /turf/open/floor/iron/white,
 /area/station/commons/locker)
 "lFw" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -7;
-	pixel_y = 1
-	},
-/obj/item/wrench/medical,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/medbay)
 "lFB" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/north{
@@ -31799,15 +31443,6 @@
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
-"lHL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "lHW" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
@@ -31992,18 +31627,12 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/maintenance/starboard/aft)
 "lKW" = (
-/obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/iron/freezer,
 /area/station/maintenance/department/medical)
 "lKY" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Psychology Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/turf/open/floor/wood,
+/obj/effect/spawner/structure/window/ice,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "lLj" = (
 /obj/structure/sign/poster/official/random/directional/east,
@@ -32167,18 +31796,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "lOs" = (
-/obj/effect/turf_decal/tile/medical/anticorner,
-/obj/machinery/disposal/delivery_chute{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/plasmaman)
+/area/station/medical/medbay)
 "lOB" = (
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "lOK" = (
@@ -32936,11 +32560,11 @@
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "mah" = (
-/obj/effect/wisp,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/station/maintenance/department/medical)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "mai" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -33224,15 +32848,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "meO" = (
-/obj/machinery/stasis,
-/obj/machinery/defibrillator_mount{
-	pixel_y = 28
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/textured,
+/area/station/medical/cryo)
 "meR" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/plating,
@@ -33448,8 +33071,7 @@
 /area/station/commons/storage/primary)
 "miW" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "miY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -33687,9 +33309,7 @@
 /area/station/service/theater)
 "mlN" = (
 /obj/effect/turf_decal/tile/engineering/half,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "mlZ" = (
@@ -33742,15 +33362,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "mmE" = (
+/obj/structure/sign/departments/psychology/directional/east,
 /obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/obj/structure/sign/departments/psychology/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "mng" = (
@@ -33970,14 +33583,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "mrk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/darkbrown{
-	dir = 4
-	},
-/obj/item/kirbyplants/random{
-	pixel_y = 7
-	},
-/turf/open/floor/wood,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "mrm" = (
 /obj/structure/chair{
@@ -34315,12 +33922,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
-"mwm" = (
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "mwx" = (
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
@@ -34448,9 +34049,6 @@
 "mzj" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/bed/medical/emergency,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay)
 "mzC" = (
@@ -34544,7 +34142,6 @@
 /obj/machinery/computer/records/medical/laptop{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/medical/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "mBe" = (
@@ -34701,15 +34298,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "mDN" = (
-/obj/machinery/door/airlock/medical{
-	name = "Psychology"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/turf/open/floor/wood,
-/area/station/medical/psychology)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "mDU" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/tile/security/fourcorners,
@@ -34849,12 +34440,10 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "mHg" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "mHk" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
@@ -35195,14 +34784,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mOg" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/structure/window/spawner/directional/west,
-/obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/cryo)
+/obj/structure/bookcase/random/reference,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "mOl" = (
 /obj/structure/closet/athletic_mixed,
 /obj/machinery/light/directional/south,
@@ -35262,9 +34848,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2
@@ -35721,9 +35304,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "mYb" = (
@@ -35942,10 +35522,8 @@
 /turf/open/floor/iron/white,
 /area/station/science)
 "nbZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/anticorner,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/turf/open/floor/plating,
+/area/station/medical/paramedic)
 "ncc" = (
 /obj/effect/turf_decal/tile/security/half{
 	dir = 8
@@ -35986,6 +35564,13 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/bomb)
+"ncF" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "ncJ" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Launch Room"
@@ -36137,12 +35722,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"nfH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/half,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
 "nfS" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
@@ -36427,8 +36006,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "nlD" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/carpet/purple,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/item/tank/internals/plasmaman/full,
+/obj/structure/closet/crate/secure/plasma,
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "nlL" = (
 /obj/machinery/door/window/left/directional/east{
@@ -37071,9 +36652,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "nvA" = (
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/department/medical)
 "nvF" = (
 /obj/machinery/rnd/server/master,
 /obj/machinery/camera/directional/south{
@@ -37134,13 +36716,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"nxF" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "nxI" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/suit_storage_unit/medical,
@@ -37160,9 +36735,8 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "nxX" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -37451,9 +37025,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "nDS" = (
@@ -37838,10 +37409,6 @@
 /area/station/maintenance/fore)
 "nMq" = (
 /obj/machinery/medical_kiosk,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "nMv" = (
@@ -37973,7 +37540,6 @@
 "nPa" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/medical/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "nPd" = (
@@ -38166,16 +37732,6 @@
 "nSA" = (
 /turf/closed/wall,
 /area/station/security/prison/safe)
-"nSF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "nSI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38327,7 +37883,7 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "nVX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
@@ -38364,11 +37920,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "nWI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
+/obj/effect/turf_decal/tile/medical/anticorner{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/starboard)
 "nXl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-ordnance-passthrough"
@@ -38540,9 +38102,6 @@
 "oaa" = (
 /obj/structure/bed/medical/emergency,
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay)
 "oan" = (
@@ -38575,6 +38134,17 @@
 /obj/effect/mob_spawn/corpse/human/cook,
 /turf/open/floor/plating,
 /area/station/security/office)
+"obq" = (
+/obj/structure/sign/warning/cold_temp/directional/north,
+/obj/machinery/airalarm/directional/east,
+/obj/item/storage/box/bodybags,
+/obj/structure/table,
+/obj/item/storage/box/beakers/variety{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "obr" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
@@ -38894,7 +38464,7 @@
 /area/station/service/library)
 "ogU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "ogX" = (
@@ -39242,16 +38812,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"ooo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/anticorner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "oor" = (
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
@@ -39328,14 +38888,6 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"opt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "opB" = (
 /turf/open/floor/plating,
 /area/station/construction)
@@ -39397,6 +38949,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
+"oqS" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
+	},
+/turf/open/floor/iron/textured,
+/area/station/medical/cryo)
 "oqY" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/duct,
@@ -39470,11 +39028,13 @@
 /turf/open/floor/iron/white/herringbone,
 /area/station/maintenance/starboard/aft)
 "osE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "osO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
@@ -39547,6 +39107,37 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"ouv" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/wrench/medical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Medical - Cryogenics";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/end{
+	dir = 1
+	},
+/turf/open/floor/iron/textured,
+/area/station/medical/cryo)
 "ouL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -39971,15 +39562,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "oDZ" = (
-/obj/item/toy/katana,
-/obj/item/toy/figure/ninja{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/station/maintenance/department/medical)
+/obj/effect/landmark/start/paramedic,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/medical/medbay)
 "oEb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -40024,14 +39610,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
-"oFh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "oFl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40507,7 +40085,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "oPh" = (
@@ -40532,13 +40110,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/security/courtroom)
-"oPq" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
 "oPu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
@@ -40558,12 +40129,6 @@
 "oPO" = (
 /turf/closed/indestructible/opshuttle,
 /area/station/science/ordnance/bomb)
-"oPS" = (
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "oQm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40648,15 +40213,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"oSn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "oSy" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
@@ -40887,9 +40443,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "oWX" = (
@@ -40921,14 +40474,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "oXs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/holopad,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/darkbrown{
-	dir = 4
+/obj/effect/wisp,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
 	},
-/turf/open/floor/wood,
-/area/station/medical/psychology)
+/area/station/maintenance/starboard/fore)
 "oXP" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -41239,9 +40789,6 @@
 /obj/structure/table/optable,
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "pdK" = (
@@ -41337,12 +40884,11 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "peR" = (
-/obj/structure/chair/sofa/right/brown{
-	dir = 1
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
 	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/area/station/maintenance/starboard/fore)
 "peT" = (
 /obj/structure/table/wood,
 /obj/item/toner/large,
@@ -41390,8 +40936,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "pgM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -41481,7 +41026,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "pis" = (
-/obj/effect/turf_decal/tile/medical/half,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -41965,7 +41509,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "prP" = (
@@ -41978,8 +41521,7 @@
 "prR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "prX" = (
 /obj/structure/rack,
@@ -41988,10 +41530,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "psk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -42419,7 +41960,6 @@
 /obj/item/radio/headset/headset_med,
 /obj/item/storage/box/syringes,
 /obj/item/radio/headset/headset_med,
-/obj/effect/turf_decal/tile/medical/anticorner,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "pAp" = (
@@ -42775,9 +42315,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "pGr" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/wood,
-/area/station/medical/psychology)
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical)
 "pGv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43883,10 +43423,7 @@
 /area/station/hallway/secondary/command)
 "qcC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/reagent_dispensers/plumbed{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/station/maintenance/department/medical)
 "qcE" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -43900,15 +43437,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "qcJ" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Medical - Central Hall NW";
-	network = list("ss13","medbay")
+/obj/structure/table/glass,
+/obj/item/storage/medkit/emergency,
+/obj/item/toy/figure/paramedic,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
 	},
-/obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "qcR" = (
 /obj/structure/cable,
@@ -44231,7 +43768,6 @@
 	name = "surgery privacy shutter control";
 	pixel_y = -5
 	},
-/obj/effect/turf_decal/tile/medical/anticorner,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "qiH" = (
@@ -44368,9 +43904,6 @@
 /area/station/engineering/atmos/storage/gas)
 "qlG" = (
 /obj/effect/spawner/random/vending/snackvend,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "qlP" = (
@@ -45091,10 +44624,6 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/status_display/ai/directional/north,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "qAV" = (
@@ -45299,12 +44828,7 @@
 /turf/open/floor/iron,
 /area/station/construction)
 "qEr" = (
-/obj/machinery/computer/records/medical{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
+/obj/machinery/photocopier,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "qEt" = (
@@ -45671,7 +45195,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -45935,11 +45458,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qSZ" = (
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space)
 "qTa" = (
 /mob/living/simple_animal/bot/secbot/beepsky/officer,
 /turf/open/floor/plating,
@@ -46043,9 +45564,6 @@
 "qUS" = (
 /obj/structure/chair/sofa/left/brown,
 /obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "qUU" = (
@@ -46165,7 +45683,6 @@
 /area/station/science/xenobiology)
 "qXX" = (
 /obj/structure/sign/departments/maint/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "qYj" = (
@@ -46184,16 +45701,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qYr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/cryo_cell,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/textured,
+/area/station/medical/cryo)
 "qYJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/textured,
@@ -46256,11 +45768,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "qZi" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/opposingcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical)
 "qZq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Boxing";
@@ -46393,7 +45904,6 @@
 /obj/item/storage/box/gloves,
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer/simple,
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rbr" = (
@@ -46463,9 +45973,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -46781,9 +46288,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "riO" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "riQ" = (
 /obj/effect/spawner/structure/window,
 /obj/effect/mapping_helpers/damaged_window,
@@ -46890,8 +46397,11 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "rld" = (
-/obj/effect/turf_decal/tile/medical/half,
-/turf/open/floor/iron/white,
+/obj/machinery/shower/directional/north,
+/obj/effect/turf_decal/siding/blue{
+	dir = 9
+	},
+/turf/open/floor/engine,
 /area/station/medical/medbay/central)
 "rlq" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -46928,9 +46438,8 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "rmc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/half,
+/obj/structure/window/spawner/directional/south,
+/obj/item/kirbyplants/organic/plant8,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "rmh" = (
@@ -47221,13 +46730,6 @@
 /obj/item/toy/figure/lawyer,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
-"rrP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "rsb" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -47302,15 +46804,6 @@
 "rtf" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
-/obj/machinery/button/door/directional/east{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
-	pixel_y = -3;
-	req_access = list("medical")
-	},
-/obj/effect/turf_decal/tile/medical/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "rto" = (
@@ -47428,9 +46921,16 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "rvE" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/medical/exam_room)
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
+/area/station/medical/medbay)
 "rvP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47729,11 +47229,11 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance)
 "rCm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/structure/cable,
+/obj/structure/sign/departments/exam_room/directional/south,
+/obj/effect/turf_decal/tile/medical/half,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/plasmaman)
 "rCp" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/disposalpipe/segment{
@@ -48175,9 +47675,6 @@
 "rKu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -48198,9 +47695,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rKP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "rKX" = (
@@ -48436,9 +47931,6 @@
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/west,
 /obj/item/book/manual/wiki/surgery,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "rQu" = (
@@ -48591,9 +48083,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "rTk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
@@ -48727,9 +48217,6 @@
 /area/station/maintenance/starboard/fore)
 "rVZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "rWb" = (
@@ -48961,11 +48448,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "rZZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/turf/open/space/basic,
+/area/station/medical/virology)
 "sab" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/wrench,
@@ -49288,9 +48772,6 @@
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light_switch/directional/south,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "sgd" = (
@@ -49311,7 +48792,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "sgo" = (
-/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sgy" = (
@@ -49339,9 +48820,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "sgG" = (
@@ -49606,6 +49084,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"slT" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "slU" = (
 /obj/machinery/brm,
 /obj/machinery/conveyor{
@@ -49624,17 +49111,13 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/courtroom)
 "smi" = (
-/obj/machinery/stasis{
-	dir = 1
-	},
-/obj/machinery/defibrillator_mount{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay)
 "smr" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Containment Pen #7";
@@ -49745,7 +49228,6 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/medical/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "snY" = (
@@ -49910,11 +49392,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "srj" = (
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/station/maintenance/department/medical)
+/obj/structure/table/glass,
+/obj/item/clothing/under/misc/pj/blue,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/storage/box,
+/obj/item/blood_filter,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "srm" = (
 /obj/item/toy/plush/beeplushie,
 /obj/structure/table/wood,
@@ -50273,9 +49757,6 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "sxC" = (
@@ -50705,14 +50186,16 @@
 /area/station/hallway/secondary/service)
 "sGj" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"sGl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/department/medical)
 "sGu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -50858,11 +50341,13 @@
 /turf/open/floor/carpet/neon/simple/black/nodots,
 /area/station/service/bar)
 "sIQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/shower/directional/north,
+/obj/effect/turf_decal/siding/blue{
+	dir = 5
 	},
-/turf/open/floor/circuit/telecomms,
-/area/station/science/xenobiology)
+/turf/open/floor/engine,
+/area/station/medical/medbay/central)
 "sIU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -50880,12 +50365,6 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"sIZ" = (
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "sJt" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -51014,17 +50493,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "sMl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
+/obj/machinery/door/airlock/medical/glass{
+	name = "Exam Room"
 	},
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/cryo)
+/obj/effect/turf_decal/tile/medical/opposingcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "sMT" = (
 /obj/structure/mirror/directional/north,
 /turf/open/floor/wood,
@@ -51082,13 +50556,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"sOX" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
 "sPf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -51516,9 +50983,6 @@
 "tbg" = (
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "tbk" = (
@@ -51528,7 +50992,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/med,
-/obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "tbl" = (
@@ -51721,9 +51184,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "tdW" = (
-/obj/structure/sign/departments/medbay,
-/turf/closed/wall,
-/area/station/medical/cryo)
+/obj/structure/table/glass,
+/obj/item/defibrillator,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "tee" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -51930,9 +51394,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "thT" = (
@@ -52184,16 +51645,20 @@
 /turf/open/floor/plating,
 /area/station/science/explab)
 "tlE" = (
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay)
 "tlI" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/medical/opposingcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/obj/structure/cable,
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/blue/anticorner,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
+/area/station/medical/medbay)
 "tlO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -52218,7 +51683,7 @@
 /area/station/maintenance/disposal/incinerator)
 "tmh" = (
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "tmp" = (
@@ -52440,18 +51905,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "tqk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/requests_console/directional/east{
-	department = "Medbay";
-	name = "Medbay RC"
-	},
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/stasis,
+/obj/structure/sign/departments/medbay/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "tqm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -52473,6 +51933,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"tqs" = (
+/obj/machinery/stasis{
+	dir = 1
+	},
+/obj/machinery/defibrillator_mount{
+	pixel_y = 28
+	},
+/obj/item/toy/plush/beefplushie,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "tqu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -52557,12 +52027,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "tsl" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/half,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "tsq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52659,12 +52126,16 @@
 "ttB" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 9;
-	pixel_y = 2
+/obj/machinery/button/door/directional/north{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	req_access = list("medical")
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/turf_decal/tile/medical/fourcorners,
+/obj/machinery/fax{
+	fax_name = "Medical";
+	name = "Medical Fax Machine"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ttC" = (
@@ -52907,7 +52378,6 @@
 	c_tag = "Medical - Surgery Hall";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "tyh" = (
@@ -53164,14 +52634,13 @@
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "tDb" = (
+/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "tDn" = (
@@ -53330,12 +52799,13 @@
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
 "tGv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/obj/effect/turf_decal/tile/medical/half,
-/turf/open/floor/iron/dark,
-/area/station/medical/cryo)
+/obj/structure/window/spawner/directional/south,
+/obj/item/kirbyplants/organic/plant8,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "tGw" = (
 /obj/effect/spawner/random/contraband/prison,
 /obj/structure/closet/crate/bin,
@@ -53343,10 +52813,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/rec)
 "tGS" = (
-/obj/structure/table/wood,
-/obj/item/toy/plush/moth,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/carpet/purple,
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Storage"
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "tHl" = (
 /obj/structure/lattice/catwalk,
@@ -53585,7 +53055,6 @@
 /area/station/maintenance/starboard)
 "tOl" = (
 /obj/structure/sign/departments/chemistry/pharmacy/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "tOE" = (
@@ -53847,13 +53316,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "tTz" = (
-/obj/machinery/stasis,
-/obj/machinery/defibrillator_mount{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tTC" = (
@@ -54254,7 +53717,6 @@
 /area/station/engineering/supermatter/room)
 "tZU" = (
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/medical/anticorner,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "uad" = (
@@ -54372,6 +53834,18 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"ubx" = (
+/obj/effect/turf_decal/stripes{
+	dir = 6
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "ubB" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/glass/bottle/beer,
@@ -54380,7 +53854,6 @@
 "ubF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "ubG" = (
@@ -54581,16 +54054,12 @@
 /area/station/science)
 "ufi" = (
 /obj/structure/cable,
-/obj/machinery/camera/directional/north{
-	c_tag = "Medical - Central Hall NE";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
+/obj/effect/landmark/start/paramedic,
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "uft" = (
@@ -55105,7 +54574,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "upw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
@@ -55185,14 +54654,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/ordnance/storage)
 "urd" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "urf" = (
@@ -55387,11 +54854,14 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "uum" = (
-/obj/vehicle/ridden/wheelchair{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/medbay)
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "uut" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment{
@@ -55399,15 +54869,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
-"uuB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/break_room)
 "uuG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -55544,20 +55005,20 @@
 /area/station/medical/medbay/central)
 "uxR" = (
 /obj/structure/table,
-/obj/item/reagent_containers/cup/glass/mug/tea,
-/obj/effect/turf_decal/tile/medical/fourcorners,
+/obj/item/bouquet/sunflower,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "uye" = (
 /turf/closed/wall,
 /area/station/science/xenobiology)
 "uyD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/medical/half,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/structure/closet/secure_closet/psychology,
+/obj/item/toy/figure/psychologist{
+	pixel_x = 4;
+	pixel_y = 16
+	},
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "uyP" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -55672,9 +55133,6 @@
 /area/station/maintenance/department/medical/plasmaman)
 "uBv" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -55785,16 +55243,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "uEl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical{
-	dir = 1
+/obj/effect/turf_decal/stripes{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "uEs" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/directional{
@@ -56294,9 +55750,6 @@
 /area/station/commons/dorms)
 "uOp" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "uOr" = (
@@ -56489,11 +55942,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
-"uRh" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "uRk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -56689,9 +56137,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -56855,18 +56300,6 @@
 /obj/effect/turf_decal/tile/command/half,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
-"uYr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "uYA" = (
 /obj/item/storage/medkit/fire{
 	pixel_x = 3;
@@ -57147,9 +56580,7 @@
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
 "vdA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "vdN" = (
@@ -57440,7 +56871,6 @@
 /area/station/maintenance/port/aft)
 "viM" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "viO" = (
@@ -57598,13 +57028,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/plasmaman)
-"vmp" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "vmt" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering - Oxygen Tank";
@@ -57965,12 +57388,14 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "vtH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "psych_shutters";
+	name = "Psychology Privacy Shutters"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/plating,
+/area/station/medical/psychology)
 "vtJ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -58555,9 +57980,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -59127,17 +58549,10 @@
 	},
 /area/station/tcommsat/computer)
 "vST" = (
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/plasmaman)
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "vSV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -59353,9 +58768,6 @@
 "vXl" = (
 /obj/structure/table/glass,
 /obj/item/surgery_tray/full,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "vXr" = (
@@ -59488,7 +58900,6 @@
 /obj/machinery/light/directional/south,
 /obj/item/reagent_containers/cup/glass/mug/coco,
 /obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "vZG" = (
@@ -59600,6 +59011,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/station/security/prison/safe)
+"wbv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "wbA" = (
 /obj/machinery/biogenerator,
 /obj/machinery/door/firedoor,
@@ -59999,9 +59415,6 @@
 /area/station/cargo/miningdock)
 "wki" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "wkm" = (
@@ -60615,12 +60028,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "wwY" = (
-/obj/machinery/shower/directional/west,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/mid_joiner,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/cryo)
 "wxt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -60847,17 +60259,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"wCc" = (
-/obj/structure/cable,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "wCd" = (
 /obj/effect/turf_decal/tile/security/half,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60870,9 +60271,6 @@
 	c_tag = "Medical - Virology Hall";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "wCq" = (
@@ -60881,8 +60279,7 @@
 /obj/structure/cable,
 /obj/structure/table/wood,
 /obj/item/newspaper,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "wCu" = (
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -61084,9 +60481,6 @@
 "wFB" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "wFK" = (
@@ -61340,10 +60734,9 @@
 /area/station/maintenance/department/science)
 "wKX" = (
 /obj/machinery/cryo_cell,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/textured,
 /area/station/medical/cryo)
 "wLh" = (
 /obj/effect/turf_decal/tile/medical/half{
@@ -61423,9 +60816,6 @@
 	name = "surgery privacy shutter control";
 	pixel_y = -5
 	},
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "wMl" = (
@@ -61484,13 +60874,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
-"wNj" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "wNm" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -61513,12 +60896,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "wNT" = (
-/obj/machinery/shower/directional/east,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/blacklight/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay)
 "wOa" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/east,
@@ -61762,8 +61145,10 @@
 /area/station/maintenance/solars/starboard/fore)
 "wRx" = (
 /obj/structure/table,
-/obj/item/bouquet/sunflower,
-/obj/effect/turf_decal/tile/medical/fourcorners,
+/obj/item/clipboard{
+	pixel_x = -4
+	},
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "wRL" = (
@@ -61892,9 +61277,6 @@
 "wTX" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/evac/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "wUw" = (
@@ -62134,6 +61516,10 @@
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"wZh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/department/medical)
 "wZi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -62144,6 +61530,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
+"wZv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "wZw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62252,9 +61643,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "xaL" = (
 /obj/effect/spawner/random/vending/snackvend,
@@ -62324,11 +61714,10 @@
 "xbM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "xbN" = (
 /obj/machinery/airalarm/directional/east,
@@ -62485,9 +61874,6 @@
 /area/station/maintenance/department/medical/plasmaman)
 "xee" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "xeH" = (
@@ -62572,11 +61958,14 @@
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/primary/central)
 "xgs" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/medbay)
 "xgv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/command/half{
@@ -62610,7 +61999,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "xha" = (
-/obj/effect/turf_decal/tile/medical/half,
 /obj/structure/chair{
 	dir = 4
 	},
@@ -62713,10 +62101,10 @@
 	name = "Medbay Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/turf_decal/tile/medical/opposingcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
 "xje" = (
@@ -62952,9 +62340,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xlX" = (
@@ -63030,8 +62415,7 @@
 /area/station/science/xenobiology)
 "xmG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "xmI" = (
 /obj/machinery/door/airlock{
@@ -63275,14 +62659,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science)
-"xqT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "xrg" = (
 /obj/machinery/button/door/incinerator_vent_ordmix{
 	pixel_x = 8;
@@ -63684,17 +63060,8 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "xzB" = (
-/obj/effect/turf_decal/stripes{
-	dir = 6
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "xzG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -63709,9 +63076,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "xAx" = (
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "xAE" = (
@@ -63803,14 +63167,17 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "xBQ" = (
-/obj/effect/turf_decal/stripes{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "xBU" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard)
@@ -63940,7 +63307,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xEa" = (
@@ -63955,9 +63321,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "xEK" = (
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "xEP" = (
 /obj/structure/cable,
@@ -64433,9 +63798,6 @@
 "xOV" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/bed/medical/emergency,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay)
 "xOX" = (
@@ -64807,7 +64169,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "xWg" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "xWh" = (
@@ -64865,15 +64227,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
-"xXk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "xXm" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -64890,9 +64243,6 @@
 "xXU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
@@ -65092,10 +64442,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"ybQ" = (
-/obj/effect/turf_decal/tile/medical/half,
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "ybS" = (
 /obj/item/toy/plush/fly,
 /turf/open/floor/plating,
@@ -65114,12 +64460,10 @@
 /turf/closed/wall,
 /area/station/maintenance/department/medical)
 "ych" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/medbay)
 "yct" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 6
@@ -65162,7 +64506,12 @@
 /area/station/engineering/lobby)
 "ydb" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
 /area/station/medical/medbay)
 "ydc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65438,9 +64787,6 @@
 "ygo" = (
 /obj/structure/chair/sofa/right/brown,
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "ygp" = (
@@ -65670,9 +65016,6 @@
 /area/station/command/heads_quarters/hop)
 "ykY" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "yla" = (
@@ -65702,9 +65045,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -91620,7 +90960,7 @@ uFS
 uVE
 lsj
 vMx
-dFE
+xWg
 oOV
 upw
 apM
@@ -92389,7 +91729,7 @@ jCT
 uFS
 uFS
 mqx
-osE
+jpQ
 jeb
 bRS
 tHM
@@ -92648,7 +91988,7 @@ uFS
 uVE
 cNK
 nic
-dFE
+xWg
 oOV
 upw
 gfa
@@ -100337,14 +99677,14 @@ akw
 tUB
 tZB
 tZB
-nWI
-aqv
-aqv
-rZZ
+rKP
+rKP
+rKP
+rKP
 nVX
-vtH
 nVX
-vtH
+nVX
+nVX
 nVX
 rKP
 ieh
@@ -100594,7 +99934,7 @@ cDr
 rCI
 tZB
 tZB
-rCm
+rKP
 tZB
 mjs
 aas
@@ -102844,7 +102184,7 @@ wJu
 wJu
 duI
 tbk
-bPQ
+aQv
 wJu
 wJu
 wJu
@@ -103088,20 +102428,20 @@ ycg
 weh
 mqh
 ycg
-sOX
+xee
 frD
 rQt
 wMg
 poU
 esY
-liH
+rXy
 wJu
 nMq
 fXU
 hfh
-eWk
+iGY
 ezs
-atB
+qOB
 glc
 aXr
 uBv
@@ -103348,14 +102688,14 @@ ycg
 pdG
 dSc
 oFl
-bRf
+oFl
 aoE
-hIw
-knL
+jsI
+ykY
 wJu
 qAE
-hAQ
-cJD
+qOB
+qOB
 miW
 xmG
 fBM
@@ -103607,7 +102947,7 @@ bfu
 cLQ
 tZU
 poU
-kdG
+lHq
 nPa
 wJu
 deG
@@ -103865,7 +103205,7 @@ kiq
 uPm
 vOK
 mXV
-nxF
+ykY
 rfN
 iGY
 muJ
@@ -104119,10 +103459,10 @@ ycg
 lOB
 oWN
 xXU
-oPq
+tZU
 egm
-oFh
-uRh
+lHq
+ykY
 wJu
 deg
 qOB
@@ -104376,10 +103716,10 @@ ycg
 pdG
 hTQ
 aFg
-nfH
+aFg
 tkH
-oFh
-uRh
+lHq
+ykY
 wJu
 rtf
 muJ
@@ -104618,7 +103958,7 @@ ycg
 ycg
 hTl
 lQH
-ygs
+nbZ
 ycg
 hlt
 wrl
@@ -104635,18 +103975,18 @@ vXl
 iiw
 qiC
 egm
-oFh
-uRh
+lHq
+ykY
 wJu
 ttB
 qEr
 wRx
-fpY
+iGY
 lEW
-gEi
+qOB
 uOp
-gEi
-lpf
+qOB
+qOB
 ihF
 ihF
 ihF
@@ -104892,7 +104232,7 @@ vOK
 vOK
 vOK
 vOK
-oFh
+lHq
 tyd
 wJu
 idc
@@ -105147,23 +104487,23 @@ oKi
 xNJ
 omb
 hlN
-jTp
-vmp
-oSn
-gyc
+rXy
+ykY
+jsI
+ykY
 tbg
-vmp
-vmp
+ykY
+ykY
 jFr
-vmp
-ane
-sIZ
+ykY
+fNJ
+rXy
 uaz
 gcB
 qrU
 iFq
 wki
-fKY
+cUe
 sgc
 uaz
 eof
@@ -105398,21 +104738,21 @@ ccz
 ykv
 wZO
 ags
-xXk
-uYr
+jsI
+psk
 nDP
-xqT
-xqT
-xqT
-opt
+lHq
+lHq
+lHq
+jsI
 hRW
-tqk
-aQv
-aQv
-aQv
+lHq
+lHq
+lHq
+lHq
 aUU
 dDp
-lHL
+jsI
 fNJ
 tOl
 uaz
@@ -105420,7 +104760,7 @@ foA
 oNI
 grY
 wki
-dyU
+cUe
 pAg
 wzS
 jCH
@@ -105655,29 +104995,29 @@ sfU
 wLh
 xFH
 yaq
-gWb
-gtN
+rXy
+urd
 lHq
 bpn
-nvA
 rXy
 rXy
-jLF
-oKi
+lOs
+mhn
+mhn
 uxN
-uxN
+sMl
 uxN
 mhn
 mhn
 kTf
 fNJ
-aPe
+rXy
 oqz
 kFY
-dzN
-dzN
+cUe
+cUe
 xlW
-ybQ
+cUe
 wzS
 wzS
 jCH
@@ -105903,7 +105243,6 @@ ycg
 ycg
 ycg
 lQH
-ygs
 ycg
 ndu
 rZz
@@ -105913,17 +105252,18 @@ rZz
 uRk
 rZz
 rZz
-wCc
-jsI
+riO
+urd
+tGv
 djl
 ydb
 ydb
-ydb
-lik
-oKi
-smi
-oPS
-wNT
+rvE
+mhn
+tqs
+mEF
+mEF
+mEF
 eZZ
 mhn
 ykY
@@ -106160,7 +105500,6 @@ ygs
 ygs
 ycg
 lQH
-ygs
 sXC
 ndu
 nzu
@@ -106170,26 +105509,27 @@ vMH
 yaM
 rwc
 rZz
-psk
+ane
+urd
 kYN
 qcJ
+oDZ
 tlE
-mHg
-tlE
-nbZ
-sPM
-mwm
+bAn
+uxN
+mEF
+mEF
 mEF
 rbr
 jUP
 uxN
 ykY
 vrG
-aPe
+rXy
 oqz
 jdu
 etQ
-cmr
+sGj
 mBv
 hfm
 lkG
@@ -106417,7 +105757,6 @@ lQH
 lQH
 eeM
 lQH
-ygs
 rMj
 ndu
 cyl
@@ -106427,26 +105766,27 @@ kJo
 opE
 fBs
 uRk
-psk
+rXy
+urd
 rmc
-oKi
-tdW
-oOD
+eTq
+atl
+atl
 tlI
-qZi
-oOD
-cbH
+mhn
 mEF
-auJ
-kna
+mEF
+mEF
+mEF
+mEF
 uxN
 ykY
 fNJ
-aPe
+rXy
 iVJ
 qrU
 oNI
-cmr
+sGj
 cUe
 gbD
 hVO
@@ -106674,7 +106014,6 @@ lQH
 ycg
 ycg
 ycg
-ygs
 wPd
 ndu
 vQx
@@ -106684,22 +106023,23 @@ tVA
 lAW
 bmk
 aAq
-ezN
-rmc
-sPM
-wKX
-cTF
+rXy
+psk
+rXy
+hey
+rXy
+rXy
 ych
-gHL
-oOD
+mhn
 wTX
 mEF
+srj
 jCv
-jps
+tTz
 viM
 ykY
 fNJ
-aPe
+rXy
 nPY
 gcB
 iyv
@@ -106930,8 +106270,7 @@ ygs
 lQH
 ycg
 dbU
-ygs
-ygs
+fNq
 ygs
 ndu
 ndu
@@ -106941,22 +106280,23 @@ wcz
 rjc
 igF
 uRk
-psk
-rmc
+rXy
+kna
+lFw
 cXM
 lFw
 xgs
-jrh
+mmE
 bzD
-qZi
-bja
-eAc
+tTz
+tTz
+rbk
 oot
 xDS
 aXc
-nSF
+thQ
 brb
-aPe
+rXy
 xaG
 xaG
 xaG
@@ -107188,28 +106528,28 @@ lQH
 ycg
 tYi
 qFe
-qFe
 ygs
 ygs
-ygs
+cdx
 hNN
 ndu
 vaW
 ndu
 ndu
 ndu
+rXy
 urd
-uyD
-sPM
+rXy
+tQz
 eEN
 kEU
-bAn
-gLv
-oOD
-eFB
+tQz
+mhn
+mHg
 mEF
+tdW
 lgz
-rld
+mEF
 viM
 ykY
 uTT
@@ -107445,7 +106785,6 @@ lQH
 ttg
 ttg
 ttg
-ttg
 kqZ
 kqZ
 ttg
@@ -107455,24 +106794,25 @@ ttg
 ttg
 kqZ
 seR
+rXy
 psk
-tsl
-oKi
-oOD
-oOD
+tQz
+tQz
+uyD
+osE
 mOg
-bAC
-oOD
-tTz
+mhn
+atB
+mEF
 sgo
-auJ
+lgz
 rld
-uxN
+mhn
 ykY
 brb
 qXX
 xBU
-dqQ
+wpj
 wpj
 ajJ
 ajJ
@@ -107702,7 +107042,6 @@ lQH
 ygs
 ygs
 qFe
-ygs
 qFe
 ygs
 ygs
@@ -107712,19 +107051,20 @@ ycg
 ycg
 ycg
 ycg
+cov
 tDb
-rmc
+tQz
+elj
 uum
-uum
-oOD
+xBQ
 lvf
-tGv
-haw
-mwm
-mEF
+mhn
+tqk
+wZv
+jqn
 auJ
-rbk
-uxN
+sIQ
+mhn
 ykY
 brb
 dGh
@@ -107954,37 +107294,37 @@ ydZ
 grD
 rQz
 isa
-isa
 lQH
-ycg
+qcC
 jRM
 ndr
-kPy
 ycg
-qFe
 ygs
 ycg
 ycg
-iiW
-bwn
+ycg
+ycg
 pGr
+iiW
+mrk
 tQz
-mmE
-rmc
-iku
-htl
-oOD
+rXy
+urd
+vtH
+rtJ
+laH
+ofS
 gdX
-sMl
 oOD
+wKX
 meO
-qSZ
+aPe
 wwY
 hmE
-mhn
-ykY
+oOD
+iJh
 gUm
-rrP
+jsI
 uIb
 rdy
 ewI
@@ -108211,37 +107551,37 @@ dKp
 nHc
 rvY
 ygs
-ygs
-lQH
-ycg
-ycg
+ttg
+qcC
 ycg
 ycg
 ycg
 ygs
-isa
+ycg
+nvA
+nvA
 lKY
 mrk
-oXs
+iiW
 cwx
-cwx
+tQz
 mDN
-ezN
-rmc
-cvb
-cov
+urd
+vtH
+nBJ
+pOF
+eOR
+jTn
 oOD
-oOD
-oOD
-oOD
-uxN
-uxN
-uxN
-mhn
-mhn
-iai
+ouv
+iku
+jrh
+wwY
+oqS
+haw
+ykY
 sWZ
-aPe
+rXy
 upW
 oGR
 vrV
@@ -108474,31 +107814,31 @@ isa
 isa
 isa
 isa
-isa
-isa
-isa
-ycg
-rtJ
-laH
-ofS
+qcC
+wZh
+frd
+lik
+xzB
+xzB
+xzB
 tGS
-tQz
+rXy
 ufi
-rcT
-rKu
-rKu
-vGd
-bIt
-fYI
+vtH
+dQB
+vQV
+dFE
+jLF
+oOD
 qYr
-hBN
-hBN
-mPE
-hBN
-ymc
-uEl
-fvn
+meO
 aPe
+wwY
+gHL
+haw
+jsI
+fNJ
+rXy
 upW
 ddv
 dVd
@@ -108731,30 +108071,30 @@ ygs
 ygs
 ygs
 ygs
-ygs
-qFe
-isa
 ycg
-nBJ
-pOF
-eOR
-clV
+sGl
+lKW
+lKY
+xzB
+xzB
+eFB
 tQz
-lrC
-thQ
-wNj
-gYX
-fLg
-jum
-dsW
-wFB
-wNj
-wNj
-bJM
-tlE
-fnA
-wNj
-lHL
+rXy
+psk
+tQz
+tQz
+tQz
+tQz
+tQz
+oOD
+oOD
+haw
+bAC
+haw
+oOD
+oOD
+iJh
+psk
 ubF
 upW
 aok
@@ -108984,35 +108324,35 @@ rvY
 rvY
 rvY
 rvY
-ycg
-ycg
-ycg
-ycg
-ycg
 ygs
-isa
+ygs
+ygs
+ygs
 ycg
-dQB
-vQV
+qcC
+ycg
+ycg
+obq
+agF
 nlD
-peR
 tQz
-hTZ
-jAS
-hTZ
-hTZ
-hTZ
-frd
-fHt
-mIp
-ouL
-ouL
-tYn
-ouL
-ouL
-mIp
+cbH
+slT
+rcT
+rKu
+wNT
+vGd
+bIt
+fYI
+rcT
+rcT
+smi
+mPE
+aqv
+ymc
+ncF
 aNn
-bRO
+rXy
 upW
 uYA
 vrV
@@ -109241,35 +108581,35 @@ uPn
 tIS
 onJ
 rvY
-mLg
-rZd
-daV
-mLg
-ycg
-cdx
+ygs
+ygs
+ygs
+ygs
+ygs
 isa
+ygs
 ycg
 ycg
 ycg
 tQz
 tQz
-tQz
-fkW
-uuB
-aWT
-dLu
-hTZ
-mzj
-gpw
-mIp
-aQA
-pak
-fWw
-aRB
-myo
-mIp
-rVZ
-ubF
+rXy
+ykY
+thQ
+ykY
+gYX
+jFr
+jum
+psk
+wFB
+ykY
+ykY
+psk
+rXy
+cov
+rXy
+clV
+bRO
 upW
 wyW
 vrV
@@ -109498,34 +108838,34 @@ uPn
 vzb
 uwR
 rvY
-mLg
-mLg
-rsL
-mLg
 ycg
-fNq
-hJa
+ycg
+ycg
+ycg
 ygs
+ygs
+hJa
+tcM
 dHz
 ycg
-xuZ
-kSE
-uia
-hta
-caB
-giA
-xha
+jpu
 hTZ
-oaa
-gpw
+hTZ
+hTZ
+jAS
+hTZ
+hTZ
+hTZ
+bYx
+fHt
+mIp
 ouL
-mHf
-qHl
-vlx
-hVa
-pna
 ouL
-rVZ
+tYn
+ouL
+ouL
+mIp
+wbv
 ubF
 upW
 teZ
@@ -109756,35 +109096,35 @@ pKQ
 jAt
 rvY
 mLg
-mah
-srj
-mLg
+rZd
+daV
 ycg
+ygs
 doC
 hJa
-ygs
+tcM
 dHz
 ycg
-jpu
-vmT
+xuZ
+kSE
 hTZ
-ygo
+fkW
 qoR
 npr
-vZA
+dLu
 hTZ
-xOV
-gpw
-ouL
-mzC
-djb
-hhx
-coL
-sXJ
-ouL
+mzj
+psk
+mIp
+aQA
+pak
+fWw
+aRB
+myo
+mIp
 rVZ
-fmk
-atl
+ubF
+upW
 kcg
 luv
 hpL
@@ -110012,35 +109352,35 @@ xYF
 xYF
 vzb
 rvY
-oDZ
 mLg
-lKW
 mLg
+rsL
+ycg
 ycg
 kPy
 isa
-hJa
-ygs
+qZi
 ycg
 ycg
+eAc
+eAc
+uia
+hta
+caB
+giA
+xha
 hTZ
-hTZ
-qUS
-qoR
-yee
-jnY
-hTZ
-wCg
-gpw
+oaa
+psk
 ouL
-rJm
-wmv
-mDd
-dun
-uOx
+mHf
+qHl
+vlx
+hVa
+pna
 ouL
-cba
-ubF
+rVZ
+fmk
 mrA
 mrA
 mrA
@@ -110269,36 +109609,36 @@ rvY
 mSG
 gPZ
 rvY
-rvY
-rvY
-rvY
-rvY
+blX
+oXs
+kuP
+blX
 ycg
 ycg
 ycg
-isa
+bxz
 ogU
 qcC
-ycg
-lBT
-dGm
-xAx
-sgF
-sxz
-etK
+eAc
+vmT
 hTZ
-qlG
-ooo
-mIp
-frE
-emF
-vDL
-hNu
-iyT
-mIp
-rVZ
-rrP
-iQK
+ygo
+qoR
+npr
+vZA
+hTZ
+xOV
+psk
+ouL
+mzC
+djb
+hhx
+coL
+sXJ
+ouL
+cba
+ubF
+mrA
 eXk
 duU
 xgZ
@@ -110380,8 +109720,8 @@ jOV
 lXl
 aUZ
 lMN
-blX
-sIQ
+vdA
+vdA
 fYj
 gyw
 mdu
@@ -110526,36 +109866,36 @@ vzb
 sPX
 vzb
 vzb
-sAu
-vkm
-ojh
-rvY
+iFv
+blX
+peR
+blX
+ycg
 rmL
 ygs
-ygs
-ygs
 tcM
+ygs
 qcC
 ycg
 ycg
-ycg
-ycg
-mBo
-ycg
-ycg
-ycg
-ycg
-rPT
-ndu
-xaG
-xaG
-xaG
-xaG
-xaG
-xaG
-kQg
-uRh
-rvE
+hTZ
+qUS
+qoR
+yee
+jnY
+hTZ
+wCg
+psk
+ouL
+rJm
+wmv
+mDd
+dun
+uOx
+ouL
+rVZ
+jsI
+iQK
 atf
 ecY
 fEj
@@ -110783,36 +110123,36 @@ vzb
 sPX
 pXQ
 pXQ
-pXQ
-pXQ
-pXQ
-eln
-ttg
+rvY
+rvY
+rvY
+rvY
+ycg
 ttg
 kqZ
-ttg
 rsV
-agG
-agG
-gxI
-agG
-gxI
-gxI
-uZc
-uZc
-iKI
-mRm
-aMq
-hAD
-qof
-fHF
-wpj
-dqQ
-iBY
-xBU
-iFv
-imL
-oKi
+ttg
+lQH
+qcC
+lBT
+dGm
+xAx
+sgF
+sxz
+etK
+hTZ
+qlG
+psk
+mIp
+frE
+emF
+vDL
+hNu
+iyT
+mIp
+rXy
+ykY
+sPM
 jQv
 mDf
 tnA
@@ -111040,35 +110380,35 @@ sPX
 sPX
 dzw
 vzb
-riO
-vzb
-vzb
-rvY
-gPz
+pXQ
+pXQ
+pXQ
+eln
+ttg
 bZY
 ygs
-ygs
-ygs
-ygs
-ygs
-ygs
-weh
-ntA
-kVq
-weh
-ttg
+tcM
+tcM
+rsV
 ycg
-xdX
-mwX
 ycg
-cCQ
-juz
-juz
-qof
-iMv
-xBU
-owp
-oeW
+ycg
+ycg
+mBo
+ycg
+ycg
+ycg
+ycg
+rPT
+ndu
+xaG
+xaG
+xaG
+xaG
+xaG
+xaG
+imL
+rCm
 vRk
 gKA
 woI
@@ -111296,36 +110636,36 @@ rvY
 wBH
 rvY
 rvY
+vzb
+ojh
+sAu
+vkm
 rvY
-rvY
-rvY
-rvY
-rvY
+gPz
 ycg
 ndu
 ndu
 ndu
-ndu
-ndu
-ndu
-ndu
-ycg
-ndu
-ycg
-ycg
-tdb
-ndu
-ndu
-lUS
-ycg
-xBU
-xBU
-xBU
-xBU
+rsV
+rsV
+gxI
+agG
+gxI
+gxI
+uZc
+uZc
+iKI
+mRm
+aMq
+hAD
 qof
+fHF
+wpj
+dqQ
+iBY
 xBU
-jFJ
-eHy
+owp
+oeW
 vRk
 mrA
 mrA
@@ -111553,37 +110893,37 @@ vmC
 aYV
 cyk
 veg
+rvY
+rvY
+rvY
+rvY
+rvY
+ycg
+ycg
 iQW
 iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-nit
-lBy
-aGF
-uPX
-fiV
-vEU
-tQO
-xaG
-tHE
-nRN
-oFK
+ndu
+ndu
+ndu
+ndu
+weh
+ntA
+kVq
+weh
+ttg
+ycg
+xdX
+mwX
 xBU
+cCQ
 juz
+juz
+qof
+iMv
 xBU
-qLg
+jFJ
 eHy
-cyE
+vRk
 rnI
 nXD
 imn
@@ -111822,23 +111162,23 @@ iQW
 iQW
 iQW
 iQW
-iQW
-iQW
-nit
-dQS
-loF
-xkF
-cMA
-tit
-qxs
-xaG
-smM
-wuo
-iIP
+ndu
+ycg
+ndu
+ycg
+ycg
+tdb
+ndu
+ndu
+lUS
 xBU
-juz
-nCg
-vmo
+xBU
+xBU
+xBU
+xBU
+qof
+xBU
+qLg
 eHy
 cyE
 rnI
@@ -112078,25 +111418,25 @@ iQW
 iQW
 iQW
 iQW
+cTF
 iQW
 iQW
-iQW
 nit
-nit
-nit
-nit
-nit
-xRV
-xSe
+lBy
+aGF
+uPX
+fiV
+vEU
+tQO
 xaG
+tHE
+nRN
+oFK
 xBU
-jEI
-qRW
-hCg
 juz
 xBU
-uAV
-rig
+vmo
+eHy
 cyE
 lJH
 bWH
@@ -112335,25 +111675,25 @@ iQW
 iQW
 iQW
 iQW
-iQW
-iQW
-iQW
-iQW
-iQW
+cTF
 iQW
 iQW
 nit
-jxa
-pun
-xTW
-xBU
-nSo
-qIN
+dQS
+loF
+xkF
+cMA
+tit
+qxs
+nit
+smM
+wuo
+iIP
 xBU
 juz
-xBU
-dGD
-sSt
+nCg
+uAV
+rig
 cyE
 jXA
 rsb
@@ -112592,26 +111932,26 @@ iQW
 iQW
 iQW
 iQW
-iQW
-iQW
-iQW
-iQW
-iQW
+cTF
 iQW
 iQW
 nit
+nit
+nit
+nit
+nit
 xRV
-rdg
-wXj
+xSe
+nit
 xBU
-ljV
-rhr
-xBU
+jEI
+qRW
+hCg
 juz
 xBU
-vST
-lOs
-bYx
+dGD
+sSt
+cyE
 pcg
 kDQ
 wwL
@@ -112849,7 +112189,7 @@ iQW
 iQW
 iQW
 iQW
-iQW
+cTF
 iQW
 iQW
 iQW
@@ -112857,18 +112197,18 @@ iQW
 iQW
 iQW
 nit
-xRV
-nit
-nit
+jxa
+pun
+xTW
 xBU
-lvD
-xBU
+nSo
+qIN
 xBU
 juz
 xBU
-gFh
-pXi
-pXi
+nWI
+fvn
+mah
 gmd
 kht
 dKO
@@ -113106,7 +112446,7 @@ iQW
 iQW
 iQW
 iQW
-iQW
+cTF
 iQW
 iQW
 iQW
@@ -113115,17 +112455,17 @@ iQW
 iQW
 nit
 xRV
-nit
-yju
+rdg
+wXj
 xBU
-cGA
-wpj
-wpj
-qof
-wpj
-fHF
-mDV
+ljV
+rhr
 xBU
+juz
+xBU
+gFh
+pXi
+pXi
 sZp
 jNB
 dKO
@@ -113363,7 +112703,7 @@ iQW
 iQW
 iQW
 iQW
-iQW
+cTF
 iQW
 iQW
 iQW
@@ -113373,15 +112713,15 @@ iQW
 nit
 xRV
 nit
-yju
+nit
+xBU
+lvD
 xBU
 xBU
-jWk
-pBD
 juz
-juz
-qof
-juz
+xBU
+fHF
+mDV
 xBU
 wXi
 rsb
@@ -113628,16 +112968,16 @@ iQW
 iQW
 iQW
 nit
-rqc
+xRV
 nit
 yju
-yju
 xBU
-xBU
-xBU
-jbX
-xBU
+cGA
 wpj
+wpj
+qof
+wpj
+qof
 juz
 xBU
 bTC
@@ -113883,19 +113223,19 @@ iQW
 iQW
 iQW
 iQW
+iQW
 nit
-nit
-umV
-nit
+xRV
 nit
 yju
 xBU
-uDO
-xeH
-wpj
 xBU
+jWk
+pBD
+juz
+juz
 wpj
-qof
+juz
 xBU
 xBU
 xBU
@@ -114137,23 +113477,23 @@ iQW
 iQW
 iQW
 iQW
-vmD
+iQW
+iQW
 iQW
 iQW
 nit
-rUY
-nHf
-nTM
+rqc
 nit
+yju
 yju
 xBU
 xBU
-tFv
-wpj
 xBU
-ssi
-juz
+jbX
+xBU
 wpj
+qof
+xBU
 fHF
 fHF
 wpj
@@ -114393,24 +113733,24 @@ iQW
 iQW
 iQW
 iQW
-yju
-xBY
+iQW
+iQW
 iQW
 iQW
 nit
-nlm
-aVP
-kEM
+nit
+umV
+nit
 nit
 yju
-yju
 xBU
-oGG
-oGG
-xBU
+uDO
+xeH
 wpj
+xBU
+ssi
 juz
-juz
+wpj
 juz
 qof
 juz
@@ -114650,24 +113990,24 @@ iQW
 iQW
 iQW
 iQW
+iQW
+vmD
+sUS
+rZZ
+nit
+rUY
+nHf
+nTM
+nit
 yju
-xBY
-yju
-nit
-nit
-nit
-urF
-nit
-nit
-nit
-yju
 xBU
 xBU
+tFv
+wpj
 xBU
-xBU
-jAZ
-xHa
-xBU
+wpj
+juz
+juz
 xBU
 xBU
 nqz
@@ -114906,24 +114246,24 @@ yju
 yju
 yju
 bfi
-xBY
-xBY
-xBY
-iQW
-nit
-pdo
-uCZ
-mpH
-tsD
-aio
-fiV
-iQW
-iQW
+sUS
 yju
+xBY
 iQW
+rZZ
+nit
+nlm
+aVP
+kEM
+nit
+yju
+adS
 xBU
+oGG
+oGG
 xBU
-xBU
+jAZ
+xHa
 xBU
 ncL
 wpj
@@ -115164,23 +114504,23 @@ iQW
 yju
 iQW
 iQW
-iQW
-iQW
-iQW
-nit
-qVt
-gqz
-bVe
-cub
-sJt
-nit
-iQW
-iQW
 yju
-iQW
-iQW
-iQW
-iQW
+xBY
+yju
+nit
+nit
+nit
+urF
+nit
+nit
+nit
+adS
+xBU
+xBU
+xBU
+xBU
+xBU
+xBU
 xBU
 qkR
 cAq
@@ -115420,22 +114760,22 @@ iQW
 iQW
 xBY
 iQW
+xBY
+xBY
+xBY
 iQW
-iQW
-iQW
-iQW
-fiV
-fOh
-ygZ
-vEF
-sFw
-hHz
 nit
+pdo
+uCZ
+mpH
+tsD
+aio
+fiV
 iQW
 iQW
 yju
 iQW
-iQW
+xBU
 iQW
 iQW
 xBU
@@ -115677,20 +115017,20 @@ yju
 yju
 xBY
 yju
+sUS
+rZZ
+rZZ
+rZZ
+nit
+qVt
+gqz
+bVe
+cub
+sJt
+nit
+sUS
+sUS
 yju
-nit
-nit
-nit
-nit
-nit
-jNf
-aaa
-jNf
-cWk
-nit
-nit
-nit
-nit
 iQW
 iQW
 iQW
@@ -115935,19 +115275,19 @@ iQW
 xBY
 iQW
 iQW
+rZZ
+rZZ
+rZZ
+fiV
+fOh
+ygZ
+vEF
+sFw
+hHz
 nit
-pqM
-oCp
-gOP
-sHD
-rDM
-lRT
-aBO
-jNf
-lrF
-cZf
-tJz
-nit
+sUS
+sUS
+yju
 iQW
 iQW
 iQW
@@ -116191,25 +115531,25 @@ iQW
 iQW
 vmD
 iQW
-iQW
-fiV
-aOT
-tpi
-jhI
+yju
+nit
+nit
+nit
+nit
+nit
 jNf
-vEU
-pef
-ubw
+aaa
 jNf
-rdg
-rdg
-ubw
-fiV
+cWk
+nit
+nit
+nit
+nit
 iQW
 iQW
-vmD
+sUS
 iQW
-iQW
+xBU
 iQW
 iQW
 iQW
@@ -116449,22 +115789,22 @@ iQW
 yju
 iQW
 iQW
-fiV
-lrF
-uJD
+nit
+pqM
+oCp
 gOP
-oQV
-ymf
-mKg
-niV
-iVl
-oWL
-qNs
-ubw
-fiV
+sHD
+rDM
+lRT
+aBO
+jNf
+lrF
+cZf
+tJz
+nit
 iQW
 iQW
-xBY
+vmD
 iQW
 iQW
 iQW
@@ -116706,24 +116046,24 @@ yju
 bfi
 iQW
 iQW
-nit
-eBx
-eWq
-tFj
+fiV
+aOT
+tpi
+jhI
 jNf
 vEU
-mKg
+pef
 ubw
 jNf
-qhP
-gTn
-nHl
-nit
-yju
-yju
+rdg
+rdg
+ubw
+fiV
+sUS
+sUS
 xBY
-yju
-yju
+sUS
+sUS
 iQW
 iQW
 iQW
@@ -116963,24 +116303,24 @@ iQW
 xBY
 iQW
 iQW
-nit
-cWk
-cWk
-cWk
-cWk
-duA
-jUl
-mve
-cWk
-cWk
-cWk
-cWk
-nit
+fiV
+lrF
+uJD
+gOP
+oQV
+ymf
+mKg
+niV
+iVl
+oWL
+qNs
+ubw
+fiV
 iQW
 iQW
 xBY
-iQW
-bfi
+adS
+yju
 iQW
 iQW
 iQW
@@ -117221,23 +116561,23 @@ xBY
 iQW
 iQW
 nit
-pqM
-tQW
-luh
-wZf
+eBx
+eWq
+tFj
+jNf
 vEU
-aEr
+mKg
 ubw
-elm
-luh
-qDE
-tJz
+jNf
+qhP
+gTn
+nHl
 nit
-iQW
-iQW
+adS
+adS
 xBY
-yju
-xBY
+sUS
+bfi
 iQW
 iQW
 iQW
@@ -117476,24 +116816,24 @@ bfi
 iQW
 xBY
 yju
-yju
+sUS
 nit
-xzG
-aGz
 cWk
 cWk
-vMY
-aEr
-iJp
 cWk
 cWk
-nFI
-cMQ
+duA
+jUl
+mve
+cWk
+cWk
+cWk
+cWk
 nit
 iQW
 iQW
-bfi
-iQW
+xBY
+adS
 xBY
 iQW
 iQW
@@ -117735,21 +117075,21 @@ xBY
 iQW
 iQW
 nit
-nit
-nit
-nit
-hTH
-ijP
+pqM
+tQW
+luh
+wZf
+vEU
 aEr
-vPV
-sOS
-nit
-nit
-nit
+ubw
+elm
+luh
+qDE
+tJz
 nit
 iQW
 iQW
-yju
+bfi
 iQW
 xBY
 iQW
@@ -117990,24 +117330,24 @@ bfi
 yju
 xBY
 iQW
-iQW
-yju
-iQW
-iQW
+adS
 nit
-afO
-tKS
-lOQ
-wpo
-gKs
+xzG
+aGz
+cWk
+cWk
+vMY
+aEr
+iJp
+cWk
+cWk
+nFI
+cMQ
 nit
 iQW
 iQW
 yju
-iQW
-iQW
-bfi
-yju
+sUS
 xBY
 iQW
 iQW
@@ -118248,24 +117588,24 @@ iQW
 iQW
 iQW
 iQW
-yju
-iQW
-iQW
 nit
 nit
-lAm
-tMW
-qZd
+nit
+nit
+hTH
+ijP
+aEr
+vPV
+sOS
+nit
+nit
 nit
 nit
 iQW
 iQW
-yju
-iQW
-iQW
+bfi
+adS
 xBY
-iQW
-vmD
 iQW
 iQW
 iQW
@@ -118504,25 +117844,25 @@ xBY
 iQW
 iQW
 vmD
-xBY
-xBY
-iQW
+sUS
+yju
 iQW
 iQW
 nit
-fiV
-mab
-fiV
+afO
+tKS
+lOQ
+wpo
+gKs
 nit
 iQW
+sUS
+yju
+sUS
+sUS
+xBY
 iQW
-vmD
-xBY
-xBY
-xBY
-xBY
-iQW
-iQW
+tsl
 iQW
 iQW
 iQW
@@ -118762,22 +118102,22 @@ iQW
 iQW
 iQW
 iQW
+yju
+iQW
+iQW
+nit
+nit
+lAm
+tMW
+qZd
+nit
+nit
+iQW
+iQW
+adS
+sUS
+iQW
 xBY
-iQW
-iQW
-iQW
-yju
-iQW
-xBQ
-xzB
-yju
-iQW
-iQW
-iQW
-iQW
-yju
-iQW
-yju
 iQW
 iQW
 iQW
@@ -119018,23 +118358,23 @@ xBY
 xBY
 xBY
 bfi
-yju
+xBY
 xBY
 iQW
 iQW
 iQW
-yju
+nit
+fiV
+mab
+fiV
+nit
 iQW
 iQW
-iQW
-yju
-iQW
-iQW
-iQW
-iQW
-bfi
-iQW
-iQW
+tsl
+qSZ
+xBY
+qSZ
+adS
 iQW
 iQW
 iQW
@@ -119276,20 +118616,20 @@ iQW
 iQW
 iQW
 iQW
-bfi
+xBY
+sUS
+sUS
+sUS
 yju
-bfi
-xBY
-xBY
-bfi
-iQW
-iQW
-xBY
-xBY
-xBY
-bfi
+sUS
+uEl
+ubx
 yju
-xBY
+sUS
+sUS
+sUS
+sUS
+yju
 iQW
 iQW
 iQW
@@ -119532,21 +118872,21 @@ iQW
 iQW
 iQW
 iQW
-iQW
-yju
-iQW
-iQW
-yju
-iQW
-yju
-iQW
-iQW
-yju
-iQW
-iQW
-iQW
-iQW
+adS
 xBY
+iQW
+iQW
+sUS
+adS
+sUS
+iQW
+iQW
+yju
+iQW
+iQW
+iQW
+iQW
+bfi
 iQW
 iQW
 iQW
@@ -119789,19 +119129,19 @@ iQW
 iQW
 iQW
 iQW
-vmD
-xBY
-xBY
-xBY
-bfi
-iQW
-bfi
-iQW
-iQW
-xBY
-xBY
+sUS
 bfi
 yju
+bfi
+xBY
+qSZ
+bfi
+iQW
+iQW
+xBY
+xBY
+xBY
+bfi
 yju
 xBY
 iQW
@@ -120047,20 +119387,20 @@ iQW
 iQW
 iQW
 iQW
+adS
+sUS
 iQW
-yju
+adS
 iQW
-iQW
-iQW
-iQW
-iQW
-iQW
+adS
 iQW
 iQW
+adS
 iQW
 iQW
 iQW
-vmD
+iQW
+xBY
 iQW
 iQW
 iQW
@@ -120303,21 +119643,21 @@ iQW
 iQW
 iQW
 iQW
+tsl
+qSZ
+xBY
+qSZ
+vST
+iQW
+vST
 iQW
 iQW
-yju
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
-iQW
+qSZ
+qSZ
+vST
+adS
+adS
+qSZ
 iQW
 iQW
 iQW
@@ -120562,6 +119902,7 @@ iQW
 iQW
 iQW
 iQW
+adS
 iQW
 iQW
 iQW
@@ -120573,8 +119914,7 @@ iQW
 iQW
 iQW
 iQW
-iQW
-iQW
+tsl
 iQW
 iQW
 iQW
@@ -120819,7 +120159,7 @@ iQW
 iQW
 iQW
 iQW
-iQW
+adS
 iQW
 iQW
 iQW
@@ -121075,7 +120415,7 @@ iQW
 iQW
 iQW
 iQW
-bDE
+iQW
 iQW
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -865,6 +865,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"aoO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "aoU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1774,11 +1783,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
-"aGl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "aGr" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -6088,6 +6092,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"cic" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "cit" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock"
@@ -8444,6 +8455,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
+"daz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/cryo)
 "daB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9675,8 +9691,9 @@
 /area/station/maintenance/department/engine)
 "dzN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
+	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "dzW" = (
@@ -13187,15 +13204,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"eQL" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "eQO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 6
@@ -14241,15 +14249,6 @@
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
-"fiT" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "fiV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -15756,13 +15755,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fKY" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "fLg" = (
@@ -17771,11 +17766,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
-"gAQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/cryo)
 "gBc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
 	dir = 6
@@ -18339,6 +18329,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"gKL" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "gKT" = (
 /obj/structure/chair/plastic{
 	dir = 1
@@ -19585,6 +19581,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"hkE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "hlb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -20407,6 +20408,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"hCD" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "hCG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -21208,16 +21217,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"hQZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "hRb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22059,6 +22058,16 @@
 /obj/effect/turf_decal/tile/prison,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
+"iio" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "iiw" = (
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/east,
@@ -22477,13 +22486,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
-"ips" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "ipw" = (
 /obj/structure/cable,
 /turf/open/floor/vault,
@@ -22881,6 +22883,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"ixM" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/medical/medbay)
 "iyg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23331,9 +23339,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "iGY" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "iHd" = (
@@ -24522,15 +24534,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"jcy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "jcB" = (
 /obj/structure/table,
 /obj/item/trash/semki,
@@ -25254,12 +25257,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"jqB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "jqM" = (
 /obj/structure/sign/warning/cold_temp/directional/south,
 /turf/open/floor/iron/white,
@@ -25381,6 +25378,19 @@
 /obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"jtf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "jtt" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -26051,15 +26061,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"jGz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "jGB" = (
 /obj/structure/bed/dogbed/renault,
 /mob/living/basic/pet/fox/renault,
@@ -29621,6 +29622,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"kQj" = (
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "kQV" = (
 /obj/effect/turf_decal/tile/command/half{
 	dir = 8
@@ -31498,6 +31511,16 @@
 /obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"lBs" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "lBt" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/window/left/directional/north{
@@ -32734,15 +32757,6 @@
 "lVL" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
-"lVR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/medbay)
 "lVW" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
@@ -35640,6 +35654,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"mVk" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "mVA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -35754,6 +35777,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
+"mXL" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "mXM" = (
 /obj/structure/railing{
 	dir = 1
@@ -37582,6 +37617,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"nFZ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "nGa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39729,6 +39768,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"owJ" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/medbay/central)
 "owL" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet,
@@ -41575,6 +41620,11 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
+"pip" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "pis" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -41621,18 +41671,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"pjC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "pjD" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/shower/directional/west,
@@ -41903,18 +41941,6 @@
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"poI" = (
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line,
-/turf/open/floor/iron/white/textured_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "poU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -43133,9 +43159,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"pMY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "pMZ" = (
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/spawner/random/structure/crate,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "pNb" = (
@@ -44249,12 +44282,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
-"qhd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "qhe" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -44386,6 +44413,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"qjt" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "qju" = (
 /obj/structure/table,
 /obj/item/food/badrecipe/moldy,
@@ -44837,10 +44873,6 @@
 /obj/effect/turf_decal/tile/science/anticorner,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"qse" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "qsg" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -44923,14 +44955,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"qtU" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "qtW" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -48618,8 +48642,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "rQV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -50457,15 +50481,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
-"syb" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "sye" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -50491,6 +50506,15 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet/purple,
 /area/station/service/lawoffice)
+"syG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "syU" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -51937,6 +51961,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"tfa" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "tfe" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plating,
@@ -53614,12 +53647,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
-"tJO" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/medbay/central)
 "tJY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -59725,11 +59752,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"waw" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "waE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60313,19 +60335,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
-"wnS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "wnU" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
@@ -62618,16 +62627,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"xdd" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "xde" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -63322,6 +63321,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"xno" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/medbay)
 "xnz" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -63924,7 +63932,7 @@
 /area/station/security/brig)
 "xzB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -65318,10 +65326,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ybQ" = (
-/obj/effect/turf_decal/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/textured_edge,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "ybS" = (
 /obj/item/toy/plush/fly,
@@ -104338,7 +104346,7 @@ ycg
 ycg
 ycg
 ycg
-lQH
+ttg
 ycg
 koe
 lVc
@@ -105389,7 +105397,7 @@ tbg
 vmp
 vmp
 jFr
-qtU
+hCD
 fNJ
 sIZ
 uaz
@@ -105893,8 +105901,8 @@ rXy
 wCc
 lHq
 bpn
-xzB
-xzB
+ybQ
+ybQ
 lOs
 mhn
 mhn
@@ -106155,7 +106163,7 @@ ydb
 rvE
 mhn
 tqs
-pjC
+mXL
 mEF
 oPS
 eZZ
@@ -106412,7 +106420,7 @@ tlE
 bAn
 uxN
 mwm
-pjC
+mXL
 mEF
 rbr
 jUP
@@ -106664,14 +106672,14 @@ rXy
 wCc
 rmc
 eTq
-ybQ
-ybQ
+ixM
+ixM
 tlI
 mhn
 mwm
-pjC
+mXL
 mEF
-syb
+qjt
 jps
 uxN
 ykY
@@ -106919,19 +106927,19 @@ bmk
 aAq
 rXy
 ezN
-iGY
+rQV
 hey
-qhd
-qhd
+gKL
+gKL
 ych
 mhn
 wTX
-eQL
+mVk
 srj
 jCv
 tTz
 viM
-xdd
+iio
 fNJ
 sIZ
 nPY
@@ -107178,7 +107186,7 @@ rXy
 kna
 lFw
 cXM
-jcy
+aoO
 xgs
 mmE
 bzD
@@ -107189,7 +107197,7 @@ oot
 xDS
 aXc
 nSF
-lVR
+xno
 sIZ
 xaG
 xaG
@@ -107433,19 +107441,19 @@ ndu
 ndu
 rXy
 urd
-rQV
+xzB
 tQz
 eEN
 kEU
 tQz
 mhn
 mHg
-fiT
+tfa
 tdW
 lgz
 mEF
 viM
-hQZ
+lBs
 uTT
 pis
 pXI
@@ -107688,7 +107696,7 @@ ttg
 ttg
 kqZ
 seR
-rXy
+dzN
 psk
 tQz
 tQz
@@ -107696,13 +107704,13 @@ uyD
 osE
 mOg
 mhn
-tJO
-poI
+owJ
+kQj
 sgo
 lgz
 rld
 mhn
-ips
+cic
 brb
 qXX
 xBU
@@ -107959,7 +107967,7 @@ jqn
 auJ
 sIQ
 mhn
-ips
+cic
 brb
 dGh
 xBU
@@ -108203,7 +108211,7 @@ iiW
 pGr
 dyU
 rXy
-fKY
+iGY
 vtH
 rtJ
 laH
@@ -108212,7 +108220,7 @@ gdX
 oOD
 wKX
 meO
-gAQ
+daz
 wwY
 hmE
 oOD
@@ -108460,7 +108468,7 @@ iiW
 cwx
 dyU
 mDN
-fKY
+iGY
 vtH
 nBJ
 pOF
@@ -108473,9 +108481,9 @@ jrh
 wwY
 oqS
 haw
-ips
+cic
 sWZ
-qse
+nFZ
 upW
 oGR
 vrV
@@ -108726,13 +108734,13 @@ jLF
 oOD
 qYr
 meO
-gAQ
+daz
 wwY
 gHL
 haw
 xXk
-jGz
-qse
+syG
+nFZ
 upW
 ddv
 dVd
@@ -109246,11 +109254,11 @@ aqv
 ymc
 ncF
 aNn
-waw
+hkE
 upW
 uYA
 vrV
-aGl
+pip
 vrV
 cBc
 xaG
@@ -109487,7 +109495,7 @@ ycg
 ycg
 dyU
 dyU
-dzN
+fKY
 wNj
 thQ
 wNj
@@ -109499,16 +109507,16 @@ wFB
 wNj
 wNj
 bJM
-xzB
+ybQ
 fnA
-xzB
+ybQ
 clV
 bRO
 upW
 wyW
 vrV
-aGl
-jqB
+pip
+pMY
 nxI
 xaG
 hpm
@@ -110779,7 +110787,7 @@ yee
 jnY
 hTZ
 wCg
-wnS
+jtf
 ouL
 rJm
 wmv

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1,8 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/green/diagonal_edge,
@@ -12,9 +10,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aab" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -302,10 +298,10 @@
 /turf/open/space/basic,
 /area/space)
 "afe" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -394,6 +390,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/coldroom)
 "agG" = (
@@ -735,7 +732,7 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "ani" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "anl" = (
@@ -794,9 +791,7 @@
 	},
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aoo" = (
@@ -872,7 +867,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aoV" = (
@@ -1083,7 +1077,7 @@
 /area/station/security/detectives_office)
 "asO" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
@@ -1105,9 +1099,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/west,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "atl" = (
@@ -1186,7 +1178,7 @@
 /obj/effect/spawner/random/vending/colavend,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "auA" = (
 /obj/structure/table/wood,
@@ -1195,7 +1187,7 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "auC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
@@ -1298,7 +1290,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "awd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1448,6 +1440,9 @@
 	name = "First-Aid Supplies";
 	req_access = list("medical")
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "ayA" = (
@@ -1576,9 +1571,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "aAH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
@@ -1586,15 +1579,13 @@
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "aAO" = (
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat)
@@ -1631,6 +1622,13 @@
 	dir = 8
 	},
 /area/station/security/brig)
+"aBL" = (
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "aBO" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 8
@@ -2136,6 +2134,10 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"aOb" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/medical/coldroom)
 "aOe" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/structure/cable,
@@ -2432,6 +2434,9 @@
 /obj/machinery/holopad,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "aSl" = (
@@ -2624,9 +2629,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "aVP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door_buttons/access_button{
 	idDoor = "virology_airlock_interior";
@@ -2713,7 +2716,9 @@
 /obj/machinery/vending/medical{
 	pixel_x = -2
 	},
-/obj/effect/turf_decal/tile/medical/anticorner,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aWT" = (
@@ -2921,7 +2926,7 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat)
 "bbd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Foyer"
@@ -2932,7 +2937,7 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat)
 "bbx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -3423,7 +3428,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bkK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -3872,6 +3877,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"btH" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "buj" = (
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
@@ -4432,8 +4443,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bCg" = (
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
@@ -4455,7 +4466,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science)
 "bCC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/west,
@@ -5007,7 +5018,9 @@
 "bNg" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bNk" = (
@@ -5426,9 +5439,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "bUH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
@@ -5834,10 +5845,9 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
 /obj/structure/curtain,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
@@ -5849,6 +5859,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "cbK" = (
@@ -6072,7 +6083,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -6341,6 +6352,7 @@
 "cne" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/clothing/head/helmet/skull,
+/obj/machinery/light/small/blacklight/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "cnm" = (
@@ -6455,11 +6467,8 @@
 /area/space)
 "coA" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -6852,9 +6861,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "cwk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/south{
@@ -7201,7 +7208,7 @@
 	pixel_y = 2
 	},
 /obj/item/clothing/glasses/hud/health,
-/obj/effect/turf_decal/tile/medical/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "cBo" = (
@@ -7212,7 +7219,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cBq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/camera/directional/east{
@@ -7465,7 +7472,7 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cGf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
 /obj/structure/cable,
@@ -7823,7 +7830,10 @@
 /area/station/engineering/gravity_generator)
 "cOq" = (
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/green/diagonal_edge,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "cOu" = (
@@ -8375,7 +8385,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green/diagonal_edge,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "cXZ" = (
@@ -8462,6 +8474,11 @@
 /mob/living/carbon/human/species/monkey,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Medical - Viro Monkey Pen";
+	dir = 10;
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -8698,9 +8715,7 @@
 	},
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "ddy" = (
@@ -9339,6 +9354,12 @@
 	},
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/command)
+"dsv" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "dsx" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron,
@@ -9500,7 +9521,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "duS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
@@ -9518,9 +9539,7 @@
 /obj/item/bedsheet/medical{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "duW" = (
@@ -9758,7 +9777,9 @@
 /area/station/commons/fitness)
 "dAi" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "dAj" = (
@@ -9821,7 +9842,7 @@
 	},
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "dAV" = (
 /obj/structure/table/reinforced,
@@ -9908,7 +9929,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "dDY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -10026,9 +10047,9 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/button/door/directional/east{
-	req_access = list("psychology");
 	id = "psych_shutters";
-	name = "Shutter Control"
+	name = "Shutter Control";
+	req_access = list("psychology")
 	},
 /turf/open/floor/carpet/purple,
 /area/station/medical/psychology)
@@ -10421,7 +10442,7 @@
 /area/station/solars/starboard/fore)
 "dLY" = (
 /obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -10442,6 +10463,11 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"dMA" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "dMI" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
@@ -10472,11 +10498,17 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
+"dNm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "dNs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/command/half,
@@ -10699,10 +10731,9 @@
 	pixel_y = 2
 	},
 /obj/item/clothing/glasses/hud/health,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/medical/half,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "dSt" = (
@@ -10832,11 +10863,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/mail_sorting/service/hydroponics,
 /obj/structure/disposalpipe/sorting/mail/flip,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "dUH" = (
@@ -10876,13 +10907,14 @@
 	red_alert_access = 1;
 	req_access = list("medical")
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "dVv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "dVC" = (
@@ -11031,6 +11063,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
+"dXw" = (
+/obj/effect/turf_decal/trimline/yellow,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "dXy" = (
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -11161,7 +11197,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "eaB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11308,6 +11344,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "edq" = (
@@ -11858,11 +11897,8 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/structure/table,
 /obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -12287,8 +12323,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
@@ -12312,7 +12348,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "exs" = (
 /obj/structure/cable,
@@ -12759,7 +12795,7 @@
 "eGf" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/effect/turf_decal/trimline/green/filled,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "eGl" = (
@@ -12825,10 +12861,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "eHy" = (
@@ -12941,12 +12976,8 @@
 /obj/item/construction/plumbing,
 /obj/item/construction/plumbing,
 /obj/structure/sign/departments/chemistry/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -12971,10 +13002,7 @@
 /obj/item/stack/cable_coil,
 /obj/structure/table,
 /obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -13223,9 +13251,7 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "eQo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/security/half{
 	dir = 1
@@ -13379,9 +13405,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "eSU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -13661,16 +13685,14 @@
 /obj/item/bedsheet/medical{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /obj/structure/curtain,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "eXr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
@@ -13890,7 +13912,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "fbE" = (
 /obj/structure/closet/secure_closet/bar,
@@ -13970,6 +13992,16 @@
 	dir = 4
 	},
 /area/station/engineering/gravity_generator)
+"fcC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "fcF" = (
 /obj/structure/dresser,
 /turf/open/floor/sepia,
@@ -14050,9 +14082,7 @@
 /obj/machinery/computer/department_orders/medical{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "fdU" = (
@@ -14202,13 +14232,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science)
 "fge" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "fgf" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14705,7 +14732,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "fpA" = (
 /obj/structure/cable,
@@ -14725,6 +14752,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating_new/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
@@ -14747,8 +14777,7 @@
 /area/station/security/detectives_office)
 "fqm" = (
 /obj/machinery/light_switch/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -15213,7 +15242,6 @@
 /turf/open/floor/iron/white,
 /area/station/science)
 "fzw" = (
-/obj/effect/turf_decal/tile/green/diagonal_edge,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -15277,9 +15305,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "fBm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/security/half{
 	dir = 1
@@ -15386,6 +15412,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "fEl" = (
@@ -15449,13 +15478,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/rec)
-"fFh" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "fFn" = (
 /obj/structure/sign/warning/vacuum/directional/west,
 /turf/open/floor/plating,
@@ -16026,7 +16048,7 @@
 	name = "AI Core"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -16285,9 +16307,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/start/cyborg,
@@ -16335,6 +16355,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
+"fUx" = (
+/obj/structure/window/spawner/directional/north,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "fUy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -16505,7 +16530,7 @@
 /obj/structure/sink/kitchen/directional/south{
 	name = "utility sink"
 	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -16528,7 +16553,7 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard)
 "fYD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -16579,13 +16604,6 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"fZc" = (
-/obj/effect/turf_decal/tile/bar/diagonal_centre,
-/obj/effect/turf_decal/siding/grey{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/cafeteria)
 "fZm" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/decal/cleanable/dirt,
@@ -16845,6 +16863,7 @@
 "gdX" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/moth,
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet/purple,
 /area/station/medical/psychology)
 "gdZ" = (
@@ -16985,6 +17004,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"ghX" = (
+/obj/effect/turf_decal/trimline/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "gia" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/computer/camera_advanced/xenobio{
@@ -17001,6 +17024,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/ai_monitored/security/armory)
+"gid" = (
+/obj/structure/window/spawner/directional/east,
+/mob/living/basic/rabbit,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "gif" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -17070,6 +17099,12 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
+"gjF" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "gkh" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -17448,7 +17483,7 @@
 	uses = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
@@ -17855,9 +17890,7 @@
 /turf/closed/wall/r_wall,
 /area/station/security/prison/visit)
 "gAM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
@@ -18013,6 +18046,9 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "gEs" = (
@@ -18152,6 +18188,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "gHm" = (
@@ -18244,6 +18283,12 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
+"gIq" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "gIr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18349,9 +18394,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "gKl" = (
@@ -18416,10 +18458,10 @@
 "gKA" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
 /obj/structure/curtain,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "gKE" = (
@@ -18572,7 +18614,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/green/diagonal_edge,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -18765,10 +18806,10 @@
 /area/station/commons/vacant_room/office)
 "gRJ" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "gRV" = (
@@ -19350,7 +19391,7 @@
 "hcn" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "hcv" = (
 /obj/structure/table/reinforced,
@@ -19717,8 +19758,10 @@
 "hlG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/effect/turf_decal/tile/medical/anticorner,
 /obj/structure/curtain,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "hlK" = (
@@ -19797,9 +19840,7 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "hmy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/turf_decal/tile/command/anticorner{
 	dir = 4
 	},
@@ -19846,8 +19887,8 @@
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
 	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -19870,11 +19911,8 @@
 /obj/item/reagent_containers/cup/beaker/large,
 /obj/item/reagent_containers/dropper,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -20001,7 +20039,7 @@
 /obj/structure/cable,
 /obj/machinery/recharge_station,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/tile/medical/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -20089,9 +20127,7 @@
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "hsl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
 /turf/open/floor/circuit,
@@ -20133,6 +20169,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/lockers)
+"htk" = (
+/obj/machinery/plumbing/reaction_chamber,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "htl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/trimline/blue/line,
@@ -20479,6 +20519,9 @@
 /turf/closed/wall,
 /area/station/security/processing)
 "hAQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "hBb" = (
@@ -20527,6 +20570,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"hCI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "hCY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21037,7 +21088,7 @@
 /turf/open/floor/iron/white/smooth_half,
 /area/station/maintenance/starboard)
 "hLJ" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -22203,6 +22254,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Medical - Equipment Storage";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/coldroom)
 "iiY" = (
@@ -22896,10 +22951,7 @@
 "iwH" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/obj/effect/turf_decal/siding/grey/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "iwI" = (
 /obj/structure/table/reinforced,
@@ -23224,9 +23276,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
@@ -23447,9 +23497,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/coldroom)
 "iHd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -23561,6 +23609,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "iJp" = (
@@ -23734,9 +23783,7 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "iMn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -23892,10 +23939,7 @@
 	c_tag = "Medical - Chemistry Lab S";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "iOH" = (
@@ -24127,9 +24171,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -24343,9 +24385,7 @@
 /turf/open/floor/iron/terracotta,
 /area/station/maintenance/starboard/aft)
 "iWw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -24372,9 +24412,7 @@
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Teleporter"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
@@ -24533,9 +24571,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -24647,6 +24683,14 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"jdb" = (
+/obj/structure/window/spawner/directional/north,
+/obj/structure/window/spawner/directional/east,
+/obj/structure/cat_house{
+	name = "rabbit hutch"
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "jdm" = (
 /obj/effect/spawner/random/maintenance/three,
 /obj/structure/rack,
@@ -25224,10 +25268,7 @@
 /obj/machinery/restaurant_portal/restaurant,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/obj/effect/turf_decal/siding/grey{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "joy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25703,9 +25744,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "jxa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -25945,11 +25984,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "jCH" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -26000,7 +26036,7 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "jDT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/east,
@@ -26741,9 +26777,18 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"jQp" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/north,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/loom,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "jQv" = (
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
@@ -26960,9 +27005,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "jUl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27277,9 +27320,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "kbb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/turf_decal/tile/security/half{
 	dir = 1
 	},
@@ -27322,11 +27363,11 @@
 	pixel_x = 6;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 4
-	},
 /obj/item/storage/box/rxglasses,
 /obj/item/hand_labeler,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "kci" = (
@@ -27601,7 +27642,7 @@
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "kgr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
 /obj/structure/cable,
@@ -28243,7 +28284,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "kpp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -28267,17 +28308,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"kpH" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/camera/directional/east{
-	c_tag = "Service - Botany E";
-	network = list("ss13","service")
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "kpJ" = (
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 1
@@ -28569,10 +28599,7 @@
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -29282,13 +29309,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kHh" = (
@@ -29479,9 +29503,7 @@
 /obj/machinery/modular_computer/preset/cargochat/medical{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "kLs" = (
@@ -29524,12 +29546,8 @@
 	c_tag = "Medical - Chemistry E";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -29777,7 +29795,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "kRZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
@@ -29953,10 +29971,10 @@
 /area/station/maintenance/department/medical)
 "kVx" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 8
-	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "kVC" = (
@@ -30190,13 +30208,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "lbi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical)
 "lbk" = (
@@ -30324,11 +30341,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
-"ldk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/green/diagonal_edge,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "lds" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30928,6 +30940,9 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "lpr" = (
@@ -31080,6 +31095,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"lsg" = (
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lsh" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -31191,7 +31215,7 @@
 "luv" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/rnd/production/techfab/department/medical,
-/obj/effect/turf_decal/tile/medical/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -31245,6 +31269,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
+"lvm" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lvn" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1
@@ -31822,6 +31852,9 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "lFb" = (
@@ -31901,11 +31934,11 @@
 /area/station/engineering/supermatter)
 "lGr" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/green/fourcorners,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/green/filled,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "lGz" = (
@@ -32557,9 +32590,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "lRT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
@@ -32598,16 +32629,11 @@
 	network = list("ss13","medbay")
 	},
 /obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "lSC" = (
@@ -33623,6 +33649,9 @@
 "miW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "miY" = (
@@ -33689,10 +33718,10 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "mjP" = (
-/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "mjT" = (
@@ -34056,9 +34085,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mpH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
@@ -34814,7 +34841,7 @@
 	},
 /obj/effect/spawner/xmastree,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "mCP" = (
 /obj/structure/closet,
@@ -34836,6 +34863,9 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "mDf" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "mDi" = (
@@ -35029,6 +35059,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/science)
+"mHs" = (
+/obj/machinery/plumbing/output,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "mHD" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -35077,14 +35114,16 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/cmo)
 "mIB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/security/half{
-	dir = 1
+/obj/machinery/duct,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 9
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/service/hydroponics)
+"mIH" = (
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "mIL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -35198,15 +35237,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
 "mKg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron,
+/area/station/medical/medbay/lobby)
 "mKk" = (
 /turf/closed/wall,
 /area/station/security/execution/transfer)
@@ -35318,6 +35357,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"mMM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "mMU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36156,7 +36199,6 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
@@ -36236,6 +36278,7 @@
 "ndK" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/book/granter/action/spell/smoke/lesser,
+/obj/machinery/light/small/blacklight/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "ndM" = (
@@ -36780,7 +36823,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "npr" = (
 /obj/structure/chair,
@@ -36997,8 +37040,18 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nst" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/structure/table,
+/obj/item/reagent_containers/cup/bottle/nutrient/ez,
+/obj/item/reagent_containers/cup/bottle/nutrient/ez{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/bottle/nutrient/ez,
+/obj/item/reagent_containers/cup/bottle/saltpetre{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "nsu" = (
@@ -37259,7 +37312,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "nvA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/freezer,
 /area/station/medical/coldroom)
@@ -37317,8 +37369,7 @@
 "nxC" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -37326,7 +37377,7 @@
 "nxI" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/suit_storage_unit/medical,
-/obj/effect/turf_decal/tile/medical/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "nxO" = (
@@ -37626,7 +37677,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "nDP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37767,11 +37818,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "nHl" = (
-/obj/machinery/camera{
-	c_tag = "Medical - Viro Monkey Pen";
-	dir = 10;
-	network = list("ss13","medbay")
-	},
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -37897,7 +37943,7 @@
 	},
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/spawner/random/trash/botanical_waste,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -38028,7 +38074,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "nMC" = (
 /obj/effect/turf_decal/tile/security/half,
@@ -38183,7 +38229,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "nPo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -38423,9 +38469,7 @@
 /area/station/command/heads_quarters/hop)
 "nUT" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -38758,10 +38802,6 @@
 /obj/machinery/airalarm/directional/east,
 /obj/item/storage/box/bodybags,
 /obj/structure/table,
-/obj/item/storage/box/beakers/variety{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
@@ -38952,10 +38992,7 @@
 /area/station/hallway/secondary/service)
 "oen" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "oet" = (
@@ -39222,11 +39259,18 @@
 /area/station/hallway/primary/fore)
 "okq" = (
 /obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"okI" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "okO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/herringbone,
@@ -39599,6 +39643,13 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/medical/cryo)
+"oqV" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "oqY" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/duct,
@@ -39780,6 +39831,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/end{
 	dir = 1
 	},
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/textured,
 /area/station/medical/cryo)
 "ouL" = (
@@ -40252,7 +40304,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "oFh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40359,9 +40411,7 @@
 	pixel_y = -7
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "oGV" = (
@@ -40722,15 +40772,6 @@
 /obj/effect/spawner/random/decoration/carpet,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"oOO" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "oOU" = (
 /obj/structure/moisture_trap,
 /turf/open/floor/plating,
@@ -41085,7 +41126,6 @@
 "oVP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "oWo" = (
@@ -41193,7 +41233,7 @@
 /area/station/maintenance/department/science)
 "oZi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -41310,9 +41350,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "pbh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/circuit,
@@ -41471,9 +41509,7 @@
 /turf/closed/wall,
 /area/station/ai_monitored/security/armory)
 "pdP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -41482,14 +41518,13 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "pdR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
+/obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "pdU" = (
 /obj/structure/chair{
 	dir = 8
@@ -41506,9 +41541,7 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "pef" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -41607,6 +41640,13 @@
 "pfG" = (
 /turf/closed/wall,
 /area/station/cargo/sorting)
+"pfJ" = (
+/obj/machinery/plumbing/synthesizer,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "pgF" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
@@ -42203,6 +42243,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "prX" = (
@@ -42666,10 +42709,7 @@
 /area/station/hallway/primary/fore)
 "pAD" = (
 /obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -42684,10 +42724,6 @@
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination/chemfactory,
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -43367,8 +43403,7 @@
 /turf/open/floor/carpet/purple,
 /area/station/medical/psychology)
 "pOG" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -43673,7 +43708,7 @@
 "pUP" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "pUQ" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -43727,7 +43762,7 @@
 /turf/open/floor/iron/white,
 /area/station/commons/fitness)
 "pVG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/start/cyborg,
@@ -43883,14 +43918,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "pYu" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/turf/open/floor/iron,
+/area/station/medical/medbay/lobby)
 "pYL" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -43909,10 +43943,9 @@
 /area/station/hallway/primary/central)
 "pYW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "pZd" = (
@@ -44007,7 +44040,7 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "qbh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/camera/directional/west{
@@ -44112,9 +44145,17 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "qcC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall,
-/area/station/maintenance/department/medical)
+/obj/structure/cable,
+/obj/structure/sign/departments/medbay/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Medical - Aft Hallway";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "qcE" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
@@ -44839,7 +44880,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "qqh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -44873,8 +44914,8 @@
 /area/station/engineering/atmos/storage/gas)
 "qqM" = (
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/green/diagonal_edge,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/green,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "qqN" = (
@@ -45324,6 +45365,9 @@
 /obj/machinery/status_display/ai/directional/north,
 /obj/structure/window/spawner/directional/west,
 /obj/item/kirbyplants/organic/plant8,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "qAV" = (
@@ -46009,13 +46053,6 @@
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
-"qOu" = (
-/obj/effect/turf_decal/tile/bar/diagonal_centre,
-/obj/effect/turf_decal/siding/grey/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/cafeteria)
 "qOB" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -46248,6 +46285,10 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard)
+"qUk" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qUt" = (
 /obj/structure/rack,
 /obj/item/shard,
@@ -46511,7 +46552,7 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "qZE" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -46729,9 +46770,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/west,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/medical/anticorner{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "rdB" = (
@@ -46811,7 +46850,7 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "reH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -47013,10 +47052,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "riO" = (
-/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "riQ" = (
@@ -47030,6 +47069,7 @@
 /obj/effect/turf_decal/tile/security/half{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "rji" = (
@@ -47382,9 +47422,7 @@
 /turf/open/floor/plating,
 /area/station/construction)
 "rqc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/biohazard/directional/north,
 /obj/structure/sign/warning/biohazard/directional/south,
@@ -47566,7 +47604,6 @@
 "rtJ" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/records/medical/laptop,
-/obj/machinery/light/directional/north,
 /turf/open/floor/carpet/purple,
 /area/station/medical/psychology)
 "rtL" = (
@@ -47574,12 +47611,8 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "rui" = (
-/obj/structure/table,
-/obj/item/reagent_containers/cup/bottle/nutrient/ez,
-/obj/item/reagent_containers/cup/bottle/nutrient/ez,
-/obj/item/reagent_containers/cup/bottle/nutrient/ez,
-/obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
 /area/station/service/hydroponics)
 "rum" = (
 /turf/open/floor/wood,
@@ -48078,7 +48111,7 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "rEP" = (
-/obj/effect/turf_decal/tile/medical{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -48233,7 +48266,7 @@
 /area/station/maintenance/department/engine)
 "rGK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -48733,7 +48766,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rRL" = (
-/obj/effect/turf_decal/tile/medical/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -48839,7 +48872,7 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "rTO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
@@ -48972,9 +49005,7 @@
 /turf/open/floor/sepia,
 /area/station/maintenance/starboard/fore)
 "rWj" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -49043,7 +49074,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -49293,6 +49324,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"scE" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "scO" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners{
 	dir = 1
@@ -49653,6 +49691,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "siv" = (
@@ -49885,11 +49924,11 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "smu" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -50123,6 +50162,13 @@
 /obj/effect/turf_decal/tile/dark,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"sqP" = (
+/obj/machinery/plumbing/synthesizer,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "sqQ" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Kitchen";
@@ -50485,9 +50531,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "sxb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
@@ -50597,7 +50641,7 @@
 /obj/structure/table/wood,
 /obj/item/toy/figure/bartender,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "szl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -50971,8 +51015,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "sGl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/camera/directional/north{
+	c_tag = "Medical - Cold Room";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/coldroom)
 "sGu" = (
@@ -51137,9 +51184,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "sIX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
 /turf/open/floor/circuit,
@@ -51171,9 +51216,8 @@
 /area/station/medical/morgue)
 "sJL" = (
 /obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -51411,6 +51455,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"sRA" = (
+/obj/machinery/plumbing/synthesizer,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "sRI" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing"
@@ -51986,7 +52035,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "teh" = (
@@ -52037,7 +52085,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/tile/medical/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -52085,9 +52133,7 @@
 "tfR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "tfV" = (
@@ -52217,9 +52263,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
 "tit" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
@@ -52269,6 +52313,7 @@
 "tjD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical)
 "tjG" = (
@@ -52560,6 +52605,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "tnF" = (
@@ -52775,6 +52823,10 @@
 /obj/item/clothing/head/cowboy,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"tqU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "tqZ" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
@@ -52999,7 +53051,7 @@
 	},
 /area/station/science/xenobiology)
 "tuc" = (
-/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "tuf" = (
@@ -53063,7 +53115,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "tvJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -53355,8 +53407,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "tAW" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -53440,10 +53491,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "tCS" = (
@@ -53508,9 +53555,8 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "tEc" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -54359,7 +54405,7 @@
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "tWF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
@@ -54746,7 +54792,7 @@
 	},
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/neck/stethoscope,
-/obj/effect/turf_decal/tile/medical/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "uce" = (
@@ -55275,9 +55321,7 @@
 	id_tag = "virology_airlock_exterior";
 	name = "Virology Exterior Airlock"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -55576,9 +55620,7 @@
 	id_tag = "virology_airlock_interior";
 	name = "Virology Interior Airlock"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -55731,6 +55773,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
+"uuA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "uuB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55848,7 +55896,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "uxd" = (
 /obj/structure/cable,
@@ -56347,6 +56395,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/construction)
+"uIv" = (
+/obj/machinery/door/window/left/directional/north{
+	name = "rabbitry";
+	req_one_access = list("hydroponics")
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "uID" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -56363,7 +56418,6 @@
 /area/station/security/detectives_office)
 "uIL" = (
 /obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "uIZ" = (
@@ -56639,6 +56693,9 @@
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
@@ -57017,9 +57074,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "uUs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/sign/departments/security/directional/north,
 /obj/effect/turf_decal/tile/security/half{
 	dir = 1
@@ -57079,9 +57134,7 @@
 /obj/effect/turf_decal/tile/security{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "uVv" = (
@@ -57229,9 +57282,7 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "uYC" = (
@@ -57660,10 +57711,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "vgt" = (
@@ -57877,7 +57928,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "vkT" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -57991,13 +58042,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/security/courtroom)
-"vnk" = (
-/obj/effect/turf_decal/tile/bar/diagonal_centre,
-/obj/effect/turf_decal/siding/grey{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/cafeteria)
 "vnr" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
@@ -58795,9 +58839,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "vEF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
@@ -59147,6 +59189,11 @@
 	dir = 8
 	},
 /area/station/security/brig/entrance)
+"vLW" = (
+/obj/structure/window/spawner/directional/west,
+/mob/living/basic/rabbit,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "vMb" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -59190,8 +59237,10 @@
 /area/station/command/heads_quarters/rd)
 "vMv" = (
 /obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /obj/item/reagent_containers/cup/watering_can,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "vMw" = (
@@ -59851,16 +59900,13 @@
 /area/station/maintenance/port/aft)
 "vZP" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "vZQ" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -60118,12 +60164,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "wga" = (
@@ -60441,11 +60481,8 @@
 /area/station/commons/dorms)
 "wmI" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -60532,8 +60569,8 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
@@ -60605,8 +60642,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "wqB" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -60705,6 +60742,12 @@
 /obj/effect/turf_decal/tile/prison,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
+"wsh" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "wsj" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -61067,12 +61110,12 @@
 "wyW" = (
 /obj/item/gun/syringe,
 /obj/item/gun/syringe,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 1
-	},
 /obj/structure/rack,
 /obj/item/mod/module/plasma_stabilizer,
 /obj/item/mod/module/thermal_regulator,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "wzl" = (
@@ -61284,7 +61327,7 @@
 /area/station/maintenance/department/cargo)
 "wCN" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -61481,16 +61524,16 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "wGi" = (
-/obj/structure/chair/comfy{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/landmark/start/bartender,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/obj/effect/landmark/start/bartender,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "wGC" = (
@@ -61877,15 +61920,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "wNT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/duct,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/blacklight/directional/west,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "wOa" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/east,
@@ -62515,7 +62554,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "wZh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/medical/coldroom)
 "wZi" = (
@@ -62664,8 +62703,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "xaT" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/green/diagonal_edge,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "xaV" = (
@@ -62737,9 +62778,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "xcn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/south,
@@ -62999,8 +63038,8 @@
 /area/station/hallway/primary/central)
 "xgZ" = (
 /obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/tile/medical/half{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
@@ -63132,17 +63171,16 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
 "xjk" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
-"xjw" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/diagonal_edge,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"xjw" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "xjz" = (
 /obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 1
@@ -63719,13 +63757,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
-"xsc" = (
-/obj/effect/turf_decal/tile/bar/diagonal_centre,
-/obj/effect/turf_decal/siding/grey{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/cafeteria)
 "xsk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -64130,12 +64161,6 @@
 "xAK" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/gravity_generator)
-"xAL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "xAR" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Xenobiology Lab - Pen #1";
@@ -64221,6 +64246,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"xCn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "xCv" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -64362,10 +64396,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "xEW" = (
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "xFd" = (
@@ -64397,7 +64430,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "xFE" = (
-/obj/effect/turf_decal/tile/green/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "xFH" = (
@@ -64518,7 +64550,7 @@
 /area/station/service/chapel)
 "xIh" = (
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "xIk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
@@ -64559,13 +64591,9 @@
 /turf/closed/wall,
 /area/station/security/checkpoint/engineering)
 "xJb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/grimy,
+/area/station/service/chapel/office)
 "xJe" = (
 /turf/open/floor/carpet,
 /area/station/service/chapel)
@@ -64588,13 +64616,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
+"xJI" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/camera/directional/north{
+	c_tag = "Medical - Exam Room"
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/medbay/central)
 "xJX" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -64951,9 +64983,7 @@
 /turf/closed/wall,
 /area/station/maintenance/port/aft)
 "xRV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
@@ -65278,10 +65308,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "xXq" = (
-/obj/effect/turf_decal/tile/medical{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "xXU" = (
@@ -65385,7 +65414,7 @@
 "yai" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -65416,7 +65445,10 @@
 "yas" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/green/diagonal_edge,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "yau" = (
@@ -65775,7 +65807,7 @@
 /area/station/maintenance/fore)
 "yfx" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/effect/turf_decal/tile/medical/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "yfI" = (
@@ -66022,10 +66054,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/medical{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ykd" = (
@@ -66045,7 +66074,7 @@
 "ykj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "yku" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66088,7 +66117,7 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "ylQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -87817,7 +87846,7 @@ iBq
 nSt
 vkl
 gTz
-fZc
+xIh
 iwH
 jyA
 xps
@@ -88075,7 +88104,7 @@ rsm
 ghl
 qTi
 kPu
-vnk
+xIh
 xIh
 bxB
 bxB
@@ -88332,7 +88361,7 @@ uQo
 aWE
 eQT
 kPu
-vnk
+xIh
 xIh
 jlh
 uFq
@@ -88589,7 +88618,7 @@ uQo
 ioD
 pzd
 kPu
-vnk
+xIh
 hcn
 fpv
 xIh
@@ -88846,7 +88875,7 @@ uQo
 ioD
 pzd
 kPu
-vnk
+xIh
 pUP
 szk
 dDC
@@ -89103,7 +89132,7 @@ uQo
 plq
 iwI
 kPu
-vnk
+xIh
 xIh
 uxc
 xIh
@@ -89360,11 +89389,11 @@ vkl
 ioD
 dto
 kPu
-xsc
-fZc
-fZc
-fZc
-qOu
+xIh
+xIh
+xIh
+xIh
+xIh
 xIh
 nDJ
 xIh
@@ -91422,7 +91451,7 @@ qMP
 lnk
 wbA
 oZi
-ldk
+mMM
 tef
 xFE
 xFE
@@ -91679,11 +91708,11 @@ uYK
 uYK
 uYK
 fYc
-cOq
-xjw
-xFE
-xFE
-nst
+mIB
+btH
+oqV
+jQp
+vLW
 wZi
 plo
 gXu
@@ -91937,9 +91966,9 @@ hZp
 hmX
 rGK
 cOq
-xjw
+wsh
 xaT
-xFE
+fUx
 rui
 wZi
 jcx
@@ -92192,12 +92221,12 @@ uNo
 eDI
 glm
 dLY
-ldk
-cOq
-xjw
+mMM
+xjk
 xFE
 xFE
-nst
+uIv
+mIH
 wZi
 iuq
 iIx
@@ -92452,9 +92481,9 @@ okq
 oVP
 yas
 cXY
-xFE
-xFE
-nst
+oqV
+fUx
+mIH
 wZi
 jcx
 oPu
@@ -92709,9 +92738,9 @@ dUx
 gOb
 qqM
 fzw
-xFE
-uIL
-tuc
+xaT
+jdb
+gid
 wZi
 jcx
 iIx
@@ -92964,10 +92993,10 @@ oxV
 hZp
 smu
 rWj
-fFh
+rWj
 afe
-fFh
-kpH
+rWj
+rWj
 vMv
 wZi
 jcx
@@ -94540,7 +94569,7 @@ qCw
 wat
 pIR
 mPS
-mIB
+kbb
 xdI
 ldQ
 dSh
@@ -94797,7 +94826,7 @@ nVn
 nVn
 nVn
 nVn
-mIB
+kbb
 xdI
 dnK
 dSh
@@ -95054,7 +95083,7 @@ qCw
 sHy
 vWS
 mPS
-mIB
+kbb
 xdI
 cjp
 dSh
@@ -95311,7 +95340,7 @@ jXu
 btr
 lYj
 mPS
-mIB
+kbb
 xdI
 lnY
 dSh
@@ -95568,7 +95597,7 @@ qCw
 odz
 dWg
 mPS
-mIB
+kbb
 xdI
 dnK
 dSh
@@ -95825,7 +95854,7 @@ nVn
 nVn
 nVn
 nVn
-mIB
+kbb
 xdI
 tDn
 ssF
@@ -96339,7 +96368,7 @@ doI
 btr
 biu
 mPS
-mIB
+kbb
 xdI
 piR
 xDi
@@ -96596,7 +96625,7 @@ qCw
 wat
 sai
 mPS
-mIB
+kbb
 xdI
 piR
 nLi
@@ -97110,7 +97139,7 @@ xYz
 giF
 iQW
 giF
-mIB
+kbb
 xdI
 gYN
 rdS
@@ -97367,7 +97396,7 @@ bwx
 giF
 iQW
 giF
-mIB
+kbb
 xdI
 piR
 xDi
@@ -97624,7 +97653,7 @@ bwx
 giF
 iQW
 giF
-mIB
+kbb
 xdI
 piR
 xDi
@@ -103272,7 +103301,7 @@ dkl
 uhW
 jfw
 tMu
-tMu
+pdR
 ttQ
 iFO
 uhW
@@ -103762,7 +103791,7 @@ xmG
 fBM
 fBM
 fBM
-bEQ
+mKg
 wJu
 qNF
 iIx
@@ -104785,7 +104814,7 @@ wJu
 rtf
 muJ
 cGi
-miW
+pYu
 xbM
 fBM
 bAt
@@ -105268,7 +105297,7 @@ vzb
 rvY
 hCh
 mdk
-mdk
+xJb
 sdn
 caz
 jgQ
@@ -105316,12 +105345,12 @@ hnk
 kvx
 lSA
 pAD
-oOO
+pOG
 vZP
 xJX
-oOO
-oOO
-xEW
+gjF
+scE
+sqP
 hVO
 dyo
 mFP
@@ -105574,11 +105603,11 @@ ptu
 jlb
 ptu
 ptu
-ptu
-ptu
-ptu
-ptu
-pOG
+tqU
+mHs
+htk
+qUk
+sRA
 hVO
 fxI
 tsJ
@@ -105830,12 +105859,12 @@ ptu
 ptu
 jlb
 ptu
-pYu
-oOO
-oOO
-xEW
 ptu
-pOG
+tqU
+lvm
+xEW
+okI
+pfJ
 hVO
 jBM
 joq
@@ -106034,7 +106063,7 @@ rvY
 rvY
 rvY
 wEX
-pzp
+vzb
 vzb
 rvY
 wQj
@@ -106056,7 +106085,7 @@ sfU
 wLh
 xFH
 yaq
-rXy
+xjw
 wCc
 lHq
 bpn
@@ -106087,11 +106116,11 @@ ptu
 vpa
 dAC
 qFr
-jCH
 ptu
-ptu
+dsv
 pOG
-ptu
+pOG
+pOG
 tEc
 xaG
 fYH
@@ -106293,7 +106322,7 @@ drK
 vzb
 vzX
 vzb
-vzb
+pzp
 rvY
 jYl
 mjP
@@ -106345,11 +106374,11 @@ srC
 hCz
 iYy
 wfR
+uuA
 iYy
-iYy
-pOG
 ptu
-pOG
+ptu
+tqU
 xaG
 wuw
 xaG
@@ -106601,12 +106630,12 @@ tAW
 tAW
 rEP
 ptu
-jCH
 ptu
+lsg
 iYy
-pOG
 ptu
-pOG
+ptu
+tqU
 xaG
 gzg
 xaG
@@ -106835,7 +106864,7 @@ rbO
 rbO
 tlI
 mhn
-mwm
+xJI
 iEv
 mEF
 toI
@@ -106857,10 +106886,10 @@ hVO
 ijY
 rlq
 jCH
-ptu
-jCH
-ptu
-iYy
+ghX
+aBL
+dXw
+xCn
 oen
 mmB
 yjZ
@@ -107115,10 +107144,10 @@ kgq
 iiY
 jCH
 ptu
-jCH
 ptu
+lsg
 dMp
-pOG
+ptu
 ptu
 iOA
 xaG
@@ -107372,12 +107401,12 @@ kyO
 lUO
 jCH
 ptu
-jCH
 ptu
+lsg
 dMp
-pOG
 ptu
-pOG
+ptu
+tqU
 xaG
 bAs
 xaG
@@ -107628,13 +107657,13 @@ hVO
 hVO
 coA
 qZE
+ghX
+aBL
+dXw
+hCI
+ghX
 ptu
-jCH
-ptu
-dMp
-pOG
-ptu
-pOG
+tqU
 xaG
 ksz
 xaG
@@ -107886,12 +107915,12 @@ hVO
 wmI
 ptu
 ptu
-xXq
-tAW
-tCK
-xjk
 ptu
-tEc
+lsg
+tCK
+ptu
+ptu
+dMA
 xaG
 wuw
 mdT
@@ -108144,11 +108173,11 @@ jCH
 ptu
 ptu
 ptu
+ghX
 ptu
 ptu
 ptu
-ptu
-pOG
+tqU
 xaG
 hqe
 lMo
@@ -108368,7 +108397,7 @@ ycg
 pGr
 iiW
 qSZ
-rZZ
+aOb
 rXy
 tzq
 vtH
@@ -108383,7 +108412,7 @@ kxx
 wwY
 hmE
 oOD
-iJh
+qcC
 gUm
 rrP
 uIb
@@ -108405,7 +108434,7 @@ tAW
 tAW
 tAW
 rEP
-pOG
+tqU
 xaG
 bNa
 lMo
@@ -108645,7 +108674,7 @@ sWZ
 eNU
 upW
 oGR
-vrV
+dNm
 aoU
 fdN
 xaG
@@ -108875,7 +108904,7 @@ isa
 isa
 isa
 isa
-qcC
+ycg
 wZh
 frd
 lik
@@ -109131,7 +109160,7 @@ ygs
 ygs
 ygs
 ygs
-ygs
+isa
 ycg
 sGl
 lKW
@@ -109388,9 +109417,9 @@ rvY
 ygs
 ygs
 ygs
-ygs
+isa
 ycg
-qcC
+ycg
 ycg
 ycg
 obq
@@ -109400,8 +109429,8 @@ rZZ
 cbH
 slT
 rcT
+fcC
 rKu
-wNT
 vGd
 bIt
 fYI
@@ -109416,7 +109445,7 @@ aNn
 uGN
 upW
 uYA
-vrV
+dNm
 haI
 vrV
 cBc
@@ -109645,8 +109674,8 @@ rvY
 ygs
 ygs
 ygs
-ygs
-ygs
+isa
+isa
 isa
 ygs
 ycg
@@ -109673,7 +109702,7 @@ clV
 bRO
 upW
 wyW
-vrV
+gIq
 haI
 fqV
 nxI
@@ -109904,7 +109933,7 @@ ycg
 ycg
 ycg
 ygs
-ygs
+isa
 hJa
 tcM
 dHz
@@ -110679,7 +110708,7 @@ ycg
 ycg
 bxz
 ogU
-qcC
+ycg
 eAc
 vmT
 hTZ
@@ -110935,8 +110964,8 @@ ycg
 rmL
 ygs
 tcM
-ygs
-qcC
+isa
+ycg
 ycg
 ycg
 hTZ
@@ -111192,9 +111221,9 @@ ycg
 ttg
 kqZ
 rsV
+eSK
 ttg
-lQH
-qcC
+ycg
 lBT
 dGm
 xAx
@@ -111449,8 +111478,8 @@ ttg
 bZY
 ygs
 tcM
-tcM
-rsV
+fge
+wNT
 ycg
 ycg
 ycg
@@ -111707,8 +111736,8 @@ ycg
 ndu
 ndu
 ndu
-rsV
-rsV
+wNT
+wNT
 gxI
 agG
 gxI
@@ -112948,9 +112977,9 @@ tWF
 iHg
 kRZ
 qbh
-xAL
+eSU
 rTO
-xAL
+eSU
 xcn
 coZ
 coZ
@@ -113198,7 +113227,7 @@ gRV
 gRV
 rqx
 uNz
-xJb
+eSU
 ijf
 ijf
 ijf
@@ -113465,7 +113494,7 @@ ijf
 roh
 isJ
 ijf
-xJb
+eSU
 coZ
 coZ
 coZ
@@ -113712,7 +113741,7 @@ aUC
 gRV
 rqx
 wMr
-xJb
+eSU
 ijf
 jom
 caV
@@ -114481,7 +114510,7 @@ cFx
 cGf
 bbx
 fYD
-xAL
+eSU
 dMW
 faG
 fOv
@@ -114740,7 +114769,7 @@ tXD
 gRV
 dIH
 wMr
-xJb
+eSU
 ijf
 gxn
 htN
@@ -115254,7 +115283,7 @@ eKQ
 gRV
 rqx
 uNz
-xJb
+eSU
 ijf
 jom
 caV
@@ -115264,7 +115293,7 @@ sKn
 caV
 rrg
 ijf
-xJb
+eSU
 coZ
 rma
 rWR
@@ -115768,7 +115797,7 @@ gRV
 gRV
 arG
 wMr
-xJb
+eSU
 ijf
 ijf
 ijf
@@ -115778,7 +115807,7 @@ ijf
 ijf
 ijf
 ijf
-xJb
+eSU
 coZ
 coZ
 coZ
@@ -116025,7 +116054,7 @@ gRV
 gRV
 fZy
 mLn
-fge
+eSU
 auC
 jDT
 duS
@@ -116035,7 +116064,7 @@ cBq
 auC
 pVG
 auC
-pdR
+xcn
 coZ
 coZ
 iQW
@@ -117370,7 +117399,7 @@ uJD
 gOP
 oQV
 ymf
-mKg
+jUl
 niV
 iVl
 oWL
@@ -117627,7 +117656,7 @@ eWq
 tFj
 jNf
 vEU
-mKg
+jUl
 ubw
 jNf
 qhP
@@ -117879,17 +117908,17 @@ xBY
 yju
 iQW
 nit
+jNf
 cWk
-cWk
-cWk
+jNf
 cWk
 duA
 jUl
 mve
 cWk
+jNf
 cWk
-cWk
-cWk
+jNf
 nit
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -392,7 +392,7 @@
 "agF" = (
 /obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/storage)
 "agG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -731,12 +731,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/office)
-"ane" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "ani" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
@@ -965,6 +959,9 @@
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "aqD" = (
@@ -1110,11 +1107,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "atl" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/turf/open/floor/iron/dark/textured_edge,
-/area/station/medical/medbay)
+/turf/open/floor/wood,
+/area/station/service/chapel/office)
 "atn" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -1140,10 +1137,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "atB" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/medical/medbay/lobby)
 "atD" = (
 /obj/machinery/vending/assist,
 /obj/machinery/camera/directional/south{
@@ -1748,6 +1746,9 @@
 "aFg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "aFK" = (
@@ -1773,6 +1774,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
+"aGl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "aGr" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -2112,6 +2118,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "aNE" = (
@@ -2196,11 +2206,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"aPe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/cryo)
 "aPm" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig"
@@ -2307,12 +2312,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "aQv" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Medbay"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/medbay)
 "aQw" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
@@ -2414,7 +2420,8 @@
 "aSi" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
-/turf/open/floor/iron/white/diagonal,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "aSl" = (
 /obj/structure/cable,
@@ -2545,6 +2552,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "aUZ" = (
@@ -2695,6 +2705,16 @@
 /obj/effect/turf_decal/tile/medical/anticorner,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"aWT" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/siding/thinplating_new/light/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/break_room)
 "aWX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2706,6 +2726,10 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aXh" = (
@@ -2725,7 +2749,10 @@
 /area/station/security/mechbay)
 "aXr" = (
 /obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "aXA" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -3104,6 +3131,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "bfx" = (
@@ -3257,6 +3287,12 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"bja" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/service/chapel/office)
 "bjj" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel Hall"
@@ -3596,6 +3632,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/spawner/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bpT" = (
@@ -4189,6 +4228,10 @@
 "bzD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bzG" = (
@@ -4258,7 +4301,7 @@
 /area/station/maintenance/starboard)
 "bAt" = (
 /mob/living/basic/bot/medbot,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "bAu" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -4517,7 +4560,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "bET" = (
 /obj/effect/turf_decal/bot,
@@ -4701,6 +4747,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bIy" = (
@@ -4765,6 +4814,18 @@
 /obj/structure/reflector/single,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"bJM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "bJP" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/directional/south{
@@ -5093,7 +5154,10 @@
 	pixel_x = -7;
 	pixel_y = 8
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
 /area/station/medical/medbay/lobby)
 "bPJ" = (
 /obj/structure/table/reinforced,
@@ -5115,7 +5179,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/medical/opposingcorners,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "bPS" = (
 /obj/item/chair/wood,
@@ -5158,6 +5222,15 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
+"bRf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "bRi" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -5197,6 +5270,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bRS" = (
@@ -5603,6 +5677,9 @@
 /area/station/security/office)
 "bYx" = (
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bYI" = (
@@ -5660,6 +5737,7 @@
 /area/space/nearstation)
 "bZY" = (
 /obj/effect/spawner/random/maintenance/four,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "cai" = (
@@ -5707,7 +5785,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/duct,
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet,
 /area/station/medical/break_room)
 "caN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5725,6 +5803,9 @@
 "cba" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /mob/living/basic/bot/cleanbot/medbay,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "cbe" = (
@@ -5746,6 +5827,9 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Medical - Central Hall NE";
 	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -6107,7 +6191,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "ckF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -6163,10 +6247,10 @@
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "clV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "cmy" = (
@@ -6291,6 +6375,9 @@
 /area/station/maintenance/fore)
 "cov" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "cow" = (
@@ -6744,7 +6831,7 @@
 /obj/machinery/iv_drip,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/storage)
 "cwA" = (
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
 /turf/open/floor/iron,
@@ -7332,7 +7419,10 @@
 /obj/machinery/computer/records/medical{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
 /area/station/medical/medbay/lobby)
 "cGn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8213,6 +8303,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "cXX" = (
@@ -8568,7 +8661,6 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "deg" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/requests_console/directional/north{
 	department = "medbay lobby";
@@ -8593,7 +8685,12 @@
 /obj/structure/table,
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/cell_charger,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
 /area/station/medical/medbay/lobby)
 "deK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9183,6 +9280,16 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"dsW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "dsX" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -9272,6 +9379,9 @@
 "duo" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "duy" = (
@@ -9302,7 +9412,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/medical/opposingcorners,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "duL" = (
 /obj/structure/rack,
@@ -9516,6 +9627,9 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/station/maintenance/department/medical/plasmaman)
+"dyU" = (
+/turf/closed/wall,
+/area/station/medical/storage)
 "dzb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -9559,6 +9673,12 @@
 /mob/living/basic/cow,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
+"dzN" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "dzW" = (
 /obj/structure/training_machine,
 /obj/item/target,
@@ -9696,6 +9816,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "dDq" = (
@@ -9869,6 +9992,7 @@
 /area/station/maintenance/department/engine)
 "dGh" = (
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "dGi" = (
@@ -10145,6 +10269,9 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "dKW" = (
@@ -10179,6 +10306,9 @@
 /obj/item/newspaper,
 /obj/item/toy/figure/md,
 /obj/item/toy/figure/paramedic,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "dLw" = (
@@ -10481,6 +10611,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "dSh" = (
@@ -10778,6 +10911,7 @@
 	c_tag = "Medical - Surgery";
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "dWR" = (
@@ -11268,6 +11402,7 @@
 	name = "Maintenance Hatch"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical)
 "ehC" = (
@@ -11876,6 +12011,9 @@
 /obj/machinery/microwave{
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "etQ" = (
@@ -12187,7 +12325,10 @@
 /area/station/maintenance/department/engine)
 "ezs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "ezt" = (
 /obj/structure/rack,
@@ -12208,6 +12349,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"ezN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "ezO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 5
@@ -12499,7 +12649,7 @@
 "eFB" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/storage)
 "eFG" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/mixed,
@@ -13037,6 +13187,15 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"eQL" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "eQO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 6
@@ -13059,7 +13218,7 @@
 "eQV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "eRa" = (
 /obj/structure/chair{
@@ -13345,6 +13504,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"eWk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating_new/corner,
+/turf/open/floor/iron,
+/area/station/medical/medbay/lobby)
 "eWq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -13514,13 +13678,16 @@
 	},
 /area/station/command/heads_quarters/qm)
 "eZW" = (
-/obj/item/kirbyplants/random,
 /obj/machinery/camera/directional/south{
 	c_tag = "Medical - Pharmacy Desk";
 	network = list("ss13","medbay")
 	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "eZY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -13537,7 +13704,8 @@
 /obj/machinery/defibrillator_mount{
 	pixel_y = -32
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "faa" = (
 /obj/structure/sink/kitchen/directional/south{
@@ -14073,6 +14241,15 @@
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
+"fiT" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "fiV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14144,6 +14321,12 @@
 	pixel_y = 10
 	},
 /obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "flb" = (
@@ -14232,6 +14415,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "fmm" = (
@@ -14289,6 +14473,13 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
+"fnA" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "fnF" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/status_display/evac/directional/west,
@@ -14452,6 +14643,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"fpY" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/medical/medbay/lobby)
 "fqa" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -14496,7 +14694,7 @@
 /area/station/maintenance/department/science)
 "frd" = (
 /turf/open/floor/iron/freezer,
-/area/station/maintenance/department/medical)
+/area/station/medical/storage)
 "fre" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment{
@@ -14537,6 +14735,7 @@
 /obj/item/surgery_tray/full,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "frE" = (
@@ -15021,7 +15220,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "fBM" = (
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "fBS" = (
 /obj/structure/cable,
@@ -15296,6 +15495,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "fHF" = (
@@ -15552,6 +15755,24 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"fKY" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
+"fLg" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "fLh" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
@@ -15675,7 +15896,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
 "fNV" = (
 /obj/structure/cable,
@@ -16187,7 +16408,7 @@
 "fXU" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "fXZ" = (
 /obj/structure/chair{
@@ -16257,6 +16478,9 @@
 /obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -16716,6 +16940,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "giC" = (
@@ -16778,8 +17005,11 @@
 /turf/closed/wall,
 /area/station/cargo/miningdock)
 "glc" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
+/obj/item/kirbyplants/organic/plant8,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "glk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16964,6 +17194,19 @@
 /obj/item/book/manual/wiki/ordnance,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"gpw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "gpB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/engineering/half,
@@ -17385,7 +17628,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "gxM" = (
 /obj/structure/closet/emcloset,
@@ -17395,6 +17641,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"gyc" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "gyr" = (
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/plating,
@@ -17518,6 +17771,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
+"gAQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/cryo)
 "gBc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
 	dir = 6
@@ -17664,6 +17922,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"gEi" = (
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/medical/medbay/lobby)
 "gEs" = (
 /obj/item/kirbyplants/random,
 /obj/structure/disposalpipe/segment{
@@ -17800,7 +18064,8 @@
 "gHh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/white/diagonal,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "gHm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18130,6 +18395,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"gLv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "gLz" = (
 /obj/machinery/modular_computer/preset/curator,
 /obj/structure/sign/poster/official/soft_cap_pop_art/directional/north,
@@ -18821,6 +19096,9 @@
 "gYX" = (
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "gYZ" = (
@@ -19039,6 +19317,9 @@
 /area/station/engineering/atmos)
 "hey" = (
 /obj/structure/window/spawner/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "heF" = (
@@ -19067,7 +19348,10 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "hfh" = (
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/loading_area/white{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "hfm" = (
 /obj/machinery/chem_mass_spec,
@@ -19740,7 +20024,7 @@
 /area/station/maintenance/starboard)
 "hta" = (
 /obj/machinery/duct,
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet,
 /area/station/medical/break_room)
 "htf" = (
 /obj/effect/turf_decal/tile/security/half,
@@ -20080,6 +20364,9 @@
 "hAJ" = (
 /turf/closed/wall,
 /area/station/security/processing)
+"hAQ" = (
+/turf/open/floor/iron,
+/area/station/medical/medbay/lobby)
 "hBb" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -20391,6 +20678,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"hIw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "hIz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20912,6 +21208,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"hQZ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "hRb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20974,6 +21280,9 @@
 	name = "Medbay RC"
 	},
 /obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "hSa" = (
@@ -21060,6 +21369,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
 /obj/effect/landmark/start/medical_doctor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "hTS" = (
@@ -21750,6 +22062,7 @@
 "iiw" = (
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "iiO" = (
@@ -21784,7 +22097,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/storage)
 "iiY" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/engine,
@@ -21998,7 +22311,7 @@
 /area/station/engineering/atmos)
 "imL" = (
 /obj/structure/sign/poster/official/cleanliness/directional/north,
-/obj/effect/turf_decal/tile/medical/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -22164,6 +22477,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
+"ips" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "ipw" = (
 /obj/structure/cable,
 /turf/open/floor/vault,
@@ -22414,7 +22734,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "iuP" = (
 /obj/effect/turf_decal/tile/command/anticorner{
@@ -23011,9 +23331,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "iGY" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/medbay)
 "iHd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
 	dir = 4
@@ -23126,6 +23448,9 @@
 "iJh" = (
 /obj/structure/cable,
 /obj/structure/sign/departments/medbay/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "iJp" = (
@@ -23196,7 +23521,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood,
 /obj/item/paper_bin,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "iKA" = (
 /obj/effect/spawner/random/structure/grille,
@@ -24197,6 +24522,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"jcy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "jcB" = (
 /obj/structure/table,
 /obj/item/trash/semki,
@@ -24388,6 +24722,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "jhn" = (
@@ -24438,7 +24775,7 @@
 /obj/structure/cable,
 /obj/structure/table/wood,
 /obj/item/book/bible,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "jhT" = (
 /obj/machinery/status_display/evac/directional/north,
@@ -24736,6 +25073,7 @@
 	network = list("ss13","medbay")
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "jnZ" = (
@@ -24825,6 +25163,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"jps" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "jpu" = (
 /obj/machinery/shower/directional/south,
 /obj/structure/curtain,
@@ -24902,6 +25254,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"jqB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "jqM" = (
 /obj/structure/sign/warning/cold_temp/directional/south,
 /turf/open/floor/iron/white,
@@ -25000,12 +25358,6 @@
 /obj/effect/turf_decal/tile/prison/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"jsI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "jsN" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 8
@@ -25102,6 +25454,9 @@
 "jum" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "jut" = (
@@ -25617,6 +25972,9 @@
 "jFr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "jFD" = (
@@ -25693,6 +26051,15 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"jGz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "jGB" = (
 /obj/structure/bed/dogbed/renault,
 /mob/living/basic/pet/fox/renault,
@@ -26324,6 +26691,9 @@
 "jRK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "jRM" = (
@@ -26428,6 +26798,12 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/medical/psychology)
+"jTp" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "jTq" = (
 /turf/open/floor/plating,
 /area/station/hallway/primary/fore)
@@ -26516,7 +26892,8 @@
 /obj/item/toy/plush/lizard_plushie,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "jUQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -26704,6 +27081,9 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /obj/item/toy/figure/chaplain{
 	pixel_y = 16
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
@@ -27638,6 +28018,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"knL" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "knM" = (
 /obj/structure/sign/warning/secure_area/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -29362,6 +29750,10 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "kTp" = (
@@ -29552,7 +29944,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "kXJ" = (
 /obj/structure/cable,
@@ -29603,6 +29995,7 @@
 /area/station/commons/fitness)
 "kYN" = (
 /obj/structure/window/spawner/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "kYR" = (
@@ -30088,13 +30481,19 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
 /turf/open/floor/iron/white,
-/area/station/maintenance/department/medical)
+/area/station/medical/storage)
 "liD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
+"liH" = (
+/obj/effect/turf_decal/trimline/blue/filled/end{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "liI" = (
 /obj/effect/turf_decal/tile/medical/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -30409,6 +30808,14 @@
 /obj/effect/turf_decal/tile/command/anticorner,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
+"lpf" = (
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/medical/medbay/lobby)
 "lpr" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -30625,7 +31032,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 2
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "ltL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31300,7 +31711,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "lFb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -31336,6 +31750,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "lFB" = (
@@ -31412,6 +31827,7 @@
 "lHq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "lHs" = (
@@ -31443,6 +31859,16 @@
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"lHL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "lHW" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
@@ -31629,11 +32055,11 @@
 "lKW" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/iron/freezer,
-/area/station/maintenance/department/medical)
+/area/station/medical/storage)
 "lKY" = (
 /obj/effect/spawner/structure/window/ice,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/medical/storage)
 "lLj" = (
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/machinery/camera/directional/east{
@@ -31799,10 +32225,14 @@
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/structure/window/spawner/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "lOB" = (
 /obj/machinery/computer/operating,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "lOK" = (
@@ -32121,7 +32551,7 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
 "lTj" = (
 /obj/structure/closet/firecloset,
@@ -32304,6 +32734,15 @@
 "lVL" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
+"lVR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/medbay)
 "lVW" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
@@ -33071,7 +33510,8 @@
 /area/station/commons/storage/primary)
 "miW" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white/diagonal,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "miY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -33138,6 +33578,9 @@
 /area/station/commons/storage/primary)
 "mjP" = (
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "mjT" = (
@@ -33364,6 +33807,9 @@
 "mmE" = (
 /obj/structure/sign/departments/psychology/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "mng" = (
@@ -33582,10 +34028,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"mrk" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
 "mrm" = (
 /obj/structure/chair{
 	dir = 1;
@@ -33922,6 +34364,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"mwm" = (
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/medbay/central)
 "mwx" = (
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
@@ -34142,7 +34588,10 @@
 /obj/machinery/computer/records/medical/laptop{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
 /area/station/medical/medbay/lobby)
 "mBe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34176,8 +34625,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/turf_decal/tile/medical/opposingcorners,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/maintenance/department/medical)
 "mBv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -34299,6 +34747,9 @@
 /area/station/command/gateway)
 "mDN" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "mDU" = (
@@ -34442,7 +34893,18 @@
 "mHg" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
 /area/station/medical/medbay/central)
 "mHk" = (
 /obj/item/kirbyplants/random,
@@ -34851,6 +35313,9 @@
 /obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -35287,7 +35752,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/medical/opposingcorners,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "mXM" = (
 /obj/structure/railing{
@@ -35304,6 +35769,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "mYb" = (
@@ -35569,6 +36037,11 @@
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "ncJ" = (
@@ -35722,6 +36195,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"nfH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "nfS" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
@@ -36010,7 +36491,7 @@
 /obj/item/tank/internals/plasmaman/full,
 /obj/structure/closet/crate/secure/plasma,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/storage)
 "nlL" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Containment Pen #8";
@@ -36180,6 +36661,9 @@
 /area/station/service/cafeteria)
 "npr" = (
 /obj/structure/chair,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "npy" = (
@@ -36655,7 +37139,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/freezer,
-/area/station/maintenance/department/medical)
+/area/station/medical/storage)
 "nvF" = (
 /obj/machinery/rnd/server/master,
 /obj/machinery/camera/directional/south{
@@ -36736,7 +37220,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "nxX" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -37025,6 +37509,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "nDS" = (
@@ -37409,7 +37896,8 @@
 /area/station/maintenance/fore)
 "nMq" = (
 /obj/machinery/medical_kiosk,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "nMv" = (
 /obj/structure/chair{
@@ -37540,6 +38028,7 @@
 "nPa" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "nPd" = (
@@ -37732,6 +38221,13 @@
 "nSA" = (
 /turf/closed/wall,
 /area/station/security/prison/safe)
+"nSF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/medbay)
 "nSI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38144,7 +38640,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/storage)
 "obr" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
@@ -38812,6 +39308,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"ooo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "oor" = (
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
@@ -38888,6 +39396,16 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"opt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "opB" = (
 /turf/open/floor/plating,
 /area/station/construction)
@@ -38907,7 +39425,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/medical/opposingcorners,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "opP" = (
 /obj/structure/closet/wardrobe/white,
@@ -39610,10 +40128,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
+"oFh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "oFl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "oFA" = (
@@ -40129,6 +40658,14 @@
 "oPO" = (
 /turf/closed/indestructible/opshuttle,
 /area/station/science/ordnance/bomb)
+"oPS" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
+/turf/open/floor/iron/white/textured_edge,
+/area/station/medical/medbay/central)
 "oQm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40213,6 +40750,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"oSn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "oSy" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
@@ -40442,6 +40988,9 @@
 "oWN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
@@ -40789,6 +41338,7 @@
 /obj/structure/table/optable,
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "pdK" = (
@@ -40936,7 +41486,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "pgM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -41027,6 +41577,10 @@
 /area/station/security/checkpoint/science)
 "pis" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "piu" = (
@@ -41067,6 +41621,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"pjC" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "pjD" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/shower/directional/west,
@@ -41337,6 +41903,18 @@
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"poI" = (
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "poU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -41509,6 +42087,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "prP" = (
@@ -41521,7 +42100,8 @@
 "prR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white/diagonal,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "prX" = (
 /obj/structure/rack,
@@ -41536,6 +42116,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "psu" = (
@@ -42317,7 +42898,7 @@
 "pGr" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
-/area/station/maintenance/department/medical)
+/area/station/medical/storage)
 "pGv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43668,6 +44249,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
+"qhd" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "qhe" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -43767,6 +44354,9 @@
 	id = "surgery3";
 	name = "surgery privacy shutter control";
 	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
@@ -43904,6 +44494,9 @@
 /area/station/engineering/atmos/storage/gas)
 "qlG" = (
 /obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "qlP" = (
@@ -44088,7 +44681,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet,
 /area/station/medical/break_room)
 "qoW" = (
 /obj/machinery/light/directional/east,
@@ -44244,6 +44837,10 @@
 /obj/effect/turf_decal/tile/science/anticorner,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"qse" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "qsg" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -44326,6 +44923,14 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"qtU" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "qtW" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -44571,7 +45176,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "qzr" = (
@@ -44624,7 +45229,9 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/white,
+/obj/structure/window/spawner/directional/west,
+/obj/item/kirbyplants/organic/plant8,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "qAV" = (
 /obj/structure/chair/stool/directional/north,
@@ -44640,6 +45247,9 @@
 /obj/item/lighter{
 	pixel_x = 11;
 	pixel_y = -7
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
@@ -45196,6 +45806,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "qMP" = (
@@ -45564,7 +46178,7 @@
 "qUS" = (
 /obj/structure/chair/sofa/left/brown,
 /obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet,
 /area/station/medical/break_room)
 "qUU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45683,6 +46297,7 @@
 /area/station/science/xenobiology)
 "qXX" = (
 /obj/structure/sign/departments/maint/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "qYj" = (
@@ -45909,7 +46524,12 @@
 "rbr" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/duct,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
+/turf/open/floor/iron/white/textured_edge,
 /area/station/medical/medbay/central)
 "rbt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45974,6 +46594,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "rdf" = (
@@ -46119,8 +46742,8 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Desk"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "rgn" = (
@@ -46289,6 +46912,9 @@
 /area/station/hallway/primary/central)
 "riO" = (
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "riQ" = (
@@ -46440,6 +47066,7 @@
 "rmc" = (
 /obj/structure/window/spawner/directional/south,
 /obj/item/kirbyplants/organic/plant8,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "rmh" = (
@@ -46730,6 +47357,13 @@
 /obj/item/toy/figure/lawyer,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
+"rrP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "rsb" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -46803,7 +47437,6 @@
 /area/station/maintenance/department/engine)
 "rtf" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "rto" = (
@@ -47041,6 +47674,9 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "ryp" = (
@@ -47231,7 +47867,7 @@
 "rCm" = (
 /obj/structure/cable,
 /obj/structure/sign/departments/exam_room/directional/south,
-/obj/effect/turf_decal/tile/medical/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/plasmaman)
 "rCp" = (
@@ -47676,6 +48312,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "rKy" = (
@@ -47931,6 +48570,7 @@
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/west,
 /obj/item/book/manual/wiki/surgery,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "rQu" = (
@@ -47978,9 +48618,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "rQV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/medical)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "rRr" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/effect/turf_decal/tile/science/anticorner{
@@ -48217,6 +48859,9 @@
 /area/station/maintenance/starboard/fore)
 "rVZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "rWb" = (
@@ -48301,6 +48946,9 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "rXy" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "rXB" = (
@@ -48820,7 +49468,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet,
 /area/station/medical/break_room)
 "sgG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -49091,6 +49739,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "slU" = (
@@ -49116,6 +49767,9 @@
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "smr" = (
@@ -49228,7 +49882,12 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 4
+	},
 /area/station/medical/medbay/lobby)
 "snY" = (
 /obj/structure/table/glass,
@@ -49757,6 +50416,12 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "sxC" = (
@@ -49792,6 +50457,15 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
+"syb" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "sye" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -50195,7 +50869,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/freezer,
-/area/station/maintenance/department/medical)
+/area/station/medical/storage)
 "sGu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -50365,6 +51039,13 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"sIZ" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "sJt" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -50983,6 +51664,9 @@
 "tbg" = (
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "tbk" = (
@@ -50992,7 +51676,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/med,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/medical/opposingcorners,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "tbl" = (
 /obj/structure/table/wood,
@@ -51394,6 +52079,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "thT" = (
@@ -51910,7 +52598,8 @@
 /obj/machinery/stasis,
 /obj/structure/sign/departments/medbay/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "tqm" = (
 /obj/structure/cable,
@@ -51941,7 +52630,8 @@
 	pixel_y = 28
 	},
 /obj/item/toy/plush/beefplushie,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "tqu" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -52125,7 +52815,6 @@
 /area/station/security/processing)
 "ttB" = (
 /obj/structure/table,
-/obj/structure/cable,
 /obj/machinery/button/door/directional/north{
 	desc = "A remote control switch for the medbay foyer.";
 	id = "MedbayFoyer";
@@ -52378,6 +53067,7 @@
 	c_tag = "Medical - Surgery Hall";
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "tyh" = (
@@ -52641,6 +53331,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "tDn" = (
@@ -52804,6 +53495,7 @@
 /obj/structure/cable,
 /obj/structure/window/spawner/directional/south,
 /obj/item/kirbyplants/organic/plant8,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "tGw" = (
@@ -52816,8 +53508,9 @@
 /obj/machinery/door/airlock/medical{
 	name = "Medbay Storage"
 	},
+/obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/storage)
 "tHl" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
@@ -52921,6 +53614,12 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
+"tJO" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/medbay/central)
 "tJY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -53055,6 +53754,10 @@
 /area/station/maintenance/starboard)
 "tOl" = (
 /obj/structure/sign/departments/chemistry/pharmacy/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "tOE" = (
@@ -53854,6 +54557,7 @@
 "ubF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "ubG" = (
@@ -54060,6 +54764,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "uft" = (
@@ -54302,6 +55007,9 @@
 "ujX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "ukk" = (
@@ -54660,6 +55368,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "urf" = (
@@ -54869,6 +55578,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
+"uuB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/break_room)
 "uuG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -55006,7 +55727,12 @@
 "uxR" = (
 /obj/structure/table,
 /obj/item/bouquet/sunflower,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
 /area/station/medical/medbay/lobby)
 "uye" = (
 /turf/closed/wall,
@@ -55137,7 +55863,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "uBM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -55750,7 +56479,10 @@
 /area/station/commons/dorms)
 "uOp" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "uOr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -55942,6 +56674,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
+"uRh" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "uRk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -56071,6 +56808,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -56300,6 +57040,18 @@
 /obj/effect/turf_decal/tile/command/half,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
+"uYr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "uYA" = (
 /obj/item/storage/medkit/fire{
 	pixel_x = 3;
@@ -56871,6 +57623,10 @@
 /area/station/maintenance/port/aft)
 "viM" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "viO" = (
@@ -57028,6 +57784,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/plasmaman)
+"vmp" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "vmt" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering - Oxygen Tank";
@@ -57320,7 +58083,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
 "vrJ" = (
 /obj/structure/table/wood,
@@ -57981,6 +58744,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "vGN" = (
@@ -58768,6 +59534,7 @@
 "vXl" = (
 /obj/structure/table/glass,
 /obj/item/surgery_tray/full,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "vXr" = (
@@ -58900,6 +59667,7 @@
 /obj/machinery/light/directional/south,
 /obj/item/reagent_containers/cup/glass/mug/coco,
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "vZG" = (
@@ -58957,6 +59725,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"waw" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "waE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59014,6 +59787,9 @@
 "wbv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "wbA" = (
@@ -59537,6 +60313,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
+"wnS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "wnU" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
@@ -60259,6 +61048,15 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"wCc" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "wCd" = (
 /obj/effect/turf_decal/tile/security/half,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60271,6 +61069,9 @@
 	c_tag = "Medical - Virology Hall";
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "wCq" = (
@@ -60279,7 +61080,7 @@
 /obj/structure/cable,
 /obj/structure/table/wood,
 /obj/item/newspaper,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "wCu" = (
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -60481,6 +61282,9 @@
 "wFB" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "wFK" = (
@@ -60816,6 +61620,9 @@
 	name = "surgery privacy shutter control";
 	pixel_y = -5
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "wMl" = (
@@ -60874,6 +61681,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
+"wNj" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "wNm" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -60900,6 +61714,9 @@
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/blacklight/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "wOa" = (
@@ -61149,7 +61966,10 @@
 	pixel_x = -4
 	},
 /obj/item/storage/fancy/donut_box,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
 /area/station/medical/medbay/lobby)
 "wRL" = (
 /obj/item/broken_bottle,
@@ -61277,7 +62097,18 @@
 "wTX" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 8
+	},
 /area/station/medical/medbay/central)
 "wUw" = (
 /obj/effect/turf_decal/siding/engineering{
@@ -61519,7 +62350,7 @@
 "wZh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
-/area/station/maintenance/department/medical)
+/area/station/medical/storage)
 "wZi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -61533,7 +62364,16 @@
 "wZv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
 /area/station/medical/medbay/central)
 "wZw" = (
 /obj/structure/cable,
@@ -61644,7 +62484,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "xaL" = (
 /obj/effect/spawner/random/vending/snackvend,
@@ -61717,7 +62557,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "xbN" = (
 /obj/machinery/airalarm/directional/east,
@@ -61778,6 +62618,16 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
+"xdd" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "xde" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -61874,6 +62724,7 @@
 /area/station/maintenance/department/medical/plasmaman)
 "xee" = (
 /obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "xeH" = (
@@ -61964,6 +62815,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "xgv" = (
@@ -62002,6 +62856,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "xhe" = (
@@ -62415,7 +63270,7 @@
 /area/station/science/xenobiology)
 "xmG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "xmI" = (
 /obj/machinery/door/airlock{
@@ -62659,6 +63514,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science)
+"xqT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "xrg" = (
 /obj/machinery/button/door/incinerator_vent_ordmix{
 	pixel_x = 8;
@@ -63060,8 +63923,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "xzB" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/medbay)
 "xzG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -63076,7 +63942,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "xAx" = (
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet,
 /area/station/medical/break_room)
 "xAE" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -63322,7 +64188,7 @@
 /area/station/security/prison/garden)
 "xEK" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/carpet,
 /area/station/medical/medbay/lobby)
 "xEP" = (
 /obj/structure/cable,
@@ -64227,6 +65093,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"xXk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "xXm" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -64442,6 +65317,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ybQ" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/medical/medbay)
 "ybS" = (
 /obj/item/toy/plush/fly,
 /turf/open/floor/plating,
@@ -64462,6 +65343,9 @@
 "ych" = (
 /obj/structure/cable,
 /obj/structure/window/spawner/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "yct" = (
@@ -64616,6 +65500,9 @@
 /area/station/ai_monitored/turret_protected/ai)
 "yee" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -64787,7 +65674,7 @@
 "ygo" = (
 /obj/structure/chair/sofa/right/brown,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
+/turf/open/floor/carpet,
 /area/station/medical/break_room)
 "ygp" = (
 /obj/structure/cable,
@@ -65016,6 +65903,10 @@
 /area/station/command/heads_quarters/hop)
 "ykY" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "yla" = (
@@ -65046,6 +65937,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "ymf" = (
@@ -102184,7 +103078,7 @@ wJu
 wJu
 duI
 tbk
-aQv
+bPQ
 wJu
 wJu
 wJu
@@ -102434,14 +103328,14 @@ rQt
 wMg
 poU
 esY
-rXy
+liH
 wJu
 nMq
 fXU
 hfh
-iGY
+eWk
 ezs
-qOB
+atB
 glc
 aXr
 uBv
@@ -102688,14 +103582,14 @@ ycg
 pdG
 dSc
 oFl
-oFl
+bRf
 aoE
-jsI
-ykY
+hIw
+knL
 wJu
 qAE
-qOB
-qOB
+hAQ
+hAQ
 miW
 xmG
 fBM
@@ -102947,7 +103841,7 @@ bfu
 cLQ
 tZU
 poU
-lHq
+oFh
 nPa
 wJu
 deG
@@ -103205,9 +104099,9 @@ kiq
 uPm
 vOK
 mXV
-ykY
+uRh
 rfN
-iGY
+qOB
 muJ
 bPs
 aSi
@@ -103461,8 +104355,8 @@ oWN
 xXU
 tZU
 egm
-lHq
-ykY
+oFh
+uRh
 wJu
 deg
 qOB
@@ -103697,7 +104591,7 @@ sPX
 hZP
 tjD
 lbi
-rQV
+tjD
 ehB
 eSK
 lQH
@@ -103716,10 +104610,10 @@ ycg
 pdG
 hTQ
 aFg
-aFg
+nfH
 tkH
-lHq
-ykY
+oFh
+uRh
 wJu
 rtf
 muJ
@@ -103975,18 +104869,18 @@ vXl
 iiw
 qiC
 egm
-lHq
-ykY
+oFh
+uRh
 wJu
 ttB
 qEr
 wRx
-iGY
+fpY
 lEW
-qOB
+gEi
 uOp
-qOB
-qOB
+gEi
+lpf
 ihF
 ihF
 ihF
@@ -104232,7 +105126,7 @@ vOK
 vOK
 vOK
 vOK
-lHq
+oFh
 tyd
 wJu
 idc
@@ -104466,7 +105360,7 @@ jjd
 mdk
 mdk
 mdk
-dIF
+atl
 ujX
 dbm
 ndK
@@ -104487,17 +105381,17 @@ oKi
 xNJ
 omb
 hlN
-rXy
-ykY
-jsI
-ykY
+jTp
+vmp
+oSn
+gyc
 tbg
-ykY
-ykY
+vmp
+vmp
 jFr
-ykY
+qtU
 fNJ
-rXy
+sIZ
 uaz
 gcB
 qrU
@@ -104723,7 +105617,7 @@ mdk
 jnA
 qAY
 duo
-dIF
+bja
 mng
 dbm
 muq
@@ -104738,21 +105632,21 @@ ccz
 ykv
 wZO
 ags
-jsI
-psk
+xXk
+uYr
 nDP
-lHq
-lHq
-lHq
-jsI
+xqT
+xqT
+xqT
+opt
 hRW
-lHq
-lHq
-lHq
-lHq
+aQv
+aQv
+aQv
+aQv
 aUU
 dDp
-jsI
+lHL
 fNJ
 tOl
 uaz
@@ -104996,11 +105890,11 @@ wLh
 xFH
 yaq
 rXy
-urd
+wCc
 lHq
 bpn
-rXy
-rXy
+xzB
+xzB
 lOs
 mhn
 mhn
@@ -105011,7 +105905,7 @@ mhn
 mhn
 kTf
 fNJ
-rXy
+sIZ
 oqz
 kFY
 cUe
@@ -105253,7 +106147,7 @@ uRk
 rZz
 rZz
 riO
-urd
+wCc
 tGv
 djl
 ydb
@@ -105261,9 +106155,9 @@ ydb
 rvE
 mhn
 tqs
+pjC
 mEF
-mEF
-mEF
+oPS
 eZZ
 mhn
 ykY
@@ -105509,23 +106403,23 @@ vMH
 yaM
 rwc
 rZz
-ane
-urd
+rXy
+wCc
 kYN
 qcJ
 oDZ
 tlE
 bAn
 uxN
-mEF
-mEF
+mwm
+pjC
 mEF
 rbr
 jUP
 uxN
 ykY
 vrG
-rXy
+sIZ
 oqz
 jdu
 etQ
@@ -105767,22 +106661,22 @@ opE
 fBs
 uRk
 rXy
-urd
+wCc
 rmc
 eTq
-atl
-atl
+ybQ
+ybQ
 tlI
 mhn
+mwm
+pjC
 mEF
-mEF
-mEF
-mEF
-mEF
+syb
+jps
 uxN
 ykY
 fNJ
-rXy
+sIZ
 iVJ
 qrU
 oNI
@@ -106024,22 +106918,22 @@ lAW
 bmk
 aAq
 rXy
-psk
-rXy
+ezN
+iGY
 hey
-rXy
-rXy
+qhd
+qhd
 ych
 mhn
 wTX
-mEF
+eQL
 srj
 jCv
 tTz
 viM
-ykY
+xdd
 fNJ
-rXy
+sIZ
 nPY
 gcB
 iyv
@@ -106284,7 +107178,7 @@ rXy
 kna
 lFw
 cXM
-lFw
+jcy
 xgs
 mmE
 bzD
@@ -106294,9 +107188,9 @@ rbk
 oot
 xDS
 aXc
-thQ
-brb
-rXy
+nSF
+lVR
+sIZ
 xaG
 xaG
 xaG
@@ -106539,19 +107433,19 @@ ndu
 ndu
 rXy
 urd
-rXy
+rQV
 tQz
 eEN
 kEU
 tQz
 mhn
 mHg
-mEF
+fiT
 tdW
 lgz
 mEF
 viM
-ykY
+hQZ
 uTT
 pis
 pXI
@@ -106802,13 +107696,13 @@ uyD
 osE
 mOg
 mhn
-atB
-mEF
+tJO
+poI
 sgo
 lgz
 rld
 mhn
-ykY
+ips
 brb
 qXX
 xBU
@@ -107037,7 +107931,7 @@ grD
 nHc
 rvY
 ygs
-ygs
+eSK
 lQH
 ygs
 ygs
@@ -107065,7 +107959,7 @@ jqn
 auJ
 sIQ
 mhn
-ykY
+ips
 brb
 dGh
 xBU
@@ -107295,7 +108189,7 @@ grD
 rQz
 isa
 lQH
-qcC
+ycg
 jRM
 ndr
 ycg
@@ -107306,10 +108200,10 @@ ycg
 ycg
 pGr
 iiW
-mrk
-tQz
+pGr
+dyU
 rXy
-urd
+fKY
 vtH
 rtJ
 laH
@@ -107318,13 +108212,13 @@ gdX
 oOD
 wKX
 meO
-aPe
+gAQ
 wwY
 hmE
 oOD
 iJh
 gUm
-jsI
+rrP
 uIb
 rdy
 ewI
@@ -107551,8 +108445,8 @@ dKp
 nHc
 rvY
 ygs
-ttg
-qcC
+eSK
+ycg
 ycg
 ycg
 ycg
@@ -107561,12 +108455,12 @@ ycg
 nvA
 nvA
 lKY
-mrk
+pGr
 iiW
 cwx
-tQz
+dyU
 mDN
-urd
+fKY
 vtH
 nBJ
 pOF
@@ -107579,9 +108473,9 @@ jrh
 wwY
 oqS
 haw
-ykY
+ips
 sWZ
-rXy
+qse
 upW
 oGR
 vrV
@@ -107818,9 +108712,9 @@ qcC
 wZh
 frd
 lik
-xzB
-xzB
-xzB
+vrV
+vrV
+vrV
 tGS
 rXy
 ufi
@@ -107832,13 +108726,13 @@ jLF
 oOD
 qYr
 meO
-aPe
+gAQ
 wwY
 gHL
 haw
-jsI
-fNJ
-rXy
+xXk
+jGz
+qse
 upW
 ddv
 dVd
@@ -108075,10 +108969,10 @@ ycg
 sGl
 lKW
 lKY
-xzB
-xzB
+vrV
+vrV
 eFB
-tQz
+dyU
 rXy
 psk
 tQz
@@ -108094,7 +108988,7 @@ haw
 oOD
 oOD
 iJh
-psk
+gLv
 ubF
 upW
 aok
@@ -108335,7 +109229,7 @@ ycg
 obq
 agF
 nlD
-tQz
+dyU
 cbH
 slT
 rcT
@@ -108352,11 +109246,11 @@ aqv
 ymc
 ncF
 aNn
-rXy
+waw
 upW
 uYA
 vrV
-wWU
+aGl
 vrV
 cBc
 xaG
@@ -108591,30 +109485,30 @@ ygs
 ycg
 ycg
 ycg
-tQz
-tQz
-rXy
-ykY
+dyU
+dyU
+dzN
+wNj
 thQ
-ykY
+wNj
 gYX
-jFr
+fLg
 jum
-psk
+dsW
 wFB
-ykY
-ykY
-psk
-rXy
-cov
-rXy
+wNj
+wNj
+bJM
+xzB
+fnA
+xzB
 clV
 bRO
 upW
 wyW
 vrV
-wWU
-vrV
+aGl
+jqB
 nxI
 xaG
 hpm
@@ -109109,12 +110003,12 @@ xuZ
 kSE
 hTZ
 fkW
-qoR
-npr
+uuB
+aWT
 dLu
 hTZ
 mzj
-psk
+gpw
 mIp
 aQA
 pak
@@ -109371,7 +110265,7 @@ giA
 xha
 hTZ
 oaa
-psk
+gpw
 ouL
 mHf
 qHl
@@ -109628,7 +110522,7 @@ npr
 vZA
 hTZ
 xOV
-psk
+gpw
 ouL
 mzC
 djb
@@ -109885,7 +110779,7 @@ yee
 jnY
 hTZ
 wCg
-psk
+wnS
 ouL
 rJm
 wmv
@@ -109894,7 +110788,7 @@ dun
 uOx
 ouL
 rVZ
-jsI
+rrP
 iQK
 atf
 ecY
@@ -110142,7 +111036,7 @@ sxz
 etK
 hTZ
 qlG
-psk
+ooo
 mIp
 frE
 emF
@@ -110151,7 +111045,7 @@ hNu
 iyT
 mIp
 rXy
-ykY
+uRh
 sPM
 jQv
 mDf
@@ -110379,7 +111273,7 @@ pXQ
 sPX
 sPX
 dzw
-vzb
+pXQ
 pXQ
 pXQ
 pXQ
@@ -112977,8 +113871,8 @@ wpj
 wpj
 qof
 wpj
-qof
-juz
+fHF
+wpj
 xBU
 bTC
 eqG
@@ -113234,7 +114128,7 @@ jWk
 pBD
 juz
 juz
-wpj
+vyw
 juz
 xBU
 xBU
@@ -113750,7 +114644,7 @@ wpj
 xBU
 ssi
 juz
-wpj
+juz
 juz
 qof
 juz
@@ -114006,8 +114900,8 @@ tFv
 wpj
 xBU
 wpj
-juz
-juz
+wpj
+xBU
 xBU
 xBU
 nqz

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -10025,6 +10025,11 @@
 	c_tag = "Medical - Psychology";
 	network = list("ss13","medbay")
 	},
+/obj/machinery/button/door/directional/east{
+	req_access = list("psychology");
+	id = "psych_shutters";
+	name = "Shutter Control"
+	},
 /turf/open/floor/carpet/purple,
 /area/station/medical/psychology)
 "dFF" = (
@@ -31231,12 +31236,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "lvf" = (
-/obj/machinery/button/door/directional/south{
-	id = "psych_shutters";
-	name = "Shutter Control";
-	pixel_x = -4;
-	req_access = list("psychology")
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1983,15 +1983,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"aJM" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "aKf" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Xenobiology Maintenance"
@@ -3641,7 +3632,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/spawner/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -4626,12 +4616,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
-"bGd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/cryo)
 "bGi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -4690,12 +4674,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
-"bHl" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "bHm" = (
 /obj/machinery/light/broken/directional/east,
 /turf/open/floor/iron,
@@ -5212,6 +5190,15 @@
 /obj/structure/stone_tile/slab,
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
+"bQn" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "bQB" = (
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/security/half{
@@ -6713,6 +6700,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"ctt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "ctx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7308,12 +7304,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"cDL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "cDO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
@@ -8017,18 +8007,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
-"cSG" = (
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line,
-/turf/open/floor/iron/white/textured_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "cSI" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/iron/dark/smooth_large,
@@ -8094,9 +8072,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/primary/port)
 "cTF" = (
-/obj/vehicle/ridden/wheelchair{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/coldroom)
 "cTO" = (
@@ -8344,6 +8323,15 @@
 /obj/effect/decal/cleanable/glitter,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"cXC" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "cXG" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
@@ -9798,6 +9786,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"dAz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "dAC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -9907,6 +9900,10 @@
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
+"dDQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "dDY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -9990,6 +9987,22 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/ordnance/storage)
+"dFi" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
+"dFt" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "dFu" = (
 /obj/machinery/pdapainter/supply,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -10150,10 +10163,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
-"dHN" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "dHU" = (
 /obj/structure/window/reinforced/spawner/directional/east{
 	layer = 2.9
@@ -10890,6 +10899,12 @@
 /obj/effect/landmark/start/captain,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain)
+"dVE" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/medbay/central)
 "dVH" = (
 /obj/machinery/door/airlock/command{
 	name = "Quartermaster's Office"
@@ -11342,6 +11357,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"eek" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "eev" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -12719,14 +12740,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"eFp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "eFB" = (
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/coldroom)
 "eFG" = (
@@ -12873,15 +12890,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"eIK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "eIM" = (
 /mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/carpet/neon/simple/black/nodots,
@@ -12898,6 +12906,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"eJs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/cryo)
 "eJI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -13698,6 +13712,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science)
+"eXY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/medbay)
 "eYc" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -15200,12 +15223,6 @@
 /obj/structure/sign/warning/vacuum/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
-"fyD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "fzk" = (
 /obj/structure/sign/departments/xenobio/directional/south,
 /turf/open/floor/iron/white,
@@ -15839,6 +15856,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fKY" = (
+/obj/vehicle/ridden/wheelchair{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/coldroom)
 "fLg" = (
@@ -17059,18 +17079,6 @@
 	dir = 8
 	},
 /area/station/tcommsat/computer)
-"giZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "gju" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/armory/laser_gun,
@@ -17731,12 +17739,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"gxW" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_edge,
-/area/station/medical/medbay)
 "gyc" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -17897,16 +17899,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"gBA" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "gBC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20355,14 +20347,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
-"hxP" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "hxX" = (
 /obj/machinery/door/airlock{
 	name = "Art Storage Room"
@@ -20797,12 +20781,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"hIv" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/medbay/central)
 "hIw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21073,12 +21051,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
-"hMR" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "hMT" = (
 /obj/structure/mineral_door/paperframe,
 /turf/open/floor/wood,
@@ -21419,12 +21391,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
-"hSn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "hSG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -23454,10 +23420,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "iGY" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/coldroom)
 "iHd" = (
@@ -24806,6 +24769,18 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/solars)
+"jfX" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "jfZ" = (
 /obj/machinery/computer/records/security,
 /obj/effect/turf_decal/tile/security/half{
@@ -25009,6 +24984,12 @@
 "jlh" = (
 /turf/open/floor/carpet/neon/simple/black/nodots,
 /area/station/service/cafeteria)
+"jlm" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/medical/medbay)
 "jlr" = (
 /obj/effect/turf_decal/tile/security/anticorner{
 	dir = 4
@@ -25259,6 +25240,15 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"joX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "jpa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4{
 	dir = 4
@@ -28064,6 +28054,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"kmX" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "kmZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28333,6 +28332,16 @@
 /obj/effect/turf_decal/tile/security/half,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"kqD" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "kqR" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/tile/engineering/half{
@@ -28467,6 +28476,14 @@
 	dir = 1
 	},
 /area/station/engineering/hallway)
+"ktc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/cryo)
 "kts" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -29698,14 +29715,6 @@
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/glass/reinforced,
 /area/station/service/cafeteria)
-"kPx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/cryo)
 "kPy" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -32337,6 +32346,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"lOh" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "lOs" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
@@ -34420,6 +34437,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"muN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "muO" = (
 /obj/structure/cable,
 /obj/structure/sign/nanotrasen{
@@ -36064,6 +36087,14 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain)
+"naP" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "nbj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36104,7 +36135,7 @@
 /turf/open/floor/iron/white,
 /area/station/science)
 "nbZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/coldroom)
 "ncc" = (
@@ -36757,6 +36788,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/research)
+"noO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "noY" = (
 /obj/structure/girder,
 /turf/open/floor/iron,
@@ -40760,6 +40804,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/security/courtroom)
+"oPr" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "oPu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
@@ -41179,15 +41229,6 @@
 "oYJ" = (
 /turf/closed/wall,
 /area/station/science/genetics)
-"oYU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "oYY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43190,15 +43231,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
-"pKH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/medbay)
 "pKQ" = (
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
@@ -43627,16 +43659,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"pTr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "pTt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -43905,6 +43927,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"pYf" = (
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "pYu" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -45055,15 +45089,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
-"qtZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "quh" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -46195,9 +46220,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qSZ" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/coldroom)
 "qTa" = (
 /mob/living/simple_animal/bot/secbot/beepsky/officer,
 /turf/open/floor/plating,
@@ -46415,6 +46443,16 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"qXt" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "qXz" = (
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -48098,16 +48136,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"rEB" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "rEP" = (
 /obj/effect/turf_decal/tile/medical{
 	dir = 4
@@ -48379,15 +48407,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
-"rJg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "rJm" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/structure/cable,
@@ -48760,7 +48779,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "rQV" = (
-/turf/closed/wall,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/station/medical/coldroom)
 "rRr" = (
 /obj/structure/tank_holder/extinguisher,
@@ -48925,19 +48947,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
-"rUM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "rUO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49248,8 +49257,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "rZZ" = (
-/turf/open/space/basic,
-/area/station/medical/virology)
+/turf/closed/wall,
+/area/station/medical/coldroom)
 "sab" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/wrench,
@@ -52868,9 +52877,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "tsl" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "tsq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53212,13 +53226,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
-"tyc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "tyd" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/south{
@@ -53504,11 +53511,6 @@
 /obj/effect/spawner/random/clothing/gloves,
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
-"tDG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "tDH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -53672,6 +53674,8 @@
 	name = "Medbay Storage"
 	},
 /obj/effect/turf_decal/tile/medical/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/coldroom)
 "tHl" = (
@@ -54339,6 +54343,13 @@
 /obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"tVv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "tVw" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -54877,6 +54888,12 @@
 /obj/effect/turf_decal/tile/dark,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"uej" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "uep" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -56933,6 +56950,11 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"uSY" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "uTa" = (
 /obj/effect/decal/cleanable/greenglow/filled,
 /turf/open/floor/engine,
@@ -57015,6 +57037,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"uUn" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "uUs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
 	dir = 4
@@ -59476,10 +59504,12 @@
 	},
 /area/station/tcommsat/computer)
 "vST" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "vSV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -60480,12 +60510,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
-"woj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "wom" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61195,15 +61219,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"wBe" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "wBH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/engineering{
@@ -61964,13 +61979,6 @@
 /obj/structure/sign/warning/vacuum/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
-"wPu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "wPB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -105547,7 +105555,7 @@ tbg
 vmp
 vmp
 jFr
-hxP
+naP
 fNJ
 sIZ
 uaz
@@ -106051,8 +106059,8 @@ rXy
 wCc
 lHq
 bpn
-cDL
-cDL
+eek
+eek
 lOs
 mhn
 mhn
@@ -106313,7 +106321,7 @@ ydb
 rvE
 mhn
 tqs
-giZ
+jfX
 mEF
 oPS
 eZZ
@@ -106570,7 +106578,7 @@ tlE
 bAn
 uxN
 mwm
-giZ
+jfX
 mEF
 rbr
 jUP
@@ -106822,14 +106830,14 @@ rXy
 wCc
 rmc
 eTq
-gxW
-gxW
+jlm
+jlm
 tlI
 mhn
 mwm
-giZ
+jfX
 mEF
-wBe
+kmX
 jps
 uxN
 ykY
@@ -107075,21 +107083,21 @@ tVA
 lAW
 bmk
 aAq
-oYU
+tsl
 ezN
-bHl
+oPr
 hey
-hMR
-hMR
+uej
+uej
 ych
 mhn
 wTX
-aJM
+bQn
 srj
 jCv
 tTz
 viM
-pTr
+kqD
 fNJ
 sIZ
 nPY
@@ -107336,7 +107344,7 @@ rXy
 kna
 lFw
 cXM
-eIK
+ctt
 xgs
 mmE
 bzD
@@ -107347,7 +107355,7 @@ oot
 xDS
 aXc
 nSF
-pKH
+eXY
 sIZ
 xaG
 xaG
@@ -107591,19 +107599,19 @@ ndu
 ndu
 rXy
 urd
-fyD
+uUn
 tQz
 eEN
 kEU
 tQz
 mhn
 mHg
-qtZ
+cXC
 tdW
 lgz
 mEF
 viM
-rEB
+qXt
 uTT
 pis
 pXI
@@ -107846,7 +107854,7 @@ ttg
 ttg
 kqZ
 seR
-wPu
+vST
 psk
 tQz
 tQz
@@ -107854,13 +107862,13 @@ uyD
 osE
 mOg
 mhn
-hIv
-cSG
+dVE
+pYf
 sgo
 lgz
 rld
 mhn
-tyc
+tVv
 brb
 qXX
 xBU
@@ -108117,7 +108125,7 @@ jqn
 auJ
 sIQ
 mhn
-tyc
+tVv
 brb
 dGh
 xBU
@@ -108358,10 +108366,10 @@ ycg
 ycg
 pGr
 iiW
-iGY
-rQV
+qSZ
+rZZ
 rXy
-gBA
+dFi
 vtH
 rtJ
 laH
@@ -108370,7 +108378,7 @@ gdX
 oOD
 wKX
 meO
-bGd
+eJs
 wwY
 hmE
 oOD
@@ -108614,11 +108622,11 @@ nvA
 nvA
 lKY
 mrk
-cTF
+fKY
 cwx
-rQV
+rZZ
 mDN
-gBA
+dFi
 vtH
 nBJ
 pOF
@@ -108631,9 +108639,9 @@ jrh
 htl
 oqS
 haw
-tyc
+tVv
 sWZ
-dHN
+dDQ
 upW
 oGR
 vrV
@@ -108871,10 +108879,10 @@ wZh
 frd
 lik
 xzB
-fKY
-nbZ
+iGY
+rQV
 tGS
-rXy
+lOh
 ufi
 vtH
 dQB
@@ -108884,13 +108892,13 @@ jLF
 oOD
 qYr
 meO
-kPx
+ktc
 htl
 gHL
 haw
 xXk
-rJg
-dHN
+joX
+dDQ
 upW
 ddv
 dVd
@@ -109127,10 +109135,10 @@ ycg
 sGl
 lKW
 lKY
-xzB
-fKY
+cTF
+nbZ
 eFB
-rQV
+rZZ
 rXy
 psk
 tQz
@@ -109387,7 +109395,7 @@ ycg
 obq
 agF
 nlD
-rQV
+rZZ
 cbH
 slT
 rcT
@@ -109404,11 +109412,11 @@ aqv
 ymc
 ncF
 aNn
-eFp
+uSY
 upW
 uYA
 vrV
-tDG
+dAz
 vrV
 cBc
 xaG
@@ -109643,9 +109651,9 @@ ygs
 ycg
 ycg
 ycg
-rQV
-rQV
-hSn
+rZZ
+rZZ
+dFt
 wNj
 thQ
 wNj
@@ -109657,16 +109665,16 @@ wFB
 wNj
 wNj
 bJM
-cDL
+eek
 fnA
-cDL
+eek
 clV
 bRO
 upW
 wyW
 vrV
-tDG
-woj
+dAz
+muN
 nxI
 xaG
 hpm
@@ -110937,7 +110945,7 @@ yee
 jnY
 hTZ
 wCg
-rUM
+noO
 ouL
 rJm
 wmv
@@ -115043,9 +115051,9 @@ iQW
 iQW
 iQW
 iQW
-vmD
-sUS
-rZZ
+iQW
+iQW
+iQW
 nit
 rUY
 nHf
@@ -115298,18 +115306,18 @@ yju
 yju
 yju
 bfi
-sUS
-yju
-xBY
 iQW
-rZZ
+iQW
+iQW
+iQW
+iQW
 nit
 nlm
 aVP
 kEM
 nit
 yju
-adS
+yju
 xBU
 oGG
 oGG
@@ -115556,8 +115564,8 @@ iQW
 yju
 iQW
 iQW
-yju
-xBY
+iQW
+vmD
 yju
 nit
 nit
@@ -115566,7 +115574,7 @@ urF
 nit
 nit
 nit
-adS
+yju
 xBU
 xBU
 xBU
@@ -115812,8 +115820,8 @@ iQW
 iQW
 xBY
 iQW
-xBY
-xBY
+iQW
+yju
 xBY
 iQW
 nit
@@ -116069,10 +116077,10 @@ yju
 yju
 xBY
 yju
-sUS
-rZZ
-rZZ
-rZZ
+iQW
+yju
+xBY
+iQW
 nit
 qVt
 gqz
@@ -116080,8 +116088,8 @@ bVe
 cub
 sJt
 nit
-sUS
-sUS
+iQW
+iQW
 yju
 iQW
 iQW
@@ -116326,10 +116334,10 @@ iQW
 iQW
 xBY
 iQW
+xBY
+xBY
+xBY
 iQW
-rZZ
-rZZ
-rZZ
 fiV
 fOh
 ygZ
@@ -116337,8 +116345,8 @@ vEF
 sFw
 hHz
 nit
-sUS
-sUS
+iQW
+iQW
 yju
 iQW
 iQW
@@ -116599,7 +116607,7 @@ nit
 nit
 iQW
 iQW
-sUS
+iQW
 iQW
 xBU
 iQW
@@ -117111,11 +117119,11 @@ rdg
 rdg
 ubw
 fiV
-sUS
-sUS
+iQW
+iQW
 xBY
-sUS
-sUS
+iQW
+iQW
 iQW
 iQW
 iQW
@@ -117371,7 +117379,7 @@ fiV
 iQW
 iQW
 xBY
-adS
+iQW
 yju
 iQW
 iQW
@@ -117625,10 +117633,10 @@ qhP
 gTn
 nHl
 nit
-adS
-adS
+yju
+yju
 xBY
-sUS
+iQW
 bfi
 iQW
 iQW
@@ -117868,7 +117876,7 @@ bfi
 iQW
 xBY
 yju
-sUS
+iQW
 nit
 cWk
 cWk
@@ -117885,7 +117893,7 @@ nit
 iQW
 iQW
 xBY
-adS
+yju
 xBY
 iQW
 iQW
@@ -118382,7 +118390,7 @@ bfi
 yju
 xBY
 iQW
-adS
+yju
 nit
 xzG
 aGz
@@ -118399,7 +118407,7 @@ nit
 iQW
 iQW
 yju
-sUS
+iQW
 xBY
 iQW
 iQW
@@ -118656,7 +118664,7 @@ nit
 iQW
 iQW
 bfi
-adS
+yju
 xBY
 iQW
 iQW
@@ -118910,11 +118918,11 @@ nit
 iQW
 sUS
 yju
-sUS
-sUS
+iQW
+iQW
 xBY
 iQW
-tsl
+vmD
 iQW
 iQW
 iQW
@@ -119166,8 +119174,8 @@ nit
 nit
 iQW
 iQW
-adS
-sUS
+yju
+iQW
 iQW
 xBY
 iQW
@@ -119422,11 +119430,11 @@ fiV
 nit
 iQW
 iQW
-tsl
-qSZ
+vmD
 xBY
-qSZ
-adS
+xBY
+xBY
+yju
 iQW
 iQW
 iQW
@@ -119669,18 +119677,18 @@ iQW
 iQW
 iQW
 xBY
-sUS
-sUS
-sUS
+iQW
+iQW
+iQW
 yju
 sUS
 uEl
 ubx
 yju
-sUS
-sUS
-sUS
-sUS
+iQW
+iQW
+iQW
+iQW
 yju
 iQW
 iQW
@@ -119924,12 +119932,12 @@ iQW
 iQW
 iQW
 iQW
-adS
+yju
 xBY
 iQW
 iQW
-sUS
-adS
+iQW
+yju
 sUS
 iQW
 iQW
@@ -120181,12 +120189,12 @@ iQW
 iQW
 iQW
 iQW
-sUS
+iQW
 bfi
 yju
 bfi
 xBY
-qSZ
+xBY
 bfi
 iQW
 iQW
@@ -120439,15 +120447,15 @@ iQW
 iQW
 iQW
 iQW
-adS
-sUS
-iQW
-adS
-iQW
-adS
+yju
 iQW
 iQW
-adS
+yju
+iQW
+yju
+iQW
+iQW
+yju
 iQW
 iQW
 iQW
@@ -120695,21 +120703,21 @@ iQW
 iQW
 iQW
 iQW
-tsl
-qSZ
+vmD
 xBY
-qSZ
-vST
+xBY
+xBY
+bfi
 iQW
-vST
+bfi
 iQW
 iQW
-qSZ
-qSZ
-vST
-adS
-adS
-qSZ
+xBY
+xBY
+bfi
+yju
+yju
+xBY
 iQW
 iQW
 iQW
@@ -120954,7 +120962,7 @@ iQW
 iQW
 iQW
 iQW
-adS
+yju
 iQW
 iQW
 iQW
@@ -120966,7 +120974,7 @@ iQW
 iQW
 iQW
 iQW
-tsl
+vmD
 iQW
 iQW
 iQW
@@ -121211,7 +121219,7 @@ iQW
 iQW
 iQW
 iQW
-adS
+yju
 iQW
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1173,6 +1173,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"atV" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "auf" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/structure/cable,
@@ -5190,15 +5199,6 @@
 /obj/structure/stone_tile/slab,
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
-"bQn" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "bQB" = (
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/security/half{
@@ -5941,6 +5941,15 @@
 "ceY" = (
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"cfa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "cfr" = (
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
@@ -6281,6 +6290,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"cmv" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "cmy" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/central)
@@ -6305,6 +6323,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
+"cmR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "cnd" = (
 /obj/effect/turf_decal/tile/command/half{
 	dir = 8
@@ -6700,15 +6727,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"ctt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "ctx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8323,15 +8341,6 @@
 /obj/effect/decal/cleanable/glitter,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"cXC" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "cXG" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
@@ -8763,6 +8772,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"dfb" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/medbay/central)
 "dfi" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -9786,11 +9801,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"dAz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "dAC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -9900,10 +9910,6 @@
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
-"dDQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "dDY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -9987,22 +9993,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/ordnance/storage)
-"dFi" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
-"dFt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "dFu" = (
 /obj/machinery/pdapainter/supply,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -10899,12 +10889,6 @@
 /obj/effect/landmark/start/captain,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain)
-"dVE" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/medbay/central)
 "dVH" = (
 /obj/machinery/door/airlock/command{
 	name = "Quartermaster's Office"
@@ -11357,12 +11341,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"eek" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "eev" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -12906,12 +12884,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"eJs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/cryo)
 "eJI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -13173,6 +13145,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"eNU" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "eOh" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -13285,6 +13261,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
+"eQF" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "eQG" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
@@ -13712,15 +13695,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science)
-"eXY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/medbay)
 "eYc" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -14791,6 +14765,12 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"fqV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "frd" = (
 /turf/open/floor/iron/freezer,
 /area/station/medical/coldroom)
@@ -17589,6 +17569,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"gvE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/medbay)
 "gvX" = (
 /obj/machinery/atmospherics/components/tank/carbon_dioxide,
 /turf/open/floor/plating,
@@ -19262,6 +19251,11 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/cryo)
+"haI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "haO" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/enzyme,
@@ -20425,6 +20419,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"hAg" = (
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "hAm" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/apron,
@@ -23322,6 +23328,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"iEv" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "iEC" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/prisoner,
@@ -24769,18 +24787,6 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/solars)
-"jfX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "jfZ" = (
 /obj/machinery/computer/records/security,
 /obj/effect/turf_decal/tile/security/half{
@@ -24984,12 +24990,6 @@
 "jlh" = (
 /turf/open/floor/carpet/neon/simple/black/nodots,
 /area/station/service/cafeteria)
-"jlm" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_edge,
-/area/station/medical/medbay)
 "jlr" = (
 /obj/effect/turf_decal/tile/security/anticorner{
 	dir = 4
@@ -25017,6 +25017,12 @@
 /obj/effect/turf_decal/tile/security/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"jlI" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "jlM" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -25240,15 +25246,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
-"joX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "jpa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4{
 	dir = 4
@@ -28054,15 +28051,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"kmX" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "kmZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28332,16 +28320,6 @@
 /obj/effect/turf_decal/tile/security/half,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"kqD" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "kqR" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/tile/engineering/half{
@@ -28476,14 +28454,6 @@
 	dir = 1
 	},
 /area/station/engineering/hallway)
-"ktc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/cryo)
 "kts" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -28687,6 +28657,12 @@
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"kxx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/cryo)
 "kxI" = (
 /obj/machinery/air_sensor/incinerator_tank,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
@@ -30241,6 +30217,14 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
+"lby" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "lbH" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -32346,14 +32330,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
-"lOh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "lOs" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
@@ -32930,6 +32906,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/cargo/miningfoundry)
+"lXR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "lXS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pillow,
@@ -34437,12 +34426,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"muN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "muO" = (
 /obj/structure/cable,
 /obj/structure/sign/nanotrasen{
@@ -36087,14 +36070,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain)
-"naP" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "nbj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36788,19 +36763,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/research)
-"noO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "noY" = (
 /obj/structure/girder,
 /turf/open/floor/iron,
@@ -40804,12 +40766,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/security/courtroom)
-"oPr" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "oPu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
@@ -43927,18 +43883,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"pYf" = (
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line,
-/turf/open/floor/iron/white/textured_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "pYu" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -44190,6 +44134,8 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
+/obj/item/fishing_hook/rescue,
+/obj/item/fishing_rod,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
@@ -46443,16 +46389,6 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"qXt" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "qXz" = (
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -46717,6 +46653,12 @@
 "rbM" = (
 /turf/closed/wall,
 /area/station/engineering/storage/tech)
+"rbO" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/medical/medbay)
 "rbS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50861,6 +50803,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"sDl" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "sDo" = (
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
@@ -52670,6 +52618,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
+"toI" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "toP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -53313,6 +53270,16 @@
 /obj/machinery/light/small/dim/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
+"tzq" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "tzv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/security/half{
@@ -53567,6 +53534,16 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/security/processing)
+"tEE" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "tEO" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -54343,13 +54320,6 @@
 /obj/effect/turf_decal/tile/medical/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"tVv" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "tVw" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -54551,6 +54521,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"tYo" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "tYG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -54888,12 +54864,6 @@
 /obj/effect/turf_decal/tile/dark,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
-"uej" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "uep" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -55535,6 +55505,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/ordnance/storage)
+"urb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "urd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -56276,6 +56256,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"uGN" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "uGO" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/laceup,
@@ -56950,11 +56935,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"uSY" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "uTa" = (
 /obj/effect/decal/cleanable/greenglow/filled,
 /turf/open/floor/engine,
@@ -57037,12 +57017,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"uUn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "uUs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
 	dir = 4
@@ -58083,6 +58057,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"vpm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "vpA" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -60573,6 +60555,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"wpf" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "wpj" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
@@ -64029,6 +64017,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"xyj" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "xyq" = (
 /obj/effect/turf_decal/lunar_sand/plating,
 /turf/open/floor/plating,
@@ -65133,6 +65127,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"xVt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/cryo)
 "xVE" = (
 /obj/structure/cable,
 /obj/structure/sign/nanotrasen{
@@ -105555,7 +105557,7 @@ tbg
 vmp
 vmp
 jFr
-naP
+lby
 fNJ
 sIZ
 uaz
@@ -106059,8 +106061,8 @@ rXy
 wCc
 lHq
 bpn
-eek
-eek
+wpf
+wpf
 lOs
 mhn
 mhn
@@ -106321,7 +106323,7 @@ ydb
 rvE
 mhn
 tqs
-jfX
+iEv
 mEF
 oPS
 eZZ
@@ -106578,7 +106580,7 @@ tlE
 bAn
 uxN
 mwm
-jfX
+iEv
 mEF
 rbr
 jUP
@@ -106830,14 +106832,14 @@ rXy
 wCc
 rmc
 eTq
-jlm
-jlm
+rbO
+rbO
 tlI
 mhn
 mwm
-jfX
+iEv
 mEF
-kmX
+toI
 jps
 uxN
 ykY
@@ -107085,19 +107087,19 @@ bmk
 aAq
 tsl
 ezN
-oPr
+xyj
 hey
-uej
-uej
+tYo
+tYo
 ych
 mhn
 wTX
-bQn
+atV
 srj
 jCv
 tTz
 viM
-kqD
+urb
 fNJ
 sIZ
 nPY
@@ -107344,7 +107346,7 @@ rXy
 kna
 lFw
 cXM
-ctt
+cfa
 xgs
 mmE
 bzD
@@ -107355,7 +107357,7 @@ oot
 xDS
 aXc
 nSF
-eXY
+gvE
 sIZ
 xaG
 xaG
@@ -107599,19 +107601,19 @@ ndu
 ndu
 rXy
 urd
-uUn
+sDl
 tQz
 eEN
 kEU
 tQz
 mhn
 mHg
-cXC
+cmv
 tdW
 lgz
 mEF
 viM
-qXt
+tEE
 uTT
 pis
 pXI
@@ -107862,13 +107864,13 @@ uyD
 osE
 mOg
 mhn
-dVE
-pYf
+dfb
+hAg
 sgo
 lgz
 rld
 mhn
-tVv
+eQF
 brb
 qXX
 xBU
@@ -108125,7 +108127,7 @@ jqn
 auJ
 sIQ
 mhn
-tVv
+eQF
 brb
 dGh
 xBU
@@ -108369,7 +108371,7 @@ iiW
 qSZ
 rZZ
 rXy
-dFi
+tzq
 vtH
 rtJ
 laH
@@ -108378,7 +108380,7 @@ gdX
 oOD
 wKX
 meO
-eJs
+kxx
 wwY
 hmE
 oOD
@@ -108626,7 +108628,7 @@ fKY
 cwx
 rZZ
 mDN
-dFi
+tzq
 vtH
 nBJ
 pOF
@@ -108639,9 +108641,9 @@ jrh
 htl
 oqS
 haw
-tVv
+eQF
 sWZ
-dDQ
+eNU
 upW
 oGR
 vrV
@@ -108882,7 +108884,7 @@ xzB
 iGY
 rQV
 tGS
-lOh
+vpm
 ufi
 vtH
 dQB
@@ -108892,13 +108894,13 @@ jLF
 oOD
 qYr
 meO
-ktc
+xVt
 htl
 gHL
 haw
 xXk
-joX
-dDQ
+cmR
+eNU
 upW
 ddv
 dVd
@@ -109412,11 +109414,11 @@ aqv
 ymc
 ncF
 aNn
-uSY
+uGN
 upW
 uYA
 vrV
-dAz
+haI
 vrV
 cBc
 xaG
@@ -109653,7 +109655,7 @@ ycg
 ycg
 rZZ
 rZZ
-dFt
+jlI
 wNj
 thQ
 wNj
@@ -109665,16 +109667,16 @@ wFB
 wNj
 wNj
 bJM
-eek
+wpf
 fnA
-eek
+wpf
 clV
 bRO
 upW
 wyW
 vrV
-dAz
-muN
+haI
+fqV
 nxI
 xaG
 hpm
@@ -110945,7 +110947,7 @@ yee
 jnY
 hTZ
 wCg
-noO
+lXR
 ouL
 rJm
 wmv


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks Selene's medbay. Here's what it looks like:
![image](https://github.com/fulpstation/fulpstation/assets/69338705/e6a886ff-c4e0-4abb-985b-0bcd310d3dd6)


Notable changes:

- Moves psych out of the corner and into an easily accessible part of medbay
- Adds a paramedic prep area
- Makes cryogenics less of a pain to set up
- Adds a storage room for cold storage, moves the corners of stuff into a less in-the-way area
- Adds a box of body bags for medical doctor use
- Embiggens medbay central
- Fixes access error in chapel

Here's botany: 
![image](https://github.com/fulpstation/fulpstation/assets/69338705/bc201690-71d2-49f8-a7f2-bdcd25481cd5)

It's pretty much just aesthetics

## Why It's Good For The Game

Mentors (shout out to @JohnFulpWillard and Max Willis) gave lots of good suggestions on how to improve medbay, and this PR implements them in a way that will (hopefully) improve playability on Selene. Having psych in a more centralized location and putting the extra equpiment in maints improves the psych's ability to interact with players in an RP-friendly way (e.g., not handcuffing crewmembers to their office chair because everyone is ignoring them).

## Changelog



:cl:

qol: Selene medbay rework


/:cl:


