### PR TITLE
Updates beefman species trait phrasing

### DIFF
--- a/fulp_modules/features/species/beefmen/mob/beefman.dm
+++ b/fulp_modules/features/species/beefmen/mob/beefman.dm
@@ -225,8 +225,8 @@
  */
 
 /datum/species/beefman/get_species_description()
-	return "Made entirely out of beef, Beefmen are completely delusional \
-		through and through, with constant hallucinations and 'tears in reality'"
+	return "Thanks to being made entirely out of beef, Beefman's brains are deeply flawed, \
+		causing them to suffer constant hallucinations and 'tears in reality'"
 
 /datum/species/beefman/get_species_lore()
 	return list(
@@ -255,7 +255,7 @@
 		//Positive
 		list(
 			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
-			SPECIES_PERK_ICON = "meat",
+			SPECIES_PERK_ICON = "handshake",
 			SPECIES_PERK_NAME = "Beefy Limbs",
 			SPECIES_PERK_DESC = "Beefmen are able to tear off and put limbs back on at will. They do this by targetting their limb and right clicking.",
 		),
@@ -263,41 +263,41 @@
 			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 			SPECIES_PERK_ICON = "running",
 			SPECIES_PERK_NAME = "Runners",
-			SPECIES_PERK_DESC = "Beefmen are 20% faster than other species by default, allowing them to outrun things that normal crewmembers cannot.",
+			SPECIES_PERK_DESC = "Beefmen are 20% faster than most other species.",
 		),
 		list(
 			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 			SPECIES_PERK_ICON = "temperature-low",
 			SPECIES_PERK_NAME = "Cold Loving",
-			SPECIES_PERK_DESC = "Beefmen are completely immune to the cold, even helping them prevent bleeding.",
+			SPECIES_PERK_DESC = "Beefmen are completely immune to the cold. Low temperatures even prevent bleeding.",
 		),
 		//Neutral
 		list(
 			SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
 			SPECIES_PERK_ICON = "link",
 			SPECIES_PERK_NAME = "Phobetor Tears",
-			SPECIES_PERK_DESC = "Beefmen can see and use Phobetor tears, small tears in reality that, \
-				When used, teleports you to the other end of the tear. This cannot if someone is near the start and end.",
+			SPECIES_PERK_DESC = "Beefmen can see and use Phobetor tears, small tears in reality, \
+				that teleport them to the other end of the tear. This can only be done when no one is watching.",
 		),
 		//Negative
 		list(
 			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
 			SPECIES_PERK_ICON = "shield-alt",
 			SPECIES_PERK_NAME = "Boneless Meat",
-			SPECIES_PERK_DESC = "Beefmen's meat is not well guarded, taking 20% more damage than normal crew.",
+			SPECIES_PERK_DESC = "Beefmen's meat is not well guarded, causing them to take 20% more damage.",
 		),
 		list(
 			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
 			SPECIES_PERK_ICON = "tint",
 			SPECIES_PERK_NAME = "Juice Bleeding",
-			SPECIES_PERK_DESC = "Beefmen will begin to bleed out when their temperature is above [BEEFMAN_BLEEDOUT_LEVEL-T0C] Celsius, \
-				Though scaling burn damage will prevent the bleeding.",
+			SPECIES_PERK_DESC = "Beefmen will begin to bleed out when their temperature is above [BEEFMAN_BLEEDOUT_LEVEL-T0C] Celsius. \
+				Burn damage will prevent bleeding.",
 		),
 		list(
 			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
 			SPECIES_PERK_ICON = "briefcase-medical",
 			SPECIES_PERK_NAME = "Mentally unfit",
-			SPECIES_PERK_DESC = "Beefmen suffer terribly from a permanent brain trauma. \
+			SPECIES_PERK_DESC = "Beefmen suffer from a permanent brain trauma \
 				that can't be repaired under normal circumstances.",
 		),
 	)


### PR DESCRIPTION

## About The Pull Request

Edits the beefman species trait descriptions for readability. Changes the icon for limb ripping off because the meat icon got moved to a paid version.

## Why It's Good For The Game

Clear language is good. Fixed icons are good.

## Changelog
:cl:
spellcheck: Upated beefman species trait descriptions.
/:cl:
