### PR TITLE
Fixes SMES and some buffs

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -8748,7 +8748,7 @@
 	dir = 6;
 	name = "engineering yellow"
 	},
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
@@ -19505,7 +19505,7 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "bTD" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
@@ -30115,9 +30115,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "exc" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
@@ -35277,9 +35275,7 @@
 "gEQ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/power/smes/engineering{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
@@ -35890,9 +35886,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "gQi" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -39087,7 +39081,7 @@
 /area/station/science/research)
 "ian" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/solars/starboard/fore)
@@ -40229,7 +40223,8 @@
 /area/station/engineering/storage/tech)
 "ixm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ixn" = (
@@ -43526,7 +43521,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "jIP" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -53486,9 +53481,7 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "nHm" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -64571,7 +64564,7 @@
 "rPA" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -68023,7 +68016,7 @@
 /area/station/hallway/secondary/entry)
 "tiy" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -70308,7 +70301,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "ucq" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ucC" = (
@@ -70423,9 +70417,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "ufp" = (
-/obj/machinery/power/smes/engineering{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/engineering/full,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/sign/warning/electric_shock/directional/north,
@@ -72280,9 +72272,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "uTo" = (
-/obj/machinery/power/smes/engineering{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/engineering/full,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -350,9 +350,7 @@
 /turf/open/floor/iron/white,
 /area/station/ai_monitored/turret_protected/ai)
 "ack" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/ai_monitored/turret_protected/ai)
@@ -6899,7 +6897,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "ayY" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/dark,
@@ -7415,7 +7413,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
 "aAY" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
@@ -9490,7 +9488,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "aJp" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
@@ -23170,9 +23168,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/gravity_generator)
 "bTs" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -26391,9 +26387,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "cky" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel/monastery)
@@ -40011,9 +40005,7 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "mxy" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -9937,7 +9937,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "dCo" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -15143,7 +15143,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/ordnance/storage)
 "fuw" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
@@ -16187,9 +16187,7 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "fPk" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/command/half,
 /turf/open/floor/iron/dark,
@@ -32586,7 +32584,7 @@
 /obj/effect/turf_decal/tile/command/half{
 	dir = 8
 	},
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
@@ -37519,9 +37517,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "nwf" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/gravity_generator)
@@ -40234,7 +40230,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "ozF" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -41956,9 +41952,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "pja" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars)
@@ -47355,9 +47349,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rka" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/tcommsat/computer)
@@ -52122,7 +52114,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "tbv" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot,
@@ -58305,7 +58297,7 @@
 /area/space/nearstation)
 "vmC" = (
 /obj/structure/cable,
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "vmD" = (

--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -445,9 +445,7 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "aiN" = (
@@ -3753,7 +3751,7 @@
 /area/station/command/heads_quarters/rd)
 "bxr" = (
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
@@ -4300,9 +4298,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bIw" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 6
@@ -5612,7 +5608,7 @@
 /area/station/security/prison/rec)
 "cjY" = (
 /obj/structure/cable,
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -7827,9 +7823,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/power/smes/engineering{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
@@ -12697,7 +12691,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light_switch/directional/east,
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
 "fdV" = (
@@ -21059,9 +21053,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "iAh" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/circuit,
@@ -41862,9 +41854,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "rot" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/railing{
 	dir = 6
 	},
@@ -56874,7 +56864,7 @@
 /turf/open/floor/iron/large,
 /area/station/cargo/miningdock)
 "xNU" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)


### PR DESCRIPTION
## About The Pull Request
We have been using var edits on some SMES that didn't work as expected anymore, they were replaced with normal versions instead.

And solar SMES units come charged to give the crew a few extra minutes before they scream at engineers.

This was a VSC coding map edit so if something breaks, I will laugh and cry at the same time.
## Why It's Good For The Game
Power was wonky and after digging a bit I figured out why.
Some SMES units were linked to the main line while not being full, which drained the main line to nothing, if the SM wasn't setup ASAP on Helio. We also had 2 auxiliary power SMES unlinked from the net and I just linked them for extra power on Helio, some rooms drain way too much power because of how many lights it takes to keep such huge station well lit.

Something something hard to learn a job when their department's power dies 5 minutes in due to bugs.
## Changelog
:cl: Guillaume Prata
balance: Solar SMES come fully charged now
fix: Some SMES, like Tcomm ones, won't spawn almost empty and drain the main net to death in the first 5 minutes of the round.
/:cl:
