### PR TITLE
Changes to blood chair and fixes dirtying

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -67,7 +67,7 @@
 
 	// Used for Bloodsucker Objectives
 	var/area/bloodsucker_lair_area
-	var/obj/structure/closet/crate/coffin
+	var/obj/structure/closet/crate/claimed_coffin
 	var/total_blood_drank = 0
 
 	///Blood display HUD

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
@@ -10,6 +10,6 @@
 // WIN CONDITIONS?
 /datum/objective/bloodsucker_lair/check_completion()
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = owner.has_antag_datum(/datum/antagonist/bloodsucker)
-	if(bloodsuckerdatum && bloodsuckerdatum.coffin && bloodsuckerdatum.bloodsucker_lair_area)
+	if(bloodsuckerdatum && bloodsuckerdatum.claimed_coffin && bloodsuckerdatum.bloodsucker_lair_area)
 		return TRUE
 	return FALSE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
@@ -69,6 +69,7 @@
 		if(!HAS_TRAIT(owner.current, TRAIT_NODEATH))
 			check_begin_torpor(TRUE)
 			owner.current.add_mood_event("vampsleep", /datum/mood_event/coffinsleep)
+		dirty_area()
 		return
 
 	if(COOLDOWN_FINISHED(src, bloodsucker_spam_sol_burn)) // Closets offer SOME protection
@@ -77,6 +78,21 @@
 	owner.current.adjustFireLoss(0.5 + (bloodsucker_level / 4))
 	owner.current.updatehealth()
 	owner.current.add_mood_event("vampsleep", /datum/mood_event/daylight_1)
+
+///Makes the area the bloodsucker is currently in dirty with cobweb and dirt.
+/datum/antagonist/bloodsucker/proc/dirty_area()
+	var/list/turf/area_turfs = get_area_turfs(get_area(owner.current))
+	var/turf/turf_to_be_dirtied = pick(area_turfs)
+	if(turf_to_be_dirtied && !turf_to_be_dirtied.density)
+		var/turf/north_turf = get_step(turf_to_be_dirtied, NORTH)
+		if(istype(north_turf, /turf/closed/wall))
+			var/turf/west_turf = get_step(turf_to_be_dirtied, WEST)
+			if(istype(west_turf, /turf/closed/wall))
+				new /obj/effect/decal/cleanable/cobweb(turf_to_be_dirtied)
+			var/turf/east_turf = get_step(turf_to_be_dirtied, EAST)
+			if(istype(east_turf, /turf/closed/wall))
+				new /obj/effect/decal/cleanable/cobweb/cobweb2(turf_to_be_dirtied)
+		new /obj/effect/decal/cleanable/dirt(turf_to_be_dirtied)
 
 /datum/antagonist/bloodsucker/proc/give_warning(atom/source, danger_level, vampire_warning_message, vassal_warning_message)
 	SIGNAL_HANDLER

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
@@ -38,7 +38,7 @@
 	if(!.)
 		return FALSE
 	/// Have No Lair (NOTE: You only got this power if you had a lair, so this means it's destroyed)
-	if(!istype(bloodsuckerdatum_power) || !bloodsuckerdatum_power.coffin)
+	if(!istype(bloodsuckerdatum_power) || !bloodsuckerdatum_power.claimed_coffin)
 		owner.balloon_alert(owner, "coffin was destroyed!")
 		return FALSE
 	return TRUE
@@ -60,7 +60,7 @@
 		if(GOHOME_FLICKER_TWO)
 			INVOKE_ASYNC(src, PROC_REF(flicker_lights), 4, 60)
 		if(GOHOME_TELEPORT)
-			INVOKE_ASYNC(src, PROC_REF(teleport_to_coffin), owner)
+			INVOKE_ASYNC(src, PROC_REF(teleport_to_coffin))
 	teleporting_stage++
 
 /datum/action/cooldown/bloodsucker/gohome/ContinueActive(mob/living/user, mob/living/target)
@@ -69,20 +69,29 @@
 		return FALSE
 	if(!isturf(owner.loc))
 		return FALSE
-	if(!bloodsuckerdatum_power.coffin)
+	if(!bloodsuckerdatum_power.claimed_coffin)
 		user.balloon_alert(user, "coffin destroyed!")
 		to_chat(owner, span_warning("Your coffin has been destroyed! You no longer have a destination."))
 		return FALSE
 	return TRUE
 
+///Flickers the lights in a flicker range around the owner and plays a beat that all nearby players can hear.
 /datum/action/cooldown/bloodsucker/gohome/proc/flicker_lights(flicker_range, beat_volume)
 	for(var/obj/machinery/light/nearby_lights in view(flicker_range, get_turf(owner)))
 		nearby_lights.flicker(5)
 	playsound(get_turf(owner), 'sound/effects/singlebeat.ogg', beat_volume, 1)
 
-/datum/action/cooldown/bloodsucker/gohome/proc/teleport_to_coffin(mob/living/carbon/user)
+/**
+ * teleport_to_coffin
+ *
+ * Checks if anyone is able to physically see the user, and if there is then we'll drop everything on them.
+ * We'll then throw some smoke up, spawn a vampirical creature,
+ * then lastly teleport the user to their coffin (properly, so it's closed up for Sol/Torpor).
+ */
+/datum/action/cooldown/bloodsucker/gohome/proc/teleport_to_coffin()
 	var/drop_item = FALSE
 	var/turf/current_turf = get_turf(owner)
+	var/mob/living/carbon/user = owner
 	// If we aren't in the dark, anyone watching us will cause us to drop out stuff
 	if(current_turf && current_turf.lighting_object && current_turf.get_lumcount() >= 0.2)
 		for(var/mob/living/watchers in viewers(world.view, get_turf(owner)) - owner)
@@ -96,31 +105,23 @@
 				drop_item = TRUE
 				break
 	// Drop all necessary items (handcuffs, legcuffs, items if seen)
-	if(user.handcuffed)
-		var/obj/item/handcuffs = user.handcuffed
-		user.dropItemToGround(handcuffs)
-	if(user.legcuffed)
-		var/obj/item/legcuffs = user.legcuffed
-		user.dropItemToGround(legcuffs)
 	if(drop_item)
-		for(var/obj/item/literally_everything in owner)
+		for(var/obj/item/literally_everything in user.get_all_worn_items())
 			owner.dropItemToGround(literally_everything, TRUE)
 
 	playsound(current_turf, 'sound/magic/summon_karp.ogg', 60, 1)
 
-	var/datum/effect_system/steam_spread/bloodsucker/puff = new /datum/effect_system/steam_spread/bloodsucker()
+	var/datum/effect_system/steam_spread/bloodsucker/puff = new(user.loc)
 	puff.set_up(3, 0, current_turf)
 	puff.start()
 
-	/// STEP FIVE: Create animal at prev location
-	var/mob/living/simple_animal/new_mob = pick_weight(spawning_mobs)
+	var/mob/living/basic/new_mob = pick_weight(spawning_mobs)
 	new new_mob(current_turf)
-	/// TELEPORT: Move to Coffin & Close it!
+
 	user.set_resting(TRUE, TRUE, FALSE)
-	do_teleport(owner, bloodsuckerdatum_power.coffin, no_effects = TRUE, forced = TRUE, channel = TELEPORT_CHANNEL_QUANTUM)
-	bloodsuckerdatum_power.coffin.close(owner)
-	bloodsuckerdatum_power.coffin.take_contents()
-	playsound(bloodsuckerdatum_power.coffin.loc, bloodsuckerdatum_power.coffin.close_sound, 15, 1, -3)
+	do_teleport(owner, bloodsuckerdatum_power.claimed_coffin, no_effects = TRUE, forced = TRUE, channel = TELEPORT_CHANNEL_QUANTUM)
+	bloodsuckerdatum_power.claimed_coffin.close(owner)
+	bloodsuckerdatum_power.claimed_coffin.take_contents()
 
 	DeactivatePower()
 


### PR DESCRIPTION
## About The Pull Request

Bloodsuckers resting in a coffin during Sol now properly dirties the area with dirt and cobweb, a feature that I don't think has worked for who knows how long.
Also lets anyone buckle to the blood chair but only Bloodsuckers can use it, and some micro optimization.
Also removes 2 sounds being played from vanishing act.