### PR TITLE
Gives Heliostation's ordnance testing lab an ordnance data disk

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -20998,6 +20998,10 @@
 	pixel_x = -5;
 	pixel_y = 8
 	},
+/obj/item/computer_disk/ordnance{
+	pixel_x = 1;
+	pixel_y = 5
+	},
 /obj/item/computer_disk{
 	pixel_x = 7;
 	pixel_y = 2


### PR DESCRIPTION

## About The Pull Request
This PR adds an ordnance data disk to Heliostation's ordnance testing lab.
## Why It's Good For The Game
Ordnance data disks contain the NT Frontier program, which is vital to most ordnance-related research. Without ordnance data disks scientists are forced to download NT Frontier instead of just moving it from a disk onto a device of their choosing.
## Changelog
:cl:
qol: Adds an ordnance data disk to Helio's ordnance testing lab
/:cl:
