### PR TITLE
Fixes some runtimes in the Prototype Space Station Ruin

### DIFF
--- a/fulp_modules/_maps/RandomRuins/SpaceRuins/syndicate_engineer.dmm
+++ b/fulp_modules/_maps/RandomRuins/SpaceRuins/syndicate_engineer.dmm
@@ -237,8 +237,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/secure/gear{
 	anchored = 1;
-	name = "mining gear crate";
-	req_access_txt = "0"
+	name = "mining gear crate"
 	},
 /obj/item/lazarus_injector,
 /obj/item/mining_scanner,
@@ -438,11 +437,10 @@
 /turf/open/floor/plating/airless,
 /area/ruin/has_grav/prototype/dorms)
 "bu" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Shuttle door";
-	req_access_txt = "150"
-	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/hatch{
+	name = "Shuttle door"
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered)
 "bv" = (
@@ -1348,8 +1346,7 @@
 "eM" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/command{
-	name = "Captain's Office";
-	req_access_txt = "20"
+	name = "Captain's Office"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,


### PR DESCRIPTION

## About The Pull Request
Some airlocks had variables assigned to them that were no longer being used, causing runtimes; those variables have been summarily executed.
## Why It's Good For The Game
Less runtimes!
## Changelog
:cl:
fix: Removes a few runtimes related to the Prototype Space Station ruin.
/:cl:
