### PR TITLE
Fixes the name of a singular pump

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -33339,7 +33339,7 @@
 "fOY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Distro Stagsing to Filter"
+	name = "Mix to Air"
 	},
 /obj/effect/turf_decal/tile/medical{
 	dir = 1


### PR DESCRIPTION

## About The Pull Request
This PR changes the name of a singular pump on Heliostation from "Distro Stagsing to Filter" to "Mix to Air".
## Why It's Good For The Game
"Stagsing" is a misspelling of "staging". Also "Distro Staging to Filter" does not accurately describe what the pump actually does.
## Changelog
:cl:
spellcheck: Fixed a pump inaccurately labeled "Distro Stagsing to Filter"
/:cl:
