### PR TITLE
Cleans up blood sucker descriptions

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -14,9 +14,9 @@
 	tip_theme = "spookyconsole"
 	antag_tips = list(
 		"You are a Bloodsucker, an undead blood-seeking monster living aboard Space Station 13.",
-		"You regenerate your health slowly, you're weak to fire, and you depend on blood to survive. Don't allow your blood to run too low, or you'll enter a Frenzy!",
-		"Use your Antagonist UI page to enter a Clan and learn how your Powers work.",
-		"While not in a Clan, you will be unable to rank up, Feed, or do any other Bloodsucker activities.",
+		"You regenerate your health slowly. You're weak to fire, and you depend on blood to survive. Don't allow your blood to run too low, or you'll enter a Frenzy!",
+		"Use your Antagonist UI page to enter a clan and learn how your powers work.",
+		"While not in a clan, you will be unable to rank up, feed, or do any other Bloodsucker activities.",
 	)
 
 	/// How much blood we have, starting off at default blood levels.

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
@@ -29,7 +29,7 @@
 
 	var/chosen_clan
 	if(person_selecting)
-		chosen_clan = tgui_input_list(person_selecting, "What Clan should [owner.current] be?", "Clan Selection", options)
+		chosen_clan = tgui_input_list(person_selecting, "What clan should [owner.current] be?", "Clan Selection", options)
 	else
 		chosen_clan = show_radial_menu(person_selecting, owner.current, radial_display)
 	chosen_clan = options[chosen_clan]
@@ -42,7 +42,7 @@
 
 /datum/antagonist/bloodsucker/proc/remove_clan(mob/admin)
 	if(owner.current.has_status_effect(/datum/status_effect/frenzy))
-		to_chat(admin, span_announce("Removing a Bloodsucker from a Clan while they are in a Frenzy will break stuff, this action has been blocked."))
+		to_chat(admin, span_announce("Removing a Bloodsucker from a clan while they are in a Frenzy will break stuff. This action has been blocked."))
 		return
 	QDEL_NULL(my_clan)
 	to_chat(owner.current, span_announce("You have been forced out of your clan! You can re-enter one by regular means."))

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
@@ -24,7 +24,7 @@
 
 /atom/movable/screen/alert/status_effect/frenzy
 	name = "Frenzy"
-	desc = "You are in a Frenzy! You are entirely Feral and, depending on your Clan, fighting for your life!"
+	desc = "You are in a Frenzy! You are entirely feral and, depending on your clan, fighting for your life!"
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/actions_bloodsucker.dmi'
 	icon_state = "power_recover"
 	alerttooltipstyle = "cult"
@@ -54,7 +54,7 @@
 	// Disable ALL Powers and notify their entry
 	bloodsuckerdatum.DisableAllPowers(forced = TRUE)
 	to_chat(owner, span_userdanger("<FONT size = 3>Blood! You need Blood, now! You enter a total Frenzy!"))
-	to_chat(owner, span_announce("* Bloodsucker Tip: While in Frenzy, you instantly Aggresively grab, have stun resistance, cannot speak, hear, or use any powers outside of Feed and Trespass (If you have it)."))
+	to_chat(owner, span_announce("* Bloodsucker Tip: While in Frenzy, you instantly aggresively grab, have stun resistance, cannot speak, hear, or use any powers outside of Feed and Trespass (If you have it)."))
 	owner.balloon_alert(owner, "you enter a frenzy!")
 	SEND_SIGNAL(bloodsuckerdatum, BLOODSUCKER_ENTERS_FRENZY)
 
@@ -76,7 +76,7 @@
 
 /datum/status_effect/frenzy/on_remove()
 	var/mob/living/carbon/human/user = owner
-	owner.balloon_alert(owner, "you come back to your senses.")
+	owner.balloon_alert(owner, "You come back to your senses.")
 	owner.remove_traits(list(TRAIT_MUTE, TRAIT_DEAF), FRENZY_TRAIT)
 	if(was_tooluser)
 		ADD_TRAIT(owner, TRAIT_ADVANCEDTOOLUSER, SPECIES_TRAIT)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_guardian.dm
@@ -30,7 +30,7 @@
 	creator_name = "Timestop"
 	creator_desc = "Devastating close combat attacks and high damage resistance. Can smash through weak walls and stop time."
 	creator_icon = "standard"
-	playstyle_string = span_holoparasite("As a <b>time manipulation</b> type you can stop time and you have a damage multiplier instead of armor as-well as powerful melee attacks capable of smashing through walls.")
+	playstyle_string = span_holoparasite("As a <b>time manipulation</b> type you can stop time. You have a damage multiplier instead of armor as well as powerful melee attacks capable of smashing through walls.")
 
 /mob/living/basic/guardian/standard/timestop/set_summoner(mob/living/to_who, different_person = FALSE)
 	. = ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -43,11 +43,11 @@
 
 /datum/antagonist/bloodsucker/proc/AddHumanityLost(value)
 	if(humanity_lost >= 500)
-		to_chat(owner.current, span_warning("You hit the maximum amount of lost Humanty, you are far from Human."))
+		to_chat(owner.current, span_warning("You hit the maximum amount of lost humanity. You are far from human."))
 		return
 	humanity_lost += value
 	frenzy_threshold = (FRENZY_MINIMUM_THRESHOLD_ENTER + humanity_lost * 10)
-	to_chat(owner.current, span_warning("You feel as if you lost some of your humanity, you will now enter Frenzy at [frenzy_threshold] Blood."))
+	to_chat(owner.current, span_warning("You feel as if you lost some of your humanity. You will now enter Frenzy at [frenzy_threshold] Blood."))
 
 /// mult: SILENT feed is 1/3 the amount
 /datum/antagonist/bloodsucker/proc/handle_feeding(mob/living/carbon/target, mult=1, power_level)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/subsystem_sunlight.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/subsystem_sunlight.dm
@@ -52,14 +52,14 @@ SUBSYSTEM_DEF(sunlight)
 			SEND_SIGNAL(src, COMSIG_SOL_NEAR_START)
 			warn_daylight(
 				danger_level = DANGER_LEVEL_FIRST_WARNING,
-				vampire_warning_message = span_danger("Solar Flares will bombard the station with dangerous UV radiation in [TIME_BLOODSUCKER_DAY_WARN / 60] minutes. <b>Prepare to seek cover in a coffin or closet.</b>"),
+				vampire_warning_message = span_danger("Solar flares will bombard the station with dangerous UV radiation in [TIME_BLOODSUCKER_DAY_WARN / 60] minutes. <b>Prepare to seek cover in a coffin or closet.</b>"),
 			)
 		if(TIME_BLOODSUCKER_DAY_FINAL_WARN)
 			message_admins("BLOODSUCKER NOTICE: Daylight beginning in [TIME_BLOODSUCKER_DAY_FINAL_WARN] seconds.)")
 			warn_daylight(
 				danger_level = DANGER_LEVEL_SECOND_WARNING,
-				vampire_warning_message = span_userdanger("Solar Flares are about to bombard the station! You have [TIME_BLOODSUCKER_DAY_FINAL_WARN] seconds to find cover!"),
-				vassal_warning_message = span_danger("In [TIME_BLOODSUCKER_DAY_FINAL_WARN] seconds, your master will be at risk of a Solar Flare. Make sure they find cover!"),
+				vampire_warning_message = span_userdanger("Solar flares are about to bombard the station! You have [TIME_BLOODSUCKER_DAY_FINAL_WARN] seconds to find cover!"),
+				vassal_warning_message = span_danger("In [TIME_BLOODSUCKER_DAY_FINAL_WARN] seconds, your master will be at risk of burning under a solar flare. Make sure they find cover!"),
 			)
 		if(TIME_BLOODSUCKER_BURN_INTERVAL)
 			warn_daylight(


### PR DESCRIPTION

## About The Pull Request

Fixes some punctuation and capitalization issues with bloodsucker descriptions. Clan is not a proper noun and doesn't need to be capitalized.

## Why It's Good For The Game

Looks more professional this way.

## Changelog
:cl:
spellcheck: punctuation and grammar updates
/:cl:
