### PR TITLE
Fixes the tiling under some of Theia's airlocks/Adds a singular cable

### DIFF
--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -1518,7 +1518,7 @@
 /obj/effect/landmark/navigate_destination/eva,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/eva,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/ai_monitored/command/storage/eva)
 "aDW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1816,6 +1816,9 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"aJq" = (
+/turf/open/floor/wood/tile,
+/area/station/maintenance/department/bridge)
 "aJC" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
@@ -1907,7 +1910,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "aLY" = (
 /obj/structure/table/wood,
@@ -3784,7 +3787,7 @@
 	name = "Aft/ Port Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bya" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4786,7 +4789,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "bSf" = (
 /obj/structure/table/wood,
@@ -5838,7 +5841,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -11836,7 +11839,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "eMo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12133,7 +12136,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
@@ -12166,7 +12169,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/cargo/bitrunning/den)
 "eSW" = (
 /obj/machinery/door/airlock/maintenance,
@@ -12767,7 +12770,7 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "feX" = (
 /obj/effect/turf_decal/trimline/blue/line{
@@ -12998,7 +13001,7 @@
 /obj/effect/landmark/navigate_destination/janitor,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/service/janitor)
 "fjJ" = (
 /obj/structure/disposalpipe/segment{
@@ -13032,7 +13035,7 @@
 /obj/effect/landmark/navigate_destination/gateway,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "fkl" = (
 /turf/open/floor/iron/white/smooth_edge,
@@ -17858,6 +17861,11 @@
 	},
 /turf/open/floor/mineral/titanium/tiled,
 /area/station/ai_monitored/command/nuke_storage)
+"hdR" = (
+/obj/structure/displaycase,
+/obj/item/stack/tile/iron,
+/turf/open/floor/carpet/royalblack,
+/area/station/maintenance/department/bridge)
 "hea" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -20283,9 +20291,11 @@
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
 "igy" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/processing)
 "igA" = (
@@ -21671,7 +21681,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/security/office)
 "iNN" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -23437,7 +23450,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "jAo" = (
 /obj/structure/cable,
@@ -28261,6 +28274,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency/starboard)
+"lwX" = (
+/obj/structure/displaycase,
+/turf/open/floor/carpet/royalblack,
+/area/station/maintenance/department/bridge)
 "lwY" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/ablative,
@@ -28843,7 +28860,7 @@
 	name = "Permabrig"
 	},
 /obj/machinery/duct,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/security/brig/hallway)
 "lLz" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
@@ -31473,6 +31490,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "mSV" = (
@@ -32238,12 +32256,12 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "nhr" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -32318,7 +32336,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Fore/Starboard Maintenance"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "niN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32659,7 +32677,7 @@
 	name = "Holodeck Tunnel"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/maintenance/aft/upper)
 "nri" = (
 /obj/structure/lattice,
@@ -35153,7 +35171,7 @@
 	name = "HFR Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "otK" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -36087,7 +36105,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/bridge,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/station/command/bridge)
 "oNF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39070,7 +39088,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/station/command/bridge)
 "qgi" = (
 /obj/machinery/igniter/incinerator_ordmix,
@@ -41603,7 +41621,10 @@
 	name = "Security Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/security/office)
 "rkk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -42985,7 +43006,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "rNE" = (
 /obj/structure/bodycontainer/morgue{
@@ -45465,7 +45486,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "sPJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47286,7 +47307,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/medical/psychology)
 "tIl" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -47674,7 +47695,9 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "tQG" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 8;
+	pixel_x = 2;
+	pixel_y = 1
 	},
 /obj/machinery/light/small/directional/west,
 /obj/structure/cable,
@@ -50309,7 +50332,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "uYQ" = (
 /obj/structure/table/wood,
@@ -53166,7 +53189,7 @@
 	name = "Vault Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/ai_monitored/command/nuke_storage)
 "wjW" = (
 /obj/item/storage/lockbox/medal,
@@ -57693,7 +57716,7 @@
 /area/station/hallway/primary/port)
 "ygT" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "yhe" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -80272,7 +80295,7 @@ gyj
 ssX
 wHn
 fkR
-pkh
+nri
 nri
 nri
 nri
@@ -86444,7 +86467,7 @@ nMo
 jkR
 lBv
 ixQ
-ixQ
+aJq
 aYb
 pkh
 pkh
@@ -86957,7 +86980,7 @@ jdk
 kkb
 hLM
 lBv
-ixQ
+aJq
 ixQ
 aYb
 pkh
@@ -87214,8 +87237,8 @@ jdk
 oHF
 sDu
 lBv
-ixQ
-ixQ
+lwX
+hdR
 aYb
 qxV
 aMA


### PR DESCRIPTION

## About The Pull Request

- Adds floor tiles that were missing under some airlocks on Theia Station
- Removes one or two floor tiles which shouldn't have been under maintenance airlocks
- Adds a single, missing cable leading to Theia's cargo delivery office
- Adds a small, relevant Easter egg to Theia's showroom maintenance area:

![Tile_Easter_Egg](https://github.com/fulpstation/fulpstation/assets/154708292/73a82d22-3efa-485f-8b5a-0684dadba327)
## Why It's Good For The Game
Most non-maintenance airlocks should have tiles under them for aesthetic reasons. Cargo's delivery office should be connected to the grid at round start— though I can make a separate PR for the cable if necessary.
## Changelog
:cl:
fix: added previously missing tiles under some Theia Station airlocks
fix: added a missing cable leading to Theia's cargo delivery office
/:cl:
