### PR TITLE
Heliostation Missing SMES Fix

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -70417,7 +70417,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "ufp" = (
-/obj/machinery/power/smes/engineering/full,
+/obj/machinery/power/smes/engineering,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/sign/warning/electric_shock/directional/north,
@@ -72272,7 +72272,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "uTo" = (
-/obj/machinery/power/smes/engineering/full,
+/obj/machinery/power/smes/engineering,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,


### PR DESCRIPTION

## About The Pull Request
Two of the engineering SMES units on Heliostation were accidentally removed recently. This PR adds them back in.
## Why It's Good For The Game
Fixes this:
![Missing_Helio_SMES_Units](https://github.com/fulpstation/fulpstation/assets/154708292/e44e0b2e-048b-4938-8b2b-469541ed7206)
## Changelog
:cl:
fix: Readds two SMES units that were accidentally removed from Heliostation engineering
/:cl:
