### PR TITLE
Monster Hunter description changes

### DIFF
--- a/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
@@ -1,6 +1,6 @@
 /obj/item/hunting_contract
 	name = "\improper Hunter's Contract"
-	desc = "A contract detailing a hunter's tasks and tools."
+	desc = "A contract written in an exotic language and marked with a red, queenly stamp.."
 	icon = 'icons/obj/scrolls.dmi'
 	icon_state = "scroll2"
 	w_class = WEIGHT_CLASS_SMALL

--- a/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
@@ -25,6 +25,20 @@
 	if(hunter)
 		owner = hunter
 
+/obj/item/hunting_contract/examine(mob/user)
+	. = ..()
+	if(user.mind == owner.owner) //If the examining mob's mind is the mind owning the antag datum that owns the contract
+		. += span_notice("This is your hunting contract.")
+		. += span_notice("You may use it to call in one trick weapon of your choosing.")
+		. += span_notice("<b>Do not lose it</b> if you intend to achieve something greater as a harbinger of Wonderland.")
+		return
+	if(IS_HERETIC_OR_MONSTER(user))
+		. += span_notice("This is the contract of a heathen who may hunt Mansus scholars.")
+	if(IS_BLOODSUCKER(user))
+		. += span_cult("This is the contract of a mortal who may hunt the Kindred in all of their forms.")
+	if(IS_CHANGELING(user))
+		. += span_changeling("This is the contract of an audacious lesser organism who may hunt those of our kind.")
+
 /obj/item/hunting_contract/ui_interact(mob/living/user, datum/tgui/ui)
 	if(!IS_MONSTERHUNTER(user))
 		to_chat(usr, span_notice("You are unable to decipher the symbols."))

--- a/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
@@ -354,6 +354,7 @@
 		return tool
 
 /obj/structure/rack/weaponsmith/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	. = ..()
 	if(!istype(held_item, /obj/item/rabbit_eye))
 		return
 	var/obj/item/melee/trick_weapon/weapon = identify_weapon()

--- a/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
@@ -242,7 +242,7 @@
 
 /obj/item/rabbit_eye
 	name = "Rabbit eye"
-	desc = "An item that resonates with trick weapons."
+	desc = "The bloodshot lenses of a lost rabbit."
 	icon_state = "rabbit_eye"
 	icon = 'fulp_modules/features/antagonists/monster_hunter/icons/weapons.dmi'
 
@@ -266,7 +266,7 @@
 
 /obj/item/gun/ballistic/revolver/hunter_revolver
 	name = "\improper Hunter's Revolver"
-	desc = "Does minimal damage but slows down the enemy."
+	desc = "A revolver delicately modified with some form of alchemical apparatus. It smells of rusted copper."
 	icon_state = "revolver"
 	icon = 'fulp_modules/features/antagonists/monster_hunter/icons/weapons.dmi'
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/bloodsilver
@@ -349,7 +349,7 @@
 
 /obj/item/clothing/mask/cursed_rabbit
 	name = "Damned Rabbit Mask"
-	desc = "Slip into wonderland."
+	desc = "An eerie visage covered with a light, almost reflective fur."
 	icon =  'fulp_modules/features/antagonists/monster_hunter/icons/weapons.dmi'
 	icon_state = "rabbit_mask"
 	worn_icon = 'fulp_modules/features/antagonists/monster_hunter/icons/worn_mask.dmi'
@@ -414,7 +414,7 @@
 
 /obj/item/rabbit_locator
 	name = "Accursed Red Queen card"
-	desc = "Hunts down the white rabbits."
+	desc = "A card bearing the sinister face of an unknown monarch. It is otherwise unremarkable."
 	icon = 'fulp_modules/features/antagonists/monster_hunter/icons/weapons.dmi'
 	icon_state = "locator"
 	w_class = WEIGHT_CLASS_SMALL

--- a/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
@@ -333,10 +333,6 @@
 	icon_state = "altar"
 	resistance_flags = INDESTRUCTIBLE
 
-/obj/structure/rack/weaponsmith/Initialize(mapload)
-	. = ..()
-	register_context()
-
 /obj/structure/rack/weaponsmith/examine(mob/user)
 	. = ..()
 	if(IS_MONSTERHUNTER(user))

--- a/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
@@ -18,6 +18,12 @@
 	var/enabled = FALSE
 
 
+/obj/item/melee/trick_weapon/examine(mob/user)
+	. = ..()
+	if(IS_MONSTERHUNTER(user))
+		. += span_notice("This is a trick weapon.")
+		. += span_notice("It will deal less damage to anyone who isn't sufficiently monstrous.")
+
 /obj/item/melee/trick_weapon/proc/upgrade_weapon()
 	SIGNAL_HANDLER
 
@@ -70,7 +76,10 @@
 	RegisterSignal(src, COMSIG_TRANSFORMING_ON_TRANSFORM, PROC_REF(on_transform))
 	RegisterSignal(src, WEAPON_UPGRADE, PROC_REF(upgrade_weapon))
 
-
+/obj/item/melee/trick_weapon/darkmoon/examine(mob/user)
+	. = ..()
+	if(IS_MONSTERHUNTER(user))
+		. += span_notice("<b>Right-click</b> a target when this weapon is active to fire a beam of moonlight at it.")
 
 /obj/item/melee/trick_weapon/darkmoon/proc/on_transform(obj/item/source, mob/user, active)
 	SIGNAL_HANDLER
@@ -157,6 +166,11 @@
 	RegisterSignal(src, COMSIG_TRANSFORMING_ON_TRANSFORM, PROC_REF(on_transform))
 	RegisterSignal(src,WEAPON_UPGRADE, PROC_REF(upgrade_weapon))
 
+/obj/item/melee/trick_weapon/threaded_cane/examine(mob/user)
+	. = ..()
+	if(IS_MONSTERHUNTER(user))
+		. += span_notice("When transformed into a whip this weapon can hit enemies who are up to two tiles away.")
+
 /obj/item/melee/trick_weapon/threaded_cane/proc/on_transform(obj/item/source, mob/user, active)
 	SIGNAL_HANDLER
 	balloon_alert(user, active ? "extended" : "collapsed")
@@ -200,6 +214,11 @@
 	)
 	RegisterSignal(src, WEAPON_UPGRADE, PROC_REF(upgrade_weapon))
 
+/obj/item/melee/trick_weapon/hunter_axe/examine(mob/user)
+	. = ..()
+	if(IS_MONSTERHUNTER(user))
+		. += span_notice("When wielded in both hands this weapon deals more damage.")
+
 /obj/item/melee/trick_weapon/hunter_axe/upgrade_weapon()
 
 	upgrade_level++
@@ -227,6 +246,11 @@
 	icon_state = "rabbit_eye"
 	icon = 'fulp_modules/features/antagonists/monster_hunter/icons/weapons.dmi'
 
+/obj/item/rabbit_eye/examine(mob/user)
+	. = ..()
+	if(IS_MONSTERHUNTER(user))
+		. += span_notice("Apply this to the weapon forge in Wonderland <b>with combat mode enabled</b> to upgrade any trick weapon currently on the forge.")
+
 /obj/item/rabbit_eye/proc/upgrade(obj/item/melee/trick_weapon/killer, mob/user)
 	if(killer.upgrade_level >= 3)
 		user.balloon_alert(user, "Already at maximum upgrade!")
@@ -247,6 +271,11 @@
 	icon = 'fulp_modules/features/antagonists/monster_hunter/icons/weapons.dmi'
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/bloodsilver
 	initial_caliber = CALIBER_BLOODSILVER
+
+/obj/item/gun/ballistic/revolver/hunter_revolver/examine(mob/user)
+	. = ..()
+	if(IS_MONSTERHUNTER(user))
+		. += span_notice("This revolver deals miniscule damage, but it will temporarily slow down any monster shot with it.")
 
 /datum/movespeed_modifier/silver_bullet
 	movetypes = GROUND
@@ -297,6 +326,11 @@
 	icon_state = "altar"
 	resistance_flags = INDESTRUCTIBLE
 
+/obj/structure/rack/weaponsmith/examine(mob/user)
+	. = ..()
+	if(IS_MONSTERHUNTER(user))
+		. += span_notice("This forge can be used to upgrade trick weapons with rabbit eyes.")
+
 /obj/structure/rack/weaponsmith/attackby(obj/item/organ, mob/living/user, params)
 	if(!istype(organ, /obj/item/rabbit_eye))
 		return ..()
@@ -333,6 +367,12 @@
 	. = ..()
 	generate_abilities()
 
+/obj/item/clothing/mask/cursed_rabbit/examine(mob/user)
+	. = ..()
+	if(IS_MONSTERHUNTER(user))
+		. += span_notice("You can use this mask to teleport to Wonderland for a short period of time.")
+		. += span_notice("It can also be used to phase through reality by repeatedly transposing your location with that of a paradox rabbit.")
+		. += span_boldnotice("Do not leave it in Wonderland unless you wish to risk losing it forever.")
 
 /obj/item/clothing/mask/cursed_rabbit/proc/generate_abilities()
 	var/datum/action/cooldown/paradox/para = new
@@ -392,6 +432,12 @@
 		return
 	hunter = killer
 	hunter.locator = src
+
+/obj/item/rabbit_locator/examine(mob/user)
+	. = ..()
+	if(IS_MONSTERHUNTER(user))
+		. += span_notice("When <b>used in hand</b> this card will vaguely indicate your distance to a nearby rabbit on the station, allowing you to gradually deduce its location.")
+		. += span_boldnotice("This card cannot be replaced.")
 
 /obj/item/rabbit_locator/attack_self(mob/user, modifiers)
 	if (!COOLDOWN_FINISHED(src, locator_timer))
@@ -466,7 +512,10 @@
 	ex_light = 4
 	ex_flame = 2
 
-
+/obj/item/grenade/jack/examine(mob/user)
+	. = ..()
+	if(IS_MONSTERHUNTER(user))
+		. += span_notice("<b>This is a bomb.</b> Use it with utmost caution.")
 
 /obj/item/grenade/jack/arm_grenade(mob/user, delayoverride, msg = TRUE, volume = 60)
 	log_grenade(user) //Inbuilt admin procs already handle null users

--- a/fulp_modules/features/antagonists/monster_hunter/wonderland.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/wonderland.dm
@@ -78,6 +78,12 @@ GLOBAL_LIST_EMPTY(wonderland_marks)
 	item_flags = NOBLUDGEON
 	var/filled = FALSE ///does the bottle contain fluid
 
+/obj/item/blood_vial/examine(mob/user)
+	. = ..()
+	if(IS_MONSTERHUNTER(user))
+		. += span_notice("This vial can only be filled at the blood fountain in Wonderland. ")
+		. += span_notice("When full this vial can be <b>used in hand</b> to grant its user a short burst of speed and lingering healing.")
+
 /obj/item/blood_vial/proc/fill_vial(mob/living/user)
 	if(filled)
 		balloon_alert(user, "Vial already full!")

--- a/fulp_modules/features/antagonists/monster_hunter/wonderland.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/wonderland.dm
@@ -37,13 +37,13 @@ GLOBAL_LIST_EMPTY(wonderland_marks)
 
 /obj/structure/chess/redqueen
 	name = "\improper Red Queen"
-	desc = "What is this doing here?"
+	desc = "What is <i>she</i> doing here?"
 	icon = 'fulp_modules/features/antagonists/monster_hunter/icons/rabbit.dmi'
 	icon_state = "red_queen"
 
 /obj/structure/blood_fountain
 	name = "blood fountain"
-	desc = "A huge resevoir of thickened blood, perhaps drinking some of it would restore some vigor..."
+	desc = "A huge resevoir of thickened blood, perhaps drinking from it would restore some vigor..."
 	icon = 'fulp_modules/features/antagonists/monster_hunter/icons/blood_fountain.dmi'
 	icon_state = "blood_fountain"
 	plane = ABOVE_GAME_PLANE
@@ -68,7 +68,7 @@ GLOBAL_LIST_EMPTY(wonderland_marks)
 
 /obj/item/blood_vial
 	name = "blood vial"
-	desc = "Used to collect samples of blood from the dead-still blood fountain."
+	desc = "A blue vial emanating what little vitality it cannot contain."
 	icon = 'fulp_modules/features/antagonists/monster_hunter/icons/weapons.dmi'
 	icon_state = "blood_vial_empty"
 	inhand_icon_state = "beaker"


### PR DESCRIPTION

## About The Pull Request
This pull request changes a lot of monster hunter descriptions and adds hidden descriptions that are only viewable by monster hunters and (in one instance,) their victims.
## Why It's Good For The Game
These changes may make monster hunter friendlier to new players. In addition it might help anyone who doesn't have an encyclopedic grasp of monster hunter mechanics.
## Changelog
:cl: 
add: Added hidden descriptions to most monster hunter items in order to better explain their function
/:cl:
