### PR TITLE
Adds Cthonians, a new species

### DIFF
--- a/fulp_modules/features/species/cthonic/cthonic.dm
+++ b/fulp_modules/features/species/cthonic/cthonic.dm
@@ -1,0 +1,58 @@
+/datum/species/cthonic
+	name = "Cthonic"
+	plural_form = "Cthonics"
+	id = SPECIES_CTHONIC
+	examine_limb_id = SPECIES_CTHONIC
+	sexes = FALSE
+	mutant_bodyparts = list(
+		"legs" = "Normal Legs",
+	)
+	inherent_traits = list(
+		TRAIT_MUTANT_COLORS,
+		TRAIT_MOVE_FLYING,
+		TRAIT_NO_UNDERWEAR,
+		TRAIT_AGENDER,
+		TRAIT_FIXED_HAIRCOLOR,
+		TRAIT_GENELESS,
+	)
+	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID
+	mutantheart = /obj/item/organ/internal/heart/fly
+	mutantlungs = /obj/item/organ/internal/lungs/fly
+	mutantliver = /obj/item/organ/internal/liver/fly
+	mutantstomach = /obj/item/organ/internal/stomach/fly
+	mutantappendix = /obj/item/organ/internal/appendix/fly
+	mutant_organs = list(/obj/item/organ/internal/fly, /obj/item/organ/internal/fly/groin)
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
+	damage_modifier = -25 // 25% More damage
+
+	bodypart_overrides = list(
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/cthonic,
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/cthonic,
+		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/cthonic,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/cthonic,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/cthonic,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/cthonic,
+	)
+	death_sound = 'sound/voice/lizard/deathsound.ogg'
+
+
+/mob/living/carbon/human/species/cthonic
+	race = /datum/species/cthonic
+
+/// Lore and shit
+
+/datum/species/cthonic/get_physical_attributes()
+	return "something about taking damage and flying?"
+
+/datum/species/cthonic/get_species_description()
+	return "The cthonic are a species  \
+		that are pretty much just mind flayers \
+		but keeping with the tradition of naming things stupidly"
+
+/datum/species/cthonic/get_species_lore()
+	return list(
+		"these little bitches are alien fish people but really just mindflayers",
+
+		"hell yeah time to write some lore I guess. \
+		lore lore lore c'mon joyce you love writing lore",
+	)

--- a/fulp_modules/features/species/cthonic/cthonic_bodyparts.dm
+++ b/fulp_modules/features/species/cthonic/cthonic_bodyparts.dm
@@ -1,4 +1,4 @@
-/obj/item/bodypart/head/robot/cthonic
+/obj/item/bodypart/head/cthonic
 	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
 	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
 	limb_id = SPECIES_CTHONIC
@@ -6,7 +6,7 @@
 	head_flags = HEAD_HAIR | HEAD_EYESPRITES | HEAD_EYECOLOR
 	should_draw_greyscale = TRUE
 
-/obj/item/bodypart/chest/robot/cthonic
+/obj/item/bodypart/chest/cthonic
 	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
 	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
 	limb_id = SPECIES_CTHONIC
@@ -14,28 +14,28 @@
 	should_draw_greyscale = TRUE
 	is_dimorphic = TRUE
 
-/obj/item/bodypart/arm/left/robot/cthonic
+/obj/item/bodypart/arm/left/cthonic
 	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
 	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
 	limb_id = SPECIES_CTHONIC
 	change_exempt_flags = NONE
 	should_draw_greyscale = TRUE
 
-/obj/item/bodypart/arm/right/robot/cthonic
+/obj/item/bodypart/arm/right/cthonic
 	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
 	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
 	limb_id = SPECIES_CTHONIC
 	change_exempt_flags = NONE
 	should_draw_greyscale = TRUE
 
-/obj/item/bodypart/leg/left/robot/cthonic
+/obj/item/bodypart/leg/left/cthonic
 	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
 	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
 	limb_id = SSPECIES_CTHONIC
 	change_exempt_flags = NONE
 	should_draw_greyscale = TRUE
 
-/obj/item/bodypart/leg/right/robot/cthonic
+/obj/item/bodypart/leg/right/cthonic
 	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
 	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
 	limb_id = SPECIES_CTHONIC

--- a/fulp_modules/features/species/cthonic/cthonic_bodyparts.dm
+++ b/fulp_modules/features/species/cthonic/cthonic_bodyparts.dm
@@ -1,0 +1,43 @@
+/obj/item/bodypart/head/robot/cthonic
+	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
+	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
+	limb_id = SPECIES_CTHONIC
+	change_exempt_flags = NONE
+	head_flags = HEAD_HAIR | HEAD_EYESPRITES | HEAD_EYECOLOR
+	should_draw_greyscale = TRUE
+
+/obj/item/bodypart/chest/robot/cthonic
+	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
+	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
+	limb_id = SPECIES_CTHONIC
+	change_exempt_flags = NONE
+	should_draw_greyscale = TRUE
+	is_dimorphic = TRUE
+
+/obj/item/bodypart/arm/left/robot/cthonic
+	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
+	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
+	limb_id = SPECIES_CTHONIC
+	change_exempt_flags = NONE
+	should_draw_greyscale = TRUE
+
+/obj/item/bodypart/arm/right/robot/cthonic
+	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
+	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
+	limb_id = SPECIES_CTHONIC
+	change_exempt_flags = NONE
+	should_draw_greyscale = TRUE
+
+/obj/item/bodypart/leg/left/robot/cthonic
+	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
+	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
+	limb_id = SSPECIES_CTHONIC
+	change_exempt_flags = NONE
+	should_draw_greyscale = TRUE
+
+/obj/item/bodypart/leg/right/robot/cthonic
+	icon = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts.dmi'
+	icon_greyscale = 'fulp_modules/features/species/icons/mob/cthonic_bodyparts_greyscale.dmi'
+	limb_id = SPECIES_CTHONIC
+	change_exempt_flags = NONE
+	should_draw_greyscale = TRUE

--- a/fulp_modules/features/species/cthonic/cthonic_organs
+++ b/fulp_modules/features/species/cthonic/cthonic_organs
@@ -1,0 +1,11 @@
+/obj/item/organ/internal/tongue/cthonic
+	name = "tentacle tongue"
+	desc = "A thin and long muscle typically found in reptilian races, apparently moonlights as a nose."
+	icon_state = "cthoniclizard"
+	say_mod = "gurgles"
+	taste_sensitivity = 100 // combined nose + tongue, extra sensitive
+	modifies_speech = FALSE
+	languages_native = list(/datum/language/draconic)
+	liked_foodtypes = GORE | MEAT | SEAFOOD | GROSS | BUGS
+	disliked_foodtypes = TOXIC
+	toxic_foodtypes =  VEGETABLES | FRUIT |


### PR DESCRIPTION

## About The Pull Request

Cthonians are the original inspiration for DnD mindflayers, and I'm drawing inspiration both from their original source as well as the DnD monster. This PR is still a draft, but I wanted to open it to invite suggestions and feedback from coders. I'd like to incorporate something with brain damage (maybe having them deal brain damage like etherals deal burn damage) and am looking for input on fun things to do with organs.

## Why It's Good For The Game

New species are fun, and deep space squid folks are fitting for the setting. 

## Changelog
:cl:
add: Adds cthonics
/:cl:
