### PR TITLE
Improves Wonderland's Appearance

### DIFF
--- a/fulp_modules/_maps/wonderland.dmm
+++ b/fulp_modules/_maps/wonderland.dmm
@@ -16,26 +16,58 @@
 "bf" = (
 /obj/structure/chess/blackrook,
 /turf/open/floor/holofloor/pure_white,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "br" = (
 /obj/structure/chess/blackknight,
 /turf/open/floor/black,
+/area/ruin/space/has_grav/wonderchess)
+"bM" = (
+/obj/structure/flora/bush/flowers_br/style_2,
+/mob/living/basic/rabbit,
+/turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
 "bZ" = (
 /obj/item/clothing/head/costume_2021/doll_hat,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
+"cg" = (
+/obj/structure/flora/tree/jungle/style_3,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
 "cj" = (
 /obj/structure/chess/blackbishop,
 /turf/open/floor/holofloor/pure_white,
+/area/ruin/space/has_grav/wonderchess)
+"cs" = (
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/purple{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/wonderland)
 "ct" = (
 /obj/structure/chess/blackqueen,
 /turf/open/floor/black,
+/area/ruin/space/has_grav/wonderchess)
+"cQ" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
 "de" = (
 /obj/structure/chess/whiterook,
 /turf/open/floor/holofloor/pure_white,
+/area/ruin/space/has_grav/wonderchess)
+"dh" = (
+/obj/structure/flora/tree/dead/style_4,
+/obj/structure/flora/bush/flowers_pp/style_2,
+/turf/open/misc/snow,
+/area/ruin/space/has_grav/wonderland)
+"di" = (
+/turf/closed/indestructible/rock,
 /area/ruin/space/has_grav/wonderland)
 "dC" = (
 /obj/effect/rune/narsie{
@@ -46,11 +78,11 @@
 "dE" = (
 /obj/structure/chess/blackking,
 /turf/open/floor/holofloor/pure_white,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "dJ" = (
 /obj/structure/chess/blackbishop,
 /turf/open/floor/black,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "eu" = (
 /obj/structure/rack/weaponsmith,
 /turf/open/floor/wood/large,
@@ -58,37 +90,79 @@
 "fb" = (
 /obj/structure/chess/blackknight,
 /turf/open/floor/holofloor/pure_white,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "gc" = (
 /obj/structure/blood_fountain,
+/obj/structure/flora/bush/flowers_br/style_2,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
+"gu" = (
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/wonderchess)
 "gw" = (
 /obj/structure/chess/blackrook,
 /turf/open/floor/black,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
+"gP" = (
+/turf/closed/indestructible/wood,
+/area/ruin/space/has_grav/wonderchess)
 "hK" = (
-/obj/structure/flora/bush/flowers_br/style_2,
-/obj/structure/flora/tree/jungle,
-/turf/open/misc/grass/jungle,
+/obj/item/flashlight/lantern{
+	light_on = 1;
+	pixel_x = -10;
+	pixel_y = -4
+	},
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/wonderland)
 "jT" = (
 /obj/structure/chess/whiteking,
 /turf/open/floor/black,
+/area/ruin/space/has_grav/wonderchess)
+"kh" = (
+/obj/item/flashlight/lantern{
+	light_on = 1;
+	pixel_x = -5
+	},
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"lg" = (
+/obj/item/reagent_containers/cup/glass/mug,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"mt" = (
+/obj/item/match/firebrand,
+/turf/open/misc/snow,
 /area/ruin/space/has_grav/wonderland)
 "mD" = (
 /obj/structure/chess,
 /turf/open/floor/black,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "mP" = (
 /obj/structure/chess/blackpawn,
 /turf/open/floor/black,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "mS" = (
 /obj/structure/flora/bush/flowers_yw,
 /obj/structure/flora/bush/flowers_br/style_2,
 /mob/living/basic/rabbit,
 /turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"nQ" = (
+/obj/structure/flora/tree/dead/style_2,
+/turf/open/misc/snow,
+/area/ruin/space/has_grav/wonderland)
+"oB" = (
+/obj/structure/dresser,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/wonderland)
 "oC" = (
 /obj/structure/chair/wood,
@@ -97,13 +171,26 @@
 /area/ruin/space/has_grav/wonderland)
 "oF" = (
 /turf/open/floor/black,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
+"pe" = (
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/wonderchess)
 "pN" = (
 /obj/structure/chess/whiterook,
 /turf/open/floor/black,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "rr" = (
 /obj/structure/flora/bush/flowers_yw,
+/obj/structure/flora/bush/flowers_br/style_2,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"rA" = (
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
 /obj/structure/flora/bush/flowers_br/style_2,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
@@ -120,13 +207,31 @@
 /obj/effect/mob_spawn/corpse/rabbit,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/wonderland)
+"tE" = (
+/obj/structure/flora/tree/stump,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"tS" = (
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"wP" = (
+/obj/item/flashlight/lantern{
+	light_on = 1;
+	pixel_x = 10;
+	pixel_y = -4
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/wonderland)
 "wY" = (
 /mob/living/basic/rabbit,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
 "yW" = (
-/obj/structure/flora/bush/flowers_pp/style_2,
 /obj/item/clothing/under/costume_2021/doll_suit,
+/obj/structure/flora/bush/flowers_pp/style_2,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
 "Av" = (
@@ -138,6 +243,10 @@
 /obj/structure/flora/bush/flowers_yw,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
+"Bh" = (
+/obj/structure/flora/tree/jungle/style_2,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
 "Ck" = (
 /obj/structure/flora/bush/flowers_yw,
 /obj/structure/flora/bush/flowers_br,
@@ -146,66 +255,106 @@
 "Cw" = (
 /obj/structure/chess/whitebishop,
 /turf/open/floor/holofloor/pure_white,
+/area/ruin/space/has_grav/wonderchess)
+"Dh" = (
+/turf/open/misc/snow,
 /area/ruin/space/has_grav/wonderland)
 "El" = (
 /turf/open/floor/holofloor/pure_white,
+/area/ruin/space/has_grav/wonderchess)
+"Ev" = (
+/obj/structure/flora/bush/flowers_pp/style_2,
+/obj/structure/flora/tree/jungle/style_6,
+/turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
 "Fd" = (
-/turf/closed/indestructible/riveted,
-/area/space)
+/turf/closed/indestructible/rock/snow,
+/area/ruin/space/has_grav/wonderland)
+"Ff" = (
+/obj/structure/flora/bush/flowers_pp/style_2,
+/obj/structure/flora/tree/jungle/style_4,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"Fj" = (
+/obj/structure/bonfire/prelit,
+/turf/open/misc/snow,
+/area/ruin/space/has_grav/wonderland)
+"Fm" = (
+/obj/structure/flora/bush/flowers_pp/style_2,
+/turf/open/misc/snow,
+/area/ruin/space/has_grav/wonderland)
 "FO" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
 "Gl" = (
 /obj/structure/mineral_door/wood,
-/turf/open/misc/grass/jungle,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/wonderland)
 "Gs" = (
 /obj/structure/table/wood,
 /obj/item/blood_vial,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/wonderland)
+"Gx" = (
+/obj/effect/mob_spawn/corpse/rabbit,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/wonderland)
 "HK" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/wonderland)
+"HR" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/item/toy/plush/shark,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
 "Iq" = (
 /obj/structure/chess/whiteknight,
 /turf/open/floor/holofloor/pure_white,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "Jy" = (
 /obj/structure/flora/tree/dead/style_6,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/snow,
 /area/ruin/space/has_grav/wonderland)
 "JP" = (
 /obj/structure/chess/whitebishop,
 /turf/open/floor/black,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "JX" = (
 /obj/structure/chess/blackpawn,
 /turf/open/floor/holofloor/pure_white,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "Kw" = (
 /obj/structure/chess,
 /turf/open/floor/holofloor/pure_white,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "Mo" = (
 /obj/structure/flora/tree/dead,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/snow,
 /area/ruin/space/has_grav/wonderland)
 "Mw" = (
 /obj/structure/flora/bush/flowers_br/style_2,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
+"Od" = (
+/obj/structure/statue/snow/snowman{
+	pixel_x = -15;
+	pixel_y = -15
+	},
+/turf/open/misc/snow,
+/area/ruin/space/has_grav/wonderland)
 "PU" = (
 /obj/structure/chess/redqueen,
 /obj/effect/decal/cleanable/blood/bubblegum,
 /turf/open/floor/holofloor/pure_white,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "RW" = (
+/obj/structure/flora/tree/jungle/style_6,
 /obj/structure/flora/bush/flowers_pp/style_2,
-/mob/living/basic/rabbit,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
 "Se" = (
@@ -218,13 +367,39 @@
 /area/ruin/space/has_grav/wonderland)
 "Tc" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/mug,
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = 7
+	},
+/obj/item/flashlight/lantern{
+	light_on = 1;
+	pixel_y = -5
+	},
 /turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"TF" = (
+/obj/structure/flora/tree/dead/style_5,
+/turf/open/misc/snow,
 /area/ruin/space/has_grav/wonderland)
 "UO" = (
 /obj/structure/flora/bush/flowers_yw,
 /obj/structure/flora/bush/flowers_pp/style_2,
 /turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"Vo" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/wonderland)
+"VG" = (
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
+/turf/open/misc/snow,
 /area/ruin/space/has_grav/wonderland)
 "Wb" = (
 /turf/open/misc/ashplanet/wateryrock{
@@ -233,11 +408,18 @@
 	slowdown = 0
 	},
 /area/ruin/space/has_grav/wonderland)
+"Wc" = (
+/obj/structure/flora/bush/flowers_pp/style_2,
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
 "WD" = (
 /turf/closed/indestructible/wood,
 /area/ruin/space/has_grav/wonderland)
 "Xk" = (
-/turf/open/floor/holofloor/beach/water,
+/turf/open/water/beach,
 /area/ruin/space/has_grav/wonderland)
 "Xr" = (
 /obj/structure/closet/crate/grave/filled,
@@ -266,11 +448,11 @@
 "Yf" = (
 /obj/effect/landmark/wonderchess_mark,
 /turf/open/floor/black,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "Yj" = (
 /obj/structure/chess/whiteknight,
 /turf/open/floor/black,
-/area/ruin/space/has_grav/wonderland)
+/area/ruin/space/has_grav/wonderchess)
 "Yp" = (
 /obj/structure/flora/bush/flowers_pp/style_2,
 /turf/open/misc/grass/jungle,
@@ -338,6 +520,19 @@ ab
 ab
 ab
 ab
+di
+di
+di
+di
+di
+di
+di
+di
+di
+di
+di
+di
+di
 Fd
 Fd
 Fd
@@ -349,22 +544,9 @@ Fd
 Fd
 Fd
 Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
+di
+di
+di
 ab
 "}
 (3,1,1) = {"
@@ -382,18 +564,7 @@ ab
 ab
 ab
 ab
-Fd
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
+di
 ZA
 ZA
 ZA
@@ -407,8 +578,19 @@ ZA
 ZA
 ZA
 ZA
+Dh
+Dh
+Dh
 ZA
-Fd
+ZA
+ZA
+ZA
+Dh
+Dh
+Dh
+ZA
+ZA
+di
 ab
 "}
 (4,1,1) = {"
@@ -426,33 +608,33 @@ ab
 ab
 ab
 ab
-Fd
+di
 ZA
 ZA
 ZA
+Mw
+ZA
+wY
 ZA
 ZA
 ZA
-ZA
-ZA
-ZA
+Ff
+wY
 Yp
-FO
-Yp
+ZA
+ZA
+nQ
+VG
 ZA
 ZA
 ZA
 ZA
 ZA
 ZA
-Mw
-Mw
-ZA
-Mw
 ZA
 ZA
 ZA
-Fd
+di
 ab
 "}
 (5,1,1) = {"
@@ -470,31 +652,31 @@ ab
 ab
 ab
 ab
-Fd
+di
 ZA
 ZA
 ZA
+RW
 ZA
 ZA
-ZA
-ZA
+rA
 Yp
 ZA
 ZA
+tS
 ZA
 ZA
 ZA
 ZA
-Yp
 ZA
 ZA
 ZA
 ZA
 ZA
-wY
+ZA
+VG
 ZA
 ZA
-Mw
 ZA
 Fd
 ab
@@ -514,7 +696,8 @@ ab
 ab
 ab
 ab
-Fd
+di
+kh
 ZA
 ZA
 ZA
@@ -523,21 +706,20 @@ ZA
 ZA
 ZA
 ZA
-ZA
-ZA
+wY
 Yp
 ZA
 wY
 Yp
-wY
-ZA
-Yp
-wY
 ZA
 ZA
 ZA
-hK
 ZA
+ZA
+ZA
+Dh
+TF
+Dh
 ZA
 ZA
 Fd
@@ -558,15 +740,15 @@ ab
 ab
 ab
 ab
-Fd
+di
+Yp
 ZA
 ZA
 ZA
+bM
 ZA
 ZA
-ZA
-ZA
-ZA
+Mw
 ZA
 ZA
 Yp
@@ -575,13 +757,13 @@ ZA
 ZA
 ZA
 ZA
+Dh
+Fm
 ZA
 ZA
-Yp
-ZA
-ZA
-wY
-ZA
+Dh
+Dh
+Dh
 ZA
 ZA
 Fd
@@ -602,7 +784,7 @@ ab
 ab
 ab
 ab
-Fd
+WD
 WD
 WD
 WD
@@ -615,20 +797,20 @@ ZA
 ZA
 wY
 ZA
-FO
+cg
 Yp
 wY
 ZA
-Yp
+Fm
 Mo
+Dh
 ZA
 ZA
 ZA
 ZA
 ZA
-Mw
 ZA
-Fd
+di
 ab
 "}
 (9,1,1) = {"
@@ -646,33 +828,33 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-tb
-Sy
+WD
+oB
+cs
+Vo
 Gs
-Sy
+Vo
 WD
 ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-Mw
-wY
+tE
 ZA
 Mw
 ZA
 ZA
 ZA
-Fd
+ZA
+ZA
+ZA
+ZA
+VG
+ZA
+ZA
+ZA
+ZA
+ZA
+ZA
+ZA
+di
 ab
 "}
 (10,1,1) = {"
@@ -690,25 +872,22 @@ ab
 ab
 ab
 ab
-Fd
+WD
 sr
+HK
+Gx
 Sy
-Sy
-Sy
-Sy
+Vo
 WD
 ZA
 ZA
 ZA
-ZA
+rA
 ZA
 ZA
 ZA
 ZA
 Yp
-Mo
-ZA
-wY
 ZA
 ZA
 ZA
@@ -716,7 +895,10 @@ ZA
 ZA
 ZA
 ZA
-Fd
+ZA
+ZA
+ZA
+di
 ab
 "}
 (11,1,1) = {"
@@ -734,12 +916,12 @@ ab
 ab
 ab
 ab
-Fd
+WD
 Sy
 Sy
-tb
+Gx
 HK
-Sy
+hK
 WD
 ZA
 ZA
@@ -751,15 +933,15 @@ ZA
 ZA
 ZA
 ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
+Wb
+Wb
+Wb
+Wb
+Wb
+Wb
+Wb
+Wb
+tS
 Fd
 ab
 "}
@@ -778,7 +960,7 @@ ab
 ab
 ab
 ab
-Fd
+WD
 eu
 Sy
 dC
@@ -788,20 +970,20 @@ Gl
 ZA
 ZA
 ZA
-ZA
 Wb
 Wb
 Wb
 Wb
+tS
 Wb
 Wb
 Wb
-Wb
-Wb
-Wb
-Wb
-Wb
-Wb
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
 Wb
 Wb
 Fd
@@ -822,22 +1004,22 @@ ab
 ab
 ab
 ab
-Fd
+WD
 Sy
-tb
+HK
 Sy
 Sy
-Sy
+wP
 WD
 ZA
 ZA
 gc
-ZA
+Wb
 Xk
 Xk
-Xk
-Xk
-Xk
+Wb
+Wb
+Wb
 Xk
 Xk
 Xk
@@ -866,17 +1048,17 @@ ab
 ab
 ab
 ab
-Fd
+WD
+HK
+tb
 Sy
 Sy
-Sy
-Sy
-Sy
+Vo
 WD
 ZA
 ZA
-ZA
-ZA
+Mw
+Wb
 Xk
 Xk
 Xk
@@ -885,10 +1067,10 @@ Xk
 Xk
 Xk
 Xk
-Xk
-Xk
-Xk
-Xk
+Wb
+Wb
+Wb
+Wb
 Xk
 Xk
 Xk
@@ -910,28 +1092,28 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
-HK
+WD
 tb
-Sy
+HK
+HK
+Vo
+Vo
 WD
 ZA
 ZA
 ZA
+Wb
+Wb
+Xk
+Xk
+Xk
+Xk
+Xk
+Wb
+Wb
+Wb
 ZA
-Wb
-Wb
-Wb
-Wb
-Wb
-Wb
-Wb
-Wb
-Wb
-Wb
-Wb
+tS
 Wb
 Wb
 Wb
@@ -954,30 +1136,30 @@ ab
 ab
 ab
 ab
-Fd
 WD
 WD
 WD
 WD
 WD
 WD
+WD
+ZA
+ZA
+ZA
+rA
+Wb
+Wb
+Wb
+Wb
+Wb
+Wb
+Wb
 ZA
 ZA
 ZA
 ZA
 ZA
 ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-Mw
 ZA
 ZA
 Fd
@@ -998,7 +1180,23 @@ ab
 ab
 ab
 ab
-Fd
+di
+rA
+ZA
+ZA
+ZA
+wY
+ZA
+ZA
+Yp
+ZA
+ZA
+ZA
+ZA
+ZA
+ZA
+ZA
+Mw
 ZA
 ZA
 ZA
@@ -1007,23 +1205,7 @@ ZA
 ZA
 ZA
 ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-av
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
+Dh
 Fd
 ab
 "}
@@ -1042,32 +1224,32 @@ ab
 ab
 ab
 ab
-Fd
+di
 ZA
 ZA
 ZA
+Bh
 ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-Jy
-ZA
-ZA
-oC
-Tc
-Xt
-ZA
-ZA
+Yp
 ZA
 ZA
 Mw
+wY
+ZA
+ZA
+cQ
+av
+ZA
+ZA
+rA
 ZA
 ZA
 ZA
 ZA
 ZA
+Dh
+mt
+Dh
 Fd
 ab
 "}
@@ -1086,32 +1268,32 @@ ab
 ab
 ab
 ab
-Fd
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-Yp
-ZA
-ZA
-ZA
-XC
+di
 ZA
 ZA
 ZA
 Mw
 ZA
-wY
+ZA
+ZA
+ZA
+ZA
+ZA
+ZA
+oC
+Tc
+lg
+Xt
+ZA
 Mw
 ZA
 ZA
 ZA
 ZA
+Dh
+dh
+Fj
+Dh
 Fd
 ab
 "}
@@ -1130,32 +1312,32 @@ ab
 ab
 ab
 ab
-Fd
+di
 Se
 Se
 Se
 AH
 AH
 UO
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-Mw
-ZA
-Yp
 wY
 ZA
+tS
+ZA
+ZA
+ZA
+XC
+HR
 ZA
 ZA
 ZA
 ZA
+Yp
+ZA
+ZA
+ZA
+Dh
+Dh
+Dh
 Fd
 ab
 "}
@@ -1174,7 +1356,7 @@ ab
 ab
 ab
 ab
-Fd
+di
 AH
 Xr
 AH
@@ -1183,7 +1365,7 @@ Ck
 UO
 ZA
 ZA
-ZA
+Mw
 wY
 ZA
 ZA
@@ -1195,11 +1377,11 @@ ZA
 ZA
 Mw
 ZA
-wY
-Mw
 ZA
 ZA
 ZA
+Od
+Dh
 Fd
 ab
 "}
@@ -1218,7 +1400,7 @@ ab
 ab
 ab
 ab
-Fd
+di
 Ck
 Ck
 Xv
@@ -1236,14 +1418,14 @@ yW
 aR
 ZA
 Yp
-wY
-ZA
-Mw
-wY
 ZA
 ZA
 ZA
 ZA
+ZA
+ZA
+ZA
+Dh
 Fd
 ab
 "}
@@ -1262,14 +1444,15 @@ ab
 ab
 ab
 ab
-Fd
+di
 AH
 AH
-AH
+tS
 AH
 Ck
 UO
 ZA
+wY
 ZA
 ZA
 ZA
@@ -1279,9 +1462,8 @@ ZA
 ZA
 ZA
 ZA
+VG
 ZA
-ZA
-Mw
 ZA
 ZA
 ZA
@@ -1306,7 +1488,7 @@ ab
 ab
 ab
 ab
-Fd
+di
 Av
 Se
 Se
@@ -1314,22 +1496,22 @@ Se
 Ck
 UO
 ZA
-ZA
+tS
 ZA
 Mw
 ZA
-Yp
-ZA
+Wc
+FO
 Yp
 wY
 Mw
+Dh
+Jy
+Dh
 ZA
 ZA
 ZA
-wY
-Mw
-ZA
-ZA
+tS
 ZA
 ZA
 Fd
@@ -1350,7 +1532,7 @@ ab
 ab
 ab
 ab
-Fd
+di
 AH
 Xr
 Se
@@ -1358,25 +1540,25 @@ Xr
 AH
 UO
 ZA
-Yp
+Ev
 ZA
 ZA
 wY
 ZA
-FO
-Yp
-RW
-ZA
 ZA
 Yp
-ZA
-ZA
 Yp
 ZA
-FO
+Dh
+Fm
 ZA
 ZA
-Fd
+ZA
+ZA
+ZA
+ZA
+ZA
+di
 ab
 "}
 (26,1,1) = {"
@@ -1394,7 +1576,7 @@ ab
 ab
 ab
 ab
-Fd
+di
 AH
 AH
 AH
@@ -1402,7 +1584,7 @@ Av
 AH
 Av
 ZA
-ZA
+wY
 ZA
 Mw
 ZA
@@ -1413,14 +1595,14 @@ ZA
 ZA
 Mw
 ZA
-Mw
 ZA
 ZA
 ZA
 ZA
 ZA
 ZA
-Fd
+ZA
+di
 ab
 "}
 (27,1,1) = {"
@@ -1438,8 +1620,8 @@ ab
 ab
 ab
 ab
-Fd
-rr
+di
+AH
 mS
 mS
 rr
@@ -1448,23 +1630,23 @@ AH
 ZA
 ZA
 ZA
-ZA
-ZA
-ZA
 wY
 ZA
 ZA
-ZA
 wY
+Dh
+Dh
 ZA
 ZA
 ZA
 ZA
+Dh
+Dh
 ZA
 ZA
 ZA
 ZA
-Fd
+di
 ab
 "}
 (28,1,1) = {"
@@ -1482,33 +1664,33 @@ ab
 ab
 ab
 ab
+di
+di
+di
+di
+di
+di
+di
+di
+di
+di
+di
+di
+di
+Fd
+Fd
+Fd
+di
+di
+di
 Fd
 Fd
 Fd
 Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
+di
+di
+di
+di
 ab
 "}
 (29,1,1) = {"
@@ -1574,21 +1756,21 @@ ab
 ab
 ab
 ab
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
 ab
 ab
 ab
@@ -1618,21 +1800,21 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Fd
+gP
+pe
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+pe
+gP
 ab
 ab
 ab
@@ -1662,21 +1844,21 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Fd
+gP
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gP
 ab
 ab
 ab
@@ -1706,9 +1888,9 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
+gP
+gu
+gu
 bf
 mP
 El
@@ -1718,9 +1900,9 @@ oF
 El
 mD
 de
-Sy
-Sy
-Fd
+gu
+gu
+gP
 ab
 ab
 ab
@@ -1750,9 +1932,9 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
+gP
+gu
+gu
 br
 JX
 oF
@@ -1762,9 +1944,9 @@ El
 oF
 Kw
 Yj
-Sy
-Sy
-Fd
+gu
+gu
+gP
 ab
 ab
 ab
@@ -1794,9 +1976,9 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
+gP
+gu
+gu
 cj
 mP
 El
@@ -1806,9 +1988,9 @@ oF
 El
 mD
 Cw
-Sy
-Sy
-Fd
+gu
+gu
+gP
 ab
 ab
 ab
@@ -1838,9 +2020,9 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
+gP
+gu
+gu
 ct
 JX
 oF
@@ -1850,9 +2032,9 @@ El
 oF
 Kw
 jT
-Sy
-Sy
-Fd
+gu
+gu
+gP
 ab
 ab
 ab
@@ -1882,9 +2064,9 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
+gP
+gu
+gu
 dE
 mP
 El
@@ -1894,9 +2076,9 @@ oF
 El
 mD
 PU
-Sy
-Sy
-Fd
+gu
+gu
+gP
 ab
 ab
 ab
@@ -1926,9 +2108,9 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
+gP
+gu
+gu
 dJ
 JX
 oF
@@ -1938,9 +2120,9 @@ El
 oF
 Kw
 JP
-Sy
-Sy
-Fd
+gu
+gu
+gP
 ab
 ab
 ab
@@ -1970,9 +2152,9 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
+gP
+gu
+gu
 fb
 mP
 El
@@ -1982,9 +2164,9 @@ oF
 El
 mD
 Iq
-Sy
-Sy
-Fd
+gu
+gu
+gP
 ab
 ab
 ab
@@ -2014,9 +2196,9 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
+gP
+gu
+gu
 gw
 JX
 oF
@@ -2026,9 +2208,9 @@ El
 oF
 Kw
 pN
-Sy
-Sy
-Fd
+gu
+gu
+gP
 ab
 ab
 ab
@@ -2058,21 +2240,21 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Fd
+gP
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gP
 ab
 ab
 ab
@@ -2102,21 +2284,21 @@ ab
 ab
 ab
 ab
-Fd
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Sy
-Fd
+gP
+pe
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+pe
+gP
 ab
 ab
 ab
@@ -2146,21 +2328,21 @@ ab
 ab
 ab
 ab
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
-Fd
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gP
 ab
 ab
 ab

--- a/fulp_modules/_maps/wonderland.dmm
+++ b/fulp_modules/_maps/wonderland.dmm
@@ -2,12 +2,29 @@
 "ab" = (
 /turf/open/space/basic,
 /area/space)
+"ah" = (
+/obj/item/flashlight/lantern{
+	light_on = 1;
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/structure/flora/bush/flowers_br/style_2,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
 "av" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /obj/item/toy/plush/goatplushie,
 /turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"aB" = (
+/obj/item/flashlight/lantern{
+	light_on = 1;
+	pixel_x = 15;
+	pixel_y = -20
+	},
+/turf/open/misc/snow,
 /area/ruin/space/has_grav/wonderland)
 "aR" = (
 /obj/item/clothing/shoes/costume_2021/doll_shoes,
@@ -24,6 +41,14 @@
 "bM" = (
 /obj/structure/flora/bush/flowers_br/style_2,
 /mob/living/basic/rabbit,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"bV" = (
+/obj/item/flashlight/lantern{
+	light_on = 1;
+	pixel_x = 17;
+	pixel_y = 24
+	},
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
 "bZ" = (
@@ -51,6 +76,13 @@
 /obj/structure/chess/blackqueen,
 /turf/open/floor/black,
 /area/ruin/space/has_grav/wonderchess)
+"cE" = (
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
+/obj/structure/flora/rock/pile/style_3,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
 "cQ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -83,6 +115,12 @@
 /obj/structure/chess/blackbishop,
 /turf/open/floor/black,
 /area/ruin/space/has_grav/wonderchess)
+"ed" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/corpse/rabbit,
+/obj/item/food/grown/carrot,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/wonderland)
 "eu" = (
 /obj/structure/rack/weaponsmith,
 /turf/open/floor/wood/large,
@@ -156,6 +194,13 @@
 /mob/living/basic/rabbit,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
+"np" = (
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
+/obj/structure/flora/rock/pile,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
 "nQ" = (
 /obj/structure/flora/tree/dead/style_2,
 /turf/open/misc/snow,
@@ -217,6 +262,13 @@
 	},
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
+"wq" = (
+/obj/item/flashlight/lantern{
+	light_on = 1;
+	pixel_x = 15
+	},
+/turf/open/misc/snow,
+/area/ruin/space/has_grav/wonderland)
 "wP" = (
 /obj/item/flashlight/lantern{
 	light_on = 1;
@@ -247,6 +299,10 @@
 /obj/structure/flora/tree/jungle/style_2,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
+"BY" = (
+/obj/structure/flora/rock/pile/style_random,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
 "Ck" = (
 /obj/structure/flora/bush/flowers_yw,
 /obj/structure/flora/bush/flowers_br,
@@ -256,7 +312,22 @@
 /obj/structure/chess/whitebishop,
 /turf/open/floor/holofloor/pure_white,
 /area/ruin/space/has_grav/wonderchess)
+"CP" = (
+/obj/structure/flora/rock/icy,
+/turf/open/misc/snow,
+/area/ruin/space/has_grav/wonderland)
 "Dh" = (
+/turf/open/misc/snow,
+/area/ruin/space/has_grav/wonderland)
+"DE" = (
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"DV" = (
+/obj/structure/flora/rock/icy/style_2,
 /turf/open/misc/snow,
 /area/ruin/space/has_grav/wonderland)
 "El" = (
@@ -286,6 +357,10 @@
 "FO" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"Ge" = (
+/obj/structure/flora/rock/icy/style_3,
+/turf/open/misc/snow,
 /area/ruin/space/has_grav/wonderland)
 "Gl" = (
 /obj/structure/mineral_door/wood,
@@ -340,12 +415,30 @@
 /obj/structure/flora/bush/flowers_br/style_2,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
+"NS" = (
+/obj/structure/flora/rock/pile/style_2,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
 "Od" = (
 /obj/structure/statue/snow/snowman{
 	pixel_x = -15;
 	pixel_y = -15
 	},
 /turf/open/misc/snow,
+/area/ruin/space/has_grav/wonderland)
+"Oq" = (
+/obj/item/flashlight/lantern{
+	light_on = 1;
+	pixel_x = 15
+	},
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"OX" = (
+/obj/structure/flora/rock/style_4{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
 "PU" = (
 /obj/structure/chess/redqueen,
@@ -382,6 +475,10 @@
 	},
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
+"Ts" = (
+/obj/structure/flora/rock/pile/icy/style_2,
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
 "TF" = (
 /obj/structure/flora/tree/dead/style_5,
 /turf/open/misc/snow,
@@ -397,7 +494,8 @@
 /area/ruin/space/has_grav/wonderland)
 "VG" = (
 /obj/item/flashlight/lantern{
-	light_on = 1
+	light_on = 1;
+	pixel_x = -15
 	},
 /turf/open/misc/snow,
 /area/ruin/space/has_grav/wonderland)
@@ -417,6 +515,14 @@
 /area/ruin/space/has_grav/wonderland)
 "WD" = (
 /turf/closed/indestructible/wood,
+/area/ruin/space/has_grav/wonderland)
+"Xc" = (
+/obj/item/flashlight/lantern{
+	light_on = 1;
+	pixel_x = 8;
+	pixel_y = 15
+	},
+/turf/open/misc/snow,
 /area/ruin/space/has_grav/wonderland)
 "Xk" = (
 /turf/open/water/beach,
@@ -457,7 +563,19 @@
 /obj/structure/flora/bush/flowers_pp/style_2,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
+"YP" = (
+/obj/item/flashlight/lantern{
+	light_on = 1;
+	pixel_x = -15;
+	pixel_y = 20
+	},
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
 "ZA" = (
+/turf/open/misc/grass/jungle,
+/area/ruin/space/has_grav/wonderland)
+"ZK" = (
+/obj/structure/flora/rock/icy/style_2,
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
 
@@ -624,7 +742,7 @@ Yp
 ZA
 ZA
 nQ
-VG
+Xc
 ZA
 ZA
 ZA
@@ -659,22 +777,22 @@ ZA
 RW
 ZA
 ZA
-rA
+ah
 Yp
 ZA
 ZA
-tS
+YP
 ZA
 ZA
 ZA
 ZA
 ZA
 ZA
+OX
 ZA
 ZA
 ZA
-ZA
-VG
+wq
 ZA
 ZA
 ZA
@@ -703,7 +821,7 @@ ZA
 ZA
 ZA
 ZA
-ZA
+Mw
 ZA
 ZA
 wY
@@ -852,8 +970,8 @@ ZA
 ZA
 ZA
 ZA
-ZA
-ZA
+Dh
+Dh
 di
 ab
 "}
@@ -895,9 +1013,9 @@ ZA
 ZA
 ZA
 ZA
-ZA
-tS
-ZA
+Dh
+aB
+DV
 di
 ab
 "}
@@ -941,7 +1059,7 @@ Wb
 Wb
 Wb
 Wb
-ZA
+CP
 Fd
 ab
 "}
@@ -974,7 +1092,7 @@ Wb
 Wb
 Wb
 Wb
-tS
+np
 Wb
 Wb
 Wb
@@ -1012,7 +1130,7 @@ Sy
 wP
 WD
 ZA
-ZA
+BY
 gc
 Wb
 Xk
@@ -1050,13 +1168,13 @@ ab
 ab
 WD
 HK
-tb
+ed
 Sy
 Sy
 Vo
 WD
 ZA
-ZA
+NS
 Mw
 Wb
 Xk
@@ -1112,8 +1230,8 @@ Xk
 Wb
 Wb
 Wb
-ZA
-tS
+Ts
+DE
 Wb
 Wb
 Wb
@@ -1146,7 +1264,7 @@ WD
 ZA
 ZA
 ZA
-rA
+cE
 Wb
 Wb
 Wb
@@ -1159,9 +1277,9 @@ ZA
 ZA
 ZA
 ZA
-ZA
-ZA
-ZA
+Dh
+Dh
+Ge
 Fd
 ab
 "}
@@ -1204,7 +1322,7 @@ ZA
 ZA
 ZA
 ZA
-ZA
+Dh
 Dh
 Fd
 ab
@@ -1462,7 +1580,7 @@ ZA
 ZA
 ZA
 ZA
-VG
+wq
 ZA
 ZA
 ZA
@@ -1496,7 +1614,7 @@ Se
 Ck
 UO
 ZA
-tS
+Oq
 ZA
 Mw
 ZA
@@ -1511,8 +1629,8 @@ Dh
 ZA
 ZA
 ZA
-tS
 ZA
+bV
 ZA
 Fd
 ab
@@ -1555,7 +1673,7 @@ ZA
 ZA
 ZA
 ZA
-ZA
+ZK
 ZA
 ZA
 di

--- a/fulp_modules/_maps/wonderland.dmm
+++ b/fulp_modules/_maps/wonderland.dmm
@@ -896,7 +896,7 @@ ZA
 ZA
 ZA
 ZA
-ZA
+tS
 ZA
 di
 ab
@@ -941,7 +941,7 @@ Wb
 Wb
 Wb
 Wb
-tS
+ZA
 Fd
 ab
 "}

--- a/fulp_modules/mapping/areas/areas.dm
+++ b/fulp_modules/mapping/areas/areas.dm
@@ -82,10 +82,17 @@
 	ambience_index = AMBIENCE_SPOOKY
 	sound_environment = SOUND_ENVIRONMENT_CAVE
 	area_flags = UNIQUE_AREA | NOTELEPORT | HIDDEN_AREA | BLOCK_SUICIDE
+	base_lighting_alpha = 128
+	base_lighting_color = "#FFDD77"
+
+/area/ruin/space/has_grav/wonderchess
+	name = "Wonderland Chess Board"
+	icon_state = "green"
+	ambience_index = AMBIENCE_SPOOKY
+	sound_environment = SOUND_ENVIRONMENT_CAVE
+	area_flags = UNIQUE_AREA | NOTELEPORT | HIDDEN_AREA | BLOCK_SUICIDE
 	static_lighting = FALSE
 	base_lighting_alpha = 255
-
-
 
 /area/ruin/has_grav/prototype
 	requires_power = TRUE


### PR DESCRIPTION

## About The Pull Request
This PR does a fair bit to improve Wonderland's appearance. For lighting purposes the "Wonderland" area has been divided into two separate areas: Wonderland and Wonderland Chess Board. Most other changes are apparent in these two images:
![Wonderland_Improvements](https://github.com/fulpstation/fulpstation/assets/154708292/520f2e82-1bd1-4315-913d-620ff4aff14b)
![Wondrchess_Improvements](https://github.com/fulpstation/fulpstation/assets/154708292/f6049783-12df-40a0-a3e3-9c4d341481bc)
_No more brutalist, riveted indestructible walls (though the walls are very much still indestructible!)_
## Why It's Good For The Game
Wonderland as is looks pretty bad. This PR fixes a few minor mistakes present in the original map, adds better lighting, and overall aims to improve the map's detail. (Oh, also, the water is now *real water*!)
## Changelog
:cl:
add: Added better lighting to Wonderland
add: Gave Wonderland more detail overall
fix: Fixed a few minor mistakes present in the original Wonderland map
code: Divided Wonderland into two separate areas for Wonderland itself and Wonderland's chess board
/:cl:
