### PR TITLE
Selene Engineering tweaks and atmos remaster

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -2623,13 +2623,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"aVE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Distro staging"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "aVI" = (
 /obj/effect/turf_decal/tile/engineering,
 /obj/structure/cable,
@@ -10794,6 +10787,16 @@
 	},
 /turf/open/floor/vault,
 /area/station/command/bridge)
+"dSJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 3
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dSO" = (
 /obj/structure/sign/warning/pods/directional/west,
 /turf/open/floor/plating,
@@ -12576,11 +12579,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
-"eAz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "eAA" = (
 /obj/structure/table_frame/wood,
 /obj/item/storage/cans/sixbeer,
@@ -33013,16 +33011,6 @@
 "lVL" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
-"lVW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 3
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lWb" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -37483,6 +37471,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/gravity_generator)
+"nwh" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Distro staging"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "nwj" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -38541,8 +38536,9 @@
 /area/station/medical/medbay)
 "nSH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 3
+	dir = 9
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nSI" = (
@@ -43671,13 +43667,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
-"pRB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 9
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pRH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51580,6 +51569,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"sNn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 3
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "sNL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark,
@@ -93364,7 +93359,7 @@ qZO
 aeg
 aeg
 kIt
-pRB
+nSH
 uFS
 nbx
 sqJ
@@ -93616,7 +93611,7 @@ uFS
 uFS
 ras
 ras
-aVE
+nwh
 iuQ
 xGw
 xGw
@@ -93878,7 +93873,7 @@ ofs
 ldo
 azt
 wJQ
-eAz
+azt
 aDL
 ojg
 pZa
@@ -94388,10 +94383,10 @@ uFS
 uFS
 uFS
 oTA
-lVW
-nSH
+dSJ
+sNn
 mXf
-nSH
+sNn
 tdz
 ola
 uFS

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -265,11 +265,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/rec)
 "aeg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aej" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -1101,6 +1100,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"ate" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "atf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1185,16 +1189,6 @@
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
-"aus" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "auA" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/flare/candle,
@@ -1484,12 +1478,6 @@
 /obj/effect/turf_decal/tile/prison/half,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"azh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "azi" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig"
@@ -1517,15 +1505,11 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "azt" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "azw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -1756,6 +1740,10 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plating,
 /area/station/construction)
+"aEj" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aEr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2117,6 +2105,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
+"aMG" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to distro";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aMH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/purple{
@@ -4219,8 +4214,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "byG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "byQ" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -6334,9 +6331,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
@@ -6633,9 +6627,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "crt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 1
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crI" = (
@@ -6718,8 +6713,11 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "csw" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "csR" = (
 /obj/machinery/vending/clothing,
@@ -7629,15 +7627,12 @@
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
 "cIi" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cIE" = (
 /obj/structure/railing{
 	dir = 1
@@ -8178,6 +8173,13 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"cUb" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "cUd" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -8830,6 +8832,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"deT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "dfb" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -9836,6 +9842,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"dAk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "dAo" = (
 /obj/structure/cable,
 /obj/machinery/navbeacon{
@@ -10008,7 +10021,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/space/basic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dEq" = (
 /obj/structure/chair{
@@ -10397,13 +10411,6 @@
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
 /turf/open/floor/iron,
 /area/station/security/processing)
-"dKc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "dKp" = (
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
@@ -10817,10 +10824,11 @@
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "dSJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 1
+/obj/effect/turf_decal/delivery,
+/obj/machinery/pipedispenser/disposal,
+/obj/effect/turf_decal/siding/engineering{
+	dir = 4
 	},
-/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dSO" = (
@@ -11998,6 +12006,7 @@
 "epH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "epU" = (
@@ -12367,12 +12376,6 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/entry)
-"ewr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ews" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -12422,11 +12425,6 @@
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
-"exm" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "exs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15367,14 +15365,6 @@
 /obj/effect/turf_decal/tile/science/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"fAu" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "fAN" = (
 /obj/machinery/door/window/right/directional/north{
 	name = "Containment Pen #6";
@@ -15947,11 +15937,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"fKX" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "fKY" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
@@ -17614,10 +17599,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "gtv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/tile/engineering/half{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gtz" = (
@@ -18396,11 +18381,6 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
-"gIN" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gIO" = (
 /obj/effect/decal/cleanable/robot_debris/old,
 /obj/structure/cable,
@@ -19185,6 +19165,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"gWU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gXa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 10
@@ -19336,8 +19325,10 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "gZV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gZY" = (
@@ -20116,6 +20107,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"hpe" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "hpm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20750,6 +20746,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"hDM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hDT" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -20905,6 +20907,10 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
+"hHi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hHz" = (
 /obj/machinery/light/directional/east,
 /obj/structure/reagent_dispensers/wall/virusfood/directional/south,
@@ -25306,6 +25312,10 @@
 /obj/item/emptysandbag,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"jnk" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jnm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/engineering/half{
@@ -25441,6 +25451,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"joV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jpa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4{
 	dir = 4
@@ -29906,6 +29921,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"kQF" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "kQV" = (
 /obj/effect/turf_decal/tile/command/half{
 	dir = 8
@@ -32125,6 +32149,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/science)
+"lHd" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lHe" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/machinery/duct,
@@ -32858,6 +32887,15 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"lTk" = (
+/obj/effect/turf_decal/siding/engineering{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lTn" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/item/kirbyplants/organic/plant18,
@@ -33036,11 +33074,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
 "lVW" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Distro"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lWb" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -33394,6 +33434,12 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"mch" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mcp" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -34696,10 +34742,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"mwU" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mwX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/south,
@@ -35155,15 +35197,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"mFR" = (
-/obj/effect/turf_decal/siding/engineering{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/engineering{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mFS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36899,15 +36932,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "nna" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "nni" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 4
@@ -37243,14 +37273,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"nsv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "nsF" = (
 /obj/effect/turf_decal/tile/engineering/anticorner{
 	dir = 4
@@ -37526,8 +37548,9 @@
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/gravity_generator)
 "nwh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nwj" = (
@@ -39250,10 +39273,15 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/central)
 "ofs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "ofw" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science/xenobiology)
@@ -41809,6 +41837,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"pfd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pfh" = (
 /obj/structure/lattice,
 /obj/item/toy/plush/lizard_plushie/space/green,
@@ -42522,6 +42555,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"puo" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Port to Processing"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pup" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -42746,11 +42789,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"pyJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pyQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -43213,6 +43251,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/coldroom)
+"pGu" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to waste"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pGv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43374,8 +43419,9 @@
 /turf/open/floor/iron/terracotta/herringbone,
 /area/station/maintenance/starboard/aft)
 "pJI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -43398,6 +43444,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"pKE" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to distro staging"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pKQ" = (
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
@@ -43713,11 +43766,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
 "pRB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "pRH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44752,8 +44809,8 @@
 /area/station/maintenance/fore)
 "qjZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 8
+/obj/effect/turf_decal/tile/engineering{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -44869,13 +44926,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"qmg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "qmi" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/directional,
@@ -45156,12 +45206,11 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/nanite)
 "qrF" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to distro staging"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qrO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45225,14 +45274,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qsE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 9
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/space/basic,
+/area/space/nearstation)
 "qsX" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Ordnance Lab"
@@ -45733,6 +45783,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"qDr" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qDs" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -46211,6 +46269,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"qMY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Port"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qNs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -46246,16 +46312,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
-"qNS" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port to Processing"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qNU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46997,13 +47053,6 @@
 "rdg" = (
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"rdj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rdk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47641,6 +47690,16 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain)
+"rot" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "roG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -48743,6 +48802,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"rKV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rKX" = (
 /obj/machinery/power/shieldwallgen/xenobiologyaccess,
 /obj/structure/cable,
@@ -49395,13 +49460,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
-"rYs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rYt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49422,6 +49480,11 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
+"rYK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rYS" = (
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
@@ -50321,12 +50384,10 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"son" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
+"sov" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sox" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -50880,14 +50941,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
-"syl" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Distro"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "syA" = (
 /obj/structure/bedsheetbin{
 	pixel_x = -3;
@@ -52293,9 +52346,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "tdz" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/pipedispenser/disposal,
-/obj/effect/turf_decal/siding/engineering{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -53362,12 +53413,6 @@
 /obj/effect/turf_decal/tile/prison/anticorner,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
-"tuM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tuN" = (
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -54498,11 +54543,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "tSO" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to distro";
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "tSQ" = (
 /obj/structure/table/reinforced,
@@ -55049,15 +55092,6 @@
 /obj/item/reagent_containers/cup/glass/bottle/beer,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"ubE" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ubF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -56039,13 +56073,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"utq" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "utF" = (
 /obj/structure/table/wood,
 /obj/item/toy/mecha/marauder{
@@ -56065,13 +56092,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"uub" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "uuf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56117,12 +56137,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"uuQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "uuZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/contraband/random/directional/west,
@@ -56257,10 +56271,6 @@
 "uye" = (
 /turf/closed/wall,
 /area/station/science/xenobiology)
-"uyr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "uyD" = (
 /obj/structure/closet/secure_closet/psychology,
 /obj/item/toy/figure/psychologist{
@@ -58037,14 +58047,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
-"vgq" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "vgr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59049,11 +59051,6 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"vAY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vAZ" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -59184,11 +59181,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"vEn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vEv" = (
 /obj/machinery/vending/sustenance,
 /obj/effect/turf_decal/tile/security{
@@ -60693,13 +60685,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library/printer)
-"wii" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to waste"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "win" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -61735,6 +61720,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"wDE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wDH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64596,6 +64587,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/bomb)
+"xBi" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xBn" = (
 /turf/closed/wall/r_wall,
 /area/station/science)
@@ -64619,7 +64618,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
-/turf/open/space/basic,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "xBQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65325,10 +65324,10 @@
 /area/station/science)
 "xQP" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xQZ" = (
@@ -90884,27 +90883,27 @@ cgD
 gQv
 yju
 yju
-utq
-fAu
-exm
+cUb
 xQP
-gIN
-xQP
-gIN
+lHd
+qDr
+aeg
+qDr
+aeg
 omv
-ofs
-byG
-ofs
+tSO
+deT
+tSO
 xbu
-fKX
+hpe
 wqT
-vgq
+xBi
 tHl
-lVW
+qrF
 qbv
-lVW
-lVW
-lVW
+qrF
+qrF
+qrF
 ksA
 iQW
 iQW
@@ -91141,7 +91140,7 @@ tbL
 gQv
 xoo
 xoo
-qmg
+csw
 wxt
 bRS
 wxt
@@ -91162,7 +91161,7 @@ wzs
 xoo
 xoo
 xoo
-nna
+pRB
 iQW
 iQW
 iQW
@@ -91398,7 +91397,7 @@ ngZ
 epU
 gtR
 epU
-qrF
+pKE
 sDX
 ife
 oJi
@@ -91419,7 +91418,7 @@ pyQ
 epU
 kfN
 xoo
-nna
+pRB
 iQW
 iQW
 iQW
@@ -91676,7 +91675,7 @@ qXm
 qgU
 iDX
 xoo
-nna
+pRB
 aNE
 aNE
 aNE
@@ -91912,7 +91911,7 @@ lsk
 uFS
 uFS
 dRq
-nsv
+qMY
 rjO
 uFS
 tew
@@ -91920,11 +91919,11 @@ fvq
 dGi
 fvq
 kvf
-gtv
-gtv
-gtv
-qsE
-gtv
+gZV
+gZV
+gZV
+gWU
+gZV
 lsj
 oXc
 uDw
@@ -92167,13 +92166,13 @@ oww
 oQE
 tnF
 wKw
-vAY
+joV
 rnJ
 fJe
 nao
 eaQ
 hlT
-mwU
+jnk
 eGA
 xNl
 dUw
@@ -92190,7 +92189,7 @@ mqx
 uFS
 fGe
 bRS
-nna
+pRB
 fgD
 sDo
 fVa
@@ -92430,10 +92429,10 @@ tDI
 qMp
 gaR
 wnl
-tdz
+dSJ
 pPK
 gaR
-mFR
+lTk
 dtN
 mdN
 cMr
@@ -92696,7 +92695,7 @@ uKQ
 jyX
 svI
 gVJ
-qNS
+puo
 kMt
 uFS
 dRq
@@ -92704,7 +92703,7 @@ mqx
 iuQ
 szM
 rTk
-nna
+pRB
 aNE
 aNE
 aNE
@@ -93213,12 +93212,12 @@ wvW
 uHi
 jCT
 uFS
-pJI
-uyr
+byG
+hHi
 uPE
 jeb
 bRS
-nna
+pRB
 fgD
 ikJ
 cdV
@@ -93464,14 +93463,14 @@ wKw
 cIS
 cIS
 wKw
-uub
+cIi
+pJI
+pJI
 qjZ
-qjZ
-dKc
 kMt
 uFS
 nbx
-uuQ
+nwh
 cNK
 nic
 xWg
@@ -93725,14 +93724,14 @@ iuQ
 xGw
 xGw
 xGw
-syl
-pyJ
-ewr
-pRB
+lVW
+ate
+wDE
+rKV
 owm
 sia
 rTk
-nna
+pRB
 aNE
 aNE
 aNE
@@ -93965,7 +93964,7 @@ lan
 cWy
 wDH
 uFS
-csw
+aEj
 uFS
 uFS
 uFS
@@ -93978,14 +93977,14 @@ uFS
 uFS
 uFS
 uFS
-rYs
+nna
 ldo
 wJQ
 aDL
-nwh
+sov
 aDL
 ojg
-gZV
+pfd
 noz
 lQM
 rZa
@@ -94220,7 +94219,7 @@ xAK
 xAK
 ibf
 mTj
-rdj
+gtv
 uFS
 uFS
 uFS
@@ -94228,25 +94227,25 @@ uFS
 uFS
 uFS
 uFS
-aeg
+azt
 uFS
 uFS
 dRq
 uFS
 uFS
 uFS
-rYs
+nna
 uFS
 uFS
 mjr
 meq
-tSO
+aMG
 uFS
 uPE
 uFS
 cAV
 bRS
-nna
+pRB
 fgD
 vNk
 unI
@@ -94492,13 +94491,13 @@ uFS
 uFS
 uFS
 uFS
-rYs
+nna
 uFS
 uFS
 uFS
 mXf
-dSJ
 crt
+mch
 jpQ
 cSx
 hPg
@@ -94753,14 +94752,14 @@ lyp
 uFS
 uFS
 uFS
-azh
-wii
-tuM
+tdz
+pGu
+hDM
 okf
 uFS
 qQm
 xoo
-nna
+pRB
 aNE
 aNE
 aNE
@@ -95010,14 +95009,14 @@ pmn
 gRZ
 tIF
 mFt
-vEn
+rYK
 une
 lAF
 une
 wHt
 ebd
 xoo
-nna
+pRB
 iQW
 yju
 iQW
@@ -95269,12 +95268,12 @@ jpo
 pZa
 azM
 jpo
-ubE
+kQF
 jpo
 igX
 xoo
 xoo
-nna
+pRB
 iQW
 yju
 iQW
@@ -95526,12 +95525,12 @@ bRS
 bRS
 rst
 bRS
-son
+dAk
 bRS
 xoo
 xoo
-cIi
-aus
+ofs
+qsE
 yju
 xrM
 iQW
@@ -95783,11 +95782,11 @@ yju
 yju
 oqd
 yju
-azt
-lVW
-lVW
-lVW
-aus
+rot
+qrF
+qrF
+qrF
+qsE
 iQW
 iQW
 xrM

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -48,6 +48,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "aaG" = (
@@ -264,9 +265,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/rec)
 "aeg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "aej" = (
@@ -274,8 +275,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "aep" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "CO2 Outlet Pump"
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
@@ -419,9 +421,7 @@
 /obj/effect/turf_decal/tile/engineering/anticorner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ahz" = (
@@ -438,7 +438,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ahM" = (
@@ -507,6 +509,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "aiE" = (
@@ -569,9 +572,8 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "ajA" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/flashlight,
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/security_all,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "ajJ" = (
@@ -827,7 +829,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1031,7 +1033,7 @@
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "asn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
@@ -1090,11 +1092,11 @@
 /area/station/maintenance/department/engine)
 "asU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -1144,11 +1146,9 @@
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "atD" = (
-/obj/machinery/vending/assist,
-/obj/machinery/camera/directional/south{
-	c_tag = "Public - Tool Storage"
-	},
 /obj/effect/turf_decal/tile/engineering/half,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "atI" = (
@@ -1209,9 +1209,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "auV" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/spawner/random/techstorage/rnd_all,
+/obj/effect/turf_decal/trimline/purple/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "auX" = (
@@ -1531,6 +1530,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"azM" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 8;
+	name = "Waste Release"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "azQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -3060,14 +3069,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "bev" = (
-/obj/structure/table/reinforced,
-/obj/item/aicard{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/item/bodypart/chest/robot,
-/obj/item/mmi,
-/obj/item/mmi,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
@@ -3098,12 +3099,16 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "beQ" = (
-/obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/item/toy/figure/engineer,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -3263,7 +3268,6 @@
 /obj/structure/table,
 /obj/item/t_scanner,
 /obj/item/clothing/gloves/color/fyellow,
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/engineering/half,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
@@ -3346,6 +3350,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/lobby)
 "bjw" = (
@@ -3388,13 +3393,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bki" = (
-/obj/machinery/airalarm/directional/west,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/engineering/anticorner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/space/basic,
+/area/space)
 "bkj" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Arrivals Dock"
@@ -3511,6 +3515,12 @@
 /obj/effect/turf_decal/tile/security/half,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
+"bmo" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste In"
+	},
+/turf/open/space/basic,
+/area/space)
 "bms" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -3602,6 +3612,16 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/command/storage/eva)
+"boc" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "boh" = (
 /obj/effect/turf_decal/tile/engineering/anticorner{
 	dir = 1
@@ -3667,6 +3687,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -3766,10 +3789,6 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "brY" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/pump,
 /obj/machinery/camera/directional/south{
 	c_tag = "Engineering - Foyer W";
 	network = list("ss13","engineering")
@@ -4400,6 +4419,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bBT" = (
@@ -4879,12 +4899,12 @@
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -5045,6 +5065,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bNp" = (
@@ -5107,13 +5128,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bOl" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bOo" = (
@@ -5751,7 +5766,9 @@
 	dir = 1;
 	layer = 3.1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/rack,
+/obj/item/pipe_dispenser,
+/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "bZH" = (
@@ -5770,6 +5787,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"cae" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
 "cai" = (
 /obj/structure/transit_tube/crossing{
 	dir = 4
@@ -5926,14 +5949,11 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "cdw" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Pure to Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "cdx" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -6001,13 +6021,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "cfP" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/iron/half,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
 /area/station/engineering/lobby)
 "cgh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -6025,7 +6040,7 @@
 "cgD" = (
 /obj/effect/turf_decal/tile/engineering/anticorner,
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 5
 	},
 /obj/structure/cable,
@@ -6170,14 +6185,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "cjh" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Distro to Waste"
 	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/iron/textured,
-/area/station/engineering/atmos)
+/turf/open/space/basic,
+/area/space)
 "cjn" = (
 /obj/item/poster/tail_board,
 /turf/open/floor/plating,
@@ -6335,6 +6348,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "cmB" = (
@@ -6527,6 +6541,9 @@
 /area/station/science/xenobiology)
 "cpq" = (
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "cpz" = (
@@ -6717,6 +6734,9 @@
 /area/station/service/cafeteria)
 "csw" = (
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "csR" = (
@@ -6836,11 +6856,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/fore)
 "cvc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "cvK" = (
@@ -6950,6 +6971,9 @@
 "cwW" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/siding/engineering,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "cwZ" = (
@@ -6993,7 +7017,6 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "cxT" = (
-/obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -7002,6 +7025,7 @@
 	c_tag = "Engineering - Shared Storage";
 	network = list("ss13","engineering")
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "cxY" = (
@@ -7074,6 +7098,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"czc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "cze" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7349,12 +7381,9 @@
 /area/station/command/heads_quarters/rd)
 "cDO" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/half,
 /area/station/engineering/lobby)
 "cEi" = (
@@ -7395,11 +7424,9 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "cER" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "N2 to Pure"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -7446,6 +7473,9 @@
 	},
 /obj/effect/turf_decal/siding/engineering/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -7834,7 +7864,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cNK" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "O2 to Pure"
+	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
@@ -8057,6 +8090,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
+"cSx" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air Outlet Pump"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cSI" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/iron/dark/smooth_large,
@@ -8238,7 +8278,7 @@
 "cVt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8433,17 +8473,13 @@
 /turf/open/floor/carpet/blue,
 /area/station/commons/dorms)
 "cYr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
 	},
 /turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/atmos)
 "cYw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8481,6 +8517,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cYP" = (
@@ -8528,8 +8565,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "cZY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "dab" = (
 /obj/item/choice_beacon/halloween,
@@ -8708,9 +8746,8 @@
 /obj/effect/turf_decal/tile/command/half{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Plasma Outlet Pump"
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -9532,8 +9569,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "duN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "duS" = (
@@ -9977,6 +10013,19 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/bomb)
+"dEj" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/station/engineering/supermatter/room)
 "dEq" = (
 /obj/structure/chair{
 	dir = 1
@@ -10028,9 +10077,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dFc" = (
@@ -10161,13 +10208,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "dGz" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 5
 	},
-/obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/magboot,
-/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "dGD" = (
@@ -10521,10 +10564,10 @@
 "dMU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -10580,6 +10623,14 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"dOl" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "N2O Outlet Pump";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dOs" = (
 /obj/structure/sign/painting/library_secure{
 	pixel_x = 32
@@ -10775,18 +10826,21 @@
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "dSJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
+/obj/machinery/door/window/brigdoor/right/directional/south{
+	name = "Engineering Delivery";
+	req_access = list("engineering")
 	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/structure/window/spawner/directional/east{
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/engineering/lobby)
 "dSO" = (
 /obj/structure/sign/warning/pods/directional/west,
 /turf/open/floor/plating,
@@ -10834,14 +10888,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
+"dTC" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Filters"
+	},
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "dTD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
@@ -11956,7 +12020,6 @@
 "epH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "epU" = (
@@ -12327,11 +12390,13 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/entry)
 "ews" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -12496,14 +12561,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "ezO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 5
+/obj/effect/turf_decal/tile/yellow/half,
+/turf/open/floor/iron/white/corner{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/lobby)
 "ezP" = (
 /obj/structure/safe,
 /obj/item/stack/spacecash/c10,
@@ -12557,14 +12619,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/break_room)
 "eAv" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "cepriv"
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
 "eAA" = (
 /obj/structure/table_frame/wood,
@@ -12939,6 +13000,9 @@
 "eJg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/emitter{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "eJo" = (
@@ -14076,6 +14140,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/emitter{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fdD" = (
@@ -14135,10 +14202,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "feg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
+/turf/open/floor/iron/corner{
+	dir = 1
 	},
-/turf/open/floor/iron,
 /area/station/engineering/lobby)
 "fek" = (
 /obj/structure/window/spawner/directional/east,
@@ -14394,10 +14460,8 @@
 /area/station/service/chapel/dock)
 "fjr" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
-/obj/effect/turf_decal/tile/yellow/anticorner,
-/turf/open/floor/iron/corner{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/yellow/half,
+/turf/open/floor/iron/corner,
 /area/station/engineering/lobby)
 "fjX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14480,6 +14544,11 @@
 /obj/effect/turf_decal/tile/command/half,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/command/storage/eva)
+"flw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "flz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -14551,7 +14620,7 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/airalarm/directional/north,
-/obj/effect/spawner/random/techstorage/medical_all,
+/obj/effect/spawner/random/techstorage/service_all,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "fmr" = (
@@ -14809,9 +14878,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
 /obj/machinery/status_display/ai/directional/west,
-/obj/item/electronics/apc,
-/obj/item/electronics/apc,
-/obj/item/electronics/apc,
+/obj/effect/spawner/random/techstorage/tcomms_all,
+/obj/effect/spawner/random/techstorage/engineering_all{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "fqH" = (
@@ -15053,6 +15123,7 @@
 /obj/effect/turf_decal/tile/engineering/anticorner{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "fum" = (
@@ -15645,20 +15716,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/primary/port)
 "fHR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 4
 	},
-/obj/machinery/requests_console/directional/east{
-	department = "Atmospherics";
-	name = "Atmospherics Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Pure to Port"
-	},
+/obj/machinery/space_heater,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fHU" = (
@@ -15745,8 +15808,10 @@
 /area/station/science)
 "fJe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Port to Network"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fJi" = (
@@ -15955,11 +16020,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/command/storage/eva)
 "fLC" = (
-/obj/machinery/power/emitter{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "fLR" = (
 /obj/structure/cable,
@@ -16425,8 +16487,8 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 10
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
@@ -16440,6 +16502,14 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"fWk" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/siding/engineering{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/storage_shared)
 "fWl" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/stool/directional/east,
@@ -16691,9 +16761,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gaR" = (
@@ -16737,10 +16805,6 @@
 /area/station/hallway/primary/fore)
 "gbL" = (
 /obj/structure/sign/departments/telecomms/directional/south,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/white/corner{
 	dir = 1
@@ -16874,9 +16938,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "gdV" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4;
-	piping_layer = 2
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -17406,6 +17471,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "gqU" = (
@@ -17418,7 +17484,7 @@
 /area/station/service/chapel)
 "gre" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17553,6 +17619,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
+"gtv" = (
+/obj/structure/disposaloutlet{
+	dir = 4;
+	name = "Cargo Deliveries"
+	},
+/obj/structure/window/spawner/directional/south{
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/engineering/lobby)
 "gtz" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance/two,
@@ -17633,9 +17715,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "gvZ" = (
-/obj/structure/rack,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 9
+	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/engine)
+/area/station/engineering/lobby)
 "gwj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -17731,6 +17817,12 @@
 "gxq" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"gxv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
 "gxw" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -18568,10 +18660,12 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "gMp" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/effect/turf_decal/trimline/purple/line,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
+/obj/item/mod/module/magboot,
+/obj/item/mod/module/thermal_regulator,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/structure/rack,
+/turf/open/floor/iron,
+/area/station/engineering/storage_shared)
 "gMG" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply{
 	dir = 4
@@ -18819,10 +18913,7 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "gRZ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gSh" = (
@@ -19111,7 +19202,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "gXa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 10
 	},
 /obj/structure/cable,
@@ -19166,19 +19257,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "gXS" = (
-/obj/structure/sign/departments/maint/alt/directional/west,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "gXU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/rnd_all,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "gYk" = (
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 8
@@ -19417,6 +19508,9 @@
 /obj/item/stock_parts/servo,
 /obj/item/stock_parts/servo,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "hcF" = (
@@ -19524,11 +19618,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "hft" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hfy" = (
@@ -19554,6 +19649,16 @@
 /obj/item/storage/box/lights/bulbs,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"hfZ" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Technology Storage"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/storage/tech)
 "hgg" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Middle N";
@@ -19715,9 +19820,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "hjH" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hjX" = (
@@ -19781,14 +19889,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "hlK" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
+/turf/open/space/basic,
+/area/space)
 "hlN" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/bed/medical/emergency,
@@ -20481,6 +20586,16 @@
 /obj/machinery/plumbing/reaction_chamber,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"hAd" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "hAg" = (
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
@@ -21270,10 +21385,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "hOP" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/west,
-/obj/effect/spawner/random/techstorage/security_all,
+/obj/machinery/cell_charger,
+/obj/item/assembly/flash/handheld{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/structure/table/reinforced,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "hOQ" = (
@@ -21302,13 +21422,10 @@
 /area/station/security/warden)
 "hPg" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air Outlet Pump"
-	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hPk" = (
@@ -21326,11 +21443,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "hPH" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
-	name = "waste release"
-	},
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air to external ports"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -21352,6 +21469,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
+/mob/living/basic/parrot/poly,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "hQC" = (
@@ -21462,6 +21580,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"hSk" = (
+/obj/effect/turf_decal/tile/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4;
+	initialize_directions = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "hSG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -21632,6 +21760,13 @@
 /obj/effect/turf_decal/tile/engineering/half,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"hWH" = (
+/obj/machinery/incident_display/delam/directional/south,
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/item/storage/bag/construction,
+/obj/effect/turf_decal/tile/yellow/half,
+/turf/open/floor/iron/half,
+/area/station/engineering/lobby)
 "hXa" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22116,11 +22251,14 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "igG" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/half,
-/turf/open/floor/iron/half,
-/area/station/engineering/lobby)
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "igJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -22488,12 +22626,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "imH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "imL" = (
@@ -22800,9 +22940,7 @@
 	c_tag = "Engineering - Atmospherics E";
 	network = list("ss13","engineering")
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "isa" = (
@@ -22922,6 +23060,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
+"iuQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"iuZ" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/yellow/half,
+/turf/open/floor/iron/half,
+/area/station/engineering/lobby)
 "ive" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
@@ -23411,13 +23560,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "iEp" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - Tech Storage";
 	network = list("ss13","engineering")
 	},
-/turf/open/floor/iron/dark,
+/turf/closed/wall,
 /area/station/engineering/storage/tech)
 "iEv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -23507,7 +23654,7 @@
 /area/station/service/library)
 "iGn" = (
 /obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23568,7 +23715,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "iHD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -24103,6 +24252,12 @@
 	},
 /turf/open/floor/carpet/lone/star,
 /area/station/service/chapel)
+"iQZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
 "iRe" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -24332,11 +24487,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "iVA" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/line{
+/obj/effect/turf_decal/trimline/purple/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -24440,8 +24594,8 @@
 /area/station/maintenance/fore)
 "iWK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iWP" = (
@@ -24542,6 +24696,7 @@
 	name = "Engineering Lockdown Blast Doors"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -24569,8 +24724,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "fuel mix to incinerator pump"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
 	dir = 4
@@ -24803,6 +24959,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/lobby)
 "jeE" = (
@@ -24846,9 +25003,11 @@
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "jfz" = (
-/obj/machinery/vending/tool,
-/obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/engineering/half,
+/obj/machinery/vending/assist,
+/obj/machinery/camera/directional/south{
+	c_tag = "Public - Tool Storage"
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "jfL" = (
@@ -24929,6 +25088,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "jhI" = (
@@ -25131,10 +25291,7 @@
 /area/station/construction)
 "jmj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jmq" = (
@@ -25683,10 +25840,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "jvd" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/techstorage/service_all,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/closed/wall,
 /area/station/engineering/storage/tech)
 "jvq" = (
 /turf/closed/wall,
@@ -26299,7 +26454,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron/dark,
@@ -27357,6 +27512,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "kbf" = (
@@ -27652,7 +27808,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
@@ -28212,6 +28368,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "knU" = (
@@ -28324,6 +28483,7 @@
 "kpv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "kpy" = (
@@ -28339,7 +28499,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -28723,7 +28882,7 @@
 /area/station/medical/cryo)
 "kxI" = (
 /obj/machinery/air_sensor/incinerator_tank,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
@@ -29013,6 +29172,11 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"kCe" = (
+/obj/structure/cable,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "kCi" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -29446,9 +29610,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/cell_charger,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -29881,9 +30047,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard)
 "kTa" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "kTb" = (
@@ -30013,10 +30180,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "kVP" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/box,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/hallway/primary/aft)
 "kVR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -30099,9 +30271,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
+/obj/item/clothing/head/utility/welding,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/weldingtool,
+/obj/item/wrench,
+/obj/structure/rack,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kXM" = (
@@ -30164,7 +30338,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "kYY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kZg" = (
@@ -30367,6 +30541,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
+"ldo" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lds" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30687,8 +30865,8 @@
 /obj/effect/turf_decal/siding/engineering{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "ljP" = (
@@ -31200,6 +31378,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ltU" = (
@@ -31259,11 +31440,13 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/cargo)
 "luW" = (
-/obj/machinery/power/emitter{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "lvb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -31468,7 +31651,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lyp" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -31596,12 +31780,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "lAF" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	name = "scrubber recycling"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Filters"
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lAH" = (
@@ -31922,11 +32101,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lGk" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Air"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/hallway/primary/aft)
 "lGl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_corner{
@@ -32176,12 +32355,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "lKC" = (
-/obj/machinery/atmospherics/components/binary/pump/on/general{
-	dir = 1;
-	name = "Air to Distro"
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/hallway/primary/aft)
 "lKE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -32371,6 +32550,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "lOs" = (
@@ -32483,11 +32663,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "lPH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
-	dir = 8
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/lobby)
+/area/station/commons/storage/primary)
 "lQa" = (
 /obj/docking_port/stationary/mining_home/common{
 	dir = 8
@@ -32922,10 +33103,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "lXj" = (
-/obj/structure/closet/crate/bin,
-/obj/item/bouquet/sunflower,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/station/maintenance/department/engine)
 "lXl" = (
 /obj/structure/cable,
@@ -33174,6 +33353,13 @@
 /obj/effect/landmark/start/mime,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"max" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "maG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -33414,10 +33600,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "meq" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Distro"
 	},
-/obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "met" = (
@@ -33450,7 +33637,7 @@
 "meS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33649,13 +33836,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "miV" = (
-/obj/structure/closet/toolcloset,
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover/closet,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/tile/engineering/anticorner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/engineering/atmos)
 "miW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating_new,
@@ -33698,11 +33883,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mjr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -33828,10 +34010,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -33902,10 +34084,11 @@
 /turf/open/floor/iron/white,
 /area/station/service/theater)
 "mlN" = (
-/obj/effect/turf_decal/tile/engineering/half,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space)
 "mlZ" = (
 /obj/machinery/air_sensor/nitrous_tank,
 /turf/open/floor/engine/n2o,
@@ -34964,6 +35147,12 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"mFt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mFv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -35210,6 +35399,10 @@
 "mJI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -35596,6 +35789,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
+"mRt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "mRD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
@@ -35713,6 +35912,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mTj" = (
@@ -35724,9 +35924,6 @@
 	network = list("ss13","engineering")
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 6
-	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -35759,9 +35956,8 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "mTJ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2O Outlet Pump"
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
@@ -35874,9 +36070,9 @@
 /area/station/hallway/primary/fore)
 "mXf" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Distro"
+	dir = 4;
+	name = "Distro to waste"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mXh" = (
@@ -36022,7 +36218,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron/dark,
@@ -36077,7 +36272,8 @@
 /area/station/security/brig)
 "nao" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nay" = (
@@ -36124,7 +36320,7 @@
 "nbx" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Air to Mix"
+	name = "Air to Pure"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -36248,12 +36444,17 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "ndq" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/aicard{
+	pixel_x = -5;
+	pixel_y = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/item/bodypart/chest/robot,
+/obj/item/mmi,
+/obj/item/mmi,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "ndr" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/structure/reagent_dispensers/watertank,
@@ -36401,13 +36602,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Turbine"
-	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -36465,10 +36665,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "O2 Outlet Pump"
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nif" = (
@@ -36529,7 +36726,9 @@
 	dir = 1;
 	layer = 3.1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/rack,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/pipe_dispenser,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "njo" = (
@@ -36591,6 +36790,13 @@
 /obj/structure/sign/poster/official/high_class_martini,
 /turf/closed/wall,
 /area/station/maintenance/fore)
+"nkA" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Distro Stagsing to Filter"
+	},
+/turf/open/space/basic,
+/area/space)
 "nkF" = (
 /obj/effect/turf_decal/tile/security/half{
 	dir = 4
@@ -37013,6 +37219,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"nry" = (
+/obj/item/storage/bag/construction,
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/effect/turf_decal/tile/yellow/half,
+/turf/open/floor/iron/half,
+/area/station/engineering/lobby)
 "nrA" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/lavendergrass,
@@ -37334,9 +37546,7 @@
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/gravity_generator)
 "nwh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nwj" = (
@@ -37792,12 +38002,11 @@
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
 "nGU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
+/obj/effect/turf_decal/tile/engineering/opposingcorners,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/commons/storage/primary)
 "nHc" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/fore)
@@ -37891,6 +38100,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "nII" = (
@@ -38125,7 +38337,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "nNB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -38282,14 +38494,12 @@
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "nQM" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Tool Storage Maintenance"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/engine)
+/area/station/hallway/primary/aft)
 "nQN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -39064,6 +39274,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/engineering/corner,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ofw" = (
@@ -39213,9 +39426,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "ojg" = (
-/obj/effect/spawner/random/engineering/toolbox,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air to Distro"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ojh" = (
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
@@ -39247,8 +39463,9 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/nanite)
 "okf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Air to waste"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -39282,11 +39499,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "olv" = (
-/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "olG" = (
@@ -39605,6 +39822,13 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"oqd" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "oqp" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/grassy/style_random,
@@ -39635,6 +39859,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
+"oqG" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "oqS" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -40424,10 +40653,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "oHn" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
@@ -40843,10 +41068,10 @@
 /area/station/security/courtroom)
 "oQE" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oQV" = (
@@ -40993,15 +41218,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "oTA" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/engineering{
-	name = "Technology Storage"
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 10
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/area/station/engineering/atmos)
 "oTX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -41696,18 +41917,14 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "phK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/half,
 /area/station/engineering/lobby)
 "phN" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
-/obj/item/storage/bag/construction,
-/obj/effect/turf_decal/tile/yellow/half,
-/turf/open/floor/iron/half,
-/area/station/engineering/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "phZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41935,13 +42152,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "pmn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pmH" = (
@@ -41983,16 +42197,11 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "pnl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
+/turf/open/space/basic,
+/area/space)
 "pnp" = (
 /obj/item/emptysandbag,
 /turf/open/floor/wood,
@@ -42300,11 +42509,11 @@
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
 "ptD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/hallway/primary/aft)
 "ptH" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42777,7 +42986,7 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/engineering/gravity_generator)
 "pCj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -42830,10 +43039,7 @@
 "pDl" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/spawner/random/techstorage/engineering_all{
-	pixel_y = 8
-	},
-/obj/effect/spawner/random/techstorage/tcomms_all,
+/obj/effect/spawner/random/techstorage/medical_all,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "pDp" = (
@@ -43190,6 +43396,10 @@
 /obj/effect/spawner/random/trash/bin,
 /turf/open/floor/iron/terracotta/herringbone,
 /area/station/maintenance/starboard/aft)
+"pJI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pJT" = (
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plating,
@@ -43562,6 +43772,7 @@
 	c_tag = "Engineering - Chief Engineer";
 	network = list("ss13","engineering")
 	},
+/obj/structure/filingcabinet,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "pRR" = (
@@ -43817,9 +44028,8 @@
 /obj/effect/turf_decal/tile/security/half{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "CO2 Outlet Pump"
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -43934,6 +44144,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"pZa" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pZd" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /mob/living/basic/butterfly,
@@ -44316,6 +44535,9 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "qga" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qgc" = (
@@ -44457,6 +44679,28 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
+"qis" = (
+/obj/structure/rack,
+/obj/item/electronics/airlock{
+	pixel_x = 4;
+	pixel_y = -5
+	},
+/obj/item/electronics/airlock{
+	pixel_x = 4;
+	pixel_y = -5
+	},
+/obj/item/electronics/airlock{
+	pixel_x = 4;
+	pixel_y = -5
+	},
+/obj/item/electronics/airalarm,
+/obj/item/electronics/airalarm,
+/obj/item/electronics/airalarm,
+/obj/item/electronics/apc,
+/obj/item/electronics/apc,
+/obj/item/electronics/apc,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "qiw" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/firealarm/directional/east,
@@ -44574,12 +44818,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "qkB" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 9
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space)
 "qkH" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
@@ -44790,14 +45036,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
 "qoC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/weldingtool,
-/obj/item/clothing/head/utility/welding,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "qoK" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/green{
@@ -45065,7 +45308,7 @@
 "qtW" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45117,6 +45360,7 @@
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 1
 	},
+/obj/machinery/vending/modularpc,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "quL" = (
@@ -45362,6 +45606,13 @@
 "qAr" = (
 /turf/closed/wall,
 /area/station/commons/toilet/restrooms)
+"qAs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/space/basic,
+/area/space)
 "qAE" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Medical - Reception";
@@ -45451,7 +45702,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
@@ -45632,6 +45883,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "qFr" = (
@@ -45937,6 +46189,9 @@
 /area/station/security/evidence)
 "qMp" = (
 /obj/effect/turf_decal/siding/engineering,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qMt" = (
@@ -46122,20 +46377,18 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "qQl" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
-/obj/item/storage/bag/construction,
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/machinery/incident_display/delam/directional/south,
-/turf/open/floor/iron/half,
-/area/station/engineering/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "qQm" = (
 /obj/effect/turf_decal/tile/engineering/half,
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -46196,14 +46449,15 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "qSX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qSZ" = (
@@ -46605,10 +46859,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "ras" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
 	},
-/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "raJ" = (
@@ -46907,14 +47160,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "rgt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 10
-	},
+/obj/machinery/space_heater,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rgC" = (
@@ -47253,6 +47504,12 @@
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 1
 	},
+/obj/machinery/button/door/directional/south{
+	id = "atmosstorage";
+	name = "Gas Storage Shutters";
+	req_access = list("atmospherics");
+	pixel_y = 24
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
 "rmy" = (
@@ -47321,6 +47578,11 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/station/maintenance/department/medical/plasmaman)
+"rnJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rnP" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
@@ -47532,7 +47794,7 @@
 /area/station/service/bar)
 "rst" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47664,7 +47926,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "rvc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47964,10 +48226,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rBA" = (
@@ -48003,9 +48265,7 @@
 /area/station/command/heads_quarters/qm)
 "rCi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible,
 /turf/open/floor/engine,
 /area/station/science/ordnance)
 "rCm" = (
@@ -48031,10 +48291,9 @@
 /area/station/service/janitor)
 "rCI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/structure/railing,
-/obj/item/pipe_dispenser,
-/obj/item/clothing/glasses/meson/engine,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "rCL" = (
@@ -48104,7 +48363,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rEh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48430,12 +48689,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rJJ" = (
-/obj/structure/railing{
-	dir = 1;
-	layer = 3.1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/area/station/hallway/primary/aft)
 "rJZ" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Lab Storage"
@@ -48544,6 +48804,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "rMj" = (
@@ -48866,10 +49127,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "rTk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
@@ -49317,7 +49581,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "scz" = (
@@ -49631,13 +49894,11 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "shG" = (
-/obj/structure/filingcabinet,
-/mob/living/basic/parrot/poly,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/ce)
+/turf/open/space/basic,
+/area/space)
 "shI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -50094,7 +50355,6 @@
 /obj/effect/turf_decal/tile/security/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/airlock/access/all/security,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -50855,10 +51115,29 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"sDE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 1
+"sDA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
+"sDE" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/obj/machinery/requests_console/directional/east{
+	department = "Atmospherics";
+	name = "Atmospherics Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sDH" = (
@@ -51627,6 +51906,10 @@
 "sWA" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"sWH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/turf/open/space/basic,
+/area/space)
 "sWS" = (
 /obj/effect/turf_decal/tile/security/opposingcorners,
 /obj/structure/cable,
@@ -51852,13 +52135,13 @@
 	},
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "tbM" = (
@@ -51964,11 +52247,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/turf/closed/wall,
 /area/station/engineering/storage/tech)
 "tcS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51995,10 +52274,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "tdz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tdL" = (
@@ -52042,13 +52318,23 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "tew" = (
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "tex" = (
 /obj/structure/chair/comfy,
 /turf/open/floor/iron,
 /area/station/science)
+"teK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/space/basic,
+/area/space)
 "teM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -52343,6 +52629,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"tjV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "tjY" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -52416,9 +52708,7 @@
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tll" = (
@@ -52519,6 +52809,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"tmm" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/tank_holder/extinguisher,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "tmp" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -52607,10 +52903,7 @@
 /area/station/medical/exam_room)
 "tnF" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port to Network"
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tnH" = (
@@ -52992,15 +53285,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ttC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ttL" = (
@@ -53429,6 +53722,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"tBY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "tBZ" = (
 /obj/effect/decal/cleanable/wrapping,
 /obj/structure/disposalpipe/segment{
@@ -53456,12 +53754,13 @@
 /area/station/engineering/atmos/office)
 "tCx" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/structure/table,
 /obj/item/storage/box/coffeepack{
 	pixel_x = 5;
 	pixel_y = 10
 	},
 /obj/item/storage/box/cups,
+/obj/structure/table,
+/obj/item/toy/figure/engineer,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "tCD" = (
@@ -53746,8 +54045,9 @@
 /turf/open/floor/plating,
 /area/station/construction)
 "tIF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste In"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tIK" = (
@@ -54155,9 +54455,8 @@
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tSn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tSp" = (
@@ -54227,9 +54526,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "tUb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
-	},
 /turf/open/floor/iron/corner{
 	dir = 8
 	},
@@ -54301,10 +54597,9 @@
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "tUB" = (
-/obj/structure/rack,
-/obj/structure/railing,
-/obj/item/pipe_dispenser,
-/obj/item/clothing/glasses/meson/engine,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "tUO" = (
@@ -54994,6 +55289,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"ufP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine)
 "ufQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55197,22 +55499,9 @@
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "ukk" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airlock{
-	pixel_x = 4;
-	pixel_y = -5
-	},
-/obj/item/electronics/airlock{
-	pixel_x = 4;
-	pixel_y = -5
-	},
-/obj/item/electronics/airlock{
-	pixel_x = 4;
-	pixel_y = -5
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
@@ -55307,6 +55596,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/lobby)
 "umV" = (
@@ -55333,7 +55623,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "une" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "unj" = (
@@ -55572,10 +55864,8 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "urs" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/engineering{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/engineering/half,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "urA" = (
@@ -55717,6 +56007,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"utk" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air to Distro"
+	},
+/turf/open/space/basic,
+/area/space)
 "utl" = (
 /obj/machinery/computer/order_console/bitrunning,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -55795,16 +56092,11 @@
 /area/station/maintenance/fore)
 "uva" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/engineering/opposingcorners,
-/obj/machinery/door/airlock/command/glass{
-	name = "Chief Engineer Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/ce)
+/area/station/engineering/lobby)
 "uvi" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -56192,14 +56484,14 @@
 /area/station/service/library/artgallery)
 "uEQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
 	sortType = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -56210,7 +56502,7 @@
 "uFa" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56437,7 +56729,7 @@
 "uJO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
@@ -56795,7 +57087,9 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/cargo)
 "uPE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "uPQ" = (
@@ -57458,7 +57752,7 @@
 /area/station/commons/dorms/laundry)
 "vbL" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
 	dir = 4
 	},
@@ -57579,7 +57873,7 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/line{
+/obj/effect/turf_decal/trimline/blue/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
@@ -58234,6 +58528,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "vqT" = (
@@ -58476,7 +58771,7 @@
 /area/station/service/chapel/dock)
 "vwy" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
 	dir = 10
 	},
@@ -58596,6 +58891,9 @@
 "vzb" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"vzg" = (
+/turf/closed/wall,
+/area/space)
 "vzm" = (
 /obj/item/storage/box/ids,
 /obj/structure/closet/secure_closet/contraband/heads,
@@ -58681,6 +58979,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "vAo" = (
@@ -59160,10 +59459,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "vLj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/structure/fluff/broken_canister_frame,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/atmos)
 "vLk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -59252,10 +59558,7 @@
 /area/station/command/heads_quarters/ce)
 "vMx" = (
 /obj/effect/turf_decal/tile/dark/half/contrasted,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "N2 Outlet Pump"
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
@@ -60157,9 +60460,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
+"wfN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "wfP" = (
 /obj/structure/sign/poster/official/wtf_is_co2/directional/south,
 /obj/effect/turf_decal/siding/engineering,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "wfR" = (
@@ -60811,15 +61124,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "wtB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/assembly/flash/handheld{
-	pixel_x = 8;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/cell/high,
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
+/turf/closed/wall,
 /area/station/engineering/storage/tech)
 "wtC" = (
 /obj/structure/rack,
@@ -60945,10 +61251,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -61557,7 +61863,9 @@
 /area/station/engineering/engine_smes)
 "wHt" = (
 /obj/effect/turf_decal/tile/engineering,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to filter"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wHG" = (
@@ -61708,6 +62016,13 @@
 	dir = 8
 	},
 /area/station/security/brig)
+"wJQ" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Distro Out"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wJZ" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -62039,7 +62354,7 @@
 /area/station/hallway/primary/aft)
 "wQh" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
@@ -62126,9 +62441,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/service)
 "wQX" = (
-/obj/machinery/vending/modularpc,
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/engineering/half,
+/obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "wRc" = (
@@ -62321,6 +62636,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wUz" = (
@@ -62367,15 +62683,17 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "wVE" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/maintenance/department/engine)
+/area/station/hallway/primary/aft)
 "wVH" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -63030,6 +63348,15 @@
 "xgw" = (
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/department/engine)
+"xgS" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "xgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63279,7 +63606,7 @@
 /area/station/medical/virology)
 "xkG" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63799,9 +64126,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xte" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/corner,
-/area/station/engineering/lobby)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/emitter{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "xtq" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -63998,10 +64329,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "xwF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/table/reinforced,
+/obj/item/flashlight,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "xwG" = (
 /obj/structure/table/wood,
 /obj/item/inspector{
@@ -64026,6 +64358,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "xxw" = (
@@ -64214,15 +64547,15 @@
 /area/station/service/hydroponics/garden)
 "xBF" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command/glass{
+	name = "Chief Engineer Office"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/effect/turf_decal/tile/engineering/opposingcorners,
+/turf/open/space/basic,
 /area/station/command/heads_quarters/ce)
 "xBQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64485,12 +64818,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "xGw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
-/area/station/engineering/lobby)
+/area/station/engineering/atmos)
 "xGz" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/computer/atmos_alert{
@@ -64550,12 +64880,14 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "xIk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 8
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/tile/yellow/half,
+/turf/open/floor/iron/half,
+/area/station/engineering/lobby)
 "xIs" = (
 /obj/structure/railing{
 	dir = 1;
@@ -64839,9 +65171,6 @@
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "xOM" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -65231,7 +65560,9 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "xWg" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "xWh" = (
@@ -65577,8 +65908,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -65752,13 +66086,13 @@
 /obj/effect/turf_decal/tile/engineering/anticorner{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	sortType = 6
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "yeQ" = (
@@ -65987,8 +66321,9 @@
 /area/station/maintenance/port/aft)
 "yiA" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Plasma Outlet Pump"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -66062,7 +66397,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -91252,10 +91587,10 @@ mRe
 riG
 wDH
 gXa
-cIS
 duN
-wKw
-wKw
+duN
+duN
+duN
 tSn
 uFS
 uVE
@@ -91270,7 +91605,7 @@ aep
 qgU
 aUf
 jsC
-aep
+dOl
 xGf
 qXm
 qgU
@@ -91509,13 +91844,13 @@ nqh
 uHi
 wDH
 lsk
+uFS
+uFS
+uFS
+uFS
 rjO
 uFS
-uFS
-uFS
-uFS
-uFS
-uVE
+tew
 fvq
 dGi
 fvq
@@ -91766,12 +92101,12 @@ xAK
 oww
 oQE
 tnF
-kYY
-eaQ
-nao
+wKw
+wKw
+rnJ
 fJe
 nao
-fvq
+eaQ
 hlT
 uFS
 uFS
@@ -92023,7 +92358,7 @@ xAK
 sid
 wDH
 uFS
-jCT
+uFS
 uFS
 dRq
 dRq
@@ -92043,8 +92378,8 @@ uFS
 qJP
 uFS
 uFS
-uVE
-lsj
+tew
+cER
 vMx
 xWg
 oOV
@@ -92280,7 +92615,7 @@ xAK
 mTg
 wDH
 uFS
-jCT
+uFS
 lVW
 gZV
 gZV
@@ -92301,7 +92636,7 @@ jCT
 uFS
 uFS
 mqx
-jpQ
+iuQ
 szM
 rTk
 tHM
@@ -92537,7 +92872,7 @@ xAK
 cYN
 wDH
 uFS
-jCT
+uFS
 eNP
 eLR
 tDI
@@ -92794,7 +93129,7 @@ xAK
 rFe
 wDH
 uFS
-azt
+uFS
 eNP
 eLR
 xrA
@@ -92815,7 +93150,7 @@ jCT
 uFS
 uFS
 mqx
-jpQ
+uPE
 jeb
 bRS
 tHM
@@ -93051,7 +93386,7 @@ xAK
 rFe
 wDH
 uFS
-jCT
+uFS
 eNP
 eLR
 krO
@@ -93308,7 +93643,7 @@ uAL
 ebA
 wDH
 uFS
-jCT
+uFS
 eff
 rFP
 rFP
@@ -93565,26 +93900,26 @@ lan
 cWy
 wDH
 uFS
-sDE
-cdw
-cIS
-cIS
-wKw
+uFS
+uFS
+uFS
+uFS
+oTA
 wKw
 vxA
 itm
 vxA
 wKw
+cIS
+cIS
 wKw
 wKw
 wKw
-xIk
 wKw
 wKw
-wKw
-vxA
-lGk
-cZY
+kMt
+uFS
+uFS
 uPE
 noz
 lQM
@@ -93820,28 +94155,28 @@ xAK
 xAK
 ibf
 mTj
-ezO
+wDH
 uFS
-jCT
 uFS
-cjh
-cjh
 uFS
-kVP
-ras
-meq
+uFS
+uFS
+uFS
+uFS
+uFS
+uFS
 uFS
 dRq
-kVP
 ras
+ras
+uFS
+iuQ
+xGw
+xGw
+xGw
 meq
-jCT
-uFS
-uFS
-uFS
-uFS
-uFS
-uFS
+xGw
+xGw
 nwh
 uFS
 cAV
@@ -94076,33 +94411,33 @@ dzi
 cxT
 aLF
 inY
+rFe
+wDH
+uFS
+uFS
+uFS
+uFS
+uFS
 bOl
-cER
-uFS
-azt
-uFS
-uFS
-uFS
-uFS
-uFS
+bOl
 gRZ
-uFS
+kYY
 dRq
 uFS
 uFS
-gRZ
+uFS
 uFS
 lyp
-uFS
-uFS
-uFS
-uFS
-uFS
-uFS
-nGU
+pJI
+ldo
+wJQ
+tdz
 aDL
+ojg
+jpQ
+cSx
 hPg
-xWg
+cZY
 oOV
 tmh
 kNt
@@ -94335,29 +94670,29 @@ jiC
 crs
 kpJ
 ews
-uFS
-jCT
-wzH
+miV
+miV
+hPH
 gdV
-uFS
+gdV
 hjH
-wzH
+hjH
 aeg
+cYr
 uFS
 uFS
 uFS
-aeg
 uFS
 wzH
-tdz
-xwF
-xwF
-xwF
+lyp
+uFS
+uFS
+uFS
 mXf
-une
-lKC
+mjr
+uFS
 okf
-ptD
+uFS
 qQm
 xoo
 tHM
@@ -94595,23 +94930,23 @@ bJT
 hft
 rgt
 fHR
-qSX
-imH
+sDE
+vLj
 qSX
 imH
 ttC
 rBg
 iWK
-xwF
 jmj
-xwF
-xwF
+jmj
+jmj
+jmj
 pmn
+kYY
+gRZ
 tIF
-tIF
-tIF
-tIF
-tIF
+bOl
+mFt
 lAF
 une
 wHt
@@ -94850,7 +95185,7 @@ crs
 jie
 mkC
 jie
-kPg
+xoo
 kPg
 kPg
 kPg
@@ -94864,11 +95199,11 @@ dEK
 irR
 tlj
 gaQ
-hPH
-mjr
+tlj
 jpo
 jpo
-jpo
+azM
+pZa
 jpo
 jpo
 igX
@@ -94877,11 +95212,11 @@ xoo
 tHM
 iQW
 yju
-iQW
-iQW
-iQW
-iQW
-iQW
+phN
+utk
+pnl
+sWH
+hlK
 iQW
 iQW
 iQW
@@ -95099,16 +95434,16 @@ ezp
 tFm
 tFm
 nqh
-nqh
-nqh
+gMp
+fWk
 dGz
 qSl
 crs
-mtj
+gtv
 asU
-igG
+phK
+iuZ
 kPg
-shG
 pRJ
 hQw
 dDq
@@ -95122,9 +95457,9 @@ xoo
 xoo
 xoo
 xoo
+bRS
+bRS
 rst
-bRS
-bRS
 bRS
 bRS
 bRS
@@ -95134,11 +95469,11 @@ hii
 dwL
 yju
 xrM
-iQW
-iQW
-iQW
-iQW
-iQW
+iQZ
+gxv
+qoC
+nkA
+hlK
 iQW
 iQW
 iQW
@@ -95355,13 +95690,13 @@ wbb
 qsg
 qsg
 whO
-jXT
-ojg
+nqh
+nqh
 nqh
 nMa
 wIF
 crs
-mtj
+dSJ
 uEQ
 cDO
 uva
@@ -95379,9 +95714,9 @@ vNu
 eRZ
 eRZ
 eRZ
-gXU
-qkB
-xdv
+yju
+yju
+oqd
 yju
 hii
 rOY
@@ -95391,11 +95726,11 @@ dwL
 iQW
 iQW
 xrM
+cjh
 iQW
 iQW
-iQW
-iQW
-iQW
+qAs
+qkB
 iQW
 iQW
 iQW
@@ -95601,7 +95936,7 @@ rGJ
 bWG
 rDF
 dSh
-bWa
+flw
 qUa
 dSh
 rbM
@@ -95617,11 +95952,11 @@ wbb
 bIi
 vzJ
 vom
-mtj
-mtj
+cfP
+bSU
 wvA
 phK
-sdC
+ezO
 eAv
 mJI
 lTr
@@ -95648,11 +95983,11 @@ xrM
 iQW
 iQW
 xrM
-iQW
-iQW
-iQW
-iQW
-iQW
+shG
+cae
+hSk
+dTC
+tjV
 iQW
 iQW
 iQW
@@ -95865,7 +96200,7 @@ wca
 fqD
 hOP
 ajA
-rbM
+xwF
 nqh
 bAu
 bAu
@@ -95878,7 +96213,7 @@ eFZ
 qrn
 wvA
 phK
-sdC
+ezO
 sdC
 qFt
 vVh
@@ -95905,11 +96240,11 @@ xrM
 iQW
 iQW
 xrM
-iQW
-iQW
-iQW
-iQW
-iQW
+mRt
+bmo
+bki
+teK
+mlN
 iQW
 iQW
 iQW
@@ -96115,15 +96450,15 @@ mhd
 mjN
 ful
 dSh
-whO
+vDm
 agp
 dSh
 pDl
 vez
 fVE
 ukk
-rbM
-iQW
+qis
+vzg
 iQW
 iQW
 iQW
@@ -96133,7 +96468,7 @@ mdx
 oAA
 mtj
 mtj
-pnl
+dMU
 tUb
 oHn
 sdC
@@ -96376,10 +96711,10 @@ laL
 agp
 dSh
 fmp
-hlK
-gMp
+oNi
+nyR
 auV
-rbM
+gXU
 vBr
 vBr
 vBr
@@ -96390,8 +96725,8 @@ ljo
 dYN
 mtj
 iIS
-pnl
-feg
+dMU
+mtj
 oHn
 sdC
 tKr
@@ -96629,11 +96964,11 @@ ydv
 iNf
 wQX
 dSh
-gvZ
-xxB
+dSh
+ufP
 dSh
 jvd
-oNi
+boc
 xOM
 iVA
 hcv
@@ -96648,7 +96983,7 @@ gBW
 mtj
 mtj
 dMU
-lPH
+mtj
 brY
 kPg
 kPg
@@ -96885,10 +97220,10 @@ urf
 jMJ
 axU
 jfz
-dSh
-vDm
-xxB
-dSh
+dwb
+ptD
+luW
+igG
 tcR
 cmA
 cUk
@@ -96905,7 +97240,7 @@ gBW
 dKA
 dKA
 ycS
-xGw
+eFZ
 gbL
 gCa
 vSJ
@@ -97142,12 +97477,12 @@ rdS
 jnm
 rMe
 atD
-dSh
-dSh
-xxB
-dSh
+dwb
+lGk
+luW
+hAd
 iEp
-epH
+wfN
 cpq
 scw
 lmI
@@ -97399,15 +97734,15 @@ xDi
 cwq
 fqd
 urs
-bki
+dwb
 nQM
-xxB
-dSh
-tew
-epH
-nyR
-bev
+qQl
+kVP
 rbM
+epH
+cdw
+bev
+ndq
 vBr
 nzy
 nzy
@@ -97419,7 +97754,7 @@ szK
 bvf
 tCx
 beQ
-xte
+mtj
 fjr
 gCa
 pAW
@@ -97654,18 +97989,18 @@ xdI
 piR
 xDi
 kfe
+lPH
 kgA
-kgA
-miV
-dSh
-xxB
-dSh
+dwb
+pqN
+rJJ
+xgS
 wtB
-epH
+kCe
 kTa
+tmm
 xhe
-rbM
-iQW
+vzg
 iQW
 iQW
 iQW
@@ -97676,8 +98011,8 @@ vom
 mtj
 uAw
 bpW
+mtj
 gyC
-gCa
 gCa
 bMe
 bMe
@@ -97911,15 +98246,15 @@ pTK
 kxO
 qek
 xDi
+nGU
 eaV
-eaV
-ssF
-dSh
+bZr
+oqG
 wVE
-dSh
+bZr
 rbM
-oTA
 rbM
+hfZ
 rbM
 rbM
 ljo
@@ -97934,9 +98269,9 @@ mtj
 vue
 knT
 cfP
-gCa
-luW
-teM
+xIk
+bMe
+xte
 tWN
 teM
 pKX
@@ -98168,8 +98503,8 @@ fLs
 elh
 bPN
 pZP
-pZP
-pZP
+olv
+olv
 olv
 gXS
 ltL
@@ -98189,9 +98524,9 @@ pRH
 nBI
 mtj
 tEX
-tLe
-qQl
-gCa
+czc
+mtj
+hWH
 fLC
 fdq
 vuF
@@ -98428,13 +98763,13 @@ vjs
 vjs
 vjs
 vjs
-vjs
+pqN
 qga
-pGU
+tBY
 kbd
 bNn
 jhz
-mRh
+lKC
 vAc
 bjt
 jeC
@@ -98446,9 +98781,9 @@ aaC
 rTe
 qFn
 aiD
-tLe
-phN
-gCa
+gvZ
+mtj
+nry
 fLC
 eJg
 dCs
@@ -98704,9 +99039,9 @@ bSU
 mtj
 ool
 tLe
+mtj
 ihI
-gCa
-onD
+fLC
 koK
 idh
 laP
@@ -98953,7 +99288,7 @@ wyn
 xIT
 vfW
 vkH
-xIT
+wyn
 xIT
 eob
 vom
@@ -98961,9 +99296,9 @@ xrt
 mtj
 jxk
 tLe
+mtj
 ihI
-gCa
-qoC
+bMe
 kXJ
 ahK
 nuA
@@ -99218,11 +99553,11 @@ mZh
 mZh
 wIk
 wqd
+feg
 hRh
-gCa
+bMe
 hne
-dSJ
-hne
+dEj
 hne
 hne
 hne
@@ -99476,9 +99811,9 @@ mZh
 uhC
 bSe
 uhC
+ssl
 bMe
-ndq
-cYr
+peB
 dTD
 fav
 fav
@@ -101015,11 +101350,11 @@ qDv
 xzu
 tON
 wHs
-rJJ
+njm
 cDr
-rCI
+aPX
 tZB
-tZB
+aPX
 rKP
 tZB
 mjs
@@ -101276,7 +101611,7 @@ njm
 cDr
 rCI
 tZB
-tZB
+aPX
 msv
 nZr
 nZr
@@ -101802,9 +102137,9 @@ ygp
 qEy
 lxz
 cvc
-tje
-ksC
-uig
+tZB
+hMP
+sDA
 iEQ
 bMe
 iQW
@@ -102058,10 +102393,10 @@ iWZ
 aOw
 wLY
 krz
-ePt
-tZB
+max
+tje
 kpv
-onD
+uig
 khd
 bMe
 yju
@@ -103330,9 +103665,9 @@ xdv
 bMe
 fUi
 bMe
-vLj
-tje
-mlN
+tZB
+tZB
+mAu
 nuO
 aPX
 tZB

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -97,6 +97,16 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
+"abo" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "abr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -1501,11 +1511,11 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "azt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "azw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2403,6 +2413,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"aRK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aRM" = (
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
@@ -3034,6 +3053,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"bda" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "bdk" = (
 /obj/machinery/atmospherics/components/binary/passive_gate,
 /turf/open/floor/plating,
@@ -4200,9 +4225,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "byG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port to Processing"
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -6617,16 +6642,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "crt" = (
-/obj/effect/turf_decal/siding/engineering{
-	dir = 4
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Engineering - Atmospherics Central";
-	network = list("ss13","engineering")
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "crI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot,
@@ -6707,11 +6727,11 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "csw" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "csR" = (
 /obj/machinery/vending/clothing,
@@ -7002,6 +7022,12 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
+"cxV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cxY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7621,9 +7647,9 @@
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
 "cIi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/engineering/corner{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -8491,7 +8517,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cYP" = (
@@ -10800,21 +10825,10 @@
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "dSJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor/right/directional/south{
-	name = "Engineering Delivery";
-	req_access = list("engineering")
-	},
-/obj/structure/window/spawner/directional/east{
-	pixel_x = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dSO" = (
 /obj/structure/sign/warning/pods/directional/west,
 /turf/open/floor/plating,
@@ -10913,7 +10927,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "dUw" = (
-/obj/effect/turf_decal/tile/engineering,
+/obj/effect/turf_decal/siding/engineering/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/engineering/half,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dUx" = (
@@ -11291,6 +11308,9 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Pure to Port"
+	},
+/obj/effect/turf_decal/siding/engineering{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -12737,6 +12757,10 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"eDO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "eDR" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -12868,14 +12892,15 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "eGA" = (
-/obj/effect/turf_decal/siding/engineering/corner{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/engineering{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/space/basic,
+/area/space/nearstation)
 "eGB" = (
 /obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 8
@@ -14618,6 +14643,14 @@
 /obj/effect/turf_decal/tile/security/half,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"fno" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/pipedispenser/disposal,
+/obj/effect/turf_decal/siding/engineering{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "fnp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2,
@@ -15771,10 +15804,13 @@
 /turf/open/floor/iron,
 /area/station/science)
 "fJe" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Port to Network"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -17580,21 +17616,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "gtv" = (
-/obj/structure/disposaloutlet{
-	dir = 4;
-	name = "Cargo Deliveries"
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
 	},
-/obj/structure/window/spawner/directional/south{
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gtz" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance/two,
@@ -17682,6 +17710,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"gwc" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gwj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -19306,11 +19343,15 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "gZV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "gZY" = (
 /obj/machinery/holopad,
 /obj/effect/mapping_helpers/ianbirthday,
@@ -19419,6 +19460,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"hbJ" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hbL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19851,6 +19896,9 @@
 "hlT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 9
+	},
+/obj/effect/turf_decal/siding/engineering/corner{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -25480,7 +25528,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "jpQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jqb" = (
@@ -26871,6 +26921,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"jPG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jPZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark/half/contrasted{
@@ -27258,6 +27314,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
+"jXe" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jXh" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/grimy,
@@ -28593,6 +28656,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 5
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "ksC" = (
@@ -28687,6 +28753,7 @@
 "kvf" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/tile/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kvi" = (
@@ -28941,6 +29008,11 @@
 /obj/effect/turf_decal/tile/command/half,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs)
+"kAx" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "kAz" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/glass/bottle/beer/light,
@@ -31241,6 +31313,9 @@
 "lsj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/machinery/meter,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lsk" = (
@@ -31712,7 +31787,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "lAF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lAH" = (
@@ -32952,6 +33030,15 @@
 /obj/effect/turf_decal/tile/command/half,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
+"lVy" = (
+/obj/effect/turf_decal/siding/engineering{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lVA" = (
 /obj/machinery/computer/mechpad{
 	dir = 8
@@ -32992,7 +33079,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
 "lVW" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Distro"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lWb" = (
@@ -33320,6 +33411,12 @@
 "mbf" = (
 /turf/closed/wall/r_wall,
 /area/station/science/server)
+"mbg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mbI" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/records/medical/laptop{
@@ -33528,11 +33625,9 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "meq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Distro"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "met" = (
@@ -35828,7 +35923,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mTj" = (
@@ -36089,6 +36183,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"mYy" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to waste"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mYz" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment{
@@ -36187,9 +36288,13 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "nao" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/machinery/meter,
+/obj/effect/turf_decal/siding/engineering/corner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/engineering/corner,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nay" = (
@@ -36840,9 +36945,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "nna" = (
-/obj/effect/turf_decal/siding/engineering{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nni" = (
@@ -37456,6 +37560,7 @@
 /area/station/engineering/gravity_generator)
 "nwh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nwj" = (
@@ -39178,13 +39283,7 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/central)
 "ofs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/engineering/corner,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ofw" = (
@@ -39446,6 +39545,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "omE" = (
@@ -40495,6 +40595,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"oGj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "oGo" = (
 /obj/machinery/door/airlock{
 	name = "Art Storage Room"
@@ -40909,6 +41013,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "oPh" = (
@@ -41434,6 +41541,11 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
+"pay" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "paC" = (
 /obj/effect/turf_decal/siding/grey{
 	dir = 8
@@ -42058,6 +42170,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pmH" = (
@@ -42760,6 +42873,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"pzM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "pzQ" = (
 /turf/closed/wall,
 /area/station/service/janitor)
@@ -43299,7 +43417,10 @@
 /turf/open/floor/iron/terracotta/herringbone,
 /area/station/maintenance/starboard/aft)
 "pJI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pJT" = (
@@ -43636,8 +43757,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
 "pRB" = (
-/obj/effect/turf_decal/tile/engineering{
-	dir = 4
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Port to Processing"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -44178,6 +44303,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "qbx" = (
@@ -44673,8 +44799,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
 "qjZ" = (
-/obj/structure/chair/stool/directional/east,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qka" = (
@@ -45069,10 +45197,10 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/nanite)
 "qrF" = (
-/obj/effect/turf_decal/siding/engineering/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qrO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45136,9 +45264,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qsE" = (
-/obj/effect/turf_decal/tile/engineering{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qsX" = (
@@ -47459,8 +47588,11 @@
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "rnJ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rnP" = (
@@ -47473,6 +47605,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "rnT" = (
@@ -48145,7 +48280,9 @@
 /area/station/command/heads_quarters/qm)
 "rCi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/science/ordnance)
 "rCm" = (
@@ -49914,6 +50051,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/purple,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "sjR" = (
@@ -50441,6 +50581,13 @@
 "ssF" = (
 /turf/closed/wall,
 /area/station/commons/storage/primary)
+"ssJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ssW" = (
 /obj/vehicle/ridden/janicart,
 /obj/machinery/light/directional/west,
@@ -52144,7 +52291,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "tdz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tdL" = (
@@ -53857,6 +54006,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "tHE" = (
@@ -54139,6 +54289,14 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
+"tPV" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tQa" = (
 /obj/structure/bed/maint,
 /obj/item/bedsheet,
@@ -54341,8 +54499,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "tSO" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/pipedispenser/disposal,
+/obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tSQ" = (
@@ -55725,6 +55882,11 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"urv" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "urA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -58124,6 +58286,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
+"vlU" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to distro";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vml" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/circuit,
@@ -58244,6 +58413,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"vpc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vpm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -58653,6 +58828,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"vxY" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "vyi" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -60837,6 +61019,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "wrb" = (
@@ -61653,6 +61836,13 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"wFP" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to distro staging"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wFS" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
@@ -62626,6 +62816,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"wWX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wXi" = (
 /obj/effect/turf_decal/loading_area/white{
 	color = "blue";
@@ -62917,6 +63112,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xbE" = (
@@ -63192,6 +63388,12 @@
 "xgw" = (
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/department/engine)
+"xgN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "xgS" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -65108,6 +65310,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xQZ" = (
@@ -90663,27 +90866,27 @@ cgD
 gQv
 yju
 yju
-yju
+vxY
+tPV
+kAx
 xQP
-yju
+qrF
 xQP
-yju
-xQP
-yju
+qrF
 omv
-xoo
-xaN
-xoo
+pzM
+eDO
+pzM
 xbu
-xdv
+urv
 wqT
-hii
+gtv
 tHl
-rOY
+crt
 qbv
-rOY
-rOY
-rOY
+crt
+crt
+crt
 ksA
 iQW
 iQW
@@ -90920,7 +91123,7 @@ tbL
 gQv
 xoo
 xoo
-bRS
+azt
 wxt
 bRS
 wxt
@@ -90941,7 +91144,7 @@ wzs
 xoo
 xoo
 xoo
-tHM
+gZV
 iQW
 iQW
 iQW
@@ -91177,7 +91380,7 @@ ngZ
 epU
 gtR
 epU
-rjO
+wFP
 sDX
 ife
 oJi
@@ -91198,7 +91401,7 @@ pyQ
 epU
 kfN
 xoo
-tHM
+gZV
 iQW
 iQW
 iQW
@@ -91455,7 +91658,7 @@ qXm
 qgU
 iDX
 xoo
-tHM
+gZV
 aNE
 aNE
 aNE
@@ -91690,8 +91893,8 @@ wDH
 lsk
 uFS
 uFS
-uFS
-uFS
+dRq
+dRq
 rjO
 uFS
 tew
@@ -91699,11 +91902,11 @@ fvq
 dGi
 fvq
 kvf
-fvq
-fvq
-fvq
-uDw
-fvq
+byG
+byG
+byG
+aRK
+byG
 lsj
 oXc
 uDw
@@ -91946,22 +92149,22 @@ oww
 oQE
 tnF
 wKw
-wKw
+wWX
 rnJ
 fJe
 nao
 eaQ
 hlT
-uFS
-uFS
-uFS
+tSO
+ofs
+xNl
 dUw
-jpo
-jpo
-jpo
-jpo
-pRB
-uFS
+cTR
+aVg
+xWc
+pSM
+wvW
+uHi
 ayL
 uFS
 uFS
@@ -91969,7 +92172,7 @@ mqx
 uFS
 fGe
 bRS
-tHM
+gZV
 fgD
 sDo
 fVa
@@ -92203,22 +92406,22 @@ sid
 wDH
 uFS
 uFS
-uFS
-dRq
-dRq
-csw
-uFS
-uFS
-uFS
-uFS
-uFS
-hWE
-cTR
-aVg
-xWc
-pSM
-wvW
-uFS
+eNP
+eLR
+tDI
+qMp
+gaR
+wnl
+fno
+pPK
+gaR
+lVy
+dtN
+mdN
+cMr
+tYW
+tCS
+uHi
 qJP
 uFS
 uFS
@@ -92460,30 +92663,30 @@ mTg
 wDH
 uFS
 uFS
-lVW
-gZV
-gZV
-ofs
-crt
-cIi
-qjZ
-qrF
-xNl
-eGA
-dtN
-mdN
-cMr
-tYW
-tCS
+eNP
+eLR
+xrA
+wfP
+gaR
+gaR
+gaR
+gaR
+gaR
+qTu
+hWE
+uKQ
+jyX
+svI
+gVJ
+pRB
+kMt
 uFS
-jCT
-uFS
-uFS
+dRq
 mqx
 iuQ
 szM
 rTk
-tHM
+gZV
 aNE
 aNE
 aNE
@@ -92719,23 +92922,23 @@ uFS
 uFS
 eNP
 eLR
-tDI
-qMp
+krO
+cwW
 gaR
-wnl
-tSO
-pPK
+wUw
+xwO
+bBu
 gaR
-nna
-hWE
-uKQ
-jyX
-svI
-gVJ
-byG
-kMt
+igw
+xGL
+epU
+dtN
+jWv
+wvW
+uHi
+jCT
 uFS
-uFS
+dRq
 mqx
 iHD
 vRR
@@ -92974,30 +93177,30 @@ rFe
 wDH
 uFS
 uFS
-eNP
-eLR
-xrA
-wfP
-gaR
-gaR
-gaR
-gaR
-gaR
-qTu
-xGL
-epU
-dtN
-jWv
-wvW
+eff
+rFP
+rFP
+cFt
+ako
+ybN
+guj
+hKJ
+faL
+jXG
 uFS
+qcc
+hWE
+bpT
+wvW
+uHi
 jCT
 uFS
-uFS
-mqx
+jPG
+oGj
 uPE
 jeb
 bRS
-tHM
+gZV
 fgD
 ikJ
 cdV
@@ -93231,26 +93434,26 @@ rFe
 wDH
 uFS
 uFS
-eNP
-eLR
-krO
-cwW
-gaR
-wUw
-xwO
-bBu
-gaR
-igw
-uFS
-qcc
-hWE
-bpT
-wvW
-uFS
-azt
 uFS
 uFS
-uVE
+uFS
+oTA
+wKw
+vxA
+itm
+vxA
+wKw
+cIS
+cIS
+wKw
+pJI
+cIi
+cIi
+jXe
+kMt
+uFS
+nbx
+tdz
 cNK
 nic
 xWg
@@ -93488,30 +93691,30 @@ ebA
 wDH
 uFS
 uFS
-eff
-rFP
-rFP
-cFt
-ako
-ybN
-guj
-hKJ
-faL
-jXG
+dRq
 uFS
 uFS
-xGL
-epU
-qsE
-uFS
-jCT
 uFS
 uFS
-nbx
+uFS
+uFS
+uFS
+uFS
+ras
+ras
+uFS
+iuQ
+xGw
+xGw
+xGw
+lVW
+dSJ
+mbg
+cxV
 owm
 sia
 rTk
-tHM
+gZV
 aNE
 aNE
 aNE
@@ -93744,27 +93947,27 @@ lan
 cWy
 wDH
 uFS
+hbJ
 uFS
 uFS
 uFS
 uFS
-oTA
-wKw
-vxA
-itm
-vxA
-wKw
-cIS
-cIS
-wKw
-wKw
-wKw
-wKw
-wKw
-kMt
 uFS
 uFS
-uPE
+uFS
+uFS
+uFS
+uFS
+uFS
+uFS
+qsE
+ldo
+wJQ
+aDL
+pay
+aDL
+ojg
+nwh
 noz
 lQM
 rZa
@@ -93999,7 +94202,7 @@ xAK
 xAK
 ibf
 mTj
-wDH
+ssJ
 uFS
 uFS
 uFS
@@ -94011,21 +94214,21 @@ uFS
 uFS
 uFS
 dRq
-ras
-ras
 uFS
-iuQ
-xGw
-xGw
-xGw
+uFS
+uFS
+qsE
+uFS
+uFS
+mjr
 meq
-xGw
-xGw
-nwh
+vlU
+uFS
+uPE
 uFS
 cAV
 bRS
-tHM
+gZV
 fgD
 vNk
 unI
@@ -94271,13 +94474,13 @@ uFS
 uFS
 uFS
 uFS
-lyp
-pJI
-ldo
-wJQ
-tdz
-aDL
-ojg
+qsE
+uFS
+uFS
+uFS
+mXf
+qjZ
+bda
 jpQ
 cSx
 hPg
@@ -94532,14 +94735,14 @@ lyp
 uFS
 uFS
 uFS
-mXf
-mjr
-uFS
+xgN
+mYy
+vpc
 okf
 uFS
 qQm
 xoo
-tHM
+gZV
 aNE
 aNE
 aNE
@@ -94786,17 +94989,17 @@ jmj
 jmj
 jmj
 pmn
-kYY
 gRZ
 tIF
-bOl
 mFt
+nna
+une
 lAF
 une
 wHt
 ebd
 xoo
-tHM
+gZV
 iQW
 yju
 iQW
@@ -95043,17 +95246,17 @@ dEK
 irR
 tlj
 gaQ
-tlj
 jpo
 jpo
-azM
 pZa
+azM
 jpo
+gwc
 jpo
 igX
 xoo
 xoo
-tHM
+gZV
 iQW
 yju
 iQW
@@ -95283,7 +95486,7 @@ fWk
 dGz
 qSl
 crs
-gtv
+mtj
 asU
 phK
 iuZ
@@ -95305,12 +95508,12 @@ bRS
 bRS
 rst
 bRS
-bRS
+csw
 bRS
 xoo
 xoo
-hii
-dwL
+abo
+eGA
 yju
 xrM
 iQW
@@ -95540,7 +95743,7 @@ nqh
 nMa
 wIF
 crs
-dSJ
+mtj
 uEQ
 cDO
 uva
@@ -95562,11 +95765,11 @@ yju
 yju
 oqd
 yju
-hii
-rOY
-rOY
-rOY
-dwL
+gtv
+crt
+crt
+crt
+eGA
 iQW
 iQW
 xrM
@@ -95796,8 +95999,8 @@ wbb
 bIi
 vzJ
 vom
-cfP
-bSU
+mtj
+mtj
 wvA
 phK
 ezO

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1154,9 +1154,10 @@
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "atD" = (
-/obj/effect/turf_decal/tile/engineering/half,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "atI" = (
@@ -1407,12 +1408,16 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "axU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 7
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_y = 10
+	},
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/engineering/lobby)
 "aye" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -11279,13 +11284,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eaV" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4;
-	name = "Connector Port"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
 	},
-/obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "eaW" = (
@@ -11972,16 +11973,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "epH" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
-	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "epU" = (
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 8
@@ -14816,16 +14815,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"fqd" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4;
-	name = "Connector Port"
-	},
-/obj/structure/window/spawner/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "fqi" = (
 /obj/structure/table,
 /obj/item/stack/sticky_tape{
@@ -19222,13 +19211,6 @@
 /obj/item/storage/box/mousetraps,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"gXS" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/obj/machinery/vending/tool,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "gXU" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/rnd_all,
@@ -20548,6 +20530,16 @@
 /obj/machinery/plumbing/reaction_chamber,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"hAd" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "Connector Port"
+	},
+/obj/structure/window/spawner/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "hAg" = (
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
@@ -22192,10 +22184,11 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "igG" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/engineering/half,
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/engineering/lobby)
 "igJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -24959,11 +24952,14 @@
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "jfz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 10
+/obj/effect/turf_decal/tile/engineering/half,
+/obj/machinery/camera/directional/south{
+	c_tag = "Public - Tool Storage"
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "jfL" = (
 /obj/machinery/pdapainter/security,
 /turf/open/floor/carpet,
@@ -25297,12 +25293,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "jnm" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/electronics/airalarm,
+/obj/item/electronics/airalarm,
+/obj/item/electronics/airalarm,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "jno" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Containment Pen #7";
@@ -26675,13 +26672,11 @@
 /turf/closed/wall/r_wall,
 /area/station/commons/fitness)
 "jMJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "jMS" = (
 /obj/structure/chair,
 /obj/effect/landmark/event_spawn,
@@ -30158,10 +30153,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "kVP" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/vending/assist,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "kVR" = (
@@ -37958,11 +37952,13 @@
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
 "nGU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "nHc" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/fore)
@@ -39827,9 +39823,14 @@
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "oqG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination/tools,
+/obj/effect/turf_decal/tile/engineering/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "oqS" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -40621,10 +40622,12 @@
 "oHn" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/structure/table,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 7
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
 	},
-/obj/item/stack/sheet/iron/fifty{
+/obj/item/stack/cable_coil,
+/obj/item/storage/box/lights/mixed{
 	pixel_y = 10
 	},
 /turf/open/floor/iron,
@@ -42475,13 +42478,15 @@
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
 "ptD" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/table/reinforced,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "Connector Port"
+	},
+/obj/structure/window/spawner/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "ptH" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47008,9 +47013,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/fore)
 "rdS" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/engineering/opposingcorners,
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/engineering/half,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "rdT" = (
@@ -48290,12 +48294,10 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "rDF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/engineering/half,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "rDK" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/disposalpipe/segment{
@@ -48485,12 +48487,9 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "rGJ" = (
-/obj/effect/turf_decal/tile/engineering/half,
-/obj/machinery/camera/directional/south{
-	c_tag = "Public - Tool Storage"
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "rGK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -48653,11 +48652,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rJJ" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/engineering/half,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/lobby)
+/area/station/hallway/primary/aft)
 "rJZ" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Lab Storage"
@@ -48763,10 +48763,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "rMe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
 	},
-/obj/structure/cable,
+/obj/machinery/vending/assist,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "rMj" = (
@@ -55248,6 +55248,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"ufP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "ufQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55808,13 +55814,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "urf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination/tools,
-/obj/effect/turf_decal/tile/engineering/opposingcorners,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "urs" = (
 /obj/effect/turf_decal/tile/engineering/half,
 /obj/item/radio/intercom/directional/south,
@@ -62400,11 +62409,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/service)
 "wQX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/engineering/half,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "wRc" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -63303,18 +63310,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/department/engine)
 "xgS" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil,
-/obj/item/storage/box/lights/mixed{
-	pixel_y = 10
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/lobby)
+/area/station/commons/storage/primary)
 "xgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -96192,7 +96192,7 @@ eFZ
 qrn
 wvA
 phK
-rJJ
+igG
 sdC
 qFt
 vVh
@@ -96427,7 +96427,7 @@ piR
 nLi
 ydv
 iNf
-igG
+rdS
 dSh
 vDm
 agp
@@ -96449,7 +96449,7 @@ mtj
 mtj
 dMU
 tUb
-oHn
+axU
 sdC
 udF
 iRe
@@ -96680,11 +96680,11 @@ biu
 mPS
 kbb
 xdI
-piR
-urf
-jMJ
-axU
-rGJ
+rJJ
+oqG
+epH
+nGU
+jfz
 dSh
 laL
 agp
@@ -96706,7 +96706,7 @@ mtj
 iIS
 dMU
 mtj
-xgS
+oHn
 sdC
 tKr
 cyj
@@ -96937,12 +96937,12 @@ sai
 mPS
 kbb
 xdI
+piR
+nLi
+xgS
+kVP
+wQX
 rDF
-rdS
-jnm
-rMe
-atD
-dSh
 whO
 agp
 dSh
@@ -97454,8 +97454,8 @@ xdI
 gYN
 xDi
 kfe
-kVP
-gXS
+rMe
+atD
 dSh
 whO
 qUa
@@ -97717,7 +97717,7 @@ dSh
 eoK
 qQl
 dSh
-ptD
+jnm
 wfN
 cdw
 bev
@@ -97966,8 +97966,8 @@ giF
 kbb
 xdI
 piR
-fqd
-eaV
+ptD
+hAd
 lPH
 kgA
 dSh
@@ -98225,8 +98225,8 @@ pTK
 kxO
 lGk
 lGk
-nGU
-nGU
+eaV
+eaV
 dSh
 dSh
 wVE
@@ -98482,8 +98482,8 @@ fLs
 elh
 bPN
 pZP
-epH
-epH
+urf
+urf
 olv
 olv
 ltL
@@ -98739,10 +98739,10 @@ rKC
 hLO
 qnK
 nQM
-jfz
-wQX
-oqG
-oqG
+ufP
+jMJ
+rGJ
+rGJ
 qga
 tBY
 kbd

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -3392,13 +3392,6 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"bki" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/space/basic,
-/area/space)
 "bkj" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Arrivals Dock"
@@ -3515,12 +3508,6 @@
 /obj/effect/turf_decal/tile/security/half,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
-"bmo" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste In"
-	},
-/turf/open/space/basic,
-/area/space)
 "bms" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -5787,12 +5774,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"cae" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space)
 "cai" = (
 /obj/structure/transit_tube/crossing{
 	dir = 4
@@ -6184,13 +6165,6 @@
 /obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"cjh" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Distro to Waste"
-	},
-/turf/open/space/basic,
-/area/space)
 "cjn" = (
 /obj/item/poster/tail_board,
 /turf/open/floor/plating,
@@ -10888,16 +10862,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
-"dTC" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Filters"
-	},
-/obj/effect/turf_decal/tile/dark_red{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "dTD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -17813,12 +17777,6 @@
 "gxq" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"gxv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space)
 "gxw" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -19884,12 +19842,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
-"hlK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "hlN" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/bed/medical/emergency,
@@ -21576,16 +21528,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
-"hSk" = (
-/obj/effect/turf_decal/tile/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4;
-	initialize_directions = 8
-	},
-/turf/open/space/basic,
-/area/space)
 "hSG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -24248,12 +24190,6 @@
 	},
 /turf/open/floor/carpet/lone/star,
 /area/station/service/chapel)
-"iQZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space)
 "iRe" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -34075,12 +34011,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/service/theater)
-"mlN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space)
 "mlZ" = (
 /obj/machinery/air_sensor/nitrous_tank,
 /turf/open/floor/engine/n2o,
@@ -35781,12 +35711,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
-"mRt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "mRD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
@@ -36782,13 +36706,6 @@
 /obj/structure/sign/poster/official/high_class_martini,
 /turf/closed/wall,
 /area/station/maintenance/fore)
-"nkA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Distro Stagsing to Filter"
-	},
-/turf/open/space/basic,
-/area/space)
 "nkF" = (
 /obj/effect/turf_decal/tile/security/half{
 	dir = 4
@@ -41910,12 +41827,6 @@
 "phK" = (
 /turf/open/floor/iron/half,
 /area/station/engineering/lobby)
-"phN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
 "phZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42188,11 +42099,11 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "pnl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pnp" = (
 /obj/item/emptysandbag,
 /turf/open/floor/wood,
@@ -44808,15 +44719,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"qkB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space)
 "qkH" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
@@ -45026,12 +44928,6 @@
 /obj/item/clothing/head/utility/hardhat,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
-"qoC" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
 "qoK" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/green{
@@ -45597,13 +45493,6 @@
 "qAr" = (
 /turf/closed/wall,
 /area/station/commons/toilet/restrooms)
-"qAs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/space/basic,
-/area/space)
 "qAE" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Medical - Reception";
@@ -49884,12 +49773,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"shG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space)
 "shI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -51897,10 +51780,6 @@
 "sWA" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"sWH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/turf/open/space/basic,
-/area/space)
 "sWS" = (
 /obj/effect/turf_decal/tile/security/opposingcorners,
 /obj/structure/cable,
@@ -52319,13 +52198,6 @@
 /obj/structure/chair/comfy,
 /turf/open/floor/iron,
 /area/station/science)
-"teK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/space/basic,
-/area/space)
 "teM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -52620,12 +52492,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"tjV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "tjY" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -55998,13 +55864,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"utk" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air to Distro"
-	},
-/turf/open/space/basic,
-/area/space)
 "utl" = (
 /obj/machinery/computer/order_console/bitrunning,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -91318,7 +91177,7 @@ ngZ
 epU
 gtR
 epU
-uFS
+rjO
 sDX
 ife
 oJi
@@ -91575,7 +91434,7 @@ gXa
 duN
 duN
 duN
-duN
+pnl
 tSn
 uFS
 uVE
@@ -95197,11 +95056,11 @@ xoo
 tHM
 iQW
 yju
-phN
-utk
-pnl
-sWH
-hlK
+iQW
+iQW
+iQW
+iQW
+iQW
 iQW
 iQW
 iQW
@@ -95454,11 +95313,11 @@ hii
 dwL
 yju
 xrM
-iQZ
-gxv
-qoC
-nkA
-hlK
+iQW
+iQW
+iQW
+iQW
+iQW
 iQW
 iQW
 iQW
@@ -95711,11 +95570,11 @@ dwL
 iQW
 iQW
 xrM
-cjh
 iQW
 iQW
-qAs
-qkB
+iQW
+iQW
+iQW
 iQW
 iQW
 iQW
@@ -95968,11 +95827,11 @@ xrM
 iQW
 iQW
 xrM
-shG
-cae
-hSk
-dTC
-tjV
+iQW
+iQW
+iQW
+iQW
+iQW
 iQW
 iQW
 iQW
@@ -96225,11 +96084,11 @@ xrM
 iQW
 iQW
 xrM
-mRt
-bmo
-bki
-teK
-mlN
+iQW
+iQW
+iQW
+iQW
+iQW
 iQW
 iQW
 iQW

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -193,6 +193,8 @@
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "adk" = (
@@ -265,10 +267,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/rec)
 "aeg" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aej" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -754,6 +758,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"anB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "anH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -1100,11 +1109,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"ate" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "atf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1505,9 +1509,10 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "azt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 8
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "azw" = (
@@ -1740,10 +1745,6 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plating,
 /area/station/construction)
-"aEj" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "aEr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2105,13 +2106,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
-"aMG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to distro";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "aMH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/purple{
@@ -2629,6 +2623,13 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"aVE" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "aVI" = (
 /obj/effect/turf_decal/tile/engineering,
 /obj/structure/cable,
@@ -3546,6 +3547,8 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bmL" = (
@@ -4214,9 +4217,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "byG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "byQ" = (
@@ -5063,8 +5064,6 @@
 /area/station/commons/locker)
 "bNn" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -6627,11 +6626,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "crt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "crI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -7627,12 +7624,13 @@
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
 "cIi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering{
-	dir = 8
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cIE" = (
 /obj/structure/railing{
 	dir = 1
@@ -8173,13 +8171,6 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"cUb" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "cUd" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -8515,6 +8506,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/storage)
+"cZd" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cZf" = (
 /mob/living/carbon/human/species/monkey,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -8832,10 +8829,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"deT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "dfb" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -9842,13 +9835,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
-"dAk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "dAo" = (
 /obj/structure/cable,
 /obj/machinery/navbeacon{
@@ -10824,13 +10810,10 @@
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "dSJ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/pipedispenser/disposal,
-/obj/effect/turf_decal/siding/engineering{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dSO" = (
 /obj/structure/sign/warning/pods/directional/west,
 /turf/open/floor/plating,
@@ -12613,6 +12596,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
+"eAz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "eAA" = (
 /obj/structure/table_frame/wood,
 /obj/item/storage/cans/sixbeer,
@@ -12890,7 +12878,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "eGA" = (
-/obj/effect/turf_decal/siding/engineering/corner,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eGB" = (
@@ -15312,6 +15302,10 @@
 /obj/structure/sign/warning/vacuum/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"fzh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "fzk" = (
 /obj/structure/sign/departments/xenobio/directional/south,
 /turf/open/floor/iron/white,
@@ -17074,6 +17068,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"ghP" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/pipedispenser/disposal,
+/obj/effect/turf_decal/siding/engineering{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gia" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/computer/camera_advanced/xenobio{
@@ -17599,10 +17601,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "gtv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gtz" = (
@@ -18015,6 +18016,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"gBX" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to distro";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gCa" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/lobby)
@@ -19165,15 +19173,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"gWU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gXa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 10
@@ -19325,12 +19324,13 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "gZV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/tile/engineering/half{
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gZY" = (
 /obj/machinery/holopad,
 /obj/effect/mapping_helpers/ianbirthday,
@@ -20107,11 +20107,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"hpe" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "hpm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20746,12 +20741,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
-"hDM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hDT" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -20907,10 +20896,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
-"hHi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hHz" = (
 /obj/machinery/light/directional/east,
 /obj/structure/reagent_dispensers/wall/virusfood/directional/south,
@@ -22568,6 +22553,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"ilT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ima" = (
 /obj/structure/cable,
 /obj/structure/grille/broken,
@@ -25312,10 +25303,6 @@
 /obj/item/emptysandbag,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"jnk" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jnm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/engineering/half{
@@ -25451,11 +25438,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
-"joV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jpa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4{
 	dir = 4
@@ -26186,6 +26168,12 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
+"jDB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jDD" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
@@ -27289,8 +27277,6 @@
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -29542,6 +29528,13 @@
 /obj/effect/decal/cleanable/garbage,
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
+"kIt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "kIw" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -29921,15 +29914,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"kQF" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "kQV" = (
 /obj/effect/turf_decal/tile/command/half{
 	dir = 8
@@ -31532,6 +31516,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"lwq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lwr" = (
 /obj/structure/table/glass,
 /obj/item/wrench/medical,
@@ -31980,6 +31971,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"lEh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lEk" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/airalarm/directional/north,
@@ -32149,11 +32149,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/science)
-"lHd" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "lHe" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/machinery/duct,
@@ -32887,15 +32882,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"lTk" = (
-/obj/effect/turf_decal/siding/engineering{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/engineering{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lTn" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/item/kirbyplants/organic/plant18,
@@ -33074,13 +33060,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
 "lVW" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Distro"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lWb" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -33434,12 +33417,6 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"mch" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mcp" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -33620,9 +33597,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "meq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "met" = (
@@ -33900,8 +33875,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mjr" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to waste"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -34774,6 +34750,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"myb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "myf" = (
 /turf/open/floor/plating,
 /area/station/maintenance/solars)
@@ -35159,8 +35142,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "mFt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -36932,12 +36915,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "nna" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "nni" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 4
@@ -37548,11 +37529,15 @@
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/gravity_generator)
 "nwh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nwj" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -38609,6 +38594,16 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
+"nSH" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nSI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39273,15 +39268,12 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/central)
 "ofs" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ofw" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science/xenobiology)
@@ -39501,6 +39493,13 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"ola" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "olv" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -41837,11 +41836,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
-"pfd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pfh" = (
 /obj/structure/lattice,
 /obj/item/toy/plush/lizard_plushie/space/green,
@@ -42555,16 +42549,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"puo" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port to Processing"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pup" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -43251,13 +43235,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/coldroom)
-"pGu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to waste"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pGv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43419,9 +43396,8 @@
 /turf/open/floor/iron/terracotta/herringbone,
 /area/station/maintenance/starboard/aft)
 "pJI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -43444,13 +43420,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
-"pKE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to distro staging"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pKQ" = (
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
@@ -43767,12 +43736,8 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "pRB" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "pRH" = (
@@ -44181,12 +44146,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "pZa" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pZd" = (
@@ -44808,12 +44769,15 @@
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
 "qjZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering{
-	dir = 1
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 9
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "qka" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
 	dir = 1
@@ -45206,11 +45170,11 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/nanite)
 "qrF" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qrO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45274,15 +45238,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qsE" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 9
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Port to Processing"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qsX" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Ordnance Lab"
@@ -45783,14 +45747,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"qDr" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "qDs" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -45848,6 +45804,14 @@
 /obj/effect/turf_decal/tile/prison,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
+"qDY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Port"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qDZ" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron/grimy,
@@ -46269,14 +46233,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"qMY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qNs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -46864,6 +46820,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
+"qZO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qZS" = (
 /obj/effect/landmark/start/mime,
 /obj/structure/chair/stool/directional/west,
@@ -47241,6 +47204,16 @@
 /obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"rgS" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "rhc" = (
 /obj/structure/table,
 /obj/item/stack/sheet/rglass{
@@ -47690,16 +47663,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain)
-"rot" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "roG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -47845,6 +47808,10 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/station/maintenance/department/medical/plasmaman)
+"rse" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rsm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47890,6 +47857,15 @@
 	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
 	},
 /area/station/maintenance/department/medical)
+"rsP" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rsT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -48719,6 +48695,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"rJr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rJw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -48802,12 +48783,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
-"rKV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rKX" = (
 /obj/machinery/power/shieldwallgen/xenobiologyaccess,
 /obj/structure/cable,
@@ -49480,11 +49455,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
-"rYK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rYS" = (
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
@@ -50384,11 +50354,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"sov" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "sox" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/under/misc/pj/red,
@@ -50498,6 +50463,12 @@
 /obj/effect/turf_decal/tile/dark,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"sqJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "sqQ" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Kitchen";
@@ -51523,6 +51494,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/medical/medbay/central)
+"sIS" = (
+/obj/effect/turf_decal/siding/engineering/corner,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "sIU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -51703,6 +51678,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"sNn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "sNL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark,
@@ -52346,8 +52325,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "tdz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Distro staging to waste"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -54543,9 +54523,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "tSO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tSQ" = (
 /obj/structure/table/reinforced,
@@ -54749,6 +54729,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"tWC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "tWD" = (
 /obj/machinery/air_sensor/air_tank,
 /turf/open/floor/engine/air,
@@ -59900,6 +59886,12 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
+"vSY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vTq" = (
 /obj/effect/turf_decal/tile/command,
 /turf/open/floor/vault,
@@ -60113,6 +60105,13 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"vXm" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to distro staging"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vXr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61279,6 +61278,14 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"wvb" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Distro"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wvc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61720,12 +61727,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
-"wDE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wDH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63181,6 +63182,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"xcD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "xcR" = (
 /turf/closed/wall/r_wall,
 /area/station/construction)
@@ -63521,6 +63529,17 @@
 /obj/item/stack/license_plates/empty/fifty,
 /turf/open/floor/iron/textured,
 /area/station/security/prison/work)
+"xiA" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"xiO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "xiQ" = (
 /obj/structure/reflector/box,
 /turf/open/floor/engine,
@@ -63763,6 +63782,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
+"xlR" = (
+/obj/effect/turf_decal/siding/engineering{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "xlV" = (
 /obj/effect/spawner/random/structure/grille,
 /obj/structure/lattice,
@@ -64587,14 +64615,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/bomb)
-"xBi" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "xBn" = (
 /turf/closed/wall/r_wall,
 /area/station/science)
@@ -65324,10 +65344,10 @@
 /area/station/science)
 "xQP" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xQZ" = (
@@ -90883,27 +90903,27 @@ cgD
 gQv
 yju
 yju
-cUb
+aVE
+gZV
+nna
 xQP
-lHd
-qDr
-aeg
-qDr
-aeg
+dSJ
+xQP
+dSJ
 omv
-tSO
-deT
-tSO
+crt
+sNn
+crt
 xbu
-hpe
+lVW
 wqT
-xBi
+cIi
 tHl
-qrF
+pRB
 qbv
-qrF
-qrF
-qrF
+pRB
+pRB
+pRB
 ksA
 iQW
 iQW
@@ -91161,7 +91181,7 @@ wzs
 xoo
 xoo
 xoo
-pRB
+nwh
 iQW
 iQW
 iQW
@@ -91397,7 +91417,7 @@ ngZ
 epU
 gtR
 epU
-pKE
+vXm
 sDX
 ife
 oJi
@@ -91418,7 +91438,7 @@ pyQ
 epU
 kfN
 xoo
-pRB
+nwh
 iQW
 iQW
 iQW
@@ -91675,7 +91695,7 @@ qXm
 qgU
 iDX
 xoo
-pRB
+nwh
 aNE
 aNE
 aNE
@@ -91911,7 +91931,7 @@ lsk
 uFS
 uFS
 dRq
-qMY
+qDY
 rjO
 uFS
 tew
@@ -91919,11 +91939,11 @@ fvq
 dGi
 fvq
 kvf
-gZV
-gZV
-gZV
-gWU
-gZV
+lwq
+lwq
+lwq
+lEh
+lwq
 lsj
 oXc
 uDw
@@ -92166,14 +92186,14 @@ oww
 oQE
 tnF
 wKw
-joV
+tSO
 rnJ
 fJe
 nao
 eaQ
 hlT
-jnk
-eGA
+xiA
+sIS
 xNl
 dUw
 cTR
@@ -92189,7 +92209,7 @@ mqx
 uFS
 fGe
 bRS
-pRB
+nwh
 fgD
 sDo
 fVa
@@ -92429,10 +92449,10 @@ tDI
 qMp
 gaR
 wnl
-dSJ
+ghP
 pPK
 gaR
-lTk
+xlR
 dtN
 mdN
 cMr
@@ -92695,7 +92715,7 @@ uKQ
 jyX
 svI
 gVJ
-puo
+qsE
 kMt
 uFS
 dRq
@@ -92703,7 +92723,7 @@ mqx
 iuQ
 szM
 rTk
-pRB
+nwh
 aNE
 aNE
 aNE
@@ -93212,12 +93232,12 @@ wvW
 uHi
 jCT
 uFS
-byG
-hHi
+gtv
+fzh
 uPE
 jeb
 bRS
-pRB
+nwh
 fgD
 ikJ
 cdV
@@ -93463,14 +93483,14 @@ wKw
 cIS
 cIS
 wKw
-cIi
-pJI
-pJI
-qjZ
+qZO
+aeg
+aeg
+kIt
 kMt
 uFS
 nbx
-nwh
+sqJ
 cNK
 nic
 xWg
@@ -93724,14 +93744,14 @@ iuQ
 xGw
 xGw
 xGw
-lVW
-ate
-wDE
-rKV
+wvb
+anB
+vSY
+mFt
 owm
 sia
 rTk
-pRB
+nwh
 aNE
 aNE
 aNE
@@ -93964,7 +93984,7 @@ lan
 cWy
 wDH
 uFS
-aEj
+byG
 uFS
 uFS
 uFS
@@ -93977,14 +93997,14 @@ uFS
 uFS
 uFS
 uFS
-nna
+ofs
 ldo
+azt
 wJQ
-aDL
-sov
+eAz
 aDL
 ojg
-pfd
+pZa
 noz
 lQM
 rZa
@@ -94219,7 +94239,7 @@ xAK
 xAK
 ibf
 mTj
-gtv
+myb
 uFS
 uFS
 uFS
@@ -94227,25 +94247,25 @@ uFS
 uFS
 uFS
 uFS
-azt
+jDB
 uFS
 uFS
 dRq
 uFS
 uFS
 uFS
-nna
+ofs
 uFS
-uFS
-mjr
+qrF
+pJI
 meq
-aMG
+gBX
 uFS
 uPE
 uFS
 cAV
 bRS
-pRB
+nwh
 fgD
 vNk
 unI
@@ -94491,13 +94511,13 @@ uFS
 uFS
 uFS
 uFS
-nna
-uFS
-uFS
+ofs
 uFS
 mXf
-crt
-mch
+uFS
+tdz
+ola
+ilT
 jpQ
 cSx
 hPg
@@ -94750,16 +94770,16 @@ uFS
 wzH
 lyp
 uFS
-uFS
-uFS
-tdz
-pGu
-hDM
+tWC
+cZd
+rse
+mjr
+eGA
 okf
 uFS
 qQm
 xoo
-pRB
+nwh
 aNE
 aNE
 aNE
@@ -95007,16 +95027,16 @@ jmj
 jmj
 pmn
 gRZ
+xiO
 tIF
-mFt
-rYK
+rJr
 une
 lAF
 une
 wHt
 ebd
 xoo
-pRB
+nwh
 iQW
 yju
 iQW
@@ -95265,15 +95285,15 @@ tlj
 gaQ
 jpo
 jpo
-pZa
+jpo
 azM
 jpo
-kQF
+rsP
 jpo
 igX
 xoo
 xoo
-pRB
+nwh
 iQW
 yju
 iQW
@@ -95525,12 +95545,12 @@ bRS
 bRS
 rst
 bRS
-dAk
+xcD
 bRS
 xoo
 xoo
-ofs
-qsE
+rgS
+qjZ
 yju
 xrM
 iQW
@@ -95782,11 +95802,11 @@ yju
 yju
 oqd
 yju
-rot
-qrF
-qrF
-qrF
-qsE
+nSH
+pRB
+pRB
+pRB
+qjZ
 iQW
 iQW
 xrM

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -7609,6 +7609,13 @@
 /obj/structure/stone_tile/slab,
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
+"cIi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 9
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cIE" = (
 /obj/structure/railing{
 	dir = 1
@@ -10787,16 +10794,6 @@
 	},
 /turf/open/floor/vault,
 /area/station/command/bridge)
-"dSJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 3
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "dSO" = (
 /obj/structure/sign/warning/pods/directional/west,
 /turf/open/floor/plating,
@@ -12579,6 +12576,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
+"eAz" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Distro staging"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "eAA" = (
 /obj/structure/table_frame/wood,
 /obj/item/storage/cans/sixbeer,
@@ -12855,6 +12859,12 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"eGA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 3
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "eGB" = (
 /obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 8
@@ -19295,6 +19305,13 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"gZV" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "gZY" = (
 /obj/machinery/holopad,
 /obj/effect/mapping_helpers/ianbirthday,
@@ -37471,13 +37488,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/gravity_generator)
-"nwh" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Distro staging"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "nwj" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -38535,10 +38545,13 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
 "nSH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 3
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nSI" = (
@@ -51569,12 +51582,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"sNn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 3
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "sNL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark,
@@ -61163,10 +61170,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"wvb" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wvc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65215,13 +65218,6 @@
 /obj/structure/sign/departments/nanites/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science)
-"xQP" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "xQZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
@@ -90776,11 +90772,11 @@ gQv
 yju
 yju
 yju
-xQP
+gZV
 yju
-xQP
+gZV
 yju
-xQP
+gZV
 yju
 omv
 crt
@@ -93359,7 +93355,7 @@ qZO
 aeg
 aeg
 kIt
-nSH
+cIi
 uFS
 nbx
 sqJ
@@ -93611,12 +93607,12 @@ uFS
 uFS
 ras
 ras
-nwh
+eAz
 iuQ
 xGw
 xGw
 xGw
-wvb
+xGw
 anB
 vSY
 mFt
@@ -94383,10 +94379,10 @@ uFS
 uFS
 uFS
 oTA
-dSJ
-sNn
+nSH
+eGA
 mXf
-sNn
+eGA
 tdz
 ola
 uFS

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1107,7 +1107,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/half{
+	dir = 8
+	},
 /area/station/engineering/lobby)
 "atf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1408,15 +1410,9 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "axU" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 7
+/turf/open/floor/iron/corner{
+	dir = 4
 	},
-/obj/item/stack/sheet/iron/fifty{
-	pixel_y = 10
-	},
-/turf/open/floor/iron,
 /area/station/engineering/lobby)
 "aye" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -3756,11 +3752,13 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "brJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/lobby)
+/area/station/commons/storage/primary)
 "brN" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/cable,
@@ -6015,7 +6013,7 @@
 /area/station/maintenance/department/engine)
 "cfP" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/half,
 /area/station/engineering/lobby)
 "cgh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -11973,14 +11971,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "epH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "epU" = (
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 8
@@ -12520,6 +12515,8 @@
 /area/station/medical/medbay)
 "ezO" = (
 /obj/effect/turf_decal/tile/yellow/half,
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "ezP" = (
@@ -12838,7 +12835,7 @@
 /area/station/cargo/office)
 "eFZ" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/half,
 /area/station/engineering/lobby)
 "eGf" = (
 /obj/structure/reagent_dispensers/watertank/high,
@@ -14815,6 +14812,15 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"fqd" = (
+/obj/effect/turf_decal/tile/engineering/half,
+/obj/machinery/camera/directional/south{
+	c_tag = "Public - Tool Storage"
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "fqi" = (
 /obj/structure/table,
 /obj/item/stack/sticky_tape{
@@ -17997,7 +18003,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/half,
 /area/station/engineering/lobby)
 "gBX" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -19211,6 +19217,19 @@
 /obj/item/storage/box/mousetraps,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"gXS" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil,
+/obj/item/storage/box/lights/mixed{
+	pixel_y = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "gXU" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/rnd_all,
@@ -20531,15 +20550,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hAd" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4;
-	name = "Connector Port"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "hAg" = (
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
@@ -22184,11 +22199,14 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "igG" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination/tools,
+/obj/effect/turf_decal/tile/engineering/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/lobby)
+/area/station/commons/storage/primary)
 "igJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -24952,14 +24970,11 @@
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "jfz" = (
-/obj/effect/turf_decal/tile/engineering/half,
-/obj/machinery/camera/directional/south{
-	c_tag = "Public - Tool Storage"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 10
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "jfL" = (
 /obj/machinery/pdapainter/security,
 /turf/open/floor/carpet,
@@ -25293,13 +25308,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "jnm" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/table/reinforced,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "jno" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Containment Pen #7";
@@ -25904,7 +25922,9 @@
 /area/station/tcommsat/server)
 "jxk" = (
 /obj/effect/landmark/start/station_engineer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
 /area/station/engineering/lobby)
 "jxB" = (
 /obj/structure/table,
@@ -26672,11 +26692,11 @@
 /turf/closed/wall/r_wall,
 /area/station/commons/fitness)
 "jMJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "jMS" = (
 /obj/structure/chair,
 /obj/effect/landmark/event_spawn,
@@ -30153,11 +30173,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "kVP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/engineering/lobby)
 "kVR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -31408,6 +31431,10 @@
 /obj/item/toy/plush/batong,
 /turf/open/floor/wood,
 /area/station/maintenance/department/cargo)
+"luW" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "lvb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -32078,11 +32105,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lGk" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 4
-	},
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/engineering/half,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "lGl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_corner{
@@ -36006,6 +36032,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"mWF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "mWM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -37952,13 +37984,14 @@
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
 "nGU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/half{
+	dir = 8
+	},
+/area/station/engineering/lobby)
 "nHc" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/fore)
@@ -39825,9 +39858,9 @@
 "oqG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination/tools,
-/obj/effect/turf_decal/tile/engineering/opposingcorners,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
@@ -40622,12 +40655,10 @@
 "oHn" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 7
 	},
-/obj/item/stack/cable_coil,
-/obj/item/storage/box/lights/mixed{
+/obj/item/stack/sheet/iron/fifty{
 	pixel_y = 10
 	},
 /turf/open/floor/iron,
@@ -43710,7 +43741,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
 /area/station/engineering/lobby)
 "pRJ" = (
 /obj/machinery/button/door/directional/west{
@@ -47013,10 +47046,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/fore)
 "rdS" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/engineering/half,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "rdT" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -48294,10 +48327,15 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "rDF" = (
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "Connector Port"
+	},
+/obj/structure/window/spawner/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "rDK" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/disposalpipe/segment{
@@ -48487,9 +48525,17 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "rGJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/corner{
+	dir = 3
+	},
+/area/station/engineering/lobby)
 "rGK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -48652,10 +48698,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rJJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/engineering/half,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rJZ" = (
@@ -50883,7 +50926,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/half,
 /area/station/engineering/lobby)
 "szL" = (
 /obj/structure/cable,
@@ -52483,7 +52526,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
 /area/station/engineering/lobby)
 "thU" = (
 /turf/open/floor/wood,
@@ -54464,6 +54509,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
+"tTF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/engineering/half,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "tTM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54479,9 +54531,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "tUb" = (
-/turf/open/floor/iron/corner{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
+/turf/open/floor/iron/half,
 /area/station/engineering/lobby)
 "tUi" = (
 /obj/machinery/door/poddoor/shutters{
@@ -55249,11 +55302,13 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "ufP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/electronics/airalarm,
+/obj/item/electronics/airalarm,
+/obj/item/electronics/airalarm,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "ufQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55814,16 +55869,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "urf" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/turf/open/floor/iron/corner{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "urs" = (
 /obj/effect/turf_decal/tile/engineering/half,
 /obj/item/radio/intercom/directional/south,
@@ -58327,7 +58376,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
 /area/station/engineering/lobby)
 "voP" = (
 /obj/structure/table,
@@ -61896,7 +61947,7 @@
 	dir = 4
 	},
 /obj/machinery/vending/cigarette,
-/turf/open/floor/iron/half{
+/turf/open/floor/iron/corner{
 	dir = 8
 	},
 /area/station/engineering/lobby)
@@ -63310,11 +63361,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/department/engine)
 "xgS" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
+/turf/open/floor/iron/half{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/engineering/lobby)
 "xgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64047,7 +64097,9 @@
 /area/station/maintenance/disposal/incinerator)
 "xrt" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/half{
+	dir = 8
+	},
 /area/station/engineering/lobby)
 "xrA" = (
 /obj/structure/table,
@@ -95418,9 +95470,9 @@ fWk
 dGz
 qSl
 crs
-mtj
+urf
 asU
-phK
+axU
 iuZ
 kPg
 pRJ
@@ -95675,7 +95727,7 @@ nqh
 nMa
 wIF
 crs
-mtj
+phK
 uEQ
 cDO
 uva
@@ -95930,12 +95982,12 @@ wbb
 wbb
 bIi
 vzJ
-vom
-mtj
-mtj
+nGU
+urf
+feg
 wvA
 phK
-ezO
+luW
 eAv
 mJI
 lTr
@@ -96192,7 +96244,7 @@ eFZ
 qrn
 wvA
 phK
-igG
+ezO
 sdC
 qFt
 vVh
@@ -96427,7 +96479,7 @@ piR
 nLi
 ydv
 iNf
-rdS
+lGk
 dSh
 vDm
 agp
@@ -96445,11 +96497,11 @@ iQW
 ljo
 mdx
 oAA
-mtj
+phK
 mtj
 dMU
-tUb
-axU
+phK
+oHn
 sdC
 udF
 iRe
@@ -96680,11 +96732,11 @@ biu
 mPS
 kbb
 xdI
-rJJ
+tTF
+igG
 oqG
-epH
-nGU
-jfz
+brJ
+fqd
 dSh
 laL
 agp
@@ -96702,11 +96754,11 @@ ljo
 ljo
 ljo
 dYN
-mtj
+phK
 iIS
 dMU
-mtj
-oHn
+phK
+gXS
 sdC
 tKr
 cyj
@@ -96939,10 +96991,10 @@ kbb
 xdI
 piR
 nLi
-xgS
-kVP
+jMJ
+hAd
 wQX
-rDF
+rdS
 whO
 agp
 dSh
@@ -96958,11 +97010,11 @@ vBr
 iom
 nDj
 leo
-gBW
-mtj
+rGJ
+feg
 mtj
 dMU
-mtj
+phK
 brY
 kPg
 kPg
@@ -97476,7 +97528,7 @@ gBW
 iTT
 suI
 kJI
-brJ
+mHH
 mHH
 nQQ
 btF
@@ -97717,7 +97769,7 @@ dSh
 eoK
 qQl
 dSh
-jnm
+ufP
 wfN
 cdw
 bev
@@ -97733,7 +97785,7 @@ szK
 bvf
 tCx
 beQ
-mtj
+phK
 fjr
 gCa
 pAW
@@ -97967,7 +98019,7 @@ kbb
 xdI
 piR
 ptD
-hAd
+rDF
 lPH
 kgA
 dSh
@@ -97985,12 +98037,12 @@ iQW
 iQW
 ljo
 vMb
-mtj
+urf
 vom
 mtj
 uAw
 bpW
-mtj
+phK
 gyC
 gCa
 bMe
@@ -98223,8 +98275,8 @@ giF
 eQo
 pTK
 kxO
-lGk
-lGk
+epH
+epH
 eaV
 eaV
 dSh
@@ -98242,7 +98294,7 @@ kiB
 ljo
 ljo
 uzp
-uAw
+tUb
 iVd
 mtj
 vue
@@ -98482,8 +98534,8 @@ fLs
 elh
 bPN
 pZP
-urf
-urf
+jnm
+jnm
 olv
 olv
 ltL
@@ -98504,7 +98556,7 @@ nBI
 mtj
 tEX
 czc
-mtj
+phK
 hWH
 bMe
 fdq
@@ -98739,10 +98791,10 @@ rKC
 hLO
 qnK
 nQM
-ufP
-jMJ
-rGJ
-rGJ
+jfz
+mWF
+rJJ
+rJJ
 qga
 tBY
 kbd
@@ -98761,7 +98813,7 @@ rTe
 qFn
 aiD
 gvZ
-mtj
+phK
 nry
 bMe
 eJg
@@ -99018,7 +99070,7 @@ bSU
 mtj
 ool
 tLe
-mtj
+phK
 ihI
 bMe
 koK
@@ -99270,12 +99322,12 @@ vkH
 wyn
 xIT
 eob
-vom
+kVP
 xrt
-mtj
+xgS
 jxk
 tLe
-mtj
+phK
 ihI
 bMe
 kXJ

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -16019,10 +16019,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/command/storage/eva)
-"fLC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
 "fLR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32712,7 +32708,7 @@
 /area/station/science/ordnance)
 "lQM" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/purple,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
@@ -33102,10 +33098,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"lXj" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/closed/wall,
-/area/station/maintenance/department/engine)
 "lXl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38494,7 +38486,6 @@
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "nQM" = (
-/obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -40997,10 +40988,10 @@
 /area/station/maintenance/starboard/fore)
 "oOV" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan,
 /turf/open/space/basic,
 /area/space/nearstation)
 "oPh" = (
@@ -44272,8 +44263,8 @@
 /area/station/science/robotics/lab)
 "qbv" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -47589,10 +47580,10 @@
 /area/station/service/cafeteria)
 "rnS" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "rnT" = (
@@ -50036,10 +50027,10 @@
 /area/station/maintenance/department/medical)
 "sjQ" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/purple,
 /turf/open/space/basic,
 /area/space/nearstation)
 "sjR" = (
@@ -58891,9 +58882,6 @@
 "vzb" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"vzg" = (
-/turf/closed/wall,
-/area/space)
 "vzm" = (
 /obj/item/storage/box/ids,
 /obj/structure/closet/secure_closet/contraband/heads,
@@ -62685,9 +62673,6 @@
 "wVE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
@@ -95944,7 +95929,7 @@ rbM
 rbM
 rbM
 rbM
-lXj
+dSh
 uMC
 qsg
 wbb
@@ -96201,11 +96186,11 @@ fqD
 hOP
 ajA
 xwF
-nqh
+dSh
 bAu
 bAu
-nqh
-nqh
+dSh
+dSh
 dSh
 osi
 vNl
@@ -96458,7 +96443,7 @@ vez
 fVE
 ukk
 qis
-vzg
+rbM
 iQW
 iQW
 iQW
@@ -98000,7 +97985,7 @@ kCe
 kTa
 tmm
 xhe
-vzg
+rbM
 iQW
 iQW
 iQW
@@ -98527,7 +98512,7 @@ tEX
 czc
 mtj
 hWH
-fLC
+bMe
 fdq
 vuF
 vuF
@@ -98784,7 +98769,7 @@ aiD
 gvZ
 mtj
 nry
-fLC
+bMe
 eJg
 dCs
 vuF
@@ -99041,7 +99026,7 @@ ool
 tLe
 mtj
 ihI
-fLC
+bMe
 koK
 idh
 laP

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -3791,9 +3791,7 @@
 	network = list("ss13","engineering")
 	},
 /obj/effect/turf_decal/tile/yellow/half,
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
+/turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bsq" = (
 /obj/machinery/light/small/directional/north,
@@ -5211,6 +5209,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bPQ" = (
@@ -6320,11 +6322,10 @@
 /area/station/hallway/primary/central)
 "cmA" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "cmB" = (
@@ -11278,10 +11279,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eaV" = (
-/obj/effect/turf_decal/tile/engineering/opposingcorners,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "Connector Port"
+	},
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "eaW" = (
 /obj/effect/turf_decal/tile/security{
 	dir = 1
@@ -11807,6 +11813,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "elj" = (
@@ -11965,11 +11972,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "epH" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "epU" = (
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 8
@@ -12509,9 +12521,7 @@
 /area/station/medical/medbay)
 "ezO" = (
 /obj/effect/turf_decal/tile/yellow/half,
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
+/turf/open/floor/iron,
 /area/station/engineering/lobby)
 "ezP" = (
 /obj/structure/safe,
@@ -14807,9 +14817,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "fqd" = (
-/obj/structure/cable,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "Connector Port"
+	},
+/obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "fqi" = (
 /obj/structure/table,
 /obj/item/stack/sticky_tape{
@@ -16760,9 +16776,7 @@
 "gbL" = (
 /obj/structure/sign/departments/telecomms/directional/south,
 /obj/effect/turf_decal/tile/yellow/half,
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
+/turf/open/floor/iron,
 /area/station/engineering/lobby)
 "gbV" = (
 /obj/machinery/airalarm/directional/south,
@@ -19209,14 +19223,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "gXS" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/vending/tool,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "gXU" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/rnd_all,
@@ -20536,16 +20548,6 @@
 /obj/machinery/plumbing/reaction_chamber,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"hAd" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "hAg" = (
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
@@ -22190,14 +22192,10 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "igG" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
-	},
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/engineering/half,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "igJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -23504,7 +23502,31 @@
 	c_tag = "Engineering - Tech Storage";
 	network = list("ss13","engineering")
 	},
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/machinery/firealarm/directional/north,
+/obj/item/electronics/airlock{
+	pixel_x = 4;
+	pixel_y = -5
+	},
+/obj/item/electronics/airlock{
+	pixel_x = 4;
+	pixel_y = -5
+	},
+/obj/item/electronics/airlock{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/electronics/apc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/electronics/apc,
+/obj/item/electronics/apc{
+	pixel_y = -4;
+	pixel_x = -4
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "iEv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -24937,13 +24959,11 @@
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "jfz" = (
-/obj/effect/turf_decal/tile/engineering/half,
-/obj/machinery/vending/assist,
-/obj/machinery/camera/directional/south{
-	c_tag = "Public - Tool Storage"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 10
 	},
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "jfL" = (
 /obj/machinery/pdapainter/security,
 /turf/open/floor/carpet,
@@ -25777,7 +25797,10 @@
 /area/station/science/research)
 "jvd" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/closed/wall,
+/obj/structure/table/reinforced,
+/obj/item/healthanalyzer,
+/obj/item/analyzer,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "jvq" = (
 /turf/closed/wall,
@@ -27771,11 +27794,15 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat)
 "kgA" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "Connector Port"
 	},
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "kgB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input{
 	dir = 4
@@ -29116,6 +29143,9 @@
 "kCe" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "kCi" = (
@@ -30128,15 +30158,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "kVP" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/vending/assist,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "kVR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -31329,9 +31356,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ltU" = (
@@ -31390,14 +31414,6 @@
 /obj/item/toy/plush/batong,
 /turf/open/floor/wood,
 /area/station/maintenance/department/cargo)
-"luW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "lvb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -32068,8 +32084,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lGk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -32630,12 +32646,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "lPH" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "Connector Port"
 	},
-/obj/structure/cable,
+/obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "lQa" = (
 /obj/docking_port/stationary/mining_home/common{
 	dir = 8
@@ -37939,11 +37958,11 @@
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
 "nGU" = (
-/obj/effect/turf_decal/tile/engineering/opposingcorners,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "nHc" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/fore)
@@ -39808,8 +39827,7 @@
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "oqG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "oqS" = (
@@ -40602,9 +40620,14 @@
 /area/station/hallway/secondary/entry)
 "oHn" = (
 /obj/effect/turf_decal/tile/yellow/half,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 7
 	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_y = 10
+	},
+/turf/open/floor/iron,
 /area/station/engineering/lobby)
 "oHt" = (
 /obj/machinery/holopad/secure,
@@ -42452,11 +42475,13 @@
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
 "ptD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/electronics/airalarm,
+/obj/item/electronics/airalarm,
+/obj/item/electronics/airalarm,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "ptH" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44141,6 +44166,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
+	dir = 3
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qah" = (
@@ -44614,24 +44643,12 @@
 /area/station/maintenance/fore)
 "qis" = (
 /obj/structure/rack,
-/obj/item/electronics/airlock{
-	pixel_x = 4;
-	pixel_y = -5
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/electronics/airlock{
-	pixel_x = 4;
-	pixel_y = -5
-	},
-/obj/item/electronics/airlock{
-	pixel_x = 4;
-	pixel_y = -5
-	},
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/apc,
-/obj/item/electronics/apc,
-/obj/item/electronics/apc,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "qiw" = (
@@ -46298,11 +46315,9 @@
 "qQl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "qQm" = (
 /obj/effect/turf_decal/tile/engineering/half,
 /obj/machinery/light/directional/south,
@@ -48275,10 +48290,12 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "rDF" = (
-/obj/structure/closet/crate/coffin/meatcoffin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/engineering/half,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "rDK" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/disposalpipe/segment{
@@ -48468,10 +48485,12 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "rGJ" = (
-/obj/item/clothing/suit/costume/dracula,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/tile/engineering/half,
+/obj/machinery/camera/directional/south{
+	c_tag = "Public - Tool Storage"
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "rGK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -48634,13 +48653,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rJJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "rJZ" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Lab Storage"
@@ -52191,10 +52208,11 @@
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
 "tcR" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/north,
+/obj/item/plant_analyzer,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "tcS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55230,13 +55248,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"ufP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "ufQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56029,6 +56040,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/command/half,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "uvi" = (
@@ -60402,7 +60414,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "wfP" = (
@@ -61063,7 +61077,14 @@
 /area/station/maintenance/department/engine)
 "wtB" = (
 /obj/item/radio/intercom/directional/east,
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack,
+/obj/item/multitool,
+/obj/item/wirecutters,
+/obj/item/screwdriver{
+	pixel_y = 6
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "wtC" = (
 /obj/structure/rack,
@@ -62379,11 +62400,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/service)
 "wQX" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/engineering/half,
-/obj/machinery/vending/tool,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "wRc" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -62623,12 +62644,10 @@
 "wVE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "wVH" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -63284,14 +63303,18 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/department/engine)
 "xgS" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
 	},
-/obj/effect/turf_decal/bot,
+/obj/item/stack/cable_coil,
+/obj/item/storage/box/lights/mixed{
+	pixel_y = 10
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "xgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64034,6 +64057,14 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_y = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "xrI" = (
@@ -95622,10 +95653,10 @@ mPS
 kbb
 xdI
 lnY
-dSh
-dSh
-dSh
-dSh
+ssF
+ssF
+ssF
+ssF
 dSh
 bWa
 hSi
@@ -95879,10 +95910,10 @@ mPS
 kbb
 xdI
 dnK
-dSh
-rGJ
-bWG
-rDF
+xDi
+mhd
+mjN
+ful
 dSh
 flw
 qUa
@@ -96136,10 +96167,10 @@ nVn
 kbb
 xdI
 tDn
-ssF
-ssF
-ssF
-ssF
+xDi
+quy
+oim
+bim
 dSh
 gtz
 xxB
@@ -96161,7 +96192,7 @@ eFZ
 qrn
 wvA
 phK
-ezO
+rJJ
 sdC
 qFt
 vVh
@@ -96393,10 +96424,10 @@ mPS
 fBm
 xdI
 piR
-xDi
-mhd
-mjN
-ful
+nLi
+ydv
+iNf
+igG
 dSh
 vDm
 agp
@@ -96650,10 +96681,10 @@ mPS
 kbb
 xdI
 piR
-xDi
-quy
-oim
-bim
+urf
+jMJ
+axU
+rGJ
 dSh
 laL
 agp
@@ -96675,7 +96706,7 @@ mtj
 iIS
 dMU
 mtj
-oHn
+xgS
 sdC
 tKr
 cyj
@@ -96906,14 +96937,14 @@ sai
 mPS
 kbb
 xdI
-piR
-nLi
-ydv
-iNf
-wQX
+rDF
+rdS
+jnm
+rMe
+atD
 dSh
-dSh
-ufP
+whO
+agp
 dSh
 jvd
 boc
@@ -97164,14 +97195,14 @@ nVn
 uUs
 xdI
 piR
-urf
-jMJ
-axU
-jfz
-dwb
-ptD
-luW
-igG
+xDi
+cwq
+oim
+urs
+dSh
+cMv
+agp
+dSh
 tcR
 cmA
 cUk
@@ -97421,14 +97452,14 @@ giF
 kbb
 xdI
 gYN
-rdS
-jnm
-rMe
-atD
-dwb
-lGk
-luW
-hAd
+xDi
+kfe
+kVP
+gXS
+dSh
+whO
+qUa
+dSh
 iEp
 wfN
 cpq
@@ -97678,16 +97709,16 @@ giF
 kbb
 xdI
 piR
+qek
 xDi
-cwq
-fqd
-urs
-dwb
-nQM
+xDi
+xDi
+dSh
+eoK
 qQl
-kVP
-rbM
-epH
+dSh
+ptD
+wfN
 cdw
 bev
 ndq
@@ -97935,14 +97966,14 @@ giF
 kbb
 xdI
 piR
-xDi
-kfe
+fqd
+eaV
 lPH
 kgA
-dwb
-pqN
-rJJ
-xgS
+dSh
+bWa
+agp
+dSh
 wtB
 kCe
 kTa
@@ -98192,14 +98223,14 @@ giF
 eQo
 pTK
 kxO
-qek
-xDi
+lGk
+lGk
 nGU
-eaV
-bZr
-oqG
+nGU
+dSh
+dSh
 wVE
-bZr
+dSh
 rbM
 rbM
 hfZ
@@ -98451,10 +98482,10 @@ fLs
 elh
 bPN
 pZP
+epH
+epH
 olv
 olv
-olv
-gXS
 ltL
 idB
 dPQ
@@ -98707,11 +98738,11 @@ nUT
 rKC
 hLO
 qnK
-vjs
-vjs
-vjs
-vjs
-pqN
+nQM
+jfz
+wQX
+oqG
+oqG
 qga
 tBY
 kbd

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -97,16 +97,6 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
-"abo" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "abr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -1149,6 +1139,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
+"atA" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "atB" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
@@ -1218,6 +1213,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"auL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "auV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/purple/line,
@@ -1511,11 +1513,8 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "azt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "azw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2413,15 +2412,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"aRK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "aRM" = (
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
@@ -3053,12 +3043,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"bda" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "bdk" = (
 /obj/machinery/atmospherics/components/binary/passive_gate,
 /turf/open/floor/plating,
@@ -4225,9 +4209,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "byG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -6642,11 +6625,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "crt" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "crI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot,
@@ -6727,11 +6713,11 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "csw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering/half{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "csR" = (
 /obj/machinery/vending/clothing,
@@ -6819,6 +6805,11 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"cun" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cuO" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/freezerchamber)
@@ -7022,12 +7013,6 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"cxV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cxY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7647,12 +7632,13 @@
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
 "cIi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 8
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cIE" = (
 /obj/structure/railing{
 	dir = 1
@@ -9111,6 +9097,16 @@
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"dlU" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "dmc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9120,6 +9116,13 @@
 /obj/item/skillchip/intj,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"dmF" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to waste"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dmI" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Vacant Office"
@@ -12757,10 +12760,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"eDO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "eDR" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -12892,15 +12891,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "eGA" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Port"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "eGB" = (
 /obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 8
@@ -14643,14 +14640,6 @@
 /obj/effect/turf_decal/tile/security/half,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
-"fno" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/pipedispenser/disposal,
-/obj/effect/turf_decal/siding/engineering{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "fnp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2,
@@ -15804,12 +15793,11 @@
 /turf/open/floor/iron,
 /area/station/science)
 "fJe" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port to Network"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -17618,9 +17606,11 @@
 "gtv" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "gtz" = (
@@ -17710,15 +17700,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"gwc" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gwj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -19343,15 +19324,11 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "gZV" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gZY" = (
 /obj/machinery/holopad,
 /obj/effect/mapping_helpers/ianbirthday,
@@ -19460,10 +19437,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"hbJ" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hbL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23160,6 +23133,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"ixl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "ixq" = (
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
@@ -23340,6 +23320,12 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
 /area/station/science/explab)
+"iAu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "iAC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25180,6 +25166,10 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
+"jkI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jkT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26049,6 +26039,13 @@
 "jzZ" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
+/area/station/engineering/atmos)
+"jAh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jAt" = (
 /obj/structure/rack,
@@ -26921,12 +26918,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"jPG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jPZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark/half/contrasted{
@@ -27314,13 +27305,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
-"jXe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jXh" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/grimy,
@@ -29008,11 +28992,6 @@
 /obj/effect/turf_decal/tile/command/half,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs)
-"kAx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "kAz" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/glass/bottle/beer/light,
@@ -30971,6 +30950,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"llx" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "llB" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -32907,6 +32893,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"lTs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lTv" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -33030,15 +33023,6 @@
 /obj/effect/turf_decal/tile/command/half,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"lVy" = (
-/obj/effect/turf_decal/siding/engineering{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/engineering{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lVA" = (
 /obj/machinery/computer/mechpad{
 	dir = 8
@@ -33079,10 +33063,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
 "lVW" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Distro"
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -33411,12 +33394,6 @@
 "mbf" = (
 /turf/closed/wall/r_wall,
 /area/station/science/server)
-"mbg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mbI" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/records/medical/laptop{
@@ -34923,6 +34900,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
+"mAK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mAQ" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -36112,6 +36095,12 @@
 /obj/item/canvas/thirtysix_twentyfour,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
+"mXD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mXH" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Medbay"
@@ -36183,13 +36172,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"mYy" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to waste"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mYz" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment{
@@ -36314,6 +36296,12 @@
 /obj/effect/turf_decal/tile/science/half,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"naE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "naI" = (
 /obj/effect/turf_decal/tile/medical/opposingcorners,
 /obj/structure/cable,
@@ -36945,9 +36933,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "nna" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "nni" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
@@ -37559,8 +37547,12 @@
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/gravity_generator)
 "nwh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/obj/machinery/meter,
+/obj/effect/turf_decal/siding/engineering{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nwj" = (
@@ -39283,9 +39275,15 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/central)
 "ofs" = (
-/obj/effect/turf_decal/siding/engineering/corner,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "ofw" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science/xenobiology)
@@ -40595,10 +40593,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"oGj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "oGo" = (
 /obj/machinery/door/airlock{
 	name = "Art Storage Room"
@@ -40664,6 +40658,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"oHc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "oHn" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/dark/corner{
@@ -40754,6 +40755,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"oJH" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "oJU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41541,11 +41546,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
-"pay" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "paC" = (
 /obj/effect/turf_decal/siding/grey{
 	dir = 8
@@ -42212,9 +42212,7 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "pnl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pnp" = (
@@ -42637,6 +42635,14 @@
 	dir = 1
 	},
 /area/station/engineering/gravity_generator)
+"pvt" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pvu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -42873,11 +42879,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"pzM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "pzQ" = (
 /turf/closed/wall,
 /area/station/service/janitor)
@@ -43103,6 +43104,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"pEe" = (
+/obj/effect/turf_decal/siding/engineering/corner,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pEg" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /obj/machinery/disposal/bin,
@@ -43417,10 +43422,10 @@
 /turf/open/floor/iron/terracotta/herringbone,
 /area/station/maintenance/starboard/aft)
 "pJI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pJT" = (
@@ -43757,15 +43762,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
 "pRB" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port to Processing"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pRH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44799,11 +44799,8 @@
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
 "qjZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "qka" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
@@ -45197,7 +45194,8 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/nanite)
 "qrF" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -45264,10 +45262,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qsE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to distro staging"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qsX" = (
@@ -46412,6 +46410,11 @@
 "qQZ" = (
 /turf/closed/wall,
 /area/station/cargo/miningdock)
+"qRu" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qRJ" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -47588,10 +47591,13 @@
 	},
 /area/station/maintenance/department/medical/plasmaman)
 "rnJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Port to Network"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -48566,6 +48572,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"rGX" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to distro";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rHd" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/hidden{
@@ -50581,13 +50594,6 @@
 "ssF" = (
 /turf/closed/wall,
 /area/station/commons/storage/primary)
-"ssJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ssW" = (
 /obj/vehicle/ridden/janicart,
 /obj/machinery/light/directional/west,
@@ -52291,8 +52297,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "tdz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -52572,6 +52578,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"tiB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "tiK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -54289,14 +54300,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
-"tPV" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "tQa" = (
 /obj/structure/bed/maint,
 /obj/item/bedsheet,
@@ -54499,8 +54502,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "tSO" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "tSQ" = (
 /obj/structure/table/reinforced,
@@ -55613,6 +55619,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/lobby)
+"umQ" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "umV" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -55882,11 +55897,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
-"urv" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "urA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -58240,6 +58250,16 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"vkX" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Port to Processing"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vkZ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -58286,13 +58306,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
-"vlU" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to distro";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vml" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/circuit,
@@ -58413,12 +58426,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"vpc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vpm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -58828,13 +58835,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"vxY" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "vyi" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -60128,6 +60128,14 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard)
+"vYc" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/pipedispenser/disposal,
+/obj/effect/turf_decal/siding/engineering{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vYg" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -61836,13 +61844,6 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"wFP" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to distro staging"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wFS" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
@@ -62816,11 +62817,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"wWX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wXi" = (
 /obj/effect/turf_decal/loading_area/white{
 	color = "blue";
@@ -63388,12 +63384,6 @@
 "xgw" = (
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/department/engine)
-"xgN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xgS" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -63702,6 +63692,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"xly" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "xlA" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64631,6 +64626,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"xCk" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Distro"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "xCv" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -65704,6 +65707,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"xYo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "xYz" = (
 /obj/structure/chair{
 	dir = 1
@@ -90866,27 +90874,27 @@ cgD
 gQv
 yju
 yju
-vxY
-tPV
-kAx
+llx
+pvt
+atA
 xQP
-qrF
+pRB
 xQP
-qrF
+pRB
 omv
-pzM
-eDO
-pzM
+nna
+qjZ
+nna
 xbu
-urv
+qRu
 wqT
-gtv
+cIi
 tHl
-crt
+qrF
 qbv
-crt
-crt
-crt
+qrF
+qrF
+qrF
 ksA
 iQW
 iQW
@@ -91123,7 +91131,7 @@ tbL
 gQv
 xoo
 xoo
-azt
+ixl
 wxt
 bRS
 wxt
@@ -91144,7 +91152,7 @@ wzs
 xoo
 xoo
 xoo
-gZV
+gtv
 iQW
 iQW
 iQW
@@ -91380,7 +91388,7 @@ ngZ
 epU
 gtR
 epU
-wFP
+qsE
 sDX
 ife
 oJi
@@ -91401,7 +91409,7 @@ pyQ
 epU
 kfN
 xoo
-gZV
+gtv
 iQW
 iQW
 iQW
@@ -91658,7 +91666,7 @@ qXm
 qgU
 iDX
 xoo
-gZV
+gtv
 aNE
 aNE
 aNE
@@ -91894,7 +91902,7 @@ lsk
 uFS
 uFS
 dRq
-dRq
+eGA
 rjO
 uFS
 tew
@@ -91902,11 +91910,11 @@ fvq
 dGi
 fvq
 kvf
-byG
-byG
-byG
-aRK
-byG
+auL
+auL
+auL
+crt
+auL
 lsj
 oXc
 uDw
@@ -92149,14 +92157,14 @@ oww
 oQE
 tnF
 wKw
-wWX
+xly
 rnJ
 fJe
 nao
 eaQ
 hlT
-tSO
-ofs
+oJH
+pEe
 xNl
 dUw
 cTR
@@ -92172,7 +92180,7 @@ mqx
 uFS
 fGe
 bRS
-gZV
+gtv
 fgD
 sDo
 fVa
@@ -92412,10 +92420,10 @@ tDI
 qMp
 gaR
 wnl
-fno
+vYc
 pPK
 gaR
-lVy
+nwh
 dtN
 mdN
 cMr
@@ -92678,7 +92686,7 @@ uKQ
 jyX
 svI
 gVJ
-pRB
+vkX
 kMt
 uFS
 dRq
@@ -92686,7 +92694,7 @@ mqx
 iuQ
 szM
 rTk
-gZV
+gtv
 aNE
 aNE
 aNE
@@ -93195,12 +93203,12 @@ wvW
 uHi
 jCT
 uFS
-jPG
-oGj
+mAK
+jkI
 uPE
 jeb
 bRS
-gZV
+gtv
 fgD
 ikJ
 cdV
@@ -93446,14 +93454,14 @@ wKw
 cIS
 cIS
 wKw
-pJI
-cIi
-cIi
-jXe
+oHc
+csw
+csw
+lVW
 kMt
 uFS
 nbx
-tdz
+byG
 cNK
 nic
 xWg
@@ -93707,14 +93715,14 @@ iuQ
 xGw
 xGw
 xGw
-lVW
+xCk
 dSJ
-mbg
-cxV
+iAu
+tdz
 owm
 sia
 rTk
-gZV
+gtv
 aNE
 aNE
 aNE
@@ -93947,7 +93955,7 @@ lan
 cWy
 wDH
 uFS
-hbJ
+azt
 uFS
 uFS
 uFS
@@ -93960,14 +93968,14 @@ uFS
 uFS
 uFS
 uFS
-qsE
+pJI
 ldo
 wJQ
 aDL
-pay
+xYo
 aDL
 ojg
-nwh
+tiB
 noz
 lQM
 rZa
@@ -94202,7 +94210,7 @@ xAK
 xAK
 ibf
 mTj
-ssJ
+jAh
 uFS
 uFS
 uFS
@@ -94217,18 +94225,18 @@ dRq
 uFS
 uFS
 uFS
-qsE
+pJI
 uFS
 uFS
 mjr
 meq
-vlU
+rGX
 uFS
 uPE
 uFS
 cAV
 bRS
-gZV
+gtv
 fgD
 vNk
 unI
@@ -94474,13 +94482,13 @@ uFS
 uFS
 uFS
 uFS
-qsE
+pJI
 uFS
 uFS
 uFS
 mXf
-qjZ
-bda
+lTs
+naE
 jpQ
 cSx
 hPg
@@ -94735,14 +94743,14 @@ lyp
 uFS
 uFS
 uFS
-xgN
-mYy
-vpc
+mXD
+dmF
+gZV
 okf
 uFS
 qQm
 xoo
-gZV
+gtv
 aNE
 aNE
 aNE
@@ -94992,14 +95000,14 @@ pmn
 gRZ
 tIF
 mFt
-nna
+cun
 une
 lAF
 une
 wHt
 ebd
 xoo
-gZV
+gtv
 iQW
 yju
 iQW
@@ -95251,12 +95259,12 @@ jpo
 pZa
 azM
 jpo
-gwc
+umQ
 jpo
 igX
 xoo
 xoo
-gZV
+gtv
 iQW
 yju
 iQW
@@ -95508,12 +95516,12 @@ bRS
 bRS
 rst
 bRS
-csw
+tSO
 bRS
 xoo
 xoo
-abo
-eGA
+dlU
+ofs
 yju
 xrM
 iQW
@@ -95765,11 +95773,11 @@ yju
 yju
 oqd
 yju
-gtv
-crt
-crt
-crt
-eGA
+cIi
+qrF
+qrF
+qrF
+ofs
 iQW
 iQW
 xrM

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1139,11 +1139,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"atA" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "atB" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
@@ -1213,13 +1208,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"auL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "auV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/purple/line,
@@ -1513,7 +1501,7 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "azt" = (
-/obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "azw" = (
@@ -4209,8 +4197,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "byG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -4990,6 +4978,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
+"bLX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "bMe" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
@@ -6429,6 +6421,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"cnI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "cnS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6625,13 +6624,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "crt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "crI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -6713,9 +6707,10 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "csw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 8
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Distro"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -6805,11 +6800,6 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"cun" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cuO" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/freezerchamber)
@@ -7633,9 +7623,7 @@
 /area/station/maintenance/fore)
 "cIi" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -8774,6 +8762,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"ddE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ded" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -9097,16 +9092,6 @@
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"dlU" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "dmc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9116,13 +9101,6 @@
 /obj/item/skillchip/intj,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"dmF" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to waste"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "dmI" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Vacant Office"
@@ -10338,6 +10316,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
+"dIJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dIL" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
@@ -10828,8 +10812,10 @@
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "dSJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dSO" = (
@@ -12496,6 +12482,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
+"eyX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "eyZ" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -12891,13 +12882,15 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "eGA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Port"
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "eGB" = (
 /obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 8
@@ -17604,13 +17597,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "gtv" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "gtz" = (
@@ -19324,8 +19312,8 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "gZV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -20175,6 +20163,15 @@
 /obj/effect/turf_decal/tile/engineering/half,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"hqZ" = (
+/obj/effect/turf_decal/siding/engineering{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hri" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -23133,13 +23130,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"ixl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "ixq" = (
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
@@ -23320,12 +23310,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
 /area/station/science/explab)
-"iAu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "iAC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23399,6 +23383,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"iBI" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to distro staging"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "iBL" = (
 /obj/structure/table/wood/fancy,
 /obj/item/toy/figure/wizard,
@@ -25065,6 +25056,11 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"jhL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "jhM" = (
 /obj/structure/railing{
 	dir = 1;
@@ -25166,10 +25162,6 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
-"jkI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jkT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26039,13 +26031,6 @@
 "jzZ" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/station/engineering/atmos)
-"jAh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jAt" = (
 /obj/structure/rack,
@@ -28245,6 +28230,11 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/commons/dorms)
+"kmM" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "kmR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken/directional{
@@ -29234,6 +29224,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"kCZ" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "kDa" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -30879,6 +30879,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"ljU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ljV" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
@@ -30897,6 +30902,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
+"lky" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lkz" = (
 /turf/open/floor/carpet,
 /area/station/maintenance/fore)
@@ -30950,13 +30960,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
-"llx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "llB" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -30965,6 +30968,15 @@
 	},
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
+"llF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "llL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -32893,13 +32905,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"lTs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lTv" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -33063,12 +33068,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
 "lVW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering{
-	dir = 1
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lWb" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -34900,12 +34906,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
-"mAK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mAQ" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -36095,12 +36095,6 @@
 /obj/item/canvas/thirtysix_twentyfour,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library/artgallery)
-"mXD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mXH" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Medbay"
@@ -36296,12 +36290,6 @@
 /obj/effect/turf_decal/tile/science/half,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"naE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "naI" = (
 /obj/effect/turf_decal/tile/medical/opposingcorners,
 /obj/structure/cable,
@@ -36933,9 +36921,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "nna" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nni" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
@@ -37547,10 +37535,8 @@
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/gravity_generator)
 "nwh" = (
-/obj/effect/turf_decal/siding/engineering{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/engineering{
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to distro";
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -38336,6 +38322,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"nNh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "nNA" = (
 /obj/effect/turf_decal/tile/security/half{
 	dir = 1
@@ -39275,15 +39266,12 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/central)
 "ofs" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ofw" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science/xenobiology)
@@ -39511,6 +39499,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"oly" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Port to Processing"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "olG" = (
 /obj/machinery/computer/telecomms/monitor{
 	dir = 4;
@@ -40658,13 +40656,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"oHc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "oHn" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/dark/corner{
@@ -40755,10 +40746,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"oJH" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "oJU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42635,14 +42622,6 @@
 	dir = 1
 	},
 /area/station/engineering/gravity_generator)
-"pvt" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "pvu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -43104,10 +43083,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"pEe" = (
-/obj/effect/turf_decal/siding/engineering/corner,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pEg" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /obj/machinery/disposal/bin,
@@ -43422,10 +43397,9 @@
 /turf/open/floor/iron/terracotta/herringbone,
 /area/station/maintenance/starboard/aft)
 "pJI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pJT" = (
@@ -43591,6 +43565,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"pNU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pOg" = (
 /obj/effect/turf_decal/trimline/dark_red,
 /obj/machinery/airalarm/directional/west,
@@ -43762,8 +43743,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
 "pRB" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 6
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "pRH" = (
@@ -44799,8 +44785,8 @@
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
 "qjZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/engineering/corner,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qka" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
@@ -45195,7 +45181,9 @@
 /area/station/science/nanite)
 "qrF" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -45262,10 +45250,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qsE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to distro staging"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qsX" = (
@@ -46290,6 +46278,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"qOb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qOc" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46410,11 +46405,6 @@
 "qQZ" = (
 /turf/closed/wall,
 /area/station/cargo/miningdock)
-"qRu" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "qRJ" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -47574,6 +47564,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/command/storage/eva)
+"rmU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rnG" = (
 /obj/machinery/door/airlock{
 	name = "Art Storage Room"
@@ -48572,13 +48569,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"rGX" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to distro";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rHd" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/hidden{
@@ -50782,6 +50772,11 @@
 /obj/effect/turf_decal/tile/medical/anticorner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"swx" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "swF" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/green,
@@ -52297,8 +52292,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "tdz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -52578,11 +52573,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"tiB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tiK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -54502,11 +54492,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "tSO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tSQ" = (
 /obj/structure/table/reinforced,
@@ -54832,6 +54824,13 @@
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"tXU" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "tXX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -54890,6 +54889,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"tYI" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "tYW" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
@@ -55525,6 +55528,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"ukw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Port"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ukC" = (
 /obj/effect/turf_decal/tile/command/half,
 /turf/open/floor/iron/dark,
@@ -55619,15 +55630,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/lobby)
-"umQ" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "umV" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -56658,6 +56660,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"uHA" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/pipedispenser/disposal,
+/obj/effect/turf_decal/siding/engineering{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "uHE" = (
 /turf/open/floor/carpet/lone/star,
 /area/station/service/chapel)
@@ -58250,16 +58260,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
-"vkX" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port to Processing"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vkZ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -59705,6 +59705,13 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/hop)
+"vOY" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to waste"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vOZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/mapping_helpers/mail_sorting/security/hos_office,
@@ -60128,14 +60135,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard)
-"vYc" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/pipedispenser/disposal,
-/obj/effect/turf_decal/siding/engineering{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vYg" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -61655,6 +61654,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"wCx" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "wCD" = (
 /obj/effect/turf_decal/tile/security/anticorner,
 /turf/open/floor/iron,
@@ -63692,11 +63701,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"xly" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xlA" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64174,6 +64178,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"xtk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "xtq" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -64626,14 +64636,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"xCk" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Distro"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xCv" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -65310,10 +65312,10 @@
 /area/station/science)
 "xQP" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xQZ" = (
@@ -65697,6 +65699,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"xXY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "xYe" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -65707,11 +65716,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
-"xYo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xYz" = (
 /obj/structure/chair{
 	dir = 1
@@ -66214,6 +66218,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"yfP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "yfT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -90874,27 +90884,27 @@ cgD
 gQv
 yju
 yju
-llx
-pvt
-atA
+tXU
 xQP
-pRB
-xQP
-pRB
+gtv
+qrF
+kmM
+qrF
+kmM
 omv
-nna
-qjZ
-nna
+jhL
+crt
+jhL
 xbu
-qRu
+swx
 wqT
-cIi
+lVW
 tHl
-qrF
+cIi
 qbv
-qrF
-qrF
-qrF
+cIi
+cIi
+cIi
 ksA
 iQW
 iQW
@@ -91131,7 +91141,7 @@ tbL
 gQv
 xoo
 xoo
-ixl
+cnI
 wxt
 bRS
 wxt
@@ -91152,7 +91162,7 @@ wzs
 xoo
 xoo
 xoo
-gtv
+eGA
 iQW
 iQW
 iQW
@@ -91388,7 +91398,7 @@ ngZ
 epU
 gtR
 epU
-qsE
+iBI
 sDX
 ife
 oJi
@@ -91409,7 +91419,7 @@ pyQ
 epU
 kfN
 xoo
-gtv
+eGA
 iQW
 iQW
 iQW
@@ -91666,7 +91676,7 @@ qXm
 qgU
 iDX
 xoo
-gtv
+eGA
 aNE
 aNE
 aNE
@@ -91902,7 +91912,7 @@ lsk
 uFS
 uFS
 dRq
-eGA
+ukw
 rjO
 uFS
 tew
@@ -91910,11 +91920,11 @@ fvq
 dGi
 fvq
 kvf
-auL
-auL
-auL
-crt
-auL
+dSJ
+dSJ
+dSJ
+llF
+dSJ
 lsj
 oXc
 uDw
@@ -92157,14 +92167,14 @@ oww
 oQE
 tnF
 wKw
-xly
+lky
 rnJ
 fJe
 nao
 eaQ
 hlT
-oJH
-pEe
+azt
+qjZ
 xNl
 dUw
 cTR
@@ -92180,7 +92190,7 @@ mqx
 uFS
 fGe
 bRS
-gtv
+eGA
 fgD
 sDo
 fVa
@@ -92420,10 +92430,10 @@ tDI
 qMp
 gaR
 wnl
-vYc
+uHA
 pPK
 gaR
-nwh
+hqZ
 dtN
 mdN
 cMr
@@ -92686,7 +92696,7 @@ uKQ
 jyX
 svI
 gVJ
-vkX
+oly
 kMt
 uFS
 dRq
@@ -92694,7 +92704,7 @@ mqx
 iuQ
 szM
 rTk
-gtv
+eGA
 aNE
 aNE
 aNE
@@ -93203,12 +93213,12 @@ wvW
 uHi
 jCT
 uFS
-mAK
-jkI
+gZV
+bLX
 uPE
 jeb
 bRS
-gtv
+eGA
 fgD
 ikJ
 cdV
@@ -93454,14 +93464,14 @@ wKw
 cIS
 cIS
 wKw
-oHc
-csw
-csw
-lVW
+qOb
+ddE
+ddE
+pNU
 kMt
 uFS
 nbx
-byG
+pJI
 cNK
 nic
 xWg
@@ -93715,14 +93725,14 @@ iuQ
 xGw
 xGw
 xGw
-xCk
-dSJ
-iAu
+csw
+eyX
 tdz
+dIJ
 owm
 sia
 rTk
-gtv
+eGA
 aNE
 aNE
 aNE
@@ -93955,7 +93965,7 @@ lan
 cWy
 wDH
 uFS
-azt
+tYI
 uFS
 uFS
 uFS
@@ -93968,14 +93978,14 @@ uFS
 uFS
 uFS
 uFS
-pJI
+qsE
 ldo
 wJQ
 aDL
-xYo
+nNh
 aDL
 ojg
-tiB
+nna
 noz
 lQM
 rZa
@@ -94210,7 +94220,7 @@ xAK
 xAK
 ibf
 mTj
-jAh
+ofs
 uFS
 uFS
 uFS
@@ -94225,18 +94235,18 @@ dRq
 uFS
 uFS
 uFS
-pJI
+qsE
 uFS
 uFS
 mjr
 meq
-rGX
+nwh
 uFS
 uPE
 uFS
 cAV
 bRS
-gtv
+eGA
 fgD
 vNk
 unI
@@ -94482,13 +94492,13 @@ uFS
 uFS
 uFS
 uFS
-pJI
+qsE
 uFS
 uFS
 uFS
 mXf
-lTs
-naE
+rmU
+byG
 jpQ
 cSx
 hPg
@@ -94743,14 +94753,14 @@ lyp
 uFS
 uFS
 uFS
-mXD
-dmF
-gZV
+xtk
+vOY
+yfP
 okf
 uFS
 qQm
 xoo
-gtv
+eGA
 aNE
 aNE
 aNE
@@ -95000,14 +95010,14 @@ pmn
 gRZ
 tIF
 mFt
-cun
+ljU
 une
 lAF
 une
 wHt
 ebd
 xoo
-gtv
+eGA
 iQW
 yju
 iQW
@@ -95259,12 +95269,12 @@ jpo
 pZa
 azM
 jpo
-umQ
+tSO
 jpo
 igX
 xoo
 xoo
-gtv
+eGA
 iQW
 yju
 iQW
@@ -95516,12 +95526,12 @@ bRS
 bRS
 rst
 bRS
-tSO
+xXY
 bRS
 xoo
 xoo
-dlU
-ofs
+pRB
+wCx
 yju
 xrM
 iQW
@@ -95773,11 +95783,11 @@ yju
 yju
 oqd
 yju
+kCZ
 cIi
-qrF
-qrF
-qrF
-ofs
+cIi
+cIi
+wCx
 iQW
 iQW
 xrM

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -265,9 +265,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/rec)
 "aeg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "aej" = (
@@ -1185,6 +1185,16 @@
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
+"aus" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "auA" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/flare/candle,
@@ -1474,6 +1484,12 @@
 /obj/effect/turf_decal/tile/prison/half,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"azh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "azi" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig"
@@ -1501,9 +1517,15 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "azt" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "azw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -4197,10 +4219,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "byG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "byQ" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -4978,10 +4998,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
-"bLX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "bMe" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
@@ -6421,13 +6437,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"cnI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "cnS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6624,8 +6633,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "crt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -6707,11 +6718,7 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "csw" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Distro"
-	},
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "csR" = (
@@ -7623,8 +7630,12 @@
 /area/station/maintenance/fore)
 "cIi" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 6
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "cIE" = (
@@ -8762,13 +8773,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"ddE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ded" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -10316,12 +10320,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
-"dIJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "dIL" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
@@ -10399,6 +10397,13 @@
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
 /turf/open/floor/iron,
 /area/station/security/processing)
+"dKc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dKp" = (
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
@@ -10812,10 +10817,10 @@
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "dSJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 1
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dSO" = (
@@ -12362,15 +12367,20 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/entry)
+"ewr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ews" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ewB" = (
@@ -12412,6 +12422,11 @@
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
+"exm" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "exs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12482,11 +12497,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
-"eyX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "eyZ" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -12882,15 +12892,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "eGA" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/siding/engineering/corner,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "eGB" = (
 /obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 8
@@ -15363,6 +15367,14 @@
 /obj/effect/turf_decal/tile/science/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"fAu" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fAN" = (
 /obj/machinery/door/window/right/directional/north{
 	name = "Containment Pen #6";
@@ -15701,6 +15713,7 @@
 /obj/machinery/space_heater,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fHU" = (
@@ -15934,6 +15947,11 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"fKX" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fKY" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
@@ -16915,7 +16933,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "gdV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 8
@@ -17597,10 +17614,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "gtv" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gtz" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance/two,
@@ -18377,6 +18396,11 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
+"gIN" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gIO" = (
 /obj/effect/decal/cleanable/robot_debris/old,
 /obj/structure/cable,
@@ -19312,9 +19336,8 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "gZV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gZY" = (
@@ -19584,6 +19607,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hfy" = (
@@ -19780,7 +19804,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "hjH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8
@@ -20163,15 +20186,6 @@
 /obj/effect/turf_decal/tile/engineering/half,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"hqZ" = (
-/obj/effect/turf_decal/siding/engineering{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/engineering{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hri" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -21409,7 +21423,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "hPH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -22590,6 +22603,7 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "imL" = (
@@ -23383,13 +23397,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"iBI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to distro staging"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "iBL" = (
 /obj/structure/table/wood/fancy,
 /obj/item/toy/figure/wizard,
@@ -25056,11 +25063,6 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"jhL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "jhM" = (
 /obj/structure/railing{
 	dir = 1;
@@ -28230,11 +28232,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/commons/dorms)
-"kmM" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "kmR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken/directional{
@@ -29224,16 +29221,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"kCZ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "kDa" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -30879,11 +30866,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"ljU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ljV" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
@@ -30902,11 +30884,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
-"lky" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lkz" = (
 /turf/open/floor/carpet,
 /area/station/maintenance/fore)
@@ -30968,15 +30945,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
-"llF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "llL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -33069,9 +33037,7 @@
 /area/station/science/ordnance/burnchamber)
 "lVW" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -33842,7 +33808,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "miV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
@@ -34731,6 +34696,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"mwU" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mwX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/south,
@@ -35186,6 +35155,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"mFR" = (
+/obj/effect/turf_decal/siding/engineering{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mFS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36921,10 +36899,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "nna" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nni" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 4
@@ -37260,6 +37243,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"nsv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Port"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "nsF" = (
 /obj/effect/turf_decal/tile/engineering/anticorner{
 	dir = 4
@@ -37535,10 +37526,8 @@
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/gravity_generator)
 "nwh" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to distro";
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nwj" = (
@@ -38322,11 +38311,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"nNh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "nNA" = (
 /obj/effect/turf_decal/tile/security/half{
 	dir = 1
@@ -39266,11 +39250,9 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/central)
 "ofs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "ofw" = (
 /turf/closed/wall/r_wall,
@@ -39499,16 +39481,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"oly" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port to Processing"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "olG" = (
 /obj/machinery/computer/telecomms/monitor{
 	dir = 4;
@@ -42774,6 +42746,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"pyJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pyQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -43398,7 +43375,7 @@
 /area/station/maintenance/starboard/aft)
 "pJI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -43565,13 +43542,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"pNU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pOg" = (
 /obj/effect/turf_decal/trimline/dark_red,
 /obj/machinery/airalarm/directional/west,
@@ -43743,15 +43713,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
 "pRB" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pRH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44785,7 +44751,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
 "qjZ" = (
-/obj/effect/turf_decal/siding/engineering/corner,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qka" = (
@@ -44900,6 +44869,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"qmg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "qmi" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/directional,
@@ -45180,13 +45156,12 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/nanite)
 "qrF" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to distro staging"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qrO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45250,10 +45225,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qsE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qsX" = (
@@ -46269,6 +46246,16 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"qNS" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Port to Processing"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qNU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46278,13 +46265,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"qOb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/engineering{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qOc" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46460,6 +46440,7 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qSZ" = (
@@ -47016,6 +46997,13 @@
 "rdg" = (
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"rdj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rdk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47168,6 +47156,7 @@
 /obj/machinery/space_heater,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rgC" = (
@@ -47564,13 +47553,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/command/storage/eva)
-"rmU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rnG" = (
 /obj/machinery/door/airlock{
 	name = "Art Storage Room"
@@ -49413,6 +49395,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"rYs" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rYt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50332,6 +50321,13 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"son" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "sox" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/under/misc/pj/red,
@@ -50374,6 +50370,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/security,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "spW" = (
@@ -50772,11 +50769,6 @@
 /obj/effect/turf_decal/tile/medical/anticorner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"swx" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "swF" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/green,
@@ -50888,6 +50880,14 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"syl" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Distro"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "syA" = (
 /obj/structure/bedsheetbin{
 	pixel_x = -3;
@@ -51160,6 +51160,7 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sDH" = (
@@ -52292,7 +52293,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "tdz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/pipedispenser/disposal,
+/obj/effect/turf_decal/siding/engineering{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -53292,15 +53295,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ttC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ttL" = (
@@ -53362,6 +53362,12 @@
 /obj/effect/turf_decal/tile/prison/anticorner,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
+"tuM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "tuN" = (
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -54492,11 +54498,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "tSO" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to distro";
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -54824,13 +54828,6 @@
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"tXU" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "tXX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -54889,10 +54886,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"tYI" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tYW" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
@@ -55056,6 +55049,15 @@
 /obj/item/reagent_containers/cup/glass/bottle/beer,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"ubE" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ubF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -55528,14 +55530,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
-"ukw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ukC" = (
 /obj/effect/turf_decal/tile/command/half,
 /turf/open/floor/iron/dark,
@@ -56045,6 +56039,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"utq" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "utF" = (
 /obj/structure/table/wood,
 /obj/item/toy/mecha/marauder{
@@ -56064,6 +56065,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"uub" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "uuf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56109,6 +56117,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"uuQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "uuZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/contraband/random/directional/west,
@@ -56243,6 +56257,10 @@
 "uye" = (
 /turf/closed/wall,
 /area/station/science/xenobiology)
+"uyr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "uyD" = (
 /obj/structure/closet/secure_closet/psychology,
 /obj/item/toy/figure/psychologist{
@@ -56660,14 +56678,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"uHA" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/pipedispenser/disposal,
-/obj/effect/turf_decal/siding/engineering{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "uHE" = (
 /turf/open/floor/carpet/lone/star,
 /area/station/service/chapel)
@@ -58027,6 +58037,14 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"vgq" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vgr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59031,6 +59049,11 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"vAY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vAZ" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -59161,6 +59184,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"vEn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vEv" = (
 /obj/machinery/vending/sustenance,
 /obj/effect/turf_decal/tile/security{
@@ -59497,6 +59525,7 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "vLk" = (
@@ -59705,13 +59734,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/hop)
-"vOY" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to waste"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vOZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/mapping_helpers/mail_sorting/security/hos_office,
@@ -60671,6 +60693,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library/printer)
+"wii" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to waste"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "win" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -61654,16 +61683,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"wCx" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "wCD" = (
 /obj/effect/turf_decal/tile/security/anticorner,
 /turf/open/floor/iron,
@@ -64178,12 +64197,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"xtk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xtq" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -65312,10 +65325,10 @@
 /area/station/science)
 "xQP" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xQZ" = (
@@ -65699,13 +65712,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
-"xXY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "xYe" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -66218,12 +66224,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
-"yfP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "yfT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -90884,27 +90884,27 @@ cgD
 gQv
 yju
 yju
-tXU
+utq
+fAu
+exm
 xQP
-gtv
-qrF
-kmM
-qrF
-kmM
+gIN
+xQP
+gIN
 omv
-jhL
-crt
-jhL
+ofs
+byG
+ofs
 xbu
-swx
+fKX
 wqT
-lVW
+vgq
 tHl
-cIi
+lVW
 qbv
-cIi
-cIi
-cIi
+lVW
+lVW
+lVW
 ksA
 iQW
 iQW
@@ -91141,7 +91141,7 @@ tbL
 gQv
 xoo
 xoo
-cnI
+qmg
 wxt
 bRS
 wxt
@@ -91162,7 +91162,7 @@ wzs
 xoo
 xoo
 xoo
-eGA
+nna
 iQW
 iQW
 iQW
@@ -91398,7 +91398,7 @@ ngZ
 epU
 gtR
 epU
-iBI
+qrF
 sDX
 ife
 oJi
@@ -91419,7 +91419,7 @@ pyQ
 epU
 kfN
 xoo
-eGA
+nna
 iQW
 iQW
 iQW
@@ -91676,7 +91676,7 @@ qXm
 qgU
 iDX
 xoo
-eGA
+nna
 aNE
 aNE
 aNE
@@ -91912,7 +91912,7 @@ lsk
 uFS
 uFS
 dRq
-ukw
+nsv
 rjO
 uFS
 tew
@@ -91920,11 +91920,11 @@ fvq
 dGi
 fvq
 kvf
-dSJ
-dSJ
-dSJ
-llF
-dSJ
+gtv
+gtv
+gtv
+qsE
+gtv
 lsj
 oXc
 uDw
@@ -92167,14 +92167,14 @@ oww
 oQE
 tnF
 wKw
-lky
+vAY
 rnJ
 fJe
 nao
 eaQ
 hlT
-azt
-qjZ
+mwU
+eGA
 xNl
 dUw
 cTR
@@ -92190,7 +92190,7 @@ mqx
 uFS
 fGe
 bRS
-eGA
+nna
 fgD
 sDo
 fVa
@@ -92430,10 +92430,10 @@ tDI
 qMp
 gaR
 wnl
-uHA
+tdz
 pPK
 gaR
-hqZ
+mFR
 dtN
 mdN
 cMr
@@ -92696,7 +92696,7 @@ uKQ
 jyX
 svI
 gVJ
-oly
+qNS
 kMt
 uFS
 dRq
@@ -92704,7 +92704,7 @@ mqx
 iuQ
 szM
 rTk
-eGA
+nna
 aNE
 aNE
 aNE
@@ -93213,12 +93213,12 @@ wvW
 uHi
 jCT
 uFS
-gZV
-bLX
+pJI
+uyr
 uPE
 jeb
 bRS
-eGA
+nna
 fgD
 ikJ
 cdV
@@ -93464,14 +93464,14 @@ wKw
 cIS
 cIS
 wKw
-qOb
-ddE
-ddE
-pNU
+uub
+qjZ
+qjZ
+dKc
 kMt
 uFS
 nbx
-pJI
+uuQ
 cNK
 nic
 xWg
@@ -93725,14 +93725,14 @@ iuQ
 xGw
 xGw
 xGw
-csw
-eyX
-tdz
-dIJ
+syl
+pyJ
+ewr
+pRB
 owm
 sia
 rTk
-eGA
+nna
 aNE
 aNE
 aNE
@@ -93965,7 +93965,7 @@ lan
 cWy
 wDH
 uFS
-tYI
+csw
 uFS
 uFS
 uFS
@@ -93978,14 +93978,14 @@ uFS
 uFS
 uFS
 uFS
-qsE
+rYs
 ldo
 wJQ
 aDL
-nNh
+nwh
 aDL
 ojg
-nna
+gZV
 noz
 lQM
 rZa
@@ -94220,7 +94220,7 @@ xAK
 xAK
 ibf
 mTj
-ofs
+rdj
 uFS
 uFS
 uFS
@@ -94228,25 +94228,25 @@ uFS
 uFS
 uFS
 uFS
-uFS
+aeg
 uFS
 uFS
 dRq
 uFS
 uFS
 uFS
-qsE
+rYs
 uFS
 uFS
 mjr
 meq
-nwh
+tSO
 uFS
 uPE
 uFS
 cAV
 bRS
-eGA
+nna
 fgD
 vNk
 unI
@@ -94492,13 +94492,13 @@ uFS
 uFS
 uFS
 uFS
-qsE
+rYs
 uFS
 uFS
 uFS
 mXf
-rmU
-byG
+dSJ
+crt
 jpQ
 cSx
 hPg
@@ -94742,7 +94742,7 @@ gdV
 gdV
 hjH
 hjH
-aeg
+jmj
 cYr
 uFS
 uFS
@@ -94753,14 +94753,14 @@ lyp
 uFS
 uFS
 uFS
-xtk
-vOY
-yfP
+azh
+wii
+tuM
 okf
 uFS
 qQm
 xoo
-eGA
+nna
 aNE
 aNE
 aNE
@@ -95010,14 +95010,14 @@ pmn
 gRZ
 tIF
 mFt
-ljU
+vEn
 une
 lAF
 une
 wHt
 ebd
 xoo
-eGA
+nna
 iQW
 yju
 iQW
@@ -95269,12 +95269,12 @@ jpo
 pZa
 azM
 jpo
-tSO
+ubE
 jpo
 igX
 xoo
 xoo
-eGA
+nna
 iQW
 yju
 iQW
@@ -95526,12 +95526,12 @@ bRS
 bRS
 rst
 bRS
-xXY
+son
 bRS
 xoo
 xoo
-pRB
-wCx
+cIi
+aus
 yju
 xrM
 iQW
@@ -95783,11 +95783,11 @@ yju
 yju
 oqd
 yju
-kCZ
-cIi
-cIi
-cIi
-wCx
+azt
+lVW
+lVW
+lVW
+aus
 iQW
 iQW
 xrM

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -2624,12 +2624,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "aVE" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Distro staging"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aVI" = (
 /obj/effect/turf_decal/tile/engineering,
 /obj/structure/cable,
@@ -6709,13 +6709,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
-"csw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "csR" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -7623,14 +7616,6 @@
 /obj/structure/stone_tile/slab,
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
-"cIi" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "cIE" = (
 /obj/structure/railing{
 	dir = 1
@@ -10809,11 +10794,6 @@
 	},
 /turf/open/floor/vault,
 /area/station/command/bridge)
-"dSJ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "dSO" = (
 /obj/structure/sign/warning/pods/directional/west,
 /turf/open/floor/plating,
@@ -12877,12 +12857,6 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
-"eGA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "eGB" = (
 /obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 8
@@ -19323,14 +19297,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"gZV" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gZY" = (
 /obj/machinery/holopad,
 /obj/effect/mapping_helpers/ianbirthday,
@@ -22553,12 +22519,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"ilT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ima" = (
 /obj/structure/cable,
 /obj/structure/grille/broken,
@@ -28628,9 +28588,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 5
-	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "ksC" = (
@@ -31769,9 +31726,6 @@
 /area/station/maintenance/starboard)
 "lAF" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lAH" = (
@@ -33060,10 +33014,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
 "lVW" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 3
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lWb" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -36060,6 +36019,7 @@
 	dir = 4;
 	name = "Distro to waste"
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mXh" = (
@@ -36914,11 +36874,6 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
-"nna" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "nni" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 4
@@ -37528,16 +37483,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/gravity_generator)
-"nwh" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "nwj" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -38595,15 +38540,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
 "nSH" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 3
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "nSI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39494,10 +39435,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "ola" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 1
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "olv" = (
@@ -39540,7 +39479,6 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "omE" = (
@@ -41004,9 +40942,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "oPh" = (
@@ -42198,7 +42133,9 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "pnl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pnp" = (
@@ -43735,11 +43672,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
 "pRB" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 9
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pRH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44273,7 +44211,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "qbx" = (
@@ -44768,16 +44705,6 @@
 "qjy" = (
 /turf/open/floor/wood,
 /area/station/maintenance/fore)
-"qjZ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "qka" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
 	dir = 1
@@ -47204,16 +47131,6 @@
 /obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"rgS" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "rhc" = (
 /obj/structure/table,
 /obj/item/stack/sheet/rglass{
@@ -47612,9 +47529,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "rnT" = (
@@ -47857,15 +47771,6 @@
 	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
 	},
 /area/station/maintenance/department/medical)
-"rsP" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rsT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -50076,9 +49981,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/purple,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "sjR" = (
@@ -51678,10 +51580,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"sNn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "sNL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark,
@@ -52329,6 +52227,7 @@
 	dir = 4;
 	name = "Distro staging to waste"
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tdL" = (
@@ -54038,7 +53937,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "tHE" = (
@@ -60105,13 +60003,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
-"vXm" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to distro staging"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vXr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61039,7 +60930,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "wrb" = (
@@ -61280,10 +61170,6 @@
 /area/station/hallway/primary/aft)
 "wvb" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Distro"
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wvc" = (
@@ -63128,7 +63014,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xbE" = (
@@ -63182,13 +63067,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"xcD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "xcR" = (
 /turf/closed/wall/r_wall,
 /area/station/construction)
@@ -65347,7 +65225,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xQZ" = (
@@ -90903,27 +90780,27 @@ cgD
 gQv
 yju
 yju
-aVE
-gZV
-nna
+yju
 xQP
-dSJ
+yju
 xQP
-dSJ
+yju
+xQP
+yju
 omv
 crt
-sNn
+xaN
 crt
 xbu
-lVW
+xdv
 wqT
-cIi
+hii
 tHl
-pRB
+rOY
 qbv
-pRB
-pRB
-pRB
+rOY
+rOY
+rOY
 ksA
 iQW
 iQW
@@ -91160,7 +91037,7 @@ tbL
 gQv
 xoo
 xoo
-csw
+bRS
 wxt
 bRS
 wxt
@@ -91181,7 +91058,7 @@ wzs
 xoo
 xoo
 xoo
-nwh
+tHM
 iQW
 iQW
 iQW
@@ -91417,7 +91294,7 @@ ngZ
 epU
 gtR
 epU
-vXm
+uFS
 sDX
 ife
 oJi
@@ -91438,7 +91315,7 @@ pyQ
 epU
 kfN
 xoo
-nwh
+tHM
 iQW
 iQW
 iQW
@@ -91695,7 +91572,7 @@ qXm
 qgU
 iDX
 xoo
-nwh
+tHM
 aNE
 aNE
 aNE
@@ -92209,7 +92086,7 @@ mqx
 uFS
 fGe
 bRS
-nwh
+tHM
 fgD
 sDo
 fVa
@@ -92723,7 +92600,7 @@ mqx
 iuQ
 szM
 rTk
-nwh
+tHM
 aNE
 aNE
 aNE
@@ -93237,7 +93114,7 @@ fzh
 uPE
 jeb
 bRS
-nwh
+tHM
 fgD
 ikJ
 cdV
@@ -93482,12 +93359,12 @@ vxA
 wKw
 cIS
 cIS
-wKw
+cIS
 qZO
 aeg
 aeg
 kIt
-kMt
+pRB
 uFS
 nbx
 sqJ
@@ -93739,7 +93616,7 @@ uFS
 uFS
 ras
 ras
-uFS
+aVE
 iuQ
 xGw
 xGw
@@ -93751,7 +93628,7 @@ mFt
 owm
 sia
 rTk
-nwh
+tHM
 aNE
 aNE
 aNE
@@ -93996,7 +93873,7 @@ uFS
 uFS
 uFS
 uFS
-uFS
+jCT
 ofs
 ldo
 azt
@@ -94253,7 +94130,7 @@ uFS
 dRq
 uFS
 uFS
-uFS
+jCT
 ofs
 uFS
 qrF
@@ -94265,7 +94142,7 @@ uPE
 uFS
 cAV
 bRS
-nwh
+tHM
 fgD
 vNk
 unI
@@ -94510,14 +94387,14 @@ dRq
 uFS
 uFS
 uFS
-uFS
-ofs
-uFS
+oTA
+lVW
+nSH
 mXf
-uFS
+nSH
 tdz
 ola
-ilT
+uFS
 jpQ
 cSx
 hPg
@@ -94774,12 +94651,12 @@ tWC
 cZd
 rse
 mjr
-eGA
+uFS
 okf
 uFS
 qQm
 xoo
-nwh
+tHM
 aNE
 aNE
 aNE
@@ -95036,7 +94913,7 @@ une
 wHt
 ebd
 xoo
-nwh
+tHM
 iQW
 yju
 iQW
@@ -95288,12 +95165,12 @@ jpo
 jpo
 azM
 jpo
-rsP
+jpo
 jpo
 igX
 xoo
 xoo
-nwh
+tHM
 iQW
 yju
 iQW
@@ -95545,12 +95422,12 @@ bRS
 bRS
 rst
 bRS
-xcD
+bRS
 bRS
 xoo
 xoo
-rgS
-qjZ
+hii
+dwL
 yju
 xrM
 iQW
@@ -95802,11 +95679,11 @@ yju
 yju
 oqd
 yju
-nSH
-pRB
-pRB
-pRB
-qjZ
+hii
+rOY
+rOY
+rOY
+dwL
 iQW
 iQW
 xrM

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1410,10 +1410,11 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "axU" = (
-/turf/open/floor/iron/corner{
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 4
 	},
-/area/station/engineering/lobby)
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "aye" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -3752,13 +3753,18 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "brJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil,
+/obj/item/storage/box/lights/mixed{
+	pixel_y = 10
+	},
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/engineering/lobby)
 "brN" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/cable,
@@ -10663,6 +10669,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"dPY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/half,
+/area/station/engineering/lobby)
 "dQv" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -11282,11 +11294,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eaV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/engineering/half,
+/obj/machinery/camera/directional/south{
+	c_tag = "Public - Tool Storage"
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "eaW" = (
 /obj/effect/turf_decal/tile/security{
 	dir = 1
@@ -11971,11 +11986,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "epH" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "epU" = (
 /obj/effect/turf_decal/tile/engineering/half{
 	dir = 8
@@ -12515,8 +12533,6 @@
 /area/station/medical/medbay)
 "ezO" = (
 /obj/effect/turf_decal/tile/yellow/half,
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "ezP" = (
@@ -13801,6 +13817,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/neon/simple/black/nodots,
 /area/station/service/bar)
+"eYL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "eYZ" = (
 /obj/machinery/vending/assist,
 /obj/machinery/camera/directional/west{
@@ -14813,12 +14835,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "fqd" = (
-/obj/effect/turf_decal/tile/engineering/half,
-/obj/machinery/camera/directional/south{
-	c_tag = "Public - Tool Storage"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "fqi" = (
@@ -19218,18 +19239,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "gXS" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil,
-/obj/item/storage/box/lights/mixed{
-	pixel_y = 10
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/lobby)
+/area/station/hallway/primary/aft)
 "gXU" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/rnd_all,
@@ -20550,11 +20564,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hAd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "hAg" = (
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
@@ -22199,12 +22218,9 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "igG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination/tools,
-/obj/effect/turf_decal/tile/engineering/opposingcorners,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "igJ" = (
@@ -24970,11 +24986,14 @@
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "jfz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "jfL" = (
 /obj/machinery/pdapainter/security,
 /turf/open/floor/carpet,
@@ -25308,14 +25327,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "jnm" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "jno" = (
@@ -26692,11 +26704,10 @@
 /turf/closed/wall/r_wall,
 /area/station/commons/fitness)
 "jMJ" = (
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
+/turf/open/floor/iron/corner{
+	dir = 5
 	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/engineering/lobby)
 "jMS" = (
 /obj/structure/chair,
 /obj/effect/landmark/event_spawn,
@@ -30173,14 +30184,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "kVP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination/tools,
+/obj/effect/turf_decal/tile/engineering/opposingcorners,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/corner{
-	dir = 8
-	},
-/area/station/engineering/lobby)
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "kVR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -31432,8 +31443,9 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/cargo)
 "luW" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/turf/open/floor/iron,
+/turf/open/floor/iron/half{
+	dir = 8
+	},
 /area/station/engineering/lobby)
 "lvb" = (
 /obj/machinery/door/firedoor,
@@ -32105,10 +32117,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lGk" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/engineering/half,
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/engineering/lobby)
 "lGl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_corner{
@@ -36032,12 +36045,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"mWF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "mWM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -37984,14 +37991,11 @@
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
 "nGU" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/iron/half{
-	dir = 8
-	},
-/area/station/engineering/lobby)
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "nHc" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/fore)
@@ -39856,14 +39860,11 @@
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "oqG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/engineering/half{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 10
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/aft)
 "oqS" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -42509,15 +42510,17 @@
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
 "ptD" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4;
-	name = "Connector Port"
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/window/spawner/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/corner{
+	dir = 3
+	},
+/area/station/engineering/lobby)
 "ptH" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47046,10 +47049,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/fore)
 "rdS" = (
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/electronics/airalarm,
+/obj/item/electronics/airalarm,
+/obj/item/electronics/airalarm,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "rdT" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -48525,17 +48531,15 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "rGJ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "Connector Port"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/corner{
-	dir = 3
-	},
-/area/station/engineering/lobby)
+/obj/structure/window/spawner/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "rGK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -48698,9 +48702,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rJJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/engineering/half,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/commons/storage/primary)
 "rJZ" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Lab Storage"
@@ -54509,13 +54514,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
-"tTF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/engineering/half,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "tTM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54531,11 +54529,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "tUb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/half,
-/area/station/engineering/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/engineering/half,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "tUi" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "secmechbay";
@@ -55302,13 +55301,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "ufP" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/table/reinforced,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "ufQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55870,7 +55866,7 @@
 /area/station/medical/medbay)
 "urf" = (
 /turf/open/floor/iron/corner{
-	dir = 5
+	dir = 4
 	},
 /area/station/engineering/lobby)
 "urs" = (
@@ -58377,7 +58373,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/corner{
-	dir = 1
+	dir = 8
 	},
 /area/station/engineering/lobby)
 "voP" = (
@@ -60472,13 +60468,13 @@
 /area/station/service/library)
 "wfN" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
+/area/station/engineering/lobby)
 "wfP" = (
 /obj/structure/sign/poster/official/wtf_is_co2/directional/south,
 /obj/effect/turf_decal/siding/engineering,
@@ -63361,6 +63357,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/department/engine)
 "xgS" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/half{
 	dir = 8
 	},
@@ -95470,9 +95470,9 @@ fWk
 dGz
 qSl
 crs
-urf
+jMJ
 asU
-axU
+urf
 iuZ
 kPg
 pRJ
@@ -95982,12 +95982,12 @@ wbb
 wbb
 bIi
 vzJ
-nGU
-urf
+xgS
+jMJ
 feg
 wvA
 phK
-luW
+ezO
 eAv
 mJI
 lTr
@@ -96244,7 +96244,7 @@ eFZ
 qrn
 wvA
 phK
-ezO
+lGk
 sdC
 qFt
 vVh
@@ -96479,7 +96479,7 @@ piR
 nLi
 ydv
 iNf
-lGk
+rJJ
 dSh
 vDm
 agp
@@ -96732,11 +96732,11 @@ biu
 mPS
 kbb
 xdI
-tTF
-igG
-oqG
-brJ
+tUb
+kVP
+jfz
 fqd
+eaV
 dSh
 laL
 agp
@@ -96758,7 +96758,7 @@ phK
 iIS
 dMU
 phK
-gXS
+brJ
 sdC
 tKr
 cyj
@@ -96991,10 +96991,10 @@ kbb
 xdI
 piR
 nLi
-jMJ
-hAd
+igG
+eYL
 wQX
-rdS
+ufP
 whO
 agp
 dSh
@@ -97010,7 +97010,7 @@ vBr
 iom
 nDj
 leo
-rGJ
+ptD
 feg
 mtj
 dMU
@@ -97513,7 +97513,7 @@ whO
 qUa
 dSh
 iEp
-wfN
+epH
 cpq
 scw
 lmI
@@ -97769,8 +97769,8 @@ dSh
 eoK
 qQl
 dSh
-ufP
-wfN
+rdS
+epH
 cdw
 bev
 ndq
@@ -98018,7 +98018,7 @@ giF
 kbb
 xdI
 piR
-ptD
+rGJ
 rDF
 lPH
 kgA
@@ -98037,8 +98037,8 @@ iQW
 iQW
 ljo
 vMb
-urf
-vom
+jMJ
+wfN
 mtj
 uAw
 bpW
@@ -98275,10 +98275,10 @@ giF
 eQo
 pTK
 kxO
-epH
-epH
-eaV
-eaV
+gXS
+gXS
+nGU
+nGU
 dSh
 dSh
 wVE
@@ -98294,7 +98294,7 @@ kiB
 ljo
 ljo
 uzp
-tUb
+dPY
 iVd
 mtj
 vue
@@ -98534,8 +98534,8 @@ fLs
 elh
 bPN
 pZP
-jnm
-jnm
+hAd
+hAd
 olv
 olv
 ltL
@@ -98791,10 +98791,10 @@ rKC
 hLO
 qnK
 nQM
-jfz
-mWF
-rJJ
-rJJ
+oqG
+axU
+jnm
+jnm
 qga
 tBY
 kbd
@@ -99322,9 +99322,9 @@ vkH
 wyn
 xIT
 eob
-kVP
+vom
 xrt
-xgS
+luW
 jxk
 tLe
 phK

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -8492,9 +8492,7 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/storage)
 "cZd" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 6
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cZf" = (
@@ -43342,9 +43340,7 @@
 /turf/open/floor/iron/terracotta/herringbone,
 /area/station/maintenance/starboard/aft)
 "pJI" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
-	dir = 6
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pJT" = (


### PR DESCRIPTION
## About The Pull Request
Changed engineering a bit and fixed some issues. Makes engineering less cramped
I will include all changes in the changelog.
Screenshots:
![image](https://github.com/fulpstation/fulpstation/assets/96586172/5104ac97-e1d7-4198-8122-5234bd556c79)
![image](https://github.com/fulpstation/fulpstation/assets/96586172/487a7faf-7c05-4857-a1f6-4bb774fb6f70)
![image](https://github.com/fulpstation/fulpstation/assets/96586172/5484bd1c-3445-452b-8d72-3df486c58434)
![image](https://github.com/fulpstation/fulpstation/assets/96586172/0cea7709-aa68-46f9-b384-65fbffec14c6)
## Why It's Good For The Game
Some features were missing from Selene like external air ports, cyborg charger, proper distro room. I've fixed that
## Changelog
:cl:
add: External air ports, atmos air refilling station, empty cans for atmos, cell charger in engineering, cyborg charger in engineering, proper distro for atmos, 
del: Removed partial atmos can in SM room since that's not how cans are made anymore
qol: added layer manifolds for gas supply to pure
fix: removed engineering access from engi sec outpost.
/:cl:
