### PR TITLE
Only Albino Gorillia has magic gorilla powers

### DIFF
--- a/fulp_modules/features/antagonists/infiltrators/albino_gorilla.dm
+++ b/fulp_modules/features/antagonists/infiltrators/albino_gorilla.dm
@@ -4,7 +4,7 @@
 	maxHealth = 170
 	health = 170
 
-/mob/living/basic/gorilla/Initialize(mapload)
+/mob/living/basic/gorilla/albino/Initialize(mapload)
 	var/datum/action/cooldown/mob_cooldown/charge/gorilla/tackle = new(src)
 	tackle.Grant(src)
 	var/datum/action/cooldown/spell/conjure/banana/trap = new(src)


### PR DESCRIPTION
## About The Pull Request

Only Albino Gorilla has magic gorilla powers NOW. All gorillas used to have these powers.

## Why It's Good For The Game

It was a bug
