### PR TITLE
Turns Pubby's monastery lanterns on at round start

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -22390,7 +22390,8 @@
 /area/station/service/chapel/asteroid/monastery)
 "bQe" = (
 /obj/item/flashlight/lantern{
-	icon_state = "lantern-on"
+	icon_state = "lantern-on";
+	light_on = 1
 	},
 /turf/open/misc/asteroid,
 /area/station/service/chapel/asteroid/monastery)
@@ -25193,10 +25194,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "ccL" = (
-/obj/item/flashlight/lantern{
-	icon_state = "lantern-on"
-	},
 /obj/effect/turf_decal/sand/plating,
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on";
+	light_on = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/chapel/asteroid/monastery)
 "ccM" = (
@@ -25269,7 +25271,15 @@
 "cdD" = (
 /obj/structure/table,
 /obj/item/trash/waffles,
-/obj/item/kitchen/fork,
+/obj/item/kitchen/fork{
+	pixel_x = 5
+	},
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on";
+	light_on = 1;
+	pixel_x = -7;
+	pixel_y = 12
+	},
 /turf/open/misc/asteroid,
 /area/station/service/chapel/asteroid/monastery)
 "cdE" = (
@@ -34487,6 +34497,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"hxl" = (
+/obj/structure/flora/bush/style_random,
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on";
+	light_on = 1
+	},
+/turf/open/misc/asteroid,
+/area/station/service/chapel/asteroid/monastery)
 "hxB" = (
 /obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -36857,9 +36875,12 @@
 /area/station/security/prison/workout)
 "jNZ" = (
 /obj/machinery/holopad,
-/obj/item/flashlight/lantern,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on";
+	light_on = 1
 	},
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
@@ -37215,9 +37236,12 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance)
 "ket" = (
-/obj/item/flashlight/lantern,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on";
+	light_on = 1
 	},
 /turf/open/floor/iron/chapel{
 	dir = 8
@@ -42817,6 +42841,13 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"oQv" = (
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on";
+	light_on = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "oRl" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -66923,7 +66954,7 @@ cqU
 bNs
 bUC
 bOw
-bOw
+bQe
 bOw
 bOw
 bOw
@@ -67185,7 +67216,7 @@ bOw
 bOw
 bOw
 bOw
-bOw
+bQe
 bOw
 ceB
 cee
@@ -67434,7 +67465,7 @@ bGD
 bQQ
 bNs
 bNs
-bQe
+bOw
 bOw
 bOw
 bOw
@@ -67690,14 +67721,14 @@ bNr
 bNs
 bNs
 bNs
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
 bQe
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
 bWV
 bWV
 bWV
@@ -68201,14 +68232,14 @@ bNs
 bNs
 bNs
 bNs
-bSm
+hxl
 bOw
 bOw
 bOw
 bOw
 bOw
 bOw
-bOw
+bQe
 bUC
 bWV
 whH
@@ -69236,7 +69267,7 @@ bOw
 bOw
 bQe
 xXp
-rfa
+oQv
 rfa
 lMK
 vaS
@@ -70007,7 +70038,7 @@ bOw
 bOw
 bQe
 xXp
-rfa
+oQv
 rfa
 dyo
 iav
@@ -71028,14 +71059,14 @@ bNs
 bNs
 bNs
 bNs
+bQe
 bOw
 bOw
 bOw
 bOw
 bOw
 bOw
-bOw
-bOw
+bQe
 bWV
 bWV
 bWV
@@ -71545,7 +71576,7 @@ bRC
 bNs
 bNs
 bNs
-bOw
+bQe
 bOw
 bOw
 bOw
@@ -71803,16 +71834,16 @@ bSn
 cFX
 bNs
 bNs
-bQe
+bOw
 bOw
 bOw
 bOw
 bQg
 bQg
-bQg
-bOw
-bOw
 ccL
+bOw
+bOw
+bQg
 bWV
 csT
 cen
@@ -72069,7 +72100,7 @@ bXL
 bNs
 bOw
 bOw
-bOw
+bQe
 bWV
 csU
 bWV
@@ -72586,7 +72617,7 @@ bOw
 bOw
 bOw
 bOw
-bQe
+bOw
 bOw
 bUC
 cfL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pull request turns Pubby Station's monastery lanterns on at round start. A few more of them have also been added for good measure as seen here:
![Well-lit_Monastery](https://github.com/fulpstation/fulpstation/assets/154708292/3087a4f0-75ef-43ec-b537-3f4c5adb1e0a)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It seems that Pubby Station's lanterns were actually supposed the be on at round start since their 'icon_state' value was set to 'lantern_on'. This didn't actually turn them on though, so for ages players have been forced to tediously turn them on one by one every round if they want Pubby's monastery to look good. Even with them on they don't provide adequate lighting for the monastery, so this PR added a few more.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Pubby Station's lanterns are now turned on at round start— there are also more of them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
