### PR TITLE
Chaplain Office maint access fix

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -45035,10 +45035,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "qzn" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Maintenance"
+/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
+/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "qzr" = (


### PR DESCRIPTION
## About The Pull Request

Fixes the maint door in chaplain office that anyone with maints could open to enter, but not to leave. Now only chaplain access can open it.

## Why It's Good For The Game

Cloeses https://github.com/fulpstation/fulpstation/issues/1150

## Changelog

:cl:
fix: Fixes the maint door in chaplain office
/:cl:
