### PR TITLE
Fixes Pubby Station's Bathroom

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -8607,6 +8607,7 @@
 /area/station/medical/medbay/central)
 "aFb" = (
 /obj/machinery/light_switch/directional/north,
+/obj/item/bikehorn/rubberducky,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "aFc" = (
@@ -8790,6 +8791,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "aFL" = (
@@ -13748,6 +13750,7 @@
 "bbO" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/light/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "bbP" = (
@@ -32210,6 +32213,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "fqJ" = (
@@ -37070,10 +37074,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "jXJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "jYh" = (
@@ -38526,6 +38530,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "lgU" = (
@@ -40358,6 +40363,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/space,
 /area/space/nearstation)
+"mOJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/restrooms)
 "mPO" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Experimentation Lab Central";
@@ -46382,6 +46395,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "rJZ" = (
@@ -53805,6 +53819,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "xqq" = (
@@ -53991,13 +54006,13 @@
 /area/station/security/lockers)
 "xxk" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Dormitory Toilets"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "xxo" = (
@@ -95883,7 +95898,7 @@ aBU
 xkF
 aEg
 dqY
-jXJ
+mOJ
 aEd
 aEd
 aEd


### PR DESCRIPTION

## About The Pull Request
Hi! This is the first time I've made a pull request on GitHub, so I apologize in advance if I've messed anything up or made any fatal mistakes.

Anyhow this PR should fix the cabling in Pubby Station's bathroom, which at the moment does not reach the bathroom's APC. This PR also removes a few unnecessary scrubber pipes from the bathroom and adds a rubber duck to it.

Before:
![Pubby_Bathroom_Before](https://github.com/fulpstation/fulpstation/assets/154708292/4b28b836-d78e-4158-81da-586e8b51074c)

After:
![Pubby_Bathroom_After](https://github.com/fulpstation/fulpstation/assets/154708292/64252869-86da-4aa0-a47b-01d0b4020f46)
## Why It's Good For The Game

Pubby Station's bathroom is probably meant to be connected to the power grid at round start. Unnecessary scrubber pipes just make things look messier, and a rubber duck is a nice addition to _any_ bathroom.
## Changelog
:cl:

fix: Fixes Pubby Station's bathroom and adds a rubber duck to it

/:cl:
