### PR TITLE
Monster Hunter mass bug/balance fixes

### DIFF
--- a/fulp_modules/_maps/wonderland.dmm
+++ b/fulp_modules/_maps/wonderland.dmm
@@ -176,10 +176,6 @@
 	},
 /turf/open/misc/grass/jungle,
 /area/ruin/space/has_grav/wonderland)
-"mt" = (
-/obj/item/match/firebrand,
-/turf/open/misc/snow/actually_safe,
-/area/ruin/space/has_grav/wonderland)
 "mD" = (
 /obj/structure/chess,
 /turf/open/floor/black,
@@ -423,7 +419,8 @@
 /obj/structure/statue/snow/snowman{
 	pixel_x = -15;
 	pixel_y = -15;
-	anchored = 1
+	anchored = 1;
+	density = 0
 	},
 /turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
@@ -1367,7 +1364,7 @@ ZA
 ZA
 ZA
 Dh
-mt
+Dh
 Dh
 Fd
 ab

--- a/fulp_modules/_maps/wonderland.dmm
+++ b/fulp_modules/_maps/wonderland.dmm
@@ -24,7 +24,7 @@
 	pixel_x = 15;
 	pixel_y = -20
 	},
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "aR" = (
 /obj/item/clothing/shoes/costume_2021/doll_shoes,
@@ -96,7 +96,7 @@
 "dh" = (
 /obj/structure/flora/tree/dead/style_4,
 /obj/structure/flora/bush/flowers_pp/style_2,
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "di" = (
 /turf/closed/indestructible/rock,
@@ -178,7 +178,7 @@
 /area/ruin/space/has_grav/wonderland)
 "mt" = (
 /obj/item/match/firebrand,
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "mD" = (
 /obj/structure/chess,
@@ -203,7 +203,7 @@
 /area/ruin/space/has_grav/wonderland)
 "nQ" = (
 /obj/structure/flora/tree/dead/style_2,
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "oB" = (
 /obj/structure/dresser,
@@ -267,7 +267,7 @@
 	light_on = 1;
 	pixel_x = 15
 	},
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "wP" = (
 /obj/item/flashlight/lantern{
@@ -314,10 +314,10 @@
 /area/ruin/space/has_grav/wonderchess)
 "CP" = (
 /obj/structure/flora/rock/icy,
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "Dh" = (
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "DE" = (
 /obj/item/flashlight/lantern{
@@ -328,7 +328,7 @@
 /area/ruin/space/has_grav/wonderland)
 "DV" = (
 /obj/structure/flora/rock/icy/style_2,
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "El" = (
 /turf/open/floor/holofloor/pure_white,
@@ -348,11 +348,11 @@
 /area/ruin/space/has_grav/wonderland)
 "Fj" = (
 /obj/structure/bonfire/prelit,
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "Fm" = (
 /obj/structure/flora/bush/flowers_pp/style_2,
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "FO" = (
 /obj/structure/flora/tree/jungle,
@@ -360,7 +360,7 @@
 /area/ruin/space/has_grav/wonderland)
 "Ge" = (
 /obj/structure/flora/rock/icy/style_3,
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "Gl" = (
 /obj/structure/mineral_door/wood,
@@ -393,7 +393,7 @@
 /area/ruin/space/has_grav/wonderchess)
 "Jy" = (
 /obj/structure/flora/tree/dead/style_6,
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "JP" = (
 /obj/structure/chess/whitebishop,
@@ -409,7 +409,7 @@
 /area/ruin/space/has_grav/wonderchess)
 "Mo" = (
 /obj/structure/flora/tree/dead,
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "Mw" = (
 /obj/structure/flora/bush/flowers_br/style_2,
@@ -422,9 +422,10 @@
 "Od" = (
 /obj/structure/statue/snow/snowman{
 	pixel_x = -15;
-	pixel_y = -15
+	pixel_y = -15;
+	anchored = 1
 	},
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "Oq" = (
 /obj/item/flashlight/lantern{
@@ -481,7 +482,7 @@
 /area/ruin/space/has_grav/wonderland)
 "TF" = (
 /obj/structure/flora/tree/dead/style_5,
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "UO" = (
 /obj/structure/flora/bush/flowers_yw,
@@ -497,7 +498,7 @@
 	light_on = 1;
 	pixel_x = -15
 	},
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "Wb" = (
 /turf/open/misc/ashplanet/wateryrock{
@@ -522,7 +523,7 @@
 	pixel_x = 8;
 	pixel_y = 15
 	},
-/turf/open/misc/snow,
+/turf/open/misc/snow/actually_safe,
 /area/ruin/space/has_grav/wonderland)
 "Xk" = (
 /turf/open/water/beach,

--- a/fulp_modules/_maps/wonderland.dmm
+++ b/fulp_modules/_maps/wonderland.dmm
@@ -122,7 +122,7 @@
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/wonderland)
 "eu" = (
-/obj/structure/rack/weaponsmith,
+/obj/structure/weaponsmith,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/wonderland)
 "fb" = (

--- a/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/scrolls.dmi'
 	icon_state = "scroll2"
 	w_class = WEIGHT_CLASS_SMALL
+	resistance_flags = INDESTRUCTIBLE
 	///have we claimed our weapon?
 	var/bought = FALSE
 	///the datum containing all weapons

--- a/fulp_modules/features/antagonists/monster_hunter/monsterhunter_datum.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/monsterhunter_datum.dm
@@ -34,12 +34,14 @@
 	var/mob/living/current_mob = mob_override || owner.current
 	current_mob.add_traits(list(TRAIT_NOSOFTCRIT, TRAIT_NOCRITDAMAGE), HUNTER_TRAIT)
 	owner.unconvertable = TRUE
+	current_mob.faction |= FACTION_RABBITS
 
 /datum/antagonist/monsterhunter/remove_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/current_mob = mob_override || owner.current
 	current_mob.remove_traits(list(TRAIT_NOSOFTCRIT, TRAIT_NOCRITDAMAGE), HUNTER_TRAIT)
 	owner.unconvertable = FALSE
+	current_mob.faction -= FACTION_RABBITS
 
 /datum/antagonist/monsterhunter/on_gain()
 	//Give Hunter Objective

--- a/fulp_modules/features/antagonists/monster_hunter/monsterhunter_datum.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/monsterhunter_datum.dm
@@ -20,6 +20,8 @@
 	var/rabbits_spotted = 0
 	///the list of white rabbits
 	var/list/obj/effect/client_image_holder/white_rabbit/rabbits = list()
+	///a list of monster hunter action/spell names; currently only used to make the on_remove() proc functional
+	var/list/monster_hunter_actions = list("Summon Monster Hunter tools", "Hunter Vision", "Recall Threaded Cane", "Recall Hunter's Axe", "Recall Darkmoon Greatsword")
 	///the red card tied to this trauma if any
 	var/obj/item/rabbit_locator/locator
 	///a list of our prey
@@ -83,15 +85,20 @@
 		contract.owner = src
 	summon_contract.Grant(owner.current)
 
-/datum/antagonist/monsterhunter/on_removal()
+/datum/antagonist/monsterhunter/on_removal() //M̶a̶y̶ ̶n̶e̶e̶d Probably needs further improvements
 	UnregisterSignal(src, COMSIG_GAIN_INSIGHT)
 	UnregisterSignal(src, COMSIG_BEASTIFY)
-	for(var/obj/effect/client_image_holder/white_rabbit/white as anything in rabbits)
-		rabbits -= white
-		qdel(white)
+	owner.forget_crafting_recipe(/datum/crafting_recipe/hardened_stake)
+	owner.forget_crafting_recipe(/datum/crafting_recipe/silver_stake)
 	if(locator)
 		locator.hunter = null
 	locator = null
+	for(var/datum/action/specific_action in owner.current.actions)
+		if(specific_action.name in monster_hunter_actions)
+			qdel(specific_action)
+	for(var/obj/effect/client_image_holder/white_rabbit/white as anything in rabbits)
+		rabbits -= white
+		qdel(white)
 	to_chat(owner.current, span_userdanger("Your hunt has ended: you enter retirement once again, and are no longer \a [name]."))
 	return ..()
 

--- a/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
@@ -404,6 +404,7 @@
 	icon_state = "rabbit_mask"
 	worn_icon = 'fulp_modules/features/antagonists/monster_hunter/icons/worn_mask.dmi'
 	worn_icon_state = "rabbit_mask"
+	clothing_flags = MASKINTERNALS
 	flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	flash_protect = FLASH_PROTECTION_WELDER

--- a/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/monsterhunter_weapons.dm
@@ -6,6 +6,7 @@
 	icon = 'fulp_modules/features/antagonists/monster_hunter/icons/weapons.dmi'
 	lefthand_file = 'fulp_modules/features/antagonists/monster_hunter/icons/weapons_lefthand.dmi'
 	righthand_file = 'fulp_modules/features/antagonists/monster_hunter/icons/weapons_righthand.dmi'
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 	///upgrade level of the weapon
 	var/upgrade_level = 0
 	///base force when transformed
@@ -278,6 +279,7 @@
 	icon = 'fulp_modules/features/antagonists/monster_hunter/icons/weapons.dmi'
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/bloodsilver
 	initial_caliber = CALIBER_BLOODSILVER
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 
 /obj/item/gun/ballistic/revolver/hunter_revolver/examine(mob/user)
 	. = ..()
@@ -326,20 +328,43 @@
 		return
 	addtimer(CALLBACK(man, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/silver_bullet), 8 SECONDS)
 
-/obj/structure/rack/weaponsmith
+/obj/structure/weaponsmith //Was a subtype of /obj/structure/rack, but that allowed it to be wrenched apart
 	name = "Weapon Forge"
 	desc = "Fueled by the tears of rabbits."
 	icon = 'icons/obj/antags/cult/structures.dmi'
 	icon_state = "altar"
+	layer = TABLE_LAYER
+	density = TRUE
+	anchored = TRUE
+	pass_flags_self = LETPASSTHROW
 	resistance_flags = INDESTRUCTIBLE
 
-/obj/structure/rack/weaponsmith/examine(mob/user)
+/obj/structure/weaponsmith/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/climbable)
+	AddElement(/datum/element/elevation, pixel_shift = 12)
+
+/obj/structure/weaponsmith/examine(mob/user)
 	. = ..()
 	if(IS_MONSTERHUNTER(user))
 		. += span_notice("This forge can be used to upgrade trick weapons with rabbit eyes.")
 
+/obj/structure/weaponsmith/CanAllowThrough(atom/movable/mover, border_dir) //Copied from tables_racks.dm
+	. = ..()
+	if(.)
+		return
+	if(istype(mover) && (mover.pass_flags & PASSTABLE))
+		return TRUE
+
+/obj/structure/weaponsmith/item_interaction(mob/living/user, obj/item/tool, list/modifiers) //See comment above
+	if(user.combat_mode)
+		return NONE
+	if(user.transferItemToLoc(tool, drop_location(), silent = FALSE))
+		return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_BLOCKING
+
 //Used to find a trick weapon placed on the smithing table and return it
-/obj/structure/rack/weaponsmith/proc/identify_weapon()
+/obj/structure/weaponsmith/proc/identify_weapon()
 	var/obj/item/melee/trick_weapon/tool
 	for(var/obj/item/weapon in src.loc.contents)
 		if(!istype(weapon, /obj/item/melee/trick_weapon))
@@ -349,7 +374,7 @@
 	if(tool)
 		return tool
 
-/obj/structure/rack/weaponsmith/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+/obj/structure/weaponsmith/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()
 	if(!istype(held_item, /obj/item/rabbit_eye))
 		return
@@ -361,7 +386,7 @@
 	context[SCREENTIP_CONTEXT_LMB] = "Upgrade Weapon with Combat Mode Active"
 	return CONTEXTUAL_SCREENTIP_SET
 
-/obj/structure/rack/weaponsmith/attackby(obj/item/organ, mob/living/user, params)
+/obj/structure/weaponsmith/attackby(obj/item/organ, mob/living/user, params)
 	if(!istype(organ, /obj/item/rabbit_eye))
 		return ..()
 	var/obj/item/rabbit_eye/eye = organ
@@ -382,6 +407,7 @@
 	flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	flash_protect = FLASH_PROTECTION_WELDER
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 	///the paradox rabbit ability
 	var/datum/action/cooldown/paradox/paradox
 	///teleporting to the wonderland
@@ -443,6 +469,7 @@
 	icon = 'fulp_modules/features/antagonists/monster_hunter/icons/weapons.dmi'
 	icon_state = "locator"
 	w_class = WEIGHT_CLASS_SMALL
+	resistance_flags = INDESTRUCTIBLE
 	///the hunter the card is tied too
 	var/datum/antagonist/monsterhunter/hunter
 	///cooldown for the locator

--- a/fulp_modules/features/antagonists/monster_hunter/wonderland.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/wonderland.dm
@@ -76,6 +76,7 @@ GLOBAL_LIST_EMPTY(wonderland_marks)
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	item_flags = NOBLUDGEON
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 	var/filled = FALSE ///does the bottle contain fluid
 
 /obj/item/blood_vial/examine(mob/user)

--- a/fulp_modules/features/antagonists/monster_hunter/wonderland.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/wonderland.dm
@@ -93,16 +93,38 @@ GLOBAL_LIST_EMPTY(wonderland_marks)
 	icon_state = "blood_vial"
 	update_appearance()
 
+/obj/item/blood_vial/proc/empty_vial(mob/living/user) //The vial's actual effects are separate from this proc
+	filled = FALSE
+	icon_state = "blood_vial_empty"
+	update_appearance()
+	playsound(src, 'fulp_modules/features/antagonists/monster_hunter/sounds/blood_vial_slurp.ogg',50)
 
 /obj/item/blood_vial/attack_self(mob/living/user)
 	if(!filled)
 		balloon_alert(user, "Empty!")
 		return
-	filled = FALSE
-	user.apply_status_effect(/datum/status_effect/cursed_blood)
-	icon_state = "blood_vial_empty"
-	update_appearance()
-	playsound(src, 'fulp_modules/features/antagonists/monster_hunter/sounds/blood_vial_slurp.ogg',50)
+	if("[get_area(user)]" == "Wonderland")
+		to_chat(user, span_warning("The blood refuses to let itself be directly spilt (and therefore drank) within Wonderland!"))
+		return
+	if(!IS_MONSTERHUNTER(user))
+		if(IS_BLOODSUCKER(user))
+			to_chat(user, span_bolddanger("That blood tasted horrible! It stills the very core of your undying form!"))
+			user.add_movespeed_modifier(/datum/movespeed_modifier/silver_bullet) //Gives them the silver bullet debuff for a prolonged period of time.
+			if(!(user.has_movespeed_modifier(/datum/movespeed_modifier/silver_bullet))) //(Code copied almost directly from bloodsilver revolver code)
+				return
+			addtimer(CALLBACK(user, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/silver_bullet), 32 SECONDS)
+			empty_vial()
+		else
+			to_chat(user, span_danger("<i>Eugh</i>... Drinking that was a terrible idea!"))
+			user.apply_damage(20, TOX, spread_damage = TRUE)
+			if(user.getStaminaLoss() < 5)
+				user.adjustStaminaLoss(75)
+			empty_vial()
+			return
+	else
+		user.apply_status_effect(/datum/status_effect/cursed_blood)
+		empty_vial()
+		return
 
 /datum/status_effect/cursed_blood
 	id = "Blood"

--- a/fulp_modules/features/antagonists/monster_hunter/wonderland_apocalypse.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/wonderland_apocalypse.dm
@@ -95,4 +95,4 @@
 	enemy_spawned = TRUE
 	var/mob/living/basic/red_rabbit/evil_rabbit = new(get_turf(src))
 	evil_rabbit.key = user.key
-	to_chat(evil_rabbit, span_boldwarning("Destroy everything, spare no one."))
+	to_chat(evil_rabbit, span_boldwarning("Destroy everything. Spare only the harbinger of Wonderland who brought you here, but know that you do not answer to them."))


### PR DESCRIPTION

## About The Pull Request
This PR attempts to implement fixes for a handful of Monster Hunter bugs/exploits/balance problems that I've discovered. A full list of these problems and their respective fixes as of this PR is as follows:

1. In PR [#1217](https://github.com/fulpstation/fulpstation/pull/1217) I accidentally added what I can only assume is snow from Icebox to Wonderland. It has been replaced with regular snow (also I anchored a snowman— I might make it not dense later.)
2. A lot of vital monster hunter equipment was flammable/vulnerable to acid and therefore very easy to destroy. Accordingly the majority of monster hunter equipment has been made either fireproof and acidproof or (in one instance) indestructible. (Oh also the weapon upgrade table in Wonderland could be deconstructed with a wrench, so that's fixed now too.)
3. The cursed rabbit mask has been rendered compatible with internals. This wasn't really a problem, but now Monster Hunters can maintain their sense of style even in deoxygenated areas.
4. The Monster Hunter blood vial could be repeatedly refilled and reused in Wonderland, allowing Monster Hunters to gain more healing than they should've gotten from it. The vial can thusly no longer be drank from within Wonderland. (Also crew members are now detrimentally affected by the blood vial if they attempt to use it, and Bloodsuckers in particular get a thirty second movement speed debuff from it.)
5. Attempting to remove Monster Hunter status from a player via the admin panel would leave the player with multiple Monster Hunter abilities and recipes. That has been corrected.
6. Monster Hunters could previously be targeted by the small red rabbits spawned by jabberwockies, and jabberwockies themselves could even directly target the Monster Hunter who summoned them in the first place. This has hopefully been fixed by making Monster Hunters a part of the "FACTION_RABBITS" faction and giving jabberwockies a bit of flavor text telling them to not directly target their summoner (though they don't have to directly obey them either since they're uncontrollable forces of "nature".)
## Why It's Good For The Game
These changes hopefully make Monster Hunter a bit more fun, functional, and polished.
## Changelog
:cl:
qol: The Monster Hunter rabbit mask is now compatible with internals.
balance: Most special Monster Hunter items/structures are no longer vulnerable to fire and acid.
balance: Monster Hunters are now allied with the Wonderland apocalypse rabbits they summon.
fix: Wonderland's snow no longer freezes those standing on it.
fix: The Monster Hunter blood vial can no longer be repeatedly drank from and refilled in Wonderland. Also non-Monster Hunters are now negatively affected by it.
admin: Monster Hunter status can now be removed from players more effectively with the traitor panel.
/:cl:
