### PR TITLE
Theia ordnance O2 tank fix

### DIFF
--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -4496,13 +4496,11 @@
 /area/station/maintenance/aft/upper)
 "bLL" = (
 /obj/effect/turf_decal/tile/purple/full,
-/obj/machinery/atmospherics/components/tank{
-	dir = 1
-	},
 /obj/machinery/camera/directional/south{
 	name = "Science - Ordnance Storage Aft"
 	},
 /obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/atmospherics/components/tank/oxygen,
 /turf/open/floor/iron/textured_large,
 /area/station/science/ordnance/testlab)
 "bLM" = (
@@ -21618,8 +21616,8 @@
 /obj/effect/turf_decal/tile/purple/full,
 /obj/effect/turf_decal/stripes/white/line,
 /obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/components/tank{
-	dir = 1
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 8
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/science/ordnance/testlab)
@@ -31810,9 +31808,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/tank{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/tank/oxygen,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "mZO" = (
@@ -36518,9 +36514,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "oWS" = (
 /obj/effect/turf_decal/tile/purple/full,
-/obj/machinery/atmospherics/components/tank{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/tank/oxygen,
 /turf/open/floor/iron/textured_large,
 /area/station/science/ordnance/testlab)
 "oXd" = (
@@ -52640,9 +52634,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/tank{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/tank/oxygen,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "vYQ" = (


### PR DESCRIPTION

## About The Pull Request
This PR replaces the large tanks in Theia's ordnance lab with large oxygen tanks.
## Why It's Good For The Game
Every ordnance lab requires a large tank full of oxygen for basic gas synthesis. Theia's large oxygen tank currently has no oxygen in it, and this PR fixes that.
## Changelog
:cl:
fix: The large oxygen tank in Theia's ordnance lab now actually has oxygen in it.
/:cl:
