### PR TITLE
removes helio's layer 1 cables in sm chamber

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -1313,7 +1313,7 @@
 	name = "Supermatter Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "agx" = (
@@ -9606,7 +9606,7 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "aXu" = (
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "aXz" = (
@@ -20058,10 +20058,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 9
 	},
-/obj/structure/cable/layer1,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored{
 	cable_layer = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "bYY" = (
@@ -21057,10 +21057,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 5
 	},
-/obj/structure/cable/layer1,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored{
 	cable_layer = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "cjk" = (
@@ -24726,7 +24726,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display/ai/directional/north,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cPe" = (
@@ -26943,7 +26943,6 @@
 	name = "Gas to Mix"
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dbH" = (
@@ -31297,10 +31296,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
 	},
-/obj/structure/cable/layer1,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored{
 	cable_layer = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "eSX" = (
@@ -32092,7 +32091,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored{
 	cable_layer = 1
 	},
@@ -32184,7 +32182,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
 	},
-/obj/structure/cable/layer1,
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored{
 	cable_layer = 1
 	},
@@ -33079,7 +33076,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fJU" = (
@@ -34733,7 +34730,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gsl" = (
@@ -35285,21 +35282,10 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/commons/toilet/auxiliary)
 "gEQ" = (
-/obj/structure/table/reinforced,
-/obj/item/crowbar,
-/obj/item/wirecutters,
-/obj/item/multitool{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/machinery/power/smes/engineering{
+	charge = 5e+006
 	},
-/obj/item/multitool{
-	pixel_x = 3;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/space/basic,
 /area/station/engineering/main)
 "gEV" = (
 /obj/structure/bed,
@@ -35430,7 +35416,7 @@
 "gHM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "gHS" = (
@@ -36406,7 +36392,6 @@
 "har" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
@@ -37651,14 +37636,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/ai)
 "hxp" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "hxq" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -39533,7 +39517,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ijT" = (
@@ -39847,7 +39831,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ipJ" = (
@@ -42196,21 +42180,21 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "jhZ" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/incident_display/delam/directional/north,
 /obj/structure/table/reinforced,
-/obj/item/t_scanner{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/item/t_scanner{
-	pixel_x = -5;
+/obj/item/crowbar,
+/obj/item/wirecutters,
+/obj/item/multitool{
+	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/item/electronics/apc{
-	pixel_y = -2
+/obj/item/multitool{
+	pixel_x = 3;
+	pixel_y = -1
 	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/machinery/incident_display/delam/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "jiy" = (
@@ -43939,14 +43923,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/power/terminal{
 	cable_layer = 1;
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jSl" = (
@@ -45409,7 +45392,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kuo" = (
@@ -45751,7 +45734,7 @@
 	name = "Mix to Gas"
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kAZ" = (
@@ -46493,7 +46476,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kPE" = (
@@ -47702,6 +47685,12 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"lrN" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "lrQ" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Lab"
@@ -49255,7 +49244,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display/evac/directional/north,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lXY" = (
@@ -51526,9 +51515,28 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "mTp" = (
-/obj/structure/cable/layer1,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/t_scanner{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/t_scanner{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/electronics/apc{
+	pixel_y = -2
+	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - SMES Room";
+	network = list("ss13","engineering")
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "mTs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -52888,6 +52896,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
+/obj/structure/sign/poster/official/safety_internals/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "nup" = (
@@ -53010,7 +53019,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/caution,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "nwM" = (
@@ -54830,7 +54839,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "ofU" = (
@@ -55200,7 +55209,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "omD" = (
@@ -55608,6 +55617,13 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
+"ovf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "ovj" = (
 /obj/structure/window/spawner/directional/north,
 /obj/effect/turf_decal/siding/wood{
@@ -55934,7 +55950,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oAS" = (
@@ -58911,12 +58926,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/terminal{
 	cable_layer = 1;
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pHo" = (
@@ -60243,7 +60257,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qjW" = (
@@ -60344,7 +60358,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qmj" = (
@@ -62617,7 +62631,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "reH" = (
@@ -63303,7 +63317,6 @@
 /area/station/command/bridge)
 "rqG" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/poster/official/safety_internals/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -63879,13 +63892,8 @@
 /area/station/security/checkpoint)
 "rAq" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering - SMES Room";
-	network = list("ss13","engineering")
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/evac/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/textured_half{
 	dir = 1
@@ -67954,7 +67962,7 @@
 "thn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "thy" = (
@@ -70587,7 +70595,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/science)
 "uiO" = (
-/obj/machinery/incident_display/delam/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/ce)
 "uje" = (
@@ -72471,7 +72478,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "uYI" = (
@@ -74884,6 +74891,7 @@
 	dir = 8
 	},
 /obj/machinery/light/dim/directional/west,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vUr" = (
@@ -75503,10 +75511,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored{
 	cable_layer = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "wgY" = (
@@ -75693,7 +75701,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "wlb" = (
@@ -78533,7 +78541,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
@@ -79420,7 +79427,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xIZ" = (
@@ -105925,9 +105932,9 @@ gtu
 dzt
 mer
 cEV
-cIq
 aXu
-cIq
+aXu
+aXu
 cEV
 kPC
 ukL
@@ -107199,7 +107206,7 @@ cNJ
 cNJ
 cNJ
 cNJ
-bXs
+mTp
 rAq
 mVl
 bXs
@@ -107467,9 +107474,9 @@ jlp
 xip
 ooW
 cEV
-cIq
 aXu
-cIq
+aXu
+aXu
 cEV
 wkU
 wdc
@@ -107714,7 +107721,7 @@ qVv
 ydu
 bXo
 gEQ
-hxp
+pHf
 rym
 guv
 bXs
@@ -107983,7 +107990,7 @@ brm
 rfa
 brm
 uYv
-brm
+hxp
 vUj
 fJM
 nBS
@@ -108233,16 +108240,16 @@ gHM
 thn
 agv
 ipI
-mTp
-mTp
-mTp
-mTp
+aIu
+aIu
+aIu
+aIu
 kAQ
-mTp
-mTp
-mTp
+aIu
+aIu
+czV
 dbB
-mTp
+czV
 ipP
 pqL
 tcu
@@ -108484,8 +108491,8 @@ cVm
 nmD
 bUW
 bXo
-uTo
-pHf
+lrN
+ovf
 psy
 wZH
 qmj

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -35282,10 +35282,12 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/commons/toilet/auxiliary)
 "gEQ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/power/smes/engineering{
 	charge = 5e+006
 	},
-/turf/open/space/basic,
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "gEV" = (
 /obj/structure/bed,
@@ -47686,10 +47688,16 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "lrN" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil{
+	pixel_y = 6
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "lrQ" = (
 /obj/machinery/door/airlock/research{
@@ -66068,13 +66076,6 @@
 /area/station/science/nanite)
 "sAc" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/cable_coil{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/stack/cable_coil{
-	pixel_y = 6
-	},
 /obj/item/storage/toolbox/electrical,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -43928,7 +43928,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/power/terminal{
-	cable_layer = 1;
 	dir = 1
 	},
 /obj/structure/cable,
@@ -58935,7 +58934,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/terminal{
-	cable_layer = 1;
 	dir = 1
 	},
 /obj/structure/cable,


### PR DESCRIPTION
## About The Pull Request

This is a good idea on paper but layered cables is pretty non functional right now. You can place cables down there as normal and it would overwrite the SMES and behaves VERY weirdly, so I think it's best to avoid this altogether. I moved things around so SMES cables don't have to go through walls but still, no more layer 1 cables in the SM chamber.

I also removed the floating sm delam counter in CE's office and fixed the floating poster in telecomms