### PR TITLE
Vassel Recuperation Spam fix

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
@@ -180,6 +180,7 @@
 		return
 	if(power_flags & BP_AM_TOGGLE)
 		STOP_PROCESSING(SSprocessing, src)
+		STOP_PROCESSING(SSfastprocess, src)
 	if(power_flags & BP_AM_SINGLEUSE)
 		remove_after_use()
 		return


### PR DESCRIPTION
## About The Pull Request

fix: Vaseel recuperation will no longer spam you when your stunned.

This spam:
![Screenshot 2024-04-02 152450](https://github.com/fulpstation/fulpstation/assets/163439532/b4f69c6c-4298-4ed6-9a05-c20429d05a5c)

## Changelog

:cl:
fix: Vaseel recuperation will no longer spam you when your stunned.
/:cl:
