### PR TITLE
Healing nanites works better on Lavaland

### DIFF
--- a/fulp_modules/Z_edits/hud_edits.dm
+++ b/fulp_modules/Z_edits/hud_edits.dm
@@ -13,8 +13,8 @@
 
 /datum/atom_hud/data/diagnostic/basic/New()
 	. = ..()
-	hud_icons += list(NANITE_HUD, DIAG_NANITE_FULL_HUD)
+	hud_icons += list(DIAG_NANITE_FULL_HUD)
 
 /datum/atom_hud/data/diagnostic/advanced/New()
 	. = ..()
-	hud_icons += list(NANITE_HUD, DIAG_NANITE_FULL_HUD)
+	hud_icons += list(DIAG_NANITE_FULL_HUD)

--- a/fulp_modules/features/nanites/code/nanite_component.dm
+++ b/fulp_modules/features/nanites/code/nanite_component.dm
@@ -127,7 +127,7 @@
 	STOP_PROCESSING(SSnanites, src)
 	QDEL_LIST(programs)
 	if(host_mob)
-		host_mob.hud_set_nanite_indicator()
+		host_mob.hud_set_nanite_indicator(remove = TRUE)
 		set_nanite_bar(remove = TRUE)
 	host_mob = null
 	linked_techweb = null
@@ -148,14 +148,14 @@
 		if(cloud_id && world.time > next_sync)
 			cloud_sync()
 			next_sync = world.time + NANITE_SYNC_DELAY
-	set_nanite_bar(remove = FALSE)
+	set_nanite_bar()
 
 /datum/component/nanites/proc/delete_nanites()
 	SIGNAL_HANDLER
 
 	qdel(src)
 
-//Syncs the nanite component to another, making it so programs are the same with the same programming (except activation status)
+///Syncs the nanite component to another, making it so programs are the same with the same programming (except activation status)
 /datum/component/nanites/proc/sync(datum/signal_source, datum/component/nanites/source, full_overwrite = TRUE, copy_activation = FALSE)
 	SIGNAL_HANDLER
 

--- a/fulp_modules/features/nanites/code/nanite_hud.dm
+++ b/fulp_modules/features/nanites/code/nanite_hud.dm
@@ -1,12 +1,14 @@
 #define NANITE_HUD "nanite_hud"
 #define DIAG_NANITE_FULL_HUD "nanite_full_hud"
 
-/mob/living/proc/hud_set_nanite_indicator()
+/mob/living/proc/hud_set_nanite_indicator(remove = FALSE)
 	var/image/holder = hud_list[NANITE_HUD]
 	var/icon/I = icon(icon, icon_state, dir)
 	holder.pixel_y = I.Height() - world.icon_size
-	holder.icon_state = null
 	holder.icon = 'fulp_modules/features/nanites/icons/nanite_hud.dmi'
+	holder.icon_state = null
+	if(remove)
+		return //bye icon
 	holder.icon_state = "nanite_ping"
 
 ///Updates the nanite volume bar visible in diagnostic HUDs

--- a/fulp_modules/features/nanites/code/programs/healing.dm
+++ b/fulp_modules/features/nanites/code/programs/healing.dm
@@ -21,7 +21,7 @@
 		host_mob.adjustBruteLoss(-0.5, TRUE)
 		host_mob.adjustFireLoss(-0.5, TRUE)
 		return
-	var/lavaland_bonus = (lavaland_equipment_pressure_check(get_turf(host_mob)) ? 1.2 : 0.6) // 0.6 on lavaland, 0.3 on station
+	var/lavaland_bonus = (lavaland_equipment_pressure_check(get_turf(host_mob)) ? 1 : 0.6) // 0.5 on lavaland, 0.3 on station
 	host_mob.heal_overall_damage(brute = (0.5 * lavaland_bonus), brute = (0.5 * lavaland_bonus), required_bodytype = BODYTYPE_ORGANIC)
 
 /datum/nanite_program/regenerative_advanced
@@ -37,7 +37,7 @@
 		host_mob.adjustBruteLoss(-3, TRUE)
 		host_mob.adjustFireLoss(-3, TRUE)
 		return
-	var/lavaland_bonus = (lavaland_equipment_pressure_check(get_turf(host_mob)) ? 1.2 : 0.8) // 1.8 on Lavaland, 1.2 on station
+	var/lavaland_bonus = (lavaland_equipment_pressure_check(get_turf(host_mob)) ? 1 : 0.8) // 1.5 on Lavaland, 1.2 on station
 	host_mob.heal_overall_damage(brute = (1.5 * lavaland_bonus), brute = (1.5 * lavaland_bonus), required_bodytype = BODYTYPE_ROBOTIC)
 
 /datum/nanite_program/temperature

--- a/fulp_modules/features/nanites/code/programs/healing.dm
+++ b/fulp_modules/features/nanites/code/programs/healing.dm
@@ -1,6 +1,8 @@
 /datum/nanite_program/regenerative
 	name = "Accelerated Regeneration"
-	desc = "The nanites boost the host's natural regeneration, increasing their healing speed. Does not consume nanites if the host is unharmed."
+	desc = "The nanites boost the host's natural regeneration, increasing their healing speed. \
+		Does not consume nanites if the host is unharmed. \
+		Works better in low-pressure environments."
 	use_rate = 0.5
 	rogue_types = list(/datum/nanite_program/necrotic)
 
@@ -15,17 +17,28 @@
 	return ..()
 
 /datum/nanite_program/regenerative/active_effect()
-	if(iscarbon(host_mob))
-		var/mob/living/carbon/host_carbon = host_mob
-		var/list/parts = host_carbon.get_damaged_bodyparts(brute = TRUE, burn = TRUE, required_bodytype = BODYTYPE_ORGANIC)
-		if(!parts.len)
-			return
-		for(var/obj/item/bodypart/bodyparts as anything in parts)
-			if(bodyparts.heal_damage(0.5 / parts.len, 0.5 / parts.len, null, required_bodytype = BODYTYPE_ORGANIC))
-				host_mob.update_damage_overlays()
-	else
+	if(!iscarbon(host_mob))
 		host_mob.adjustBruteLoss(-0.5, TRUE)
 		host_mob.adjustFireLoss(-0.5, TRUE)
+		return
+	var/lavaland_bonus = (lavaland_equipment_pressure_check(get_turf(host_mob)) ? 1.2 : 0.6) // 0.6 on lavaland, 0.3 on station
+	host_mob.heal_overall_damage(brute = (0.5 * lavaland_bonus), brute = (0.5 * lavaland_bonus), required_bodytype = BODYTYPE_ORGANIC)
+
+/datum/nanite_program/regenerative_advanced
+	name = "Bio-Reconstruction"
+	desc = "The nanites manually repair and replace organic cells, acting much faster than normal regeneration. \
+			However, this program cannot detect the difference between harmed and unharmed, causing it to consume nanites even if it has no effect. \
+			Works better in low-pressure environments."
+	use_rate = 5.5
+	rogue_types = list(/datum/nanite_program/suffocating, /datum/nanite_program/necrotic)
+
+/datum/nanite_program/regenerative_advanced/active_effect()
+	if(!iscarbon(host_mob))
+		host_mob.adjustBruteLoss(-3, TRUE)
+		host_mob.adjustFireLoss(-3, TRUE)
+		return
+	var/lavaland_bonus = (lavaland_equipment_pressure_check(get_turf(host_mob)) ? 1.2 : 0.8) // 1.8 on Lavaland, 1.2 on station
+	host_mob.heal_overall_damage(brute = (1.5 * lavaland_bonus), brute = (1.5 * lavaland_bonus), required_bodytype = BODYTYPE_ROBOTIC)
 
 /datum/nanite_program/temperature
 	name = "Temperature Adjustment"
@@ -135,16 +148,7 @@
 		host_mob.adjustBruteLoss(-1.5, TRUE)
 		host_mob.adjustFireLoss(-1.5, TRUE)
 		return
-	var/mob/living/carbon/carbon_host = host_mob
-	var/list/parts = carbon_host.get_damaged_bodyparts(brute = TRUE, burn = TRUE, required_bodytype = BODYTYPE_ROBOTIC)
-	if(!parts.len)
-		return
-	var/update = FALSE
-	for(var/obj/item/bodypart/bodypart as anything in parts)
-		if(bodypart.heal_damage(1.5 / parts.len, 1.5 / parts.len, null, BODYTYPE_ROBOTIC)) //much faster than organic healing
-			update = TRUE
-	if(update)
-		host_mob.update_damage_overlays()
+	host_mob.heal_overall_damage(brute = 1.5, brute = 1.5, required_bodytype = BODYTYPE_ROBOTIC)
 
 /datum/nanite_program/purging_advanced
 	name = "Selective Blood Purification"
@@ -166,29 +170,6 @@
 	host_mob.adjustToxLoss(-1)
 	for(var/datum/reagent/toxin/toxic_reagents in host_mob.reagents.reagent_list)
 		host_mob.reagents.remove_reagent(toxic_reagents.type, 1)
-
-/datum/nanite_program/regenerative_advanced
-	name = "Bio-Reconstruction"
-	desc = "The nanites manually repair and replace organic cells, acting much faster than normal regeneration. \
-			However, this program cannot detect the difference between harmed and unharmed, causing it to consume nanites even if it has no effect."
-	use_rate = 5.5
-	rogue_types = list(/datum/nanite_program/suffocating, /datum/nanite_program/necrotic)
-
-/datum/nanite_program/regenerative_advanced/active_effect()
-	if(!iscarbon(host_mob))
-		host_mob.adjustBruteLoss(-3, TRUE)
-		host_mob.adjustFireLoss(-3, TRUE)
-		return
-	var/mob/living/carbon/carbon_host = host_mob
-	var/list/parts = carbon_host.get_damaged_bodyparts(brute = TRUE, burn = TRUE, required_bodytype = BODYTYPE_ORGANIC)
-	if(!parts.len)
-		return
-	var/update = FALSE
-	for(var/obj/item/bodypart/bodypart as anything in parts)
-		if(bodypart.heal_damage(3 / parts.len, 3 / parts.len, null, BODYTYPE_ORGANIC))
-			update = TRUE
-	if(update)
-		host_mob.update_damage_overlays()
 
 /datum/nanite_program/brain_heal_advanced
 	name = "Neural Reimaging"

--- a/fulp_modules/features/nanites/code/programs/utility.dm
+++ b/fulp_modules/features/nanites/code/programs/utility.dm
@@ -62,10 +62,12 @@
 /datum/nanite_program/stealth/enable_passive_effect()
 	. = ..()
 	nanites.stealth = TRUE
+	host_mob.hud_set_nanite_indicator(remove = TRUE)
 
 /datum/nanite_program/stealth/disable_passive_effect()
 	. = ..()
 	nanites.stealth = FALSE
+	host_mob.hud_set_nanite_indicator()
 
 /datum/nanite_program/reduced_diagnostics
 	name = "Reduced Diagnostics"


### PR DESCRIPTION
## About The Pull Request

Regular healing nanite program now heals 0.3 per tick on the station, previously was 0.5
Advanced healing nanites now heals 1.2 a tick on the station. Previously was 1.5
You get the old healing if you're in low-pressure (space/lavaland/etc)

Also fixed the nanite dot icon not going away when you lose nanites (or make them stealth).

Mechanical repair not affected by this.

## Why It's Good For The Game

Nanites are a good tool that you can give miners to help them survive on Lavaland easier, while also being a useful tool on the station. This hopefully allows Nanites to keep its use in both cases while being better for miners than everyone else, as to encourage their use more and discourage its use as simply a tool to evade medbay.
