### PR TITLE
Bloodsucker textual overhaul/grammar review

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_conversion.dm
@@ -29,7 +29,7 @@
 		return FALSE
 	// No Mind!
 	if(!conversion_target.mind)
-		to_chat(owner.current, span_danger("[conversion_target] isn't self-aware enough to be made into a Vassal."))
+		to_chat(owner.current, span_danger("[conversion_target] isn't self-aware enough to be made into a vassal."))
 		return FALSE
 	if(AmValidAntag(conversion_target) == VASSALIZATION_BANNED)
 		to_chat(owner.current, span_danger("[conversion_target] resists the power of your blood to dominate their mind!"))
@@ -67,8 +67,8 @@
 	vassaldatum.master = bloodsuckerdatum
 	conversion_target.mind.add_antag_datum(vassaldatum)
 
-	message_admins("[conversion_target] has become a Vassal, and is enslaved to [owner.current].")
-	log_admin("[conversion_target] has become a Vassal, and is enslaved to [owner.current].")
+	message_admins("[conversion_target] has become a vassal, and is enslaved to [owner.current].")
+	log_admin("[conversion_target] has become a vassal, and is enslaved to [owner.current].")
 	return TRUE
 
 /*

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -13,9 +13,9 @@
 	preview_outfit = /datum/outfit/bloodsucker_outfit
 	tip_theme = "spookyconsole"
 	antag_tips = list(
-		"You are a Bloodsucker, an undead blood-seeking monster living aboard Space Station 13.",
-		"You regenerate your health slowly. You're weak to fire, and you depend on blood to survive. Don't allow your blood to run too low, or you'll enter a Frenzy!",
-		"Use your Antagonist UI page to enter a clan and learn how your powers work.",
+		"You are a Bloodsucker, a type of vampire who has infiltrated Space Station 13.",
+		"You regenerate your health slowly, you're weak to fire, and you depend on blood to survive. Don't allow your blood to run too low, or you'll enter a frenzy!",
+		"Use your antagonist UI page to enter a clan and learn how your powers work.",
 		"While not in a clan, you will be unable to rank up, feed, or do any other Bloodsucker activities.",
 	)
 
@@ -263,7 +263,7 @@
 	to_chat(owner, span_userdanger("You are [fullname], a strain of vampire known as a Bloodsucker!"))
 	owner.announce_objectives()
 	if(bloodsucker_level_unspent >= 2)
-		to_chat(owner, span_announce("As a latejoiner, you have [bloodsucker_level_unspent] bonus Ranks, entering your claimed coffin allows you to spend a Rank."))
+		to_chat(owner, span_announce("As a latejoiner, you have [bloodsucker_level_unspent] bonus ranks, entering your claimed coffin allows you to spend a rank."))
 	owner.current.playsound_local(null, 'fulp_modules/features/antagonists/bloodsuckers/sounds/BloodsuckerAlert.ogg', 100, FALSE, pressure_affected = FALSE)
 	antag_memory += "Although you were born a mortal, in undeath you earned the name <b>[fullname]</b>.<br>"
 
@@ -275,11 +275,11 @@
 
 // Called when using admin tools to give antag status
 /datum/antagonist/bloodsucker/admin_add(datum/mind/new_owner, mob/admin)
-	var/levels = input("How many unspent Ranks would you like [new_owner] to have?","Bloodsucker Rank", bloodsucker_level_unspent) as null | num
+	var/levels = input("How many unspent ranks would you like [new_owner] to have?","Bloodsucker Rank", bloodsucker_level_unspent) as null | num
 	var/msg = " made [key_name_admin(new_owner)] into \a [name]"
 	if(levels > 1)
 		bloodsucker_level_unspent = levels
-		msg += " with [levels] extra unspent Ranks."
+		msg += " with [levels] extra unspent ranks."
 	message_admins("[key_name_admin(usr)][msg]")
 	log_admin("[key_name(usr)][msg]")
 	new_owner.add_antag_datum(src)
@@ -354,7 +354,7 @@
 
 	// Now list their vassals
 	if(vassals.len)
-		report += "<span class='header'>Their Vassals were...</span>"
+		report += "<span class='header'>Their vassals were...</span>"
 		for(var/datum/antagonist/vassal/all_vassals as anything in vassals)
 			if(!all_vassals.owner)
 				continue

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -15,7 +15,7 @@
 	antag_tips = list(
 		"You are a Bloodsucker, a type of vampire who has infiltrated Space Station 13.",
 		"You regenerate your health slowly, you're weak to fire, and you depend on blood to survive. Don't allow your blood to run too low, or you'll enter a frenzy!",
-		"Use your antagonist UI page to enter a clan and learn how your powers work.",
+		"Use your Antagonist UI page to enter a clan and learn how your powers work.",
 		"While not in a clan, you will be unable to rank up, feed, or do any other Bloodsucker activities.",
 	)
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
@@ -24,7 +24,7 @@
 
 /atom/movable/screen/alert/status_effect/frenzy
 	name = "Frenzy"
-	desc = "You are in a Frenzy! You are entirely feral and, depending on your clan, fighting for your life!"
+	desc = "You are in a frenzy! You are entirely feral and, depending on your clan, fighting for your life!"
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/actions_bloodsucker.dmi'
 	icon_state = "power_recover"
 	alerttooltipstyle = "cult"
@@ -41,7 +41,7 @@
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum
 
 /datum/status_effect/frenzy/get_examine_text()
-	return span_notice("They seem... inhumane, and feral!")
+	return span_notice("They seem inhuman and feral!")
 
 /atom/movable/screen/alert/status_effect/masquerade/MouseEntered(location,control,params)
 	desc = initial(desc)
@@ -53,8 +53,8 @@
 
 	// Disable ALL Powers and notify their entry
 	bloodsuckerdatum.DisableAllPowers(forced = TRUE)
-	to_chat(owner, span_userdanger("<FONT size = 3>Blood! You need Blood, now! You enter a total Frenzy!"))
-	to_chat(owner, span_announce("* Bloodsucker Tip: While in Frenzy, you instantly aggresively grab, have stun resistance, cannot speak, hear, or use any powers outside of Feed and Trespass (If you have it)."))
+	to_chat(owner, span_userdanger("<FONT size = 3>Blood! You need blood, <b>now</b>! You enter a total frenzy!"))
+	to_chat(owner, span_announce("* Bloodsucker Tip: While in a frenzy, you instantly aggresively grab, have stun resistance, cannot speak, hear, or use any powers outside of Feed and Trespass (If you have it)."))
 	owner.balloon_alert(owner, "you enter a frenzy!")
 	SEND_SIGNAL(bloodsuckerdatum, BLOODSUCKER_ENTERS_FRENZY)
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -47,7 +47,7 @@
 		return
 	humanity_lost += value
 	frenzy_threshold = (FRENZY_MINIMUM_THRESHOLD_ENTER + humanity_lost * 10)
-	to_chat(owner.current, span_warning("You feel as if you lost some of your humanity. You will now enter Frenzy at [frenzy_threshold] Blood."))
+	to_chat(owner.current, span_warning("You feel as if you lost some of your humanity. You will now enter frenzy at [frenzy_threshold] Blood."))
 
 /// mult: SILENT feed is 1/3 the amount
 /datum/antagonist/bloodsucker/proc/handle_feeding(mob/living/carbon/target, mult=1, power_level)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_moodlets.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_moodlets.dm
@@ -24,7 +24,7 @@
 	timeout = 10 MINUTES
 
 /datum/mood_event/madevamp
-	description = span_boldwarning("A mortal has reached an apotheosis- undeath- by my own hand.")
+	description = span_boldwarning("A mortal has reached an apotheosis— undeath— by my own hand.")
 	mood_change = 15
 	timeout = 5 MINUTES
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/subsystem_sunlight.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/subsystem_sunlight.dm
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(sunlight)
 			issued_XP = FALSE
 			//randomize the next sol timer
 			time_til_cycle = round(rand((TIME_BLOODSUCKER_NIGHT-TIME_BLOODSUCKER_SOL_DELAY), (TIME_BLOODSUCKER_NIGHT+TIME_BLOODSUCKER_SOL_DELAY)), 60)
-			message_admins("BLOODSUCKER NOTICE: Daylight Ended. Resetting to Night (Lasts for [time_til_cycle / 60] minutes.")
+			message_admins("BLOODSUCKER NOTICE: Daylight Ended. Resetting to night (Lasts for [time_til_cycle / 60] minutes.")
 			SEND_SIGNAL(src, COMSIG_SOL_END)
 			warn_daylight(
 				danger_level = DANGER_LEVEL_SOL_ENDED,

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/_clan.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/_clan.dm
@@ -10,10 +10,10 @@
 	///The name of the clan we're in.
 	var/name = CLAN_NONE
 	///Description of what the clan is, given when joining and through your antag UI.
-	var/description = "The Caitiff is as basic as you can get with Bloodsuckers. \n\
-		Entirely Clan-less, they are blissfully unaware of who they really are. \n\
-		No additional abilities is gained, nothing is lost, if you want a plain Bloodsucker, this is it. \n\
-		The Favorite Vassal will gain the Brawn ability, to help in combat."
+	var/description = "The Caitiff are as basic as you can get with Bloodsuckers. \n\
+		Entirely clanless, they are blissfully unaware of the greater clan structure. \n\
+		No additional abilities are gained, none are lost: if you want a plain Bloodsucker then this is it. \n\
+		The favorite vassal will gain the Brawn ability to help in combat."
 	///The clan objective that is required to greentext.
 	var/datum/objective/clan_objective
 	///The icon of the radial icon to join this clan.
@@ -21,7 +21,7 @@
 	///Same as join_icon, but the state
 	var/join_icon_state = "caitiff"
 	///Description shown when trying to join the clan.
-	var/join_description = "The default, Classic Bloodsucker."
+	var/join_description = "The default, classic Bloodsucker."
 	///Whether the clan can be joined by players. FALSE for flavortext-only clans.
 	var/joinable_clan = TRUE
 	///Boolean on whether the clan shows up in the Archives of the Kindred.
@@ -229,7 +229,7 @@
 		to_chat(bloodsuckerdatum.owner.current, span_notice("This Vassal was already assigned a special position."))
 		return FALSE
 	if(!vassaldatum.owner.can_make_special(creator = bloodsuckerdatum.owner))
-		to_chat(bloodsuckerdatum.owner.current, span_notice("This Vassal is unable to gain a Special rank due to innate features."))
+		to_chat(bloodsuckerdatum.owner.current, span_notice("This Vassal is unable to gain a special rank due to innate features."))
 		return FALSE
 
 	var/list/options = list()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_flavortext.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_flavortext.dm
@@ -1,9 +1,9 @@
 /datum/bloodsucker_clan/gangrel
 	name = CLAN_GANGREL
-	description = "Closer to Animals than Bloodsuckers, known as Werewolves waiting to happen, \n\
-		these are the most fearful of True Faith, being the most lethal thing they would ever see the night of. \n\
-		Full Moons do not seem to have an effect, despite common-told stories. \n\
-		The Favorite Vassal turns into a Werewolf whenever their Master does."
+	description = "Closer to animals than bloodsuckers and often improperly characterized as werewolves: \n\
+		these fearful Kindred are the most lethal to those who wield True Faith. \n\
+		Full moons do not seem to affect them, despite what folklore may suggest. \n\
+		Their favorite vassal turns into a werewolf whenever they do."
 	joinable_clan = FALSE
 	blood_drink_type = BLOODSUCKER_DRINK_INHUMANELY
 
@@ -17,31 +17,32 @@
 	. = ..()
 	var/area/current_area = get_area(bloodsuckerdatum.owner.current)
 	if(istype(current_area, /area/station/service/chapel))
-		to_chat(bloodsuckerdatum.owner.current, span_warning("You don't belong in holy areas! The Faith burns you to a crisp!"))
+		to_chat(bloodsuckerdatum.owner.current, span_warning("You don't belong in holy areas! The faith burns you to a crisp!"))
 		bloodsuckerdatum.owner.current.adjustFireLoss(20)
 		bloodsuckerdatum.owner.current.adjust_fire_stacks(2)
 		bloodsuckerdatum.owner.current.ignite_mob()
 
 /datum/bloodsucker_clan/toreador
 	name = CLAN_TOREADOR
-	description = "The most charming Clan of them all, allowing them to very easily disguise among the crew. \n\
-		More in touch with their morals, they suffer and benefit more strongly from humanity cost or gain of their actions. \n\
-		Known as 'The most humane kind of vampire', they have an obsession with perfectionism and beauty \n\
-		The Favorite Vassal gains the Mesmerize ability."
+	description = "The most charming clan, whose members may easily conceal themselves within the crew. \n\
+		More in touch with their morals, they are greatly impacted by the humanity of their actions. \n\
+		Known as the most \"humane\" kind of vampire, they are perfectionists obsessed with vanity. \n\
+		Their favorite vassal gains the Mesmerize ability."
 	joinable_clan = FALSE
 	blood_drink_type = BLOODSUCKER_DRINK_SNOBBY
 
 /datum/bloodsucker_clan/brujah
 	name = CLAN_BRUJAH
-	description = "The Brujah Clan has proven to be the strongest in melee combat, boasting a powerful punch. \n\
-		They also appear to be more calm than the others, entering their 'frenzies' whenever they want, but dont seem affected much by them. \n\
-		Be wary, as they are fearsome warriors, rebels and anarchists, with an inclination towards Frenzy. \n\
-		The Favorite Vassal gains brawn and a massive increase in brute damage from punching."
+	description = "The Brujah clan has proven to be the strongest in melee combat, boasting a powerful punch. \n\
+		They appear to be calmer than their kin, entering their \"frenzies\" whenever they want but conversely being less affected by them. \n\
+		Be wary, as they are fearsome insurgents, rebels, and anarchists, with an inclination towards chaos. \n\
+		Their favorite vassal gains Brawn and substantially strengthened fists."
 	joinable_clan = FALSE
 
 /datum/bloodsucker_clan/tzimisce
 	name = CLAN_TZIMISCE
-	description = "The Tzimisce Clan has no knowledge about it. \n\
-		If you see one, you should probably run away.\n\
-		*the rest of the page is full of undecipherable scribbles...*"
+	description = "Much of the information about the Tzimisce clan has yet to be reliably confirmed. \n\
+		Most accounts indicate that they are amiable and often kinder than those of other clans, but when. . . \n\
+		. . .are also. . . \n\
+		. . .DO Ṉ̷̎O̶̯͂T UNDER ANY C̵I̸R̸C̶U̶M̷S̴T̸A̴N—. . ."
 	joinable_clan = FALSE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_malkavian.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_malkavian.dm
@@ -1,10 +1,11 @@
 /datum/bloodsucker_clan/malkavian
 	name = CLAN_MALKAVIAN
-	description = "Little is documented about Malkavians. Complete insanity is the most common theme. \n\
-		The Favorite Vassal will suffer the same fate as the Master."
+	description = "The history of the Malkavian clan is not well known, even to most modern Malkavians. \n\
+		Complete insanity and an almost puritanical devotion to the Masquerade are the most common themes throughout the literature. \n\
+		Their favorite vassal suffers from insanity just as they do."
 	join_icon_state = "malkavian"
-	join_description = "Completely insane. You gain constant hallucinations, become a prophet with unintelligable rambling, \
-		and become the enforcer of the Masquerade code."
+	join_description = "Become completely insane, travel through tears in reality, ramble in whispers constantly, \
+		and become an enforcer of the Masquerade."
 	blood_drink_type = BLOODSUCKER_DRINK_INHUMANELY
 
 /datum/bloodsucker_clan/malkavian/on_enter_frenzy(datum/antagonist/bloodsucker/source)
@@ -48,7 +49,7 @@
 	if(istype(carbonowner))
 		carbonowner.gain_trauma(/datum/brain_trauma/mild/hallucinations, TRAUMA_RESILIENCE_ABSOLUTE)
 		carbonowner.gain_trauma(/datum/brain_trauma/special/bluespace_prophet/phobetor, TRAUMA_RESILIENCE_ABSOLUTE)
-	to_chat(vassaldatum.owner.current, span_notice("Additionally, you now suffer the same fate as your Master."))
+	to_chat(vassaldatum.owner.current, span_notice("Additionally, you now suffer the same fate as your master."))
 
 /datum/bloodsucker_clan/malkavian/on_exit_torpor(datum/antagonist/bloodsucker/source)
 	var/mob/living/carbon/carbonowner = bloodsuckerdatum.owner.current

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_nosferatu.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_nosferatu.dm
@@ -1,13 +1,13 @@
 /datum/bloodsucker_clan/nosferatu
 	name = CLAN_NOSFERATU
-	description = "The Nosferatu Clan is unable to blend in with the crew, with no abilities such as Masquerade and Veil. \n\
-		Additionally, has a permanent bad back and looks like a Bloodsucker upon a simple examine, and is entirely unidentifiable, \n\
-		they can fit in the vents regardless of their form and equipment. \n\
-		The Favorite Vassal is permanetly disfigured, and can also ventcrawl, but only while entirely nude."
+	description = "The Nosferatu clan is unable to blend in with the crew, with no human mimicry abilities such as Masquerade or Veil. \n\
+		Additionally, they have a permanent bad back, are completely unrecognizable, and look like a Bloodsucker at a simple glance.  \n\
+		They can fit in vents regardless of their form and equipment. \n\
+		Their favorite vassal becomes permanetly disfigured, and can also ventcrawl though only while entirely nude."
 	clan_objective = /datum/objective/nosferatu_clan_objective
 	join_icon_state = "nosferatu"
 	join_description = "You are permanetly disfigured, look like a Bloodsucker to all who examine you, \
-		lose your Masquerade ability, but gain the ability to Ventcrawl even while clothed."
+		lose your Masquerade ability, but become capable of ventcrawling."
 	blood_drink_type = BLOODSUCKER_DRINK_INHUMANELY
 
 /datum/bloodsucker_clan/nosferatu/New(datum/antagonist/bloodsucker/owner_datum)
@@ -42,7 +42,7 @@
  */
 /datum/objective/nosferatu_clan_objective
 	name = "steal kindred"
-	explanation_text = "Ensure Nosferatu steals and keeps control over the Archive of the Kindred."
+	explanation_text = "Ensure that the <i>Archives of the Kindred</i> are stolen by a Bloodsucker."
 
 /datum/objective/nosferatu_clan_objective/check_completion()
 	for(var/datum/mind/bloodsucker_minds as anything in get_antag_minds(/datum/antagonist/bloodsucker))

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_tremere.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_tremere.dm
@@ -1,13 +1,13 @@
 /datum/bloodsucker_clan/tremere
 	name = CLAN_TREMERE
-	description = "The Tremere Clan is extremely weak to True Faith, and will burn when entering areas considered such, like the Chapel. \n\
-		Additionally, a whole new moveset is learned, built on Blood magic rather than Blood abilities, which are upgraded overtime. \n\
-		More ranks can be gained by Vassalizing crewmembers. \n\
-		The Favorite Vassal gains the Batform spell, being able to morph themselves at will."
+	description = "The Tremere clan is extremely weak to True Faith, and will burn when entering hallowed areas. \n\
+		Additionally, the Tremere possess a unique moveset built on blood magic rather than blood abilities. \n\
+		They can gain extra ranks by vassalizing crewmembers, and level up their three default spells instead of gaining new ones. \n\
+		Their favorite vassal gains the Batform spell, which allows them to turn into a bat at will."
 	clan_objective = /datum/objective/tremere_clan_objective
 	join_icon_state = "tremere"
-	join_description = "You will burn if you enter the Chapel, lose all default powers, \
-		but gain Blood Magic instead, powers you level up overtime."
+	join_description = "You will burn if you enter the chapel, lose all default powers, \
+		but gain blood spells instead, which are individually leveled up over time."
 
 /datum/bloodsucker_clan/tremere/New(mob/living/carbon/user)
 	. = ..()
@@ -45,7 +45,7 @@
 		to_chat(bloodsuckerdatum.owner.current, span_notice("You grow more ancient by the night!"))
 	else
 		// Give them the UI to purchase a power.
-		var/choice = tgui_input_list(bloodsuckerdatum.owner.current, "You have the opportunity to grow more ancient. Select a power you wish to upgrade.", "Your Blood Thickens...", options)
+		var/choice = tgui_input_list(bloodsuckerdatum.owner.current, "You have the opportunity to grow more ancient. Select a spell you wish to upgrade.", "Your Blood Thickens...", options)
 		// Prevent Bloodsuckers from closing/reopning their coffin to spam Levels.
 		if(cost_rank && bloodsuckerdatum.bloodsucker_level_unspent <= 0)
 			return
@@ -55,7 +55,7 @@
 			return
 		// Prevent Bloodsuckers from purchasing a power while outside of their Coffin.
 		if(!istype(bloodsuckerdatum.owner.current.loc, /obj/structure/closet/crate/coffin))
-			to_chat(bloodsuckerdatum.owner.current, span_warning("You must be in your Coffin to purchase Powers."))
+			to_chat(bloodsuckerdatum.owner.current, span_warning("You must be in your coffin to purchase spells."))
 			return
 
 		// Good to go - Buy Power!
@@ -87,7 +87,7 @@
  */
 /datum/objective/tremere_clan_objective
 	name = "tremerepower"
-	explanation_text = "Upgrade a Blood Magic power to the maximum level, remember that Vassalizing gives more Ranks!"
+	explanation_text = "Upgrade a blood spell to the maximum level, remember that vassalizing gives more ranks!"
 
 /datum/objective/tremere_clan_objective/check_completion()
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = owner.has_antag_datum(/datum/antagonist/bloodsucker)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_vassal.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_vassal.dm
@@ -6,8 +6,8 @@
  */
 /datum/bloodsucker_clan/vassal
 	name = CLAN_VASSAL
-	description = "As a Vassal, you are too young to enter a Clan of your own. \n\
-		Continue to help your Master advance in their aspirations."
+	description = "As a vassal, you are too young to enter a clan of your own. \n\
+		Continue to help your master advance in their aspirations."
 	joinable_clan = FALSE
 	shows_in_archives = FALSE
 	blood_drink_type = BLOODSUCKER_DRINK_SNOBBY //You drink the same as your Master.

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
@@ -5,18 +5,14 @@
 
 /datum/bloodsucker_clan/ventrue
 	name = CLAN_VENTRUE
-	description = "The Ventrue Clan is extremely snobby with their meals, and refuse to drink blood from people without a mind. \n\
-		You may only level yourself up to Level %MAX_LEVEL%, anything further will be ranks to spend on their Favorite Vassal through a Persuasion Rack. \n\
-		The Favorite Vassal will slowly turn more Vampiric this way, until they finally lose their last bits of Humanity."
+	description = "The Ventrue are extremely snobby with their meals, and refuse to drink blood from people without a mind. \n\
+		They may only gain three abilities, with the rest of their progress being given to (and to some extent shared with,) their favorite vassal. \n\
+		Their favorite vassal will slowly turn more vampiric this way, until they finally lose their last bits of their humanity."
 	clan_objective = /datum/objective/ventrue_clan_objective
 	join_icon_state = "ventrue"
-	join_description = "Lose the ability to drink from mindless mobs, can't level up or gain new powers, \
-		instead you raise a vassal into a Bloodsucker."
+	join_description = "Lose the ability to drink from the mindless; become unable to gain more than three powers, \
+		instead raise a vassal into a Bloodsucker."
 	blood_drink_type = BLOODSUCKER_DRINK_SNOBBY
-
-/datum/bloodsucker_clan/ventrue/New(datum/antagonist/bloodsucker/owner_datum)
-	. = ..()
-	description = replacetext(description, "%MAX_LEVEL%", VENTRUE_MAX_LEVEL)
 
 /datum/bloodsucker_clan/ventrue/spend_rank(datum/antagonist/bloodsucker/source, mob/living/carbon/target, cost_rank = TRUE, blood_cost)
 	if(!target)
@@ -70,16 +66,16 @@
 			to_chat(target, span_notice("Your blood begins to feel cold, and as a mote of ash lands upon your tongue, you stop breathing..."))
 		if(3)
 			target.add_traits(list(TRAIT_NOCRITDAMAGE, TRAIT_NOSOFTCRIT), BLOODSUCKER_TRAIT)
-			to_chat(target, span_notice("You feel your Master's blood reinforce you, strengthening you up."))
+			to_chat(target, span_notice("You feel your master's blood improve your endurance, you will not fall that easily."))
 		if(4)
 			target.add_traits(list(TRAIT_SLEEPIMMUNE, TRAIT_VIRUSIMMUNE), BLOODSUCKER_TRAIT)
-			to_chat(target, span_notice("You feel your Master's blood begin to protect you from bacteria."))
+			to_chat(target, span_notice("You feel your master's blood begin to invigorate your thymus."))
 			if(ishuman(target))
 				var/mob/living/carbon/human/human_target = target
 				human_target.skin_tone = "albino"
 		if(5)
 			target.add_traits(list(TRAIT_NOHARDCRIT, TRAIT_HARDLY_WOUNDED), BLOODSUCKER_TRAIT)
-			to_chat(target, span_notice("You feel yourself able to take cuts and stabbings like it's nothing."))
+			to_chat(target, span_notice("Your blood stills, you feel like you'd be able to withstand cuts and stabbings."))
 		if(6 to INFINITY)
 			if(!vassal_bloodsuker_datum)
 				if(vassaldatum.info_button_ref)
@@ -87,7 +83,7 @@
 				vassal_bloodsuker_datum = target.mind.add_antag_datum(/datum/antagonist/bloodsucker)
 				vassal_bloodsuker_datum.my_clan = new /datum/bloodsucker_clan/vassal(src)
 
-				to_chat(target, span_notice("You feel your heart stop pumping for the last time as you begin to thirst for blood, you feel... dead."))
+				to_chat(target, span_cult("You feel your heart pump for the last time as you begin to thirst for blood, you feel... <b>dead</b>."))
 				bloodsuckerdatum.owner.current.add_mood_event("madevamp", /datum/mood_event/madevamp)
 
 			vassaldatum.set_vassal_level(vassal_bloodsuker_datum)
@@ -106,7 +102,7 @@
 		return TRUE
 	if(bloodsuckerdatum.bloodsucker_blood_volume >= BLOODSUCKER_BLOOD_RANKUP_COST)
 		// We don't have any ranks to spare? Let them upgrade... with enough Blood.
-		to_chat(bloodsuckerdatum.owner.current, span_warning("Do you wish to spend [BLOODSUCKER_BLOOD_RANKUP_COST] Blood to Rank [vassaldatum.owner.current] up?"))
+		to_chat(bloodsuckerdatum.owner.current, span_warning("Do you wish to spend [BLOODSUCKER_BLOOD_RANKUP_COST] blood to rank [vassaldatum.owner.current] up?"))
 		var/static/list/rank_options = list(
 			"Yes" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_yes"),
 			"No" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_no"),
@@ -115,11 +111,11 @@
 		if(rank_response == "Yes")
 			bloodsuckerdatum.SpendRank(vassaldatum.owner.current, cost_rank = FALSE, blood_cost = BLOODSUCKER_BLOOD_RANKUP_COST)
 		return TRUE
-	to_chat(bloodsuckerdatum.owner.current, span_danger("You don't have any levels or enough Blood to Rank [vassaldatum.owner.current] up with."))
+	to_chat(bloodsuckerdatum.owner.current, span_danger("You don't have any levels or enough blood to rank [vassaldatum.owner.current] up with."))
 	return TRUE
 
 /datum/bloodsucker_clan/ventrue/on_favorite_vassal(datum/source, datum/antagonist/vassal/favorite/vassaldatum)
-	to_chat(source, span_announce("* Bloodsucker Tip: You can now upgrade your Favorite Vassal by buckling them onto a Candelabrum!"))
+	to_chat(source, span_announce("* Bloodsucker Tip: You can now upgrade your favorite vassal with a persuassion rack!"))
 	vassaldatum.BuyPower(new /datum/action/cooldown/bloodsucker/distress)
 
 #undef BLOODSUCKER_BLOOD_RANKUP_COST
@@ -132,7 +128,7 @@
  */
 /datum/objective/ventrue_clan_objective
 	name = "embrace"
-	explanation_text = "Use the Persuasion Rack to Rank your Favorite Vassal up enough to become a Bloodsucker and keep them alive until the end."
+	explanation_text = "Use a persuasion rack to rank your favorite vassal up enough to become a Bloodsucker and keep them alive until the end."
 	martyr_compatible = TRUE
 
 /datum/objective/ventrue_clan_objective/check_completion()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_ventrue.dm
@@ -7,7 +7,7 @@
 	name = CLAN_VENTRUE
 	description = "The Ventrue are extremely snobby with their meals, and refuse to drink blood from people without a mind. \n\
 		They may only gain three abilities, with the rest of their progress being given to (and to some extent shared with,) their favorite vassal. \n\
-		Their favorite vassal will slowly turn more vampiric this way, until they finally lose their last bits of their humanity."
+		Their favorite vassal will slowly turn more vampiric this way, until they finally lose the last bits of their humanity and become a Fledgling."
 	clan_objective = /datum/objective/ventrue_clan_objective
 	join_icon_state = "ventrue"
 	join_description = "Lose the ability to drink from the mindless; become unable to gain more than three powers, \

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
@@ -43,9 +43,9 @@
 /datum/action/cooldown/bloodsucker/New(Target)
 	. = ..()
 	if(bloodcost > 0)
-		desc += "<br><br><b>COST:</b> [bloodcost] Blood"
+		desc += "<br><br><b>COST:</b> [bloodcost] blood"
 	if(constant_bloodcost > 0)
-		desc += "<br><br><b>CONSTANT COST:</b><i> [name] costs [constant_bloodcost] Blood maintain active.</i>"
+		desc += "<br><br><b>CONSTANT COST:</b><i> [name] costs [constant_bloodcost] blood maintain active.</i>"
 	if(power_flags & BP_AM_SINGLEUSE)
 		desc += "<br><br><b>SINGLE USE:</br><i> [name] can only be used once per night.</i>"
 
@@ -113,7 +113,7 @@
 		return FALSE
 	// Frenzy?
 	if((check_flags & BP_CANT_USE_IN_FRENZY) && (bloodsuckerdatum_power?.frenzied))
-		to_chat(user, span_warning("You cannot use powers while in a Frenzy!"))
+		to_chat(user, span_warning("You cannot use powers while in a frenzy!"))
 		return FALSE
 	// Stake?
 	if((check_flags & BP_CANT_USE_WHILE_STAKED) && user.am_staked())

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/cloak.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/cloak.dm
@@ -1,12 +1,12 @@
 /datum/action/cooldown/bloodsucker/cloak
 	name = "Cloak of Darkness"
-	desc = "Blend into the shadows and become invisible to the untrained and Artificial eye."
+	desc = "Blend into shadow and become invisible to the untrained and artificial eye."
 	button_icon_state = "power_cloak"
 	power_explanation = "Cloak of Darkness:\n\
-		Activate this Power in the shadows and you will slowly turn nearly invisible.\n\
+		Activate this power and you will slowly become transparent.\n\
 		While using Cloak of Darkness, attempting to run will crush you.\n\
-		Additionally, while Cloak is active, you are completely invisible to the AI.\n\
-		Higher levels will increase how invisible you are."
+		Additionally, while Cloak is active, you are completely invisible to AIs.\n\
+		Higher levels will increase your transparency."
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_IN_FRENZY|BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY|VASSAL_CAN_BUY

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
@@ -7,12 +7,12 @@
 	button_icon_state = "power_feed"
 	power_explanation = "Feed:\n\
 		Activate Feed while next to someone and you will begin to feed blood off of them.\n\
-		The time needed before you start feeding speeds up the higher level you are.\n\
+		The time needed before you start feeding decrases as you gain ranks.\n\
 		Feeding off of someone while you have them aggressively grabbed will put them to sleep.\n\
 		While feeding, you can't speak, as your mouth is covered.\n\
-		Feeding while nearby (2 tiles away from) a mortal who is unaware of Bloodsuckers' existence, will cause a Masquerade Infraction\n\
-		If you get too many Masquerade Infractions, you will break the Masquerade.\n\
-		If you are in desperate need of blood, mice can be fed off of, at a cost."
+		Feeding while nearby (2 tiles away from) a mortal who is unaware of Bloodsuckers' existence will cause a Masquerade infraction\n\
+		If you get too many Masquerade infractions, you will break the Masquerade.\n\
+		If you are in desperate need of blood, mice can be fed off of— at a cost..."
 	power_flags = BP_AM_TOGGLE|BP_AM_STATIC_COOLDOWN
 	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_WHILE_STAKED|BP_CANT_USE_WHILE_INCAPACITATED|BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY|BLOODSUCKER_DEFAULT_POWER

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/fortitude.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/fortitude.dm
@@ -4,10 +4,10 @@
 	button_icon_state = "power_fortitude"
 	power_explanation = "Fortitude:\n\
 		Activating Fortitude will provide pierce, stun and dismember immunity.\n\
-		You will additionally gain resistance to Brute and Stamina damge, scaling with level.\n\
+		You will additionally gain resistance to brute and stamina damge, scaling with level.\n\
 		While using Fortitude, attempting to run will crush you.\n\
 		At level 4, you gain complete stun immunity.\n\
-		Higher levels will increase Brute and Stamina resistance."
+		Higher levels will increase brute and stamina resistance."
 	power_flags = BP_AM_TOGGLE|BP_AM_COSTLESS_UNCONSCIOUS
 	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_IN_FRENZY
 	purchase_flags = BLOODSUCKER_CAN_BUY|VASSAL_CAN_BUY

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
@@ -15,10 +15,10 @@
 	active_background_icon_state = "vamp_power_off_oneshot"
 	base_background_icon_state = "vamp_power_off_oneshot"
 	power_explanation = "Vanishing Act: \n\
-		Activating Vanishing Act will, after a short delay, teleport the user to their Claimed Coffin. \n\
-		The power will cancel out if the Claimed Coffin is somehow destroyed. \n\
+		Activating Vanishing Act will, after a short delay, teleport the user to their claimed coffin. \n\
+		The power will cancel out if the claimed coffin is somehow destroyed. \n\
 		Immediately after activating, lights around the user will begin to flicker. \n\
-		Once the user teleports to their coffin, in their place will be a Rat or Bat."
+		Once the user teleports to their coffin, a rat or bat will appear at their prior location."
 	power_flags = BP_AM_TOGGLE|BP_AM_SINGLEUSE|BP_AM_STATIC_COOLDOWN
 	check_flags = BP_CANT_USE_IN_FRENZY|BP_CANT_USE_WHILE_STAKED
 	purchase_flags = NONE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/masquerade.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/masquerade.dm
@@ -17,7 +17,7 @@
 	power_explanation = "Masquerade:\n\
 		Activating Masquerade will physiologically make you identical to a human;\n\
 		- You lose nearly all Bloodsucker benefits, including healing, sleep, radiation, crit, virus and cold immunity.\n\
-		- Your eyes turn to that of a regular human as your heart begins to beat.\n\
+		- Your eyes become less vulnerable to bright lights.\n\
 		- You gain a genetic sequence, and appear to have 100% blood when scanned by a health analyzer.\n\
 		- You will not appear as pale when examined. Anything further than pale, however, will not be hidden.\n\
 		At the end of Masquerade you will re-gain your vampiric qualities and lose any diseases or genetic alterations you might have."
@@ -71,7 +71,7 @@
 	var/obj/item/organ/internal/eyes/eyes = user.get_organ_slot(ORGAN_SLOT_EYES)
 	if(eyes)
 		eyes.flash_protect = max(initial(eyes.flash_protect) - 1, FLASH_PROTECTION_SENSITIVE)
-	to_chat(user, span_notice("Your heart beats one final time, while your skin dries out and your icy pallor returns."))
+	to_chat(user, span_notice("Your heart beats one final time as your skin dries out and your icy pallor returns."))
 
 /**
  * # Status effect

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/masquerade.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/masquerade.dm
@@ -15,12 +15,12 @@
 	desc = "Feign the vital signs of a mortal, and escape both casual and medical notice as the monster you truly are."
 	button_icon_state = "power_human"
 	power_explanation = "Masquerade:\n\
-		Activating Masquerade will forge your identity to be practically identical to that of a human;\n\
+		Activating Masquerade will physiologically make you identical to a human;\n\
 		- You lose nearly all Bloodsucker benefits, including healing, sleep, radiation, crit, virus and cold immunity.\n\
 		- Your eyes turn to that of a regular human as your heart begins to beat.\n\
-		- You gain a Genetic sequence, and appear to have 100% blood when scanned by a Health Analyzer.\n\
-		- You will not appear as Pale when examined. Anything further than Pale, however, will not be hidden.\n\
-		At the end of a Masquerade, you will re-gain your Vampiric abilities, as well as lose any Disease & Gene you might have."
+		- You gain a genetic sequence, and appear to have 100% blood when scanned by a health analyzer.\n\
+		- You will not appear as pale when examined. Anything further than pale, however, will not be hidden.\n\
+		At the end of Masquerade you will re-gain your vampiric qualities and lose any diseases or genetic alterations you might have."
 	power_flags = BP_AM_TOGGLE|BP_AM_STATIC_COOLDOWN|BP_AM_COSTLESS_UNCONSCIOUS
 	check_flags = BP_CANT_USE_IN_FRENZY
 	purchase_flags = BLOODSUCKER_CAN_BUY|BLOODSUCKER_DEFAULT_POWER
@@ -87,7 +87,7 @@
 
 /atom/movable/screen/alert/status_effect/masquerade
 	name = "Masquerade"
-	desc = "You are currently hiding your identity using the Masquerade power. This halts Vampiric healing."
+	desc = "You are currently hiding your true nature using the Masquerade power. This halts vampiric healing."
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/actions_bloodsucker.dmi'
 	icon_state = "power_human"
 	alerttooltipstyle = "cult"

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/brawn.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/brawn.dm
@@ -1,13 +1,13 @@
 /datum/action/cooldown/bloodsucker/targeted/brawn
 	name = "Brawn"
-	desc = "Snap restraints, break lockers and doors, or deal terrible damage with your bare hands."
+	desc = "Snap restraints, break lockers and doors, or deal substantial damage with your bare hands."
 	button_icon_state = "power_strength"
 	power_explanation = "Brawn:\n\
-		Click any person to bash into them, break restraints you have or knocking a grabber down. Only one of these can be done per use.\n\
-		Punching a Cyborg will heavily EMP them in addition to deal damage.\n\
-		At level 3, you get the ability to break closets open, additionally can both break restraints AND knock a grabber down in the same use.\n\
-		At level 4, you get the ability to bash airlocks open, as long as they aren't bolted.\n\
-		Higher levels will increase the damage and knockdown when punching someone."
+		Click a person to bash into them. Use while restrained or grabbed to break restraints or knock your grabber down. Only one of these can be done per use.\n\
+		Punching a cyborg will heavily EMP them in addition to dealing damage.\n\
+		At level 3, this ability will break closets open. Additionally you may both break restraints <i>and</i> knock a grabber down in the same use.\n\
+		At level 4, this ability wlil bash airlocks open as long as they aren't bolted.\n\
+		Higher levels will increase this ability's damage and knockdown."
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_IN_FRENZY|BP_CANT_USE_WHILE_INCAPACITATED|BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY|VASSAL_CAN_BUY
@@ -53,8 +53,8 @@
 	var/obj/legcuffs = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
 	if(!used && (istype(cuffs) || istype(legcuffs)))
 		user.visible_message(
-			span_warning("[user] discards their restraints like it's nothing!"),
-			span_warning("We break through our restraints!"),
+			span_warning("[user] breaks their restraint like it's nothing!"),
+			span_warning("We break through our restraint!"),
 		)
 		user.clear_cuffs(cuffs, TRUE)
 		user.clear_cuffs(legcuffs, TRUE)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/haste.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/haste.dm
@@ -5,11 +5,11 @@
 
 /datum/action/cooldown/bloodsucker/targeted/haste
 	name = "Immortal Haste"
-	desc = "Dash somewhere with supernatural speed. Those nearby may be knocked away, stunned, or left empty-handed."
+	desc = "Dash somewhere with supernatural speed. Those in your path may be knocked away, stunned, or left empty-handed."
 	button_icon_state = "power_speed"
 	power_explanation = "Immortal Haste:\n\
-		Click anywhere to immediately dash towards that location.\n\
-		The Power will not work if you are lying down, in no gravity, or are aggressively grabbed.\n\
+		Click a location to immediately dash towards it.\n\
+		The power will not work if you are lying down, not under gravitational force, or are aggressively grabbed.\n\
 		Anyone in your way during your Haste will be knocked down.\n\
 		Higher levels will increase the knockdown dealt to enemies."
 	power_flags = BP_AM_TOGGLE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/lunge.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/lunge.dm
@@ -1,14 +1,14 @@
 /datum/action/cooldown/bloodsucker/targeted/lunge
 	name = "Predatory Lunge"
-	desc = "Spring at your target to grapple them without warning, or tear the dead's heart out. Attacks from concealment or the rear may even knock them down if strong enough."
+	desc = "Spring at your target to grapple them without warning, or tear their heart out if they're dead. Attacks from concealment or the rear may even knock them down if strong enough."
 	button_icon_state = "power_lunge"
 	power_explanation = "Predatory Lunge:\n\
-		Click any player to start spinning wildly and, after a short delay, dash at them.\n\
-		When lunging at someone, you will grab them, immediately starting off at aggressive.\n\
-		Riot gear and Monster Hunters are protected and will only be passively grabbed.\n\
-		You cannot use the Power if you are already grabbing someone, or are being grabbed.\n\
-		If you grab from behind, or from darkness (Cloak of Darkness works), you will knock the target down.\n\
-		If used on a dead body, will tear their heart out.\n\
+		Click any person to start spinning wildly and, after a short delay, dash at them.\n\
+		When the dash is complete you will have an aggressive hold on your target.\n\
+		Monster Hunters and those with riot gear are protected and will only be passively grabbed.\n\
+		You cannot use this power if you are already grabbing someone, or are being grabbed.\n\
+		If you grab from behind, or from darkness (Cloak of Darkness works,) you will knock the target down.\n\
+		If used on a dead body, you will tear its heart out.\n\
 		Higher levels increase the knockdown dealt to enemies.\n\
 		At level 4, you will no longer spin, but you will be limited to tackling from only 6 tiles away."
 	power_flags = NONE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/mesmerize.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/mesmerize.dm
@@ -13,13 +13,13 @@
 	button_icon_state = "power_mez"
 	power_explanation = "Mesmerize:\n\
 		Click any player to attempt to mesmerize them.\n\
-		You cannot wear anything covering your face, and both parties must be facing eachother. Obviously, both parties need to not be blind. \n\
-		If your target is already mesmerized or a Monster Hunter, the Power will fail.\n\
+		You cannot wear anything covering your face, and both parties must be facing eachother. This does not work if anyone involved is blind, obviously. \n\
+		If your target is already mesmerized or a Monster Hunter then the power will fail.\n\
 		Once mesmerized, the target will be unable to move for a certain amount of time, scaling with level.\n\
 		At level 2, your target will additionally be muted.\n\
 		At level 3, you will be able to use the power through items covering your face.\n\
 		At level 5, you will be able to mesmerize regardless of your target's direction.\n\
-		Higher levels will increase the time of the mesmerize's freeze."
+		Higher levels will increase the time of the victim's paralysis."
 	power_flags = NONE
 	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_IN_FRENZY|BP_CANT_USE_WHILE_INCAPACITATED|BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY|VASSAL_CAN_BUY

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/trespass.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/trespass.dm
@@ -1,11 +1,11 @@
 /datum/action/cooldown/bloodsucker/targeted/trespass
 	name = "Trespass"
-	desc = "Become mist and advance two tiles in one direction. Useful for skipping past doors and barricades."
+	desc = "Become mist and advance up to two tiles away. Useful for skipping past doors and barricades— or making a stylish entrance."
 	button_icon_state = "power_tres"
 	power_explanation = "Trespass:\n\
-		Click anywhere from 1-2 tiles away from you to teleport.\n\
-		This power goes through all obstacles except Walls.\n\
-		Higher levels decrease the sound played from using the Power, and increase the speed of the transition."
+		Click anywhere within one to two tiles to teleport there.\n\
+		This power goes through all obstacles except walls.\n\
+		Higher levels make the power faster and quieter."
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_WHILE_INCAPACITATED|BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY|VASSAL_CAN_BUY

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/auspex.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/auspex.dm
@@ -17,8 +17,8 @@
 	desc = "Hide yourself within a Cloak of Darkness, click on an area to teleport up to 2 tiles away."
 	button_icon_state = "power_auspex"
 	power_explanation = "Level 1: Auspex:\n\
-		When Activated, you will be hidden in a Cloak of Darkness.\n\
-		Click any area up to 2 tile away to teleport there, ending the Power."
+		When activated you will be hidden in a Cloak of Darkness.\n\
+		Click any area up to 2 tiles away to teleport there, ending the power."
 	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_WHILE_INCAPACITATED|BP_CANT_USE_WHILE_UNCONSCIOUS
 	bloodcost = 5
 	constant_bloodcost = 2
@@ -32,8 +32,8 @@
 	level_current = 2
 	desc = "Hide yourself within a Cloak of Darkness, click on an area to teleport up to 3 tiles away."
 	power_explanation = "Level 2: Auspex:\n\
-		When Activated, you will be hidden in a Cloak of Darkness.\n\
-		Click any area up to 3 tile away to teleport there, ending the Power."
+		When activated you will be hidden in a Cloak of Darkness.\n\
+		Click any area up to 3 tiles away to teleport there, ending the power."
 	bloodcost = 10
 	cooldown_time = 10 SECONDS
 	target_range = 3
@@ -44,8 +44,8 @@
 	level_current = 3
 	desc = "Hide yourself within a Cloak of Darkness, click on an area to teleport."
 	power_explanation = "Level 3: Auspex:\n\
-		When Activated, you will be hidden in a Cloak of Darkness.\n\
-		Click any area up to teleport there, ending the Power."
+		When activated you will be hidden in a Cloak of Darkness.\n\
+		Click any area to teleport there, ending the power."
 	bloodcost = 15
 	cooldown_time = 8 SECONDS
 	target_range = null
@@ -56,8 +56,8 @@
 	level_current = 4
 	desc = "Hide yourself within a Cloak of Darkness, click on an area to teleport, leaving nearby people bleeding."
 	power_explanation = "Level 4: Auspex:\n\
-		When Activated, you will be hidden in a Cloak of Darkness.\n\
-		Click any area up to teleport there, ending the Power and causing people at your end location to start bleeding."
+		When activated you will be hidden in a Cloak of Darkness.\n\
+		Click any area to teleport there, ending the power and causing people at your end location to start bleeding."
 	background_icon_state = "tremere_power_gold_off"
 	active_background_icon_state = "tremere_power_gold_on"
 	base_background_icon_state = "tremere_power_gold_off"
@@ -71,8 +71,8 @@
 	level_current = 5
 	desc = "Hide yourself within a Cloak of Darkness, click on an area to teleport, leaving nearby people bleeding and asleep."
 	power_explanation = "Level 5: Auspex:\n\
-		When Activated, you will be hidden in a Cloak of Darkness.\n\
-		Click any area up to teleport there, ending the Power and causing people at your end location to fall over in pain."
+		When activated you will be hidden in a Cloak of Darkness.\n\
+		Click any area up to teleport there, ending the power and causing people at your end location to fall over in pain."
 	bloodcost = 25
 	cooldown_time = 8 SECONDS
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/dominate.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/dominate.dm
@@ -17,7 +17,7 @@
 	desc = "Mesmerize any foe who stands still long enough."
 	button_icon_state = "power_dominate"
 	power_explanation = "Level 1: Dominate:\n\
-		Click any person to, after a 4 second timer, Mesmerize them.\n\
+		Click any person to mesmerize them after four seconds.\n\
 		This will completely immobilize them for the next 10.5 seconds."
 	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_IN_FRENZY|BP_CANT_USE_WHILE_UNCONSCIOUS
 	bloodcost = 15
@@ -32,7 +32,7 @@
 	level_current = 2
 	desc = "Mesmerize and mute any foe who stands still long enough."
 	power_explanation = "Level 2: Dominate:\n\
-		Click any person to, after a 4 second timer, Mesmerize them.\n\
+		Click any person to mesmerize them after four seconds.\n\
 		This will completely immobilize and mute them for the next 12 seconds."
 	bloodcost = 20
 	cooldown_time = 40 SECONDS
@@ -43,7 +43,7 @@
 	level_current = 3
 	desc = "Mesmerize, mute and blind any foe who stands still long enough."
 	power_explanation = "Level 3: Dominate:\n\
-		Click any person to, after a 4 second timer, Mesmerize them.\n\
+		Click any person to mesmerize them after four seconds.\n\
 		This will completely immobilize, mute, and blind them for the next 13.5 seconds."
 	bloodcost = 30
 	cooldown_time = 35 SECONDS
@@ -68,13 +68,13 @@
 	name = "Level 4: Possession"
 	upgraded_power = /datum/action/cooldown/bloodsucker/targeted/tremere/dominate/advanced/two
 	level_current = 4
-	desc = "Mesmerize, mute and blind any foe who stands still long enough, or convert the damaged to temporary Vassals."
+	desc = "Mesmerize, mute and blind any foe who stands still long enough, or convert the damaged to temporary vassals."
 	power_explanation = "Level 4: Possession:\n\
-		Click any person to, after a 4 second timer, Mesmerize them.\n\
+		Click any person to mesmerize them after four seconds.\n\
 		This will completely immobilize, mute, and blind them for the next 13.5 seconds.\n\
-		However, while adjacent to the target, if your target is in critical condition or dead, they will instead be turned into a temporary Vassal.\n\
-		If you use this on a currently dead normal Vassal, you will instead revive them normally.\n\
-		Despite being Mute and Deaf, they will still have complete loyalty to you, until their death in 5 minutes upon use."
+		However, if your target is in critical condition or dead and you are adjacent to them, they will instead be turned into a temporary vassal.\n\
+		If you use this on a currently dead full-time vassal, you will instead revive them normally.\n\
+		Despite being mute and deaf, they will still have complete loyalty to you, but <b>they will die five minutes after use</b>."
 	background_icon_state = "tremere_power_gold_off"
 	active_background_icon_state = "tremere_power_gold_on"
 	base_background_icon_state = "tremere_power_gold_off"
@@ -83,15 +83,15 @@
 
 /datum/action/cooldown/bloodsucker/targeted/tremere/dominate/advanced/two
 	name = "Level 5: Possession"
-	desc = "Mesmerize, mute and blind any foe who stands still long enough, or convert the damaged to temporary Vassals."
+	desc = "Mesmerize, mute and blind any foe who stands still long enough, or convert the damaged to temporary vassals."
 	level_current = 5
 	upgraded_power = null
 	power_explanation = "Level 5: Possession:\n\
-		Click any person to, after a 4 second timer, Mesmerize them.\n\
+		Click any person to mesmerize them after four seconds.\n\
 		This will completely immobilize, mute, and blind them for the next 13.5 seconds.\n\
-		However, while adjacent to the target, if your target is in critical condition or dead, they will instead be turned into a temporary Vassal.\n\
-		If you use this on a currently dead normal Vassal, you will instead revive them normally.\n\
-		They will have complete loyalty to you, until their death in 8 minutes upon use."
+		However, if your target is in critical condition or dead and you are adjacent to them, they will instead be turned into a temporary vassal.\n\
+		If you use this on a currently dead full-time vassal, you will instead revive them normally.\n\
+		They will have complete loyalty to you, but <b>they will die eight minutes after use</b>."
 	bloodcost = 100
 	cooldown_time = 2 MINUTES
 
@@ -187,5 +187,5 @@
 /datum/action/cooldown/bloodsucker/targeted/tremere/proc/end_possession(mob/living/user)
 	user.remove_traits(list(TRAIT_MUTE, TRAIT_DEAF), BLOODSUCKER_TRAIT)
 	user.mind.remove_antag_datum(/datum/antagonist/vassal)
-	to_chat(user, span_warning("You feel the Blood of your Master run out!"))
+	to_chat(user, span_warning("You feel the blood of your master run out! Your time amongst the living was much more temporary than you intially thought!"))
 	user.death()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/thaumaturgy.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/thaumaturgy.dm
@@ -11,11 +11,11 @@
 /datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy
 	name = "Level 1: Thaumaturgy"
 	upgraded_power = /datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/two
-	desc = "Fire a blood bolt at your enemy, dealing Burn damage."
+	desc = "Fire a blood bolt at your enemy, dealing burn damage."
 	level_current = 1
 	button_icon_state = "power_thaumaturgy"
 	power_explanation = "Thaumaturgy:\n\
-		Gives you a one shot blood bolt spell, firing it at a person deals 20 Burn damage"
+		Gives you a one shot blood bolt spell, firing it at a person deals 20 burn damage"
 	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_IN_FRENZY|BP_CANT_USE_WHILE_UNCONSCIOUS
 	bloodcost = 20
 	constant_bloodcost = 0
@@ -27,13 +27,13 @@
 /datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/two
 	name = "Level 2: Thaumaturgy"
 	upgraded_power = /datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/three
-	desc = "Create a Blood shield and fire a blood bolt at your enemy, dealing Burn damage."
+	desc = "Create a blood shield and fire a blood bolt at your enemy, dealing burn damage."
 	level_current = 2
 	power_explanation = "Thaumaturgy:\n\
-		Activating Thaumaturgy will temporarily give you a Blood Shield,\n\
-		The blood shield has a 75% block chance, but costs 15 Blood per hit to maintain.\n\
-		You will also have the ability to fire a Blood beam, ending the Power.\n\
-		If the Blood beam hits a person, it will deal 20 Burn damage."
+		Activating Thaumaturgy will temporarily give you a blood shield,\n\
+		The blood shield has a 75% block chance, but costs 15 blood per hit to maintain.\n\
+		You will also have the ability to fire a blood beam, ending the power.\n\
+		If the blood beam hits a person, it will deal 20 burn damage."
 	prefire_message = "Click where you wish to fire (using your power removes blood shield)."
 	bloodcost = 40
 	cooldown_time = 4 SECONDS
@@ -41,26 +41,26 @@
 /datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/three
 	name = "Level 3: Thaumaturgy"
 	upgraded_power = /datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/advanced
-	desc = "Create a Blood shield and fire a blood bolt, dealing Burn damage and opening doors/lockers."
+	desc = "Create a blood shield and fire a blood bolt, dealing burn damage and opening doors/lockers."
 	level_current = 3
 	power_explanation = "Thaumaturgy:\n\
-		Activating Thaumaturgy will temporarily give you a Blood Shield,\n\
-		The blood shield has a 75% block chance, but costs 15 Blood per hit to maintain.\n\
-		You will also have the ability to fire a Blood beam, ending the Power.\n\
-		If the Blood beam hits a person, it will deal 20 Burn damage. If it hits a locker or door, it will break it open."
+		Activating Thaumaturgy will temporarily give you a blood shield,\n\
+		The blood shield has a 75% block chance, but costs 15 blood per hit to maintain.\n\
+		You will also have the ability to fire a blood beam, ending the power.\n\
+		If the blood beam hits a person, it will deal 20 burn damage. If it hits a locker or door, it will break it open."
 	bloodcost = 50
 	cooldown_time = 6 SECONDS
 
 /datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/advanced
 	name = "Level 4: Blood Strike"
 	upgraded_power = /datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/advanced/two
-	desc = "Create a Blood shield and fire a blood bolt, dealing Burn damage and opening doors/lockers."
+	desc = "Create a blood shield and fire a blood bolt, dealing burn damage and opening doors/lockers."
 	level_current = 4
 	power_explanation = "Thaumaturgy:\n\
-		Activating Thaumaturgy will temporarily give you a Blood Shield,\n\
+		Activating Thaumaturgy will temporarily give you a blood shield,\n\
 		The blood shield has a 75% block chance, but costs 15 Blood per hit to maintain.\n\
-		You will also have the ability to fire a Blood beam, ending the Power.\n\
-		If the Blood beam hits a person, it will deal 40 Burn damage.\n\
+		You will also have the ability to fire a blood beam, ending the power.\n\
+		If the blood beam hits a person, it will deal 40 burn damage.\n\
 		If it hits a locker or door, it will break it open."
 	background_icon_state = "tremere_power_gold_off"
 	active_background_icon_state = "tremere_power_gold_on"
@@ -72,13 +72,13 @@
 /datum/action/cooldown/bloodsucker/targeted/tremere/thaumaturgy/advanced/two
 	name = "Level 5: Blood Strike"
 	upgraded_power = null
-	desc = "Create a Blood shield and fire a blood bolt, dealing Burn damage, stealing Blood and opening doors/lockers."
+	desc = "Create a blood shield and fire a blood bolt, dealing burn damage, refunding a bit of blood on hitting a mortal, and opening doors/lockers."
 	level_current = 5
 	power_explanation = "Thaumaturgy:\n\
-		Activating Thaumaturgy will temporarily give you a Blood Shield,\n\
-		The blood shield has a 75% block chance, but costs 15 Blood per hit to maintain.\n\
-		You will also have the ability to fire a Blood beam, ending the Power.\n\
-		If the Blood beam hits a person, it will deal 40 Burn damage and steal blood to feed yourself, though at a net-negative.\n\
+		Activating Thaumaturgy will temporarily give you a blood shield,\n\
+		The blood shield has a 75% block chance, but costs 15 blood per hit to maintain.\n\
+		You will also have the ability to fire a blood beam, ending the power.\n\
+		If the blood beam hits a person, it will deal 40 burn damage and steal blood to feed yourself, though at a net-negative.\n\
 		If it hits a locker or door, it will break it open."
 	bloodcost = 80
 	cooldown_time = 8 SECONDS
@@ -95,7 +95,7 @@
 			return FALSE
 		owner.visible_message(
 			span_warning("[owner]\'s hands begins to bleed and forms into a blood shield!"),
-			span_warning("We activate our Blood shield!"),
+			span_warning("We activate our blood shield!"),
 			span_hear("You hear liquids forming together."),
 		)
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/distress.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/distress.dm
@@ -1,9 +1,9 @@
 /datum/action/cooldown/bloodsucker/distress
 	name = "Distress"
-	desc = "Injure yourself, allowing you to make a desperate call for help to your Master."
+	desc = "Injure yourself to make a desperate call for help to your Master."
 	button_icon_state = "power_distress"
 	power_explanation = "Distress:\n\
-		Use this Power from anywhere and your Master Bloodsucker will instantly be alerted of your location."
+		Use this Power from anywhere and your master Bloodsucker will instantly be alerted of your location."
 	power_flags = NONE
 	check_flags = NONE
 	purchase_flags = NONE
@@ -16,7 +16,7 @@
 	var/datum/antagonist/vassal/vassaldatum = owner.mind.has_antag_datum(/datum/antagonist/vassal)
 
 	owner.balloon_alert(owner, "you call out for your master!")
-	to_chat(vassaldatum.master.owner, span_userdanger("[owner], your loyal Vassal, is desperately calling for aid at [target_area]!"))
+	to_chat(vassaldatum.master.owner, span_userdanger("[owner], your loyal vassal, is desperately calling for aid at [target_area]!"))
 
 	var/mob/living/user = owner
 	user.adjustBruteLoss(10)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/recuperate.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/recuperate.dm
@@ -1,13 +1,13 @@
 /// Used by Vassals
 /datum/action/cooldown/bloodsucker/recuperate
 	name = "Sanguine Recuperation"
-	desc = "Slowly heals you overtime using your master's blood, in exchange for some of your own blood and effort."
+	desc = "Slowly heals you overtime using a combination of your master's blood and your own."
 	button_icon_state = "power_recup"
 	power_explanation = "Recuperate:\n\
-		Activating this Power will begin to heal your wounds.\n\
-		You will heal Brute and Toxin damage, at the cost of Stamina damage, and blood from both you and your Master.\n\
-		If you aren't a bloodless race, you will additionally heal Burn damage.\n\
-		The power will cancel out if you are incapacitated or dead."
+		Activating this power will begin to heal your wounds.\n\
+		You will heal brute and toxin damage at the cost of stamina damage and blood from both you and your master.\n\
+		If you aren't a bloodless race, you will additionally heal burn damage.\n\
+		The power will halt if you are incapacitated or dead."
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_WHILE_INCAPACITATED
 	purchase_flags = NONE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/vassal_fold.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/vassal_fold.dm
@@ -1,12 +1,12 @@
 /datum/action/cooldown/bloodsucker/vassal_blood
 	name = "Help Vassal"
-	desc = "Bring an ex-Vassal back into the fold, or create blood using a bag. RMB: Check Vassal status."
+	desc = "Bring an ex-vassal back into the fold, or create blood using a bag. RMB: Check vassal status."
 	button_icon_state = "power_torpor"
-	power_explanation = "Help Vassal:\n\
-		Use this power while you have an ex-Vassal grabbed to bring them back into the fold. \
-		Use this power with a bloodbag in your hand to instead fill it with Vampiric Blood which \
+	power_explanation = "Help vassal:\n\
+		Use this power while you have an ex-vassal grabbed to bring them back into the fold. \
+		Use this power with a bloodbag in your hand to instead fill it with vampiric blood which \
 		can be used to reset ex-vassal deconversion timers. \
-		Right-Click will show the status of all Vassals."
+		Right-Click will show the status of all vassals."
 	power_flags = NONE
 	check_flags = NONE
 	purchase_flags = NONE
@@ -58,7 +58,7 @@
 	if(trigger_flags & TRIGGER_SECONDARY_ACTION)
 		for(var/datum/antagonist/ex_vassal/former_vassals as anything in revenge_vassal.ex_vassals)
 			var/information = "[former_vassals.owner.current]"
-			information += " - has [round(COOLDOWN_TIMELEFT(former_vassals, blood_timer) / 600)] minutes left of Blood"
+			information += " - has [round(COOLDOWN_TIMELEFT(former_vassals, blood_timer) / 600)] minutes left of blood"
 			var/turf/open/floor/target_area = get_area(owner)
 			if(target_area)
 				information += " - currently at [target_area]."

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/veil.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/veil.dm
@@ -1,11 +1,12 @@
 /datum/action/cooldown/bloodsucker/veil
 	name = "Veil of Many Faces"
-	desc = "Disguise yourself in the illusion of another identity."
+	desc = "Disguise yourself under a random identity."
 	button_icon_state = "power_veil"
 	power_explanation = "Veil of Many Faces: \n\
-		Activating Veil of Many Faces will shroud you in smoke and forge you a new identity.\n\
-		Your name and appearance will be completely randomized, and turning the ability off again will undo it all.\n\
-		Clothes, gear, and Security/Medical HUD status is kept the same while this power is active."
+		Activating Veil of Many Faces will shroud you in smoke and change your identity.\n\
+		Your name, voice, and appearance will be completely randomized. \n\
+		Turning the ability off again will undo its effects.\n\
+		Clothing, gear, and security/medical HUD status is kept the same while this power is active."
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_IN_FRENZY
 	purchase_flags = BLOODSUCKER_DEFAULT_POWER
@@ -45,7 +46,7 @@
 /datum/action/cooldown/bloodsucker/veil/proc/veil_user()
 	// Change Name/Voice
 	var/mob/living/carbon/human/user = owner
-	to_chat(owner, span_warning("You mystify the air around your person. Your identity is now altered."))
+	to_chat(owner, span_warning("You mystify the air around your person: your identity is now altered."))
 
 	// Store Prev Appearance
 	disguise_name = user.dna.species.random_name(user.gender)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_coffin.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_coffin.dm
@@ -19,7 +19,7 @@
 		owner.teach_crafting_recipe(/datum/crafting_recipe/meatcoffin)
 		owner.current.balloon_alert(owner.current, "new recipes learned!")
 	to_chat(owner, span_userdanger("You have claimed the [claimed] as your place of immortal rest! Your lair is now [bloodsucker_lair_area]."))
-	to_chat(owner, span_announce("Bloodsucker Tip: Find new lair recipes in the Structures tab of the <i>Crafting Menu</i>, including the <i>Persuasion Rack</i> for converting crew into Vassals."))
+	to_chat(owner, span_announce("Bloodsucker Tip: Find new lair recipes in the Structures tab of the <i>Crafting Menu</i>, including the <i>persuasion rack</i> for converting crew into vassals."))
 	return TRUE
 
 /// From crate.dm
@@ -33,10 +33,10 @@
 /obj/structure/closet/crate/coffin/examine(mob/user)
 	. = ..()
 	if(user == resident)
-		. += span_cult("This is your Claimed Coffin.")
-		. += span_cult("Rest in it while injured to enter Torpor. Entering it with unspent Ranks will allow you to spend one.")
-		. += span_cult("Alt-Click while inside the Coffin to Lock/Unlock.")
-		. += span_cult("Alt-Click while outside of your Coffin to Unclaim it, unwrenching it and all your other structures as a result.")
+		. += span_cult("This is your claimed coffin.")
+		. += span_cult("Rest in it while injured to enter Torpor. Entering it with unspent ranks will allow you to spend one.")
+		. += span_cult("Alt-Click while inside the coffin to lock/unlock.")
+		. += span_cult("Alt-Click while outside of your coffin to unclaim it, unanchoring it and all your other structures as a result.")
 
 /obj/structure/closet/crate/coffin/blackcoffin
 	name = "black coffin"
@@ -109,7 +109,7 @@
 
 /obj/structure/closet/crate/coffin/metalcoffin
 	name = "metal coffin"
-	desc = "A big metal sardine can inside of another big metal sardine can, in space."
+	desc = "A big metal sardine can inside of another big metal sardine can— in <b>space</b>!"
 	icon_state = "metalcoffin"
 	base_icon_state = "metalcoffin"
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/vamp_obj.dmi'
@@ -196,7 +196,7 @@
 		LockMe(user)
 		//Level up if possible.
 		if(!bloodsuckerdatum.my_clan)
-			to_chat(user, span_notice("You must enter a Clan to rank up."))
+			to_chat(user, span_notice("You must enter a clan to rank up."))
 		else
 			bloodsuckerdatum.SpendRank()
 		// You're in a Coffin, everything else is done, you're likely here to heal. Let's offer them the oppertunity to do so.
@@ -209,10 +209,10 @@
 		return ..()
 	if(user != resident)
 		if(istype(item, cutting_tool))
-			to_chat(user, span_notice("This is a much more complex mechanical structure than you thought. You don't know where to begin cutting [src]."))
+			to_chat(user, span_notice("This structure is much more difficult to deconstruct upon further inspection, but maybe a <b>prying tool</b> would help with opening it."))
 			return
 	if(anchored && (item.tool_behaviour == TOOL_WRENCH))
-		to_chat(user, span_danger("The coffin won't come unanchored from the floor.[user == resident ? " You can Alt-Click to unclaim and unwrench your Coffin." : ""]"))
+		to_chat(user, span_danger("The coffin won't come unanchored from the floor.[user == resident ? " You can Alt-Click to unclaim and unanchor your Coffin." : ""]"))
 		return
 
 	if(locked && (item.tool_behaviour == TOOL_CROWBAR))
@@ -257,7 +257,7 @@
 			to_chat(user, span_notice("You flip a secret latch and unlock [src]."))
 		return
 	// Broken? Let's fix it.
-	to_chat(resident, span_notice("The secret latch that would lock [src] from the inside is broken. You set it back into place..."))
+	to_chat(resident, span_notice("The secret latch that would lock [src] from the inside is broken. You start setting it back into place..."))
 	if(!do_after(resident, 5 SECONDS, src, timed_action_flags = IGNORE_INCAPACITATED))
 		to_chat(resident, span_notice("You fail to fix [src]'s mechanism."))
 		return

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -113,8 +113,8 @@
 	buckle_lying = 180
 	ghost_desc = "This is a persuassion rack, which allows Bloodsuckers to thrall crewmembers into loyal minions."
 	vamp_desc = "This is a persuassion rack, which allows you to thrall crewmembers into loyal minions in your service.\n\
-		Simply drag a victim's sprite onto the rack to buckle them to it. Right-click on the vassal rack to unbuckle them.\n\
-		To convert into a Vassal, repeatedly click on the persuasion rack. The time required scales with the tool in your off hand. This costs Blood to do.\n\
+		Simply drag a victim's sprite onto the rack to buckle them to it. Right-click on the rack to unbuckle them.\n\
+		To convert into a vassal, repeatedly click on the persuasion rack. The time required scales with the tool in your off hand. This costs nlood to do.\n\
 		Vassals can be turned into special ones by continuing to torture them once converted."
 	vassal_desc = "This is a persuassion rack, which allows your master to thrall crewmembers into their service.\n\
 		Aid your master in bringing their victims here and keeping them secure.\n\

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -104,24 +104,24 @@
 
 /obj/structure/bloodsucker/vassalrack
 	name = "persuasion rack"
-	desc = "If this wasn't meant for torture, then someone has some fairly horrifying hobbies."
+	desc = "This is clearly either meant for torture or correcting spinal injuries." //TODO: Make persuasion racks actually correct torso bone wounds
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/vamp_obj.dmi'
 	icon_state = "vassalrack"
 	anchored = FALSE
 	density = TRUE
 	can_buckle = TRUE
 	buckle_lying = 180
-	ghost_desc = "This is a Vassal rack, which allows Bloodsuckers to thrall crewmembers into loyal minions."
-	vamp_desc = "This is the Vassal rack, which allows you to thrall crewmembers into loyal minions in your service.\n\
-		Simply click and hold on a victim, and then drag their sprite on the vassal rack. Right-click on the vassal rack to unbuckle them.\n\
+	ghost_desc = "This is a persuassion rack, which allows Bloodsuckers to thrall crewmembers into loyal minions."
+	vamp_desc = "This is a persuassion rack, which allows you to thrall crewmembers into loyal minions in your service.\n\
+		Simply drag a victim's sprite onto the rack to buckle them to it. Right-click on the vassal rack to unbuckle them.\n\
 		To convert into a Vassal, repeatedly click on the persuasion rack. The time required scales with the tool in your off hand. This costs Blood to do.\n\
 		Vassals can be turned into special ones by continuing to torture them once converted."
-	vassal_desc = "This is the vassal rack, which allows your master to thrall crewmembers into their minions.\n\
+	vassal_desc = "This is a persuassion rack, which allows your master to thrall crewmembers into their service.\n\
 		Aid your master in bringing their victims here and keeping them secure.\n\
-		You can secure victims to the vassal rack by click dragging the victim onto the rack while it is secured."
-	hunter_desc = "This is the vassal rack, which monsters use to brainwash crewmembers into their loyal slaves.\n\
+		You can secure victims to the rack by dragging their sprite onto the rack while it is secured."
+	hunter_desc = "This is a persuassion rack, which vampires use to brainwash crewmembers into their loyal slaves.\n\
 		They usually ensure that victims are handcuffed, to prevent them from running away.\n\
-		Their rituals take time, allowing us to disrupt it."
+		Their rituals take time, allowing us to disrupt them."
 
 #ifdef BLOODSUCKER_TESTING
 	var/convert_progress = 1
@@ -154,7 +154,7 @@
 	var/mob/living/living_target = movable_atom
 	if(!anchored && IS_BLOODSUCKER(user))
 		to_chat(user, span_danger("Until this rack is secured in place, it cannot serve its purpose."))
-		to_chat(user, span_announce("* Bloodsucker Tip: Examine the Persuasion Rack to understand how it functions!"))
+		to_chat(user, span_announce("* Bloodsucker Tip: Examine the persuasion rack to understand how it functions!"))
 		return
 	// Default checks
 	if(!isliving(movable_atom) || !living_target.Adjacent(src) || living_target == user || !isliving(user) || has_buckled_mobs() || user.incapacitated() || living_target.buckled)
@@ -190,7 +190,7 @@
 		return
 	user.visible_message(
 		span_notice("[user] straps [target] into the rack, immobilizing them."),
-		span_boldnotice("You secure [target] tightly in place. They won't escape you now."),
+		span_boldnotice("You secure [target] tightly in place. They won't escape now."),
 	)
 
 	playsound(loc, 'sound/effects/pop_expl.ogg', 25, 1)
@@ -209,7 +209,7 @@
 
 	if(buckled_mob == user)
 		buckled_mob.visible_message(
-			span_danger("[user] tries to release themself from the rack!"),
+			span_danger("[user] struggles to break off of the rack!"),
 			span_danger("You attempt to release yourself from the rack!"),
 			span_hear("You hear a squishy wet noise."))
 		if(!do_after(user, 20 SECONDS, buckled_mob))
@@ -249,7 +249,7 @@
 		user_unbuckle_mob(buckled_carbons, user)
 		return
 	if(!bloodsuckerdatum.my_clan)
-		to_chat(user, span_warning("You can't vassalize people until you enter a Clan (Through your Antagonist UI button)"))
+		to_chat(user, span_warning("You can't vassalize people until you enter a clan through your Antagonist UI button"))
 		user.balloon_alert(user, "join a clan first!")
 		return
 
@@ -413,7 +413,7 @@
 
 /obj/structure/bloodsucker/candelabrum
 	name = "candelabrum"
-	desc = "It burns slowly, but doesn't radiate any heat."
+	desc = "It burns slowly and doesn't radiate heat."
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/vamp_obj.dmi'
 	icon_state = "candelabrum"
 	light_color = "#66FFFF"//LIGHT_COLOR_BLUEGREEN // lighting.dm
@@ -421,14 +421,13 @@
 	light_range = 0 // to 2
 	density = FALSE
 	anchored = FALSE
-	ghost_desc = "This is a magical candle which drains at the sanity of non Bloodsuckers and Vassals.\n\
-		Vassals can turn the candle on manually, while Bloodsuckers can do it from a distance."
-	vamp_desc = "This is a magical candle which drains at the sanity of mortals who are not under your command while it is active.\n\
-		You can right-click on it from any range to turn it on remotely, or simply be next to it and click on it to turn it on and off normally."
-	vassal_desc = "This is a magical candle which drains at the sanity of the fools who havent yet accepted your master, as long as it is active.\n\
-		You can turn it on and off by clicking on it while you are next to it.\n\
-		If your Master is part of the Ventrue Clan, they utilize this to upgrade their Favorite Vassal."
-	hunter_desc = "This is a blue Candelabrum, which causes insanity to those near it while active."
+	ghost_desc = "This is a magical candle which drains the sanity of non-Bloodsuckers and non-vassals.\n\
+		Only bloodsuckers and their vassals can toggle it."
+	vamp_desc = "This is a magical candle which drains at the sanity of unvassalized mortals while it is active.\n\
+		Only you and your vassals can toggle it."
+	vassal_desc = "This is a magical candle which drains at the sanity of the fools who havent yet accepted your master while active.\n\
+		Only you, your master, and your master's other devotees may toggle it."
+	hunter_desc = "This is a blue candelabrum, which causes insanity to those near it while active."
 	var/lit = FALSE
 
 /obj/structure/bloodsucker/candelabrum/Destroy()
@@ -483,18 +482,17 @@
 /// Blood Throne - Allows Bloodsuckers to remotely speak with their Vassals. - Code (Mostly) stolen from comfy chairs (armrests) and chairs (layers)
 /obj/structure/bloodsucker/bloodthrone
 	name = "wicked throne"
-	desc = "Twisted metal shards jut from the arm rests. Very uncomfortable looking. It would take a masochistic sort to sit on this jagged piece of furniture."
+	desc = "Twisted metal shards jut from the arm rests, making it appear very uncomfortable. Still, it might sell well at an antique shop."
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/vamp_obj_64.dmi'
 	icon_state = "throne"
 	buckle_lying = 0
 	anchored = FALSE
 	density = TRUE
 	can_buckle = TRUE
-	ghost_desc = "This is a Bloodsucker throne, any Bloodsucker sitting on it can remotely speak to their Vassals by attempting to speak aloud."
+	ghost_desc = "This is a Bloodsucker's throne, any Bloodsucker sitting on it can remotely speak to their vassals by attempting to speak aloud."
 	vamp_desc = "This is a blood throne, sitting on it will allow you to telepathically speak to your vassals by simply speaking."
-	vassal_desc = "This is a blood throne, it allows your Master to telepathically speak to you and others like you."
-	hunter_desc = "This blood-red looking torture device latches onto anyone that sits onto its throne, but allows\n\
-		Monsters to telepathically communicate with others while contained in it."
+	vassal_desc = "This is a blood throne, it allows your master to telepathically speak to you and others who work under them."
+	hunter_desc = "This blood-red seat allows vampires to telepathically communicate with those in their fold."
 
 	///The static armrest that the throne has while someone is buckled onto it.
 	var/static/mutable_appearance/armrest

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_objects.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_objects.dm
@@ -214,7 +214,7 @@
 /obj/item/book/kindred
 	name = "\improper Archive of the Kindred"
 	starting_title = "the Archive of the Kindred"
-	desc = "Cryptic documents explaining hidden truths behind Undead beings. It is said only Curators can decipher what they really mean."
+	desc = "Cryptic documents explaining the hidden truths of undead beings. It is said only Curators can decipher what they really mean."
 	icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/vamp_obj.dmi'
 	lefthand_file = 'fulp_modules/features/antagonists/bloodsuckers/icons/bs_leftinhand.dmi'
 	righthand_file = 'fulp_modules/features/antagonists/bloodsuckers/icons/bs_rightinhand.dmi'
@@ -261,7 +261,7 @@
 		if(bloodsuckerdatum.broke_masquerade)
 			to_chat(user, span_warning("[target], also known as '[bloodsuckerdatum.return_full_name()]', is indeed a Bloodsucker, but you already knew this."))
 			return
-		to_chat(user, span_warning("[target], also known as '[bloodsuckerdatum.return_full_name()]', [bloodsuckerdatum.my_clan ? "is part of the [bloodsuckerdatum.my_clan]!" : "is not part of a clan."] You quickly note this information down, memorizing it."))
+		to_chat(user, span_warning("[target], also known as '[bloodsuckerdatum.return_full_name()]', [bloodsuckerdatum.my_clan ? "is part of the [bloodsuckerdatum.my_clan]!" : "is not part of a clan."]"))
 		bloodsuckerdatum.break_masquerade()
 	else
 		to_chat(user, span_notice("You fail to draw any conclusions to [target] being a Bloodsucker."))

--- a/fulp_modules/features/antagonists/bloodsuckers/code/vassal/ex_vassal.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/vassal/ex_vassal.dm
@@ -75,7 +75,7 @@
 	SIGNAL_HANDLER
 
 	if(COOLDOWN_TIMELEFT(src, blood_timer) <= BLOOD_TIMER_HALWAY + 2 && COOLDOWN_TIMELEFT(src, blood_timer) >= BLOOD_TIMER_HALWAY - 2) //just about halfway
-		to_chat(owner.current, span_cult_bold("You need new blood from your Master!"))
+		to_chat(owner.current, span_cult_bold("You need new blood from your master!"))
 	if(!COOLDOWN_FINISHED(src, blood_timer))
 		return
 	to_chat(owner.current, span_cult_bold("You are out of blood!"))
@@ -94,7 +94,7 @@
 /datum/reagent/blood/bloodsucker/expose_mob(mob/living/exposed_mob, methods, reac_volume, show_message, touch_protection)
 	var/datum/antagonist/ex_vassal/former_vassal = exposed_mob.mind.has_antag_datum(/datum/antagonist/ex_vassal)
 	if(former_vassal)
-		to_chat(exposed_mob, span_cult("You feel the blood restore you... You feel safe."))
+		to_chat(exposed_mob, span_cult("You feel the blood restore you... you feel safe."))
 		COOLDOWN_RESET(former_vassal, blood_timer)
 		COOLDOWN_START(former_vassal, blood_timer, BLOOD_TIMER_REQUIREMENT)
 	return ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/vassal/vassal_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/vassal/vassal_datum.dm
@@ -13,11 +13,11 @@
 	hud_icon = 'fulp_modules/features/antagonists/bloodsuckers/icons/bloodsucker_icons.dmi'
 	tip_theme = "spookyconsole"
 	antag_tips = list(
-		"You are a Vassal, enslaved to your Vampiric Master, you obey their instructions above all else.",
-		"You have the ability tp Recuperate, allowing you to heal at the exchange of your own Blood.",
-		"Fear Mindshields! You will get deconverted if you get mindshielded, resist them at all costs!",
-		"Help ensure your Master is safe from Daylight! Solar flares will bombard the station periodically, and if your Master is exposed, they will burn alive.",
-		"Your Master can optionally upgrade you into the Favorite Vassal. Depending on their Clan, you will get different benefits.",
+		"You are a Vassal, enslaved to your vampiric master, you obey their instructions above all else.",
+		"You have the ability to Recuperate, allowing you to heal at the cost of your blood, your master's blood, and some of your stamina.",
+		"Fear mindshield implants! You will get deconverted if you get mindshielded, resist them at all costs!",
+		"Help ensure your master is safe from daylight! Solar flares will bombard the station periodically, and if your master is exposed, they will burn alive.",
+		"Your master can optionally upgrade you into the Favorite Vassal. Depending on their clan, you will get different benefits.",
 	)
 
 	/// The Master Bloodsucker's antag datum.
@@ -71,7 +71,7 @@
 /// This is called when the antagonist is successfully mindshielded.
 /datum/antagonist/vassal/on_mindshield(mob/implanter, mob/living/mob_override)
 	owner.remove_antag_datum(/datum/antagonist/vassal)
-	owner.current.log_message("has been deconverted from Vassalization by [implanter]!", LOG_ATTACK, color="#960000")
+	owner.current.log_message("has been deconverted from vassalization by [implanter]!", LOG_ATTACK, color="#960000")
 	return COMPONENT_MINDSHIELD_DECONVERTED
 
 /datum/antagonist/vassal/proc/on_examine(datum/source, mob/examiner, examine_text)
@@ -183,7 +183,7 @@
 
 /datum/objective/vassal_objective
 	name = "vassal objective"
-	explanation_text = "Help your Master with whatever is requested of you."
+	explanation_text = "Help your master with whatever is requested of you."
 	martyr_compatible = TRUE
 
 /datum/objective/vassal_objective/check_completion()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/vassal/vassal_procs.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/vassal/vassal_procs.dm
@@ -67,6 +67,6 @@
 	vassaldatum.silent = FALSE
 
 	//send alerts of completion
-	to_chat(master, span_danger("You have turned [vassal_owner.current] into your [vassaldatum.name]! They will no longer be deconverted upon Mindshielding!"))
-	to_chat(vassal_owner, span_notice("As Blood drips over your body, you feel closer to your Master... You are now the Favorite Vassal!"))
+	to_chat(master, span_danger("You have turned [vassal_owner.current] into your [vassaldatum.name]! They will no longer be deconverted upon mindshielding!"))
+	to_chat(vassal_owner, span_notice("As blood drips over your body, you feel closer to your master... you are now the Favorite Vassal!"))
 	vassal_owner.current.playsound_local(null, 'sound/magic/mutate.ogg', 75, FALSE, pressure_affected = FALSE)


### PR DESCRIPTION

## About The Pull Request
This PR aims to correct and improve _all_ player-facing Bloodsucker text (item descriptions, structure descriptions, ability descriptions, notices, tips, flavor text, etc.)
## Why It's Good For The Game
While I understand that, due to it being inspired by _Vampire: The Masquerade_, Bloodsucker intentionally has some words capitalized which wouldn't be in other contexts, current Bloodsucker text has a particularly high amount of improperly capitalized common nouns. This PR tries to fix/improve upon both that and other instances of more common grammatical errors. Still, I may have overdone it with some terms ("frenzy" in particular comes to mind,) but I can re-edit to account for any of those if desired.
## Changelog
:cl:
add: tries to improve some Bloodsucker-related text
spellcheck: tries to grammatically correct a lot of Bloodsucker-related text
/:cl:
