### PR TITLE
Adds exiled king to megafauna ore vent

### DIFF
--- a/fulp_modules/Z_edits/ore_vent.dm
+++ b/fulp_modules/Z_edits/ore_vent.dm
@@ -1,0 +1,10 @@
+/obj/structure/ore_vent/boss/Initialize(mapload)
+	defending_mobs += /mob/living/basic/exiled_king
+	return ..()
+
+
+/obj/structure/ore_vent/boss/examine(mob/user)
+	. = ..()
+	if(summoned_boss == /mob/living/basic/exiled_king)
+		.[length(.)] = span_notice("A mass of tentacles is etched onto the side of the vent.")
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6429,6 +6429,7 @@
 #include "fulp_modules\Z_edits\hud_edits.dm"
 #include "fulp_modules\Z_edits\job_edits.dm"
 #include "fulp_modules\Z_edits\nightmare_edit.dm"
+#include "fulp_modules\Z_edits\ore_vent.dm"
 #include "fulp_modules\Z_edits\research_edits.dm"
 #include "fulp_modules\Z_edits\upstream_bot.dm"
 #include "fulp_modules\Z_edits\antag_edits\antag_datum.dm"


### PR DESCRIPTION

## About The Pull Request
This PR makes it so that the megafauna ore vents can now spawn the sunken king. The way I've done it is a tiiiny bit janky in order to stay modular but Smokey says he's working on porting sunken king upstream anyway so probably won't be permanent.
## Why It's Good For The Game
Fulp megafauna gets to be in the megafauna club too
## Changelog
:cl:
add: Menacing ore vents can now spawn the Sunken King
/:cl:
