### PR TITLE
Pubby Station Exterior/Space Detailing (again!)

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -363,7 +363,7 @@
 	c_tag = "MiniSat External Port";
 	network = list("minisat")
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "acn" = (
 /obj/machinery/porta_turret/ai{
@@ -14608,12 +14608,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/kitchen)
-"bgl" = (
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/station/tcommsat/computer)
 "bgn" = (
 /obj/structure/chair{
 	dir = 4
@@ -21913,6 +21907,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"bOL" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "bOM" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/newscaster/directional/east,
@@ -22046,6 +22047,13 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"bPm" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/chair/sofa/bench{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bPo" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
@@ -26505,7 +26513,7 @@
 	c_tag = "Telecomms External Port";
 	network = list("tcomms")
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cmu" = (
 /obj/structure/table,
@@ -26561,7 +26569,7 @@
 	c_tag = "Telecomms External Starboard";
 	network = list("tcomms")
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cmB" = (
 /turf/closed/wall/r_wall,
@@ -26735,7 +26743,7 @@
 	c_tag = "Telecomms External Port Aft";
 	network = list("tcomms")
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cnz" = (
 /obj/structure/lattice,
@@ -26743,7 +26751,7 @@
 	c_tag = "Telecomms External Starboard Aft";
 	network = list("tcomms")
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cnC" = (
 /obj/machinery/turretid{
@@ -27235,6 +27243,10 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"cpX" = (
+/turf/open/floor/plating/airless,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cpY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -27434,6 +27446,17 @@
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
 /turf/open/space,
+/area/space/nearstation)
+"crr" = (
+/obj/structure/lattice/catwalk,
+/obj/item/clothing/head/soft/black,
+/obj/item/clothing/under/costume/referee,
+/obj/item/clothing/mask/whistle{
+	name = "Referee's Whistle"
+	},
+/obj/structure/rack,
+/obj/item/binoculars,
+/turf/open/space/basic,
 /area/space/nearstation)
 "crt" = (
 /obj/structure/table/wood/fancy,
@@ -29650,6 +29673,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"dsZ" = (
+/obj/item/toy/basketball,
+/turf/open/floor/glass/reinforced/plasma/airless,
+/area/space/nearstation)
 "dtj" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/structure/table,
@@ -30118,6 +30145,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"dQw" = (
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "dRj" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -30194,6 +30228,12 @@
 "dTT" = (
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"dTZ" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/obj/item/stack/rods,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dUh" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
@@ -30657,6 +30697,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"eoF" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "eoP" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -30854,6 +30901,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"eyZ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/chair/sofa/bench/left{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "ezk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32008,6 +32062,11 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"fsg" = (
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation)
 "fsA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -32260,6 +32319,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"fDp" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "fEo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -32613,6 +32678,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"fUl" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"fUo" = (
+/obj/structure/lattice,
+/obj/item/radio,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fUJ" = (
 /obj/machinery/light/no_nightlight/directional/south,
 /obj/machinery/duct,
@@ -32782,6 +32859,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"geY" = (
+/obj/effect/turf_decal/trimline/red/corner,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "gfi" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 2
@@ -33118,6 +33200,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"guc" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "gue" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -33195,6 +33284,12 @@
 "gvM" = (
 /turf/closed/wall,
 /area/station/maintenance/department/science/central)
+"gvT" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/obj/item/stack/rods,
+/turf/open/space,
+/area/space/nearstation)
 "gwn" = (
 /obj/structure/sign/warning/directional/north,
 /obj/structure/sign/warning/directional/south,
@@ -33593,6 +33688,15 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"gMw" = (
+/obj/structure/hoop{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "gMF" = (
 /obj/item/toy/basketball,
 /obj/effect/turf_decal/stripes/white/line{
@@ -33885,6 +33989,12 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"hcP" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "hdk" = (
 /obj/structure/flora/bush/large/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -34181,6 +34291,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"hpy" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space,
+/area/space/nearstation)
 "hqc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -34502,6 +34617,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"hGX" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "hGY" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -34685,6 +34804,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"hRA" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "hRF" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -35431,6 +35555,7 @@
 	network = list("tcomms");
 	start_active = 1
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "iBY" = (
@@ -35658,6 +35783,10 @@
 	dir = 4
 	},
 /area/station/security/prison/workout)
+"iLa" = (
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "iLl" = (
 /obj/structure/sink{
 	pixel_y = 29
@@ -35713,6 +35842,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"iNq" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/chair/sofa/bench/right,
+/turf/open/space/basic,
+/area/space/nearstation)
 "iNw" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -35938,7 +36072,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "jcc" = (
 /obj/machinery/chem_mass_spec,
@@ -37753,6 +37887,13 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
+"kFs" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "kFx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Law Office Maintenance"
@@ -38933,6 +39074,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"lFI" = (
+/obj/item/toy/snowball,
+/turf/open/misc/asteroid/snow/airless,
+/area/centcom/asteroid/nearstation/bomb_site)
 "lFK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -39402,6 +39547,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/station/service/library)
+"mcK" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "mcL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -39676,6 +39828,11 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
+"mpf" = (
+/obj/machinery/power/floodlight,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation)
 "mpy" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
@@ -39968,6 +40125,11 @@
 /obj/structure/sign/departments/nanites/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"mAp" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "mAQ" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -40190,6 +40352,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"mNE" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "mNN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -41053,6 +41222,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"nzo" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "nzp" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine,
@@ -41395,6 +41571,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"nQo" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/chair/sofa/bench/left,
+/turf/open/space/basic,
+/area/space/nearstation)
 "nQH" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/brown{
@@ -41652,6 +41833,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"oaD" = (
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "oaM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -41676,6 +41862,18 @@
 /obj/effect/mapping_helpers/mail_sorting/science/research,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
+"obn" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
+"obP" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "odh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -42221,6 +42419,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"owe" = (
+/obj/structure/lattice,
+/obj/item/wrench,
+/turf/open/space/basic,
+/area/space/nearstation)
 "owM" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -42472,6 +42675,15 @@
 /obj/item/book/bible,
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
+"oGf" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "oGm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42509,6 +42721,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"oHt" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "oJj" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical)
@@ -42984,6 +43202,13 @@
 	},
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
+"pbZ" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "pcg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -43022,6 +43247,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"pdM" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/secure_area/directional/east,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pec" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43047,6 +43277,9 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
+"pfn" = (
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "pfw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -43192,6 +43425,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/medical/cryo)
+"pjC" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "pjM" = (
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
@@ -43317,6 +43554,13 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
+"poF" = (
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "ppf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43638,6 +43882,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"pFa" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pFy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44704,6 +44953,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"qsn" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "qsF" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
@@ -45303,6 +45556,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"qWd" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "qWG" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -45491,9 +45751,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "rcF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/plating/airless,
-/area/station/tcommsat/computer)
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rdU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -45613,6 +45874,13 @@
 "riB" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"riC" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "riF" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron/dark,
@@ -46253,6 +46521,10 @@
 /obj/effect/landmark/start/bitrunner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
+"rIf" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "rIm" = (
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -46356,10 +46628,9 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "rLJ" = (
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 1
-	},
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/meter/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "rLQ" = (
@@ -46375,6 +46646,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
+"rMt" = (
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "rMy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -46769,6 +47046,18 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"sdc" = (
+/obj/structure/lattice,
+/obj/item/toy/plush/lizard_plushie{
+	pixel_x = 12;
+	pixel_y = 7
+	},
+/obj/item/food/grown/citrus/orange{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/turf/open/space,
+/area/space/nearstation)
 "sdr" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -47681,6 +47970,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"sSM" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "sTi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48061,6 +48357,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
+"tff" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/chair/sofa/bench,
+/obj/item/food/popcorn,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tfh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -48129,6 +48431,10 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
+"thg" = (
+/obj/effect/spawner/random/contraband/prison,
+/turf/open/misc/asteroid/airless,
+/area/centcom/asteroid/nearstation/bomb_site)
 "thT" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/meter,
@@ -49053,6 +49359,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"tPl" = (
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/cable_coil,
+/obj/structure/closet/crate/engineering,
+/obj/item/toy/plush/supermatter,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "tPm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49098,6 +49412,11 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"tSb" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/chair/office/light,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tSK" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -49142,6 +49461,13 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
+"tTz" = (
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "tTB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -49344,6 +49670,14 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"udc" = (
+/obj/structure/fluff/fokoff_sign{
+	pixel_y = 6;
+	pixel_x = 9
+	},
+/obj/structure/statue/snow/snowman,
+/turf/open/misc/asteroid/snow/airless,
+/area/centcom/asteroid/nearstation/bomb_site)
 "udk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -49830,6 +50164,11 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
+"urX" = (
+/obj/structure/lattice,
+/obj/item/radio,
+/turf/open/space,
+/area/space/nearstation)
 "usl" = (
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
@@ -50751,6 +51090,15 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
+"vcn" = (
+/obj/structure/hoop{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "vcJ" = (
 /obj/machinery/door/window/right/directional/east{
 	name = "Danger: Conveyor Access";
@@ -52298,6 +52646,16 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"wqk" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/closet/crate,
+/obj/item/toy/basketball,
+/obj/item/toy/basketball,
+/obj/item/toy/basketball,
+/obj/item/toy/basketball,
+/obj/item/toy/basketball,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wqu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -53726,6 +54084,11 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"xmY" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/chair/sofa/bench,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xnm" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
@@ -53791,6 +54154,10 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"xqs" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "xqI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -54066,6 +54433,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/commons/storage/primary)
+"xyH" = (
+/obj/effect/turf_decal/trimline/dark_blue/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "xyI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "CMO Maintenance"
@@ -54554,6 +54927,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"xTR" = (
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "xUU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54642,6 +55022,13 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"xZk" = (
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
 "xZT" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -54652,6 +55039,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"yab" = (
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "yat" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -54670,6 +55063,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"ybx" = (
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "yby" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -54860,6 +55259,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"yjj" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/airless,
+/area/space/nearstation)
 "yjt" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -68864,8 +69269,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+anl
+anl
 aby
 aed
 aby
@@ -68873,7 +69278,7 @@ aht
 aby
 aby
 aby
-aht
+tHo
 aby
 aby
 aby
@@ -69391,7 +69796,7 @@ wSC
 wSC
 gwZ
 gwZ
-aht
+aaa
 aaa
 gKn
 aaa
@@ -69648,7 +70053,7 @@ pdq
 kYq
 dci
 gwZ
-aht
+aaa
 aaa
 gKn
 aaa
@@ -69905,7 +70310,7 @@ grq
 kzO
 mwg
 gwZ
-aht
+aaa
 aaa
 gKn
 aaa
@@ -70162,7 +70567,7 @@ grq
 rLi
 tlc
 gwZ
-aht
+aaa
 aaa
 gKn
 aaa
@@ -70401,12 +70806,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anl
+anl
+anl
+anl
+anl
+anl
 aaa
 aiu
 aiu
@@ -70659,13 +71064,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aht
+aaa
+aaa
+aaa
 aiu
 gwn
 pwo
@@ -70687,7 +71092,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -70921,8 +71326,8 @@ ait
 ait
 aiu
 aiu
-aht
-aht
+aaa
+aaa
 aiu
 ajD
 ajD
@@ -71927,23 +72332,23 @@ aaa
 aaa
 aaa
 aaa
+acO
+anl
+anl
+anl
+anl
+anl
+anl
+anl
+aaa
+tXE
 aaa
 aaa
 aaa
+hpy
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-adR
-adR
-aht
 ait
 aiY
 ajE
@@ -72187,20 +72592,20 @@ aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
+aht
 aaa
 aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa
 aht
-aht
-aht
-aht
+aaa
+aaa
+aaa
 aiu
 aiu
 aiu
@@ -72230,7 +72635,7 @@ pzm
 oTC
 ait
 aaa
-abN
+bBW
 aaa
 aHA
 aKz
@@ -72450,7 +72855,7 @@ aOn
 aOn
 aaa
 aaa
-aaa
+pdM
 aaa
 aaa
 aaa
@@ -72689,15 +73094,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anl
+anl
+anl
+anl
+anl
+anl
+anl
+anl
+anl
 aaa
 aaa
 aaa
@@ -72947,13 +73352,13 @@ aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -73204,7 +73609,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -73460,7 +73865,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 knG
 dof
 dof
@@ -73717,7 +74122,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 knG
 aeE
 jZC
@@ -73974,7 +74379,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 knG
 arl
 vXF
@@ -74231,7 +74636,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 knG
 aeW
 aik
@@ -74488,7 +74893,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 knG
 ikt
 iFG
@@ -74743,9 +75148,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aht
+anl
+tHo
+anl
 knG
 aeT
 fTp
@@ -74999,7 +75404,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aht
 aht
 aht
@@ -75256,7 +75661,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aht
 acM
 aem
@@ -75513,7 +75918,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aht
 acM
 sfh
@@ -75770,7 +76175,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 kdf
 acM
 hAp
@@ -76027,7 +76432,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aht
 acM
 hsN
@@ -76284,7 +76689,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aht
 acM
 aem
@@ -76541,7 +76946,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aht
 aht
 aht
@@ -76799,10 +77204,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aht
+anl
+anl
+anl
+tHo
 aem
 fJd
 flR
@@ -77059,7 +77464,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 aem
 aem
 aem
@@ -77316,7 +77721,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 anl
 aht
 aht
@@ -77573,7 +77978,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 pDW
 pDW
 aht
@@ -77711,12 +78116,12 @@ rnE
 aaa
 aaa
 aaa
-nge
-adR
-adR
-adR
 aaa
-aaa
+aby
+adR
+adR
+tHo
+anl
 aaa
 aaa
 aaa
@@ -77830,8 +78235,8 @@ aaa
 aaa
 aaa
 aaa
-aht
-aht
+aaa
+aaa
 pDW
 aht
 aht
@@ -77843,7 +78248,7 @@ adE
 aht
 aht
 pDW
-aht
+aaa
 aaa
 aaa
 aaa
@@ -77968,10 +78373,10 @@ ukn
 bIZ
 bva
 bva
+aaa
+aaa
 aht
-aht
-aht
-aht
+aaa
 aaa
 aaa
 aaa
@@ -78089,7 +78494,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 pDW
 aht
 aht
@@ -78099,7 +78504,7 @@ aht
 aht
 aht
 anl
-aht
+aaa
 aaa
 aaa
 aaa
@@ -78229,7 +78634,7 @@ bBX
 bBX
 bBX
 bBX
-aht
+aaa
 adR
 aaa
 aaa
@@ -78347,7 +78752,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 pDW
 pDW
 pDW
@@ -78355,7 +78760,7 @@ pDW
 pDW
 pDW
 pDW
-aht
+aaa
 aaa
 aaa
 aaa
@@ -78487,7 +78892,7 @@ bDi
 bDi
 bBX
 aht
-nge
+adR
 aaa
 aaa
 aaa
@@ -78605,13 +79010,13 @@ aaa
 aaa
 aaa
 aaa
-aht
-aht
-aht
-aht
-aht
-aht
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -78743,7 +79148,7 @@ bBX
 wfO
 bDi
 bBX
-aht
+aaa
 nge
 aaa
 aaa
@@ -79000,7 +79405,7 @@ ehM
 bDi
 dWk
 bBX
-aht
+aaa
 adR
 aaa
 aaa
@@ -79132,7 +79537,7 @@ aaa
 aaa
 aaa
 aaa
-aby
+aed
 aaa
 aKw
 ahd
@@ -79514,7 +79919,7 @@ xaO
 sww
 bDi
 bBX
-aht
+aaa
 pDW
 aaa
 aaa
@@ -79643,9 +80048,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 cFB
+aaa
+aaa
 aby
 aaa
 aKw
@@ -79771,7 +80176,7 @@ bBX
 bDi
 wfO
 bBX
-aht
+aaa
 pDW
 aaa
 aaa
@@ -80285,7 +80690,7 @@ bBX
 bBX
 bBX
 bBX
-aht
+aaa
 pDW
 aaa
 aaa
@@ -80314,7 +80719,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+tXE
 aaa
 aaa
 aaa
@@ -80538,40 +80943,40 @@ bva
 bIZ
 bva
 bva
+aaa
+aaa
 aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aht
-aht
-aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -80796,6 +81201,11 @@ aaa
 aaa
 aaa
 aaa
+tHo
+anl
+anl
+anl
+anl
 aaa
 aaa
 aaa
@@ -80818,22 +81228,17 @@ aaa
 aaa
 aaa
 aaa
+tXE
 aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tXE
 aaa
 aaa
 aaa
@@ -80931,7 +81336,7 @@ aaa
 aaa
 aaa
 aaa
-aby
+aed
 aaa
 dAa
 wtp
@@ -81080,17 +81485,17 @@ aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -81332,27 +81737,27 @@ aaa
 aaa
 aaa
 aaa
+abI
 aaa
 aaa
 aaa
 aaa
+sdc
 aaa
 aaa
 aaa
 aaa
+abI
 aaa
 aaa
 aaa
 aaa
+abI
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -81445,7 +81850,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aaa
 vRp
 vRp
@@ -81587,30 +81992,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bBW
+abI
+adR
+adR
+adR
+adR
+adR
+adR
+adR
+adR
+gvT
+adR
+adR
+adR
+adR
+adR
+adR
+adR
+adR
+adR
+anl
+anl
+anl
+aht
 aaa
 aaa
 aaa
@@ -81702,7 +82107,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aaa
 vRp
 aWA
@@ -81866,7 +82271,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -81959,7 +82364,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aaa
 vRp
 xsw
@@ -82101,29 +82506,29 @@ aaa
 aaa
 aaa
 aaa
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
 aaa
 adR
-aaa
 aaa
 aaa
 aaa
@@ -82216,7 +82621,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aaa
 vRp
 sPh
@@ -82357,30 +82762,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 cmt
-aaa
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+fUo
+aht
+aht
 aaa
 adR
-aaa
 aaa
 aaa
 aaa
@@ -82473,15 +82878,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+anl
+aht
 vRp
 vRp
 naQ
 naQ
 vRp
 vRp
-abI
+aaa
 ajs
 ake
 akX
@@ -82636,11 +83041,11 @@ cmB
 cmB
 cmB
 cny
+abI
 adR
 abI
-aaa
-aaa
-aaa
+aht
+tXE
 aaa
 aaa
 aaa
@@ -82732,12 +83137,12 @@ aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aht
 aaa
 ajs
 ajs
@@ -82892,9 +83297,9 @@ cnj
 cmK
 cnr
 cmB
+aht
 aaa
 adR
-aaa
 aaa
 aaa
 aaa
@@ -82989,12 +83394,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anl
+anl
+tHo
+anl
+anl
+anl
 aaa
 aaa
 aiR
@@ -83149,9 +83554,9 @@ cnk
 cmK
 cns
 cmB
+aht
 aaa
 adR
-aaa
 aaa
 aaa
 aaa
@@ -83406,9 +83811,9 @@ cnl
 cmK
 cnt
 cmB
+aht
 aaa
 adR
-aaa
 aaa
 aaa
 aaa
@@ -83515,7 +83920,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 aht
 aht
 aht
@@ -83663,14 +84068,14 @@ cmK
 cmK
 cnu
 cmB
+aht
 abI
 adR
 abI
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+tXE
 aaa
 aaa
 aaa
@@ -83771,7 +84176,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
 anl
 aht
 aht
@@ -83897,7 +84302,7 @@ aaa
 aaa
 aaa
 aaa
-bgl
+aht
 clw
 nTk
 nTk
@@ -83920,9 +84325,9 @@ cnm
 cmK
 eel
 cmB
+aht
 aaa
 adR
-aaa
 aaa
 aaa
 aaa
@@ -84027,9 +84432,9 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
+aaa
 anl
-aht
 aht
 aht
 apo
@@ -84177,9 +84582,9 @@ cnn
 cmK
 cnw
 cmB
+aht
 aaa
 adR
-aaa
 aaa
 aaa
 aaa
@@ -84283,9 +84688,9 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
+aaa
 anl
-aht
 aht
 aht
 alO
@@ -84434,9 +84839,9 @@ cno
 cmK
 cnx
 cmB
+aht
 aaa
 adR
-aaa
 aaa
 aaa
 aaa
@@ -84537,11 +84942,11 @@ aaa
 aaa
 aaa
 aaa
+cFB
 aaa
 aaa
 aaa
 anl
-aht
 aht
 aht
 alO
@@ -84692,11 +85097,11 @@ cmB
 cmB
 cmB
 cnz
+abI
 adR
 abI
-aaa
-aaa
-aaa
+aht
+tXE
 aaa
 aaa
 aaa
@@ -84925,32 +85330,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 cmz
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 aaa
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-adR
-aaa
+gvT
 aaa
 aaa
 aaa
@@ -85054,7 +85459,7 @@ aaa
 aaa
 aaa
 aaa
-anl
+tHo
 aht
 amA
 aht
@@ -85185,29 +85590,29 @@ aaa
 aaa
 aaa
 aaa
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-adR
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
 aaa
 adR
-aaa
 aaa
 aaa
 aaa
@@ -85271,47 +85676,47 @@ aaa
 aaa
 aaa
 aaa
+aby
+aby
+aby
+anl
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
 acO
 aby
 aby
 aby
 aby
 aby
-aaa
-aby
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 tHo
+aby
+aht
+aht
+dee
+anl
+anl
+anl
+anl
+anl
+anl
 aht
 amB
 aht
@@ -85464,7 +85869,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -85528,30 +85933,26 @@ aaa
 aaa
 aaa
 aaa
+dTZ
+aaa
+abI
 aaa
 aaa
 aaa
 aaa
 aaa
+abI
+bBW
 aaa
 aaa
 aaa
+abI
+aaa
+aaa
+abI
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
 aaa
 abI
 aaa
@@ -85559,16 +85960,20 @@ aaa
 aaa
 abI
 aaa
-aby
+aaa
+aaa
+abI
+aaa
+aht
+aaa
+aht
+aaa
+aht
 aaa
 aaa
 aaa
+aht
 aaa
-aaa
-aaa
-aaa
-aaa
-anl
 aht
 amC
 aht
@@ -85700,29 +86105,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abI
+adR
+adR
+gvT
+adR
+adR
+adR
+adR
+adR
+adR
+adR
+adR
+adR
+adR
+gvT
+adR
+adR
+adR
+adR
+anl
+anl
+anl
+aht
 aaa
 aaa
 aaa
@@ -85785,28 +86190,28 @@ aaa
 aaa
 aaa
 aaa
-aby
-aby
-aby
 anl
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
 aaa
-aaa
-abI
+aht
 aaa
 aaa
 aaa
 aaa
-abI
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aht
 aaa
 aaa
 aaa
@@ -85815,17 +86220,17 @@ acP
 acP
 acP
 acP
-abI
-aby
 aaa
+aht
 aaa
+aht
 aaa
+mVM
+aht
+mVM
+mVM
+mVM
 aaa
-cFB
-aaa
-aaa
-aaa
-anl
 aht
 amC
 aht
@@ -85958,27 +86363,27 @@ aaa
 aaa
 aaa
 aaa
+abI
 aaa
 aaa
 aaa
 aaa
+urX
 aaa
 aaa
 aaa
 aaa
+abI
 aaa
 aaa
 aaa
 aaa
+abI
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -86044,18 +86449,18 @@ aaa
 aaa
 aaa
 aaa
-abI
+aht
 aaa
 aaa
 aaa
 aaa
 aaa
-abI
+aht
 acm
 aaa
 aaa
 aaa
-abI
+aht
 aaa
 acP
 acP
@@ -86073,16 +86478,16 @@ aft
 afK
 acP
 aaa
-aby
+aht
 aaa
+aht
 aaa
+mVM
+cpX
+aht
+cpX
+aht
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-anl
 aht
 amC
 aht
@@ -86220,17 +86625,17 @@ aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -86329,17 +86734,17 @@ aeZ
 rAe
 afL
 acP
-abI
-aby
 aaa
+aht
 aaa
+aht
 aaa
+cpX
+aht
+aht
+aht
+mVM
 aaa
-aaa
-aaa
-aaa
-aaa
-tHo
 aht
 amB
 aht
@@ -86477,17 +86882,17 @@ aaa
 aaa
 aaa
 aaa
+tXE
 aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+tXE
 aaa
 aaa
 aaa
@@ -86587,16 +86992,16 @@ afv
 afM
 acP
 aaa
+aht
 aaa
+aht
 aaa
+aht
+tPl
+mVM
+aht
+aht
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-anl
 aht
 amC
 aht
@@ -86739,7 +87144,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -86846,14 +87251,14 @@ acP
 agq
 adX
 aaa
+aht
 aaa
+cpX
+aht
+mVM
+aht
+mVM
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-anl
 aht
 amC
 aht
@@ -86996,7 +87401,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+tXE
 aaa
 aaa
 aaa
@@ -87103,14 +87508,14 @@ age
 agr
 adX
 aaa
+aht
 aaa
+mVM
+mVM
+aht
+mVM
+mVM
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-anl
 aht
 amC
 aht
@@ -87361,13 +87766,13 @@ ags
 adX
 adX
 adX
-dee
-anl
-anl
-anl
-anl
-anl
-anl
+aaa
+aht
+aaa
+aaa
+aaa
+aht
+aaa
 aht
 amC
 aht
@@ -88655,7 +89060,7 @@ ahR
 ala
 aht
 aht
-aht
+aaa
 aaa
 aaa
 app
@@ -90670,7 +91075,7 @@ aaa
 aaa
 aaa
 aaa
-tHo
+dTZ
 aaa
 aaa
 aaa
@@ -91322,22 +91727,23 @@ svD
 bJP
 aaa
 abI
+aaa
+aaa
+aht
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aht
+aaa
 anl
 aaa
-aht
-aaa
-aht
-aaa
-aaa
-aaa
-aht
-aaa
-aaa
-cFB
-aaa
-aht
-aaa
-anl
 aaa
 aaa
 aaa
@@ -91360,9 +91766,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cju
+cju
 aaa
 aaa
 aaa
@@ -91586,12 +91991,12 @@ aaa
 aht
 aaa
 aaa
-pDW
-pDW
-pDW
-pDW
-pDW
 aaa
+pDW
+pDW
+pDW
+pDW
+pDW
 anl
 anl
 anl
@@ -91617,12 +92022,12 @@ aaa
 aaa
 aaa
 aaa
+cju
+ckK
+cju
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cju
 aaa
 aaa
 aaa
@@ -91842,6 +92247,7 @@ auI
 auI
 hzr
 aaa
+anl
 aaa
 aaa
 aaa
@@ -91873,13 +92279,12 @@ aaa
 aaa
 aaa
 aaa
+cju
+cjx
+cjx
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cju
 aaa
 aaa
 aaa
@@ -92098,6 +92503,8 @@ xJb
 xJb
 tSV
 auI
+aht
+anl
 aaa
 aaa
 aaa
@@ -92125,18 +92532,16 @@ aaa
 aaa
 aaa
 aaa
+cju
 aaa
 aaa
 aaa
+cjx
+cjx
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cju
 aaa
 aaa
 abN
@@ -92356,7 +92761,7 @@ evU
 ijt
 auI
 aaa
-aaa
+anl
 aaa
 aaa
 aaa
@@ -92613,6 +93018,16 @@ syt
 ijt
 auI
 aaa
+anl
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cFB
 aaa
 aaa
 aaa
@@ -92644,17 +93059,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cju
 aaa
 aaa
 aaa
@@ -92870,6 +93275,7 @@ azm
 ijt
 auI
 aaa
+anl
 aaa
 aaa
 aaa
@@ -92894,6 +93300,8 @@ aaa
 aaa
 aaa
 aaa
+cju
+cju
 aaa
 aaa
 aaa
@@ -92901,18 +93309,15 @@ aaa
 aaa
 aaa
 aaa
+ckK
+cju
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cju
+cju
 aaa
 aaa
 aaa
@@ -93127,6 +93532,7 @@ pjM
 hCg
 auI
 aaa
+anl
 aaa
 aaa
 aaa
@@ -93150,6 +93556,9 @@ aaa
 aaa
 aaa
 aaa
+cju
+cju
+ckK
 aaa
 aaa
 aaa
@@ -93157,19 +93566,15 @@ aaa
 aaa
 aaa
 aaa
+cju
+cju
 aaa
 aaa
 aaa
+cju
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ckK
+cju
 aaa
 aaa
 aaa
@@ -93384,6 +93789,7 @@ pjM
 wfp
 wQE
 imB
+anl
 aaa
 aaa
 aaa
@@ -93406,6 +93812,15 @@ aaa
 aaa
 aaa
 aaa
+cju
+cju
+ckK
+cjx
+aaa
+aaa
+aaa
+aaa
+ckK
 aaa
 aaa
 aaa
@@ -93415,18 +93830,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ckK
+cju
 aaa
 aaa
 aaa
@@ -93641,6 +94046,7 @@ pjM
 ijt
 auI
 aaa
+anl
 aaa
 aaa
 aaa
@@ -93663,6 +94069,10 @@ aaa
 aaa
 aaa
 aaa
+cju
+ckK
+cjx
+cjx
 aaa
 aaa
 aaa
@@ -93677,14 +94087,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cjx
+cju
+cju
 aaa
 aaa
 aaa
@@ -93897,6 +94302,8 @@ sxs
 tlU
 wMm
 auI
+aht
+anl
 aaa
 aaa
 aaa
@@ -93919,6 +94326,9 @@ aaa
 aaa
 aaa
 aaa
+cju
+cju
+cjx
 aaa
 aaa
 aaa
@@ -93934,14 +94344,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cjx
+ckK
+cju
 aaa
 aaa
 aaa
@@ -94155,6 +94560,7 @@ hzr
 hzr
 hzr
 aaa
+anl
 aaa
 aaa
 aaa
@@ -94187,18 +94593,17 @@ aaa
 aaa
 aaa
 aaa
+cju
+cju
+cju
+cju
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cjx
+cjx
+cju
 aaa
 aaa
 aaa
@@ -94445,17 +94850,17 @@ aaa
 aaa
 aaa
 aaa
+cju
+thg
+cjx
+cjx
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cjx
+cjx
+cju
 aaa
 aaa
 aaa
@@ -94698,21 +95103,21 @@ aaa
 aaa
 aaa
 aaa
+cju
+aaa
+aaa
+aaa
+cju
+udc
+cjx
+cju
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cjx
+cju
 aaa
 aaa
 aaa
@@ -94959,17 +95364,17 @@ aaa
 aaa
 aaa
 aaa
+cju
+lFI
+cjx
+cju
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cju
 aaa
 aaa
 aaa
@@ -95039,7 +95444,7 @@ aaa
 aaa
 aaa
 aaa
-tHo
+dTZ
 aaa
 saE
 saE
@@ -95216,12 +95621,12 @@ aaa
 aaa
 aaa
 aaa
+cju
+cju
+cju
+cju
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ckK
 aaa
 aaa
 aaa
@@ -95436,7 +95841,7 @@ axO
 uhR
 rGD
 rLJ
-aaa
+fUl
 aaa
 aaa
 aaa
@@ -95665,23 +96070,23 @@ oBc
 wRy
 iIT
 aaa
-aaa
-aaa
 aht
 aaa
 aht
 aaa
+aht
+aaa
+aaa
+aaa
+abI
 aaa
 aaa
 abI
 aaa
 aaa
-aaa
-abI
-aaa
+aht
 aaa
 aaa
-abI
 bYw
 bYw
 aqx
@@ -95693,7 +96098,7 @@ klp
 njg
 ryS
 aaa
-gYo
+aaa
 aaa
 aaa
 aaa
@@ -95923,23 +96328,23 @@ iaL
 iIT
 aht
 aht
-aaa
+aht
+aht
+aht
 aht
 aaa
+aaa
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aaa
 aht
-aaa
-aaa
-bSg
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aaa
 bYw
 bWQ
 caQ
@@ -95949,8 +96354,8 @@ njz
 woV
 azC
 bYw
-aht
-anl
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96089,7 +96494,7 @@ anl
 anl
 anl
 anl
-tHo
+dTZ
 anl
 anl
 anl
@@ -96101,8 +96506,8 @@ anl
 anl
 anl
 anl
-tHo
 anl
+aht
 aiS
 aiS
 aiS
@@ -96180,11 +96585,10 @@ iIT
 iIT
 bHy
 wcg
-aht
-aht
-aht
+aaa
 aht
 aaa
+aht
 aaa
 aaa
 aaa
@@ -96195,7 +96599,8 @@ aaa
 aaa
 abI
 aaa
-aht
+aaa
+aaa
 aht
 aht
 aht
@@ -96207,7 +96612,7 @@ tlJ
 bYw
 bYw
 aht
-aaa
+tXE
 aaa
 aaa
 aaa
@@ -96252,8 +96657,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cjx
+cju
 aaa
 aaa
 aaa
@@ -96358,16 +96763,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tHo
+aht
+aht
+aht
+aht
+aht
+rIf
+aht
+aht
+aht
 aiS
 sFK
 ajv
@@ -96444,14 +96849,14 @@ aht
 aaa
 aaa
 aaa
-acO
 aby
 aby
 aby
 aaa
-acO
+aby
 aby
 bSg
+aaa
 aaa
 aaa
 aaa
@@ -96509,8 +96914,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cju
+cju
 aaa
 aaa
 aaa
@@ -96615,16 +97020,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anl
+aht
+mpf
+aht
+hcP
+yjj
+vcn
+yjj
+oHt
+aht
 aiS
 sFK
 sFK
@@ -96698,8 +97103,8 @@ iUX
 iUX
 iUX
 iUX
-aaa
-aaa
+aht
+tXE
 aaa
 aaa
 aaa
@@ -96720,8 +97125,8 @@ bYw
 mGP
 bYw
 bYw
-aaa
-aaa
+aht
+tXE
 aaa
 aaa
 aaa
@@ -96766,7 +97171,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cju
 aaa
 aaa
 aaa
@@ -96872,16 +97277,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anl
+owe
+pFa
+pFa
+mNE
+tTz
+poF
+yab
+qsn
+aht
 aiS
 aiS
 aiS
@@ -96974,8 +97379,8 @@ bYw
 bYw
 nzp
 bYw
-aht
-aht
+aaa
+aaa
 aht
 aaa
 aaa
@@ -97129,17 +97534,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anl
+aht
+aht
+aht
+fDp
+rMt
+riC
+rMt
+xqs
+aht
+aht
 aaa
 aiT
 sFK
@@ -97226,16 +97631,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aht
-aht
+aaa
 aht
 aaa
 gYo
 gYo
-gYo
-aaa
-aaa
-aaa
+anl
+anl
 aaa
 aaa
 aaa
@@ -97384,19 +97789,19 @@ aaa
 aaa
 aaa
 aaa
+anl
+tHo
+anl
+aht
+iNq
 aaa
+fDp
+pfn
+pjC
+pfn
+xqs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eyZ
 aaa
 aiT
 sFK
@@ -97485,9 +97890,9 @@ aaa
 aaa
 aaa
 aaa
+tXE
 aaa
-aaa
-aaa
+tXE
 aaa
 aaa
 aaa
@@ -97641,20 +98046,20 @@ aaa
 aaa
 aaa
 aaa
+anl
+aht
+aht
+aht
+xmY
 aaa
+fDp
+pfn
+pjC
+pfn
+xqs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bPm
+aht
 aiS
 asm
 aiS
@@ -97726,8 +98131,8 @@ bHy
 iUX
 iUX
 iUX
-aaa
-aaa
+aht
+tXE
 aaa
 aaa
 aaa
@@ -97898,19 +98303,19 @@ aaa
 aaa
 aaa
 aaa
+anl
+aht
+crr
 aaa
+xmY
 aaa
+fDp
+geY
+xZk
+dQw
+xqs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bPm
 aaa
 aiT
 sFK
@@ -98155,19 +98560,19 @@ aaa
 aaa
 aaa
 aaa
+anl
+aht
+tSb
 aaa
+xmY
 aaa
+oGf
+oaD
+dsZ
+xTR
+eoF
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bPm
 aaa
 aiT
 sFK
@@ -98412,20 +98817,20 @@ aaa
 aaa
 aaa
 aaa
+anl
+aht
+wqk
 aaa
+xmY
 aaa
+obP
+mcK
+guc
+kFs
+hGX
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bPm
+aht
 aiS
 sFK
 aiS
@@ -98669,19 +99074,19 @@ aaa
 aaa
 aaa
 aaa
+anl
+aht
+aht
+aht
+tff
 aaa
+obP
+pfn
+pjC
+pfn
+hGX
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bPm
 aaa
 aiT
 asm
@@ -98926,19 +99331,19 @@ aaa
 aaa
 aaa
 aaa
+anl
+anl
+anl
+aht
+nQo
 aaa
+obP
+pfn
+pjC
+pfn
+hGX
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+qWd
 aaa
 aiT
 sFK
@@ -99185,18 +99590,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anl
+aht
+aht
+aht
+obP
+xyH
+nzo
+xyH
+hGX
+aht
+owe
+aht
 aiS
 sFK
 aiS
@@ -99442,17 +99847,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dTZ
+aht
+pFa
+pFa
+bOL
+mAp
+sSM
+pbZ
+hRA
+pFa
+fsg
 aaa
 aiT
 sFK
@@ -99699,17 +100104,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anl
+aht
+mpf
+aht
+ybx
+obn
+gMw
+obn
+iLa
+aht
+mpf
 aaa
 aiT
 sFK
@@ -99956,17 +100361,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anl
+aht
+aht
+aht
+aht
+aht
+rIf
+aht
+aht
+aht
+aht
 aaa
 aiS
 hfX
@@ -100213,18 +100618,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anl
+anl
+tHo
+anl
+anl
+anl
+anl
+anl
+anl
+anl
+anl
+aht
 aiS
 aiT
 aiT
@@ -100479,10 +100884,10 @@ aaa
 aaa
 aaa
 aaa
+aht
 aaa
 aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -100736,15 +101141,15 @@ aaa
 aaa
 aaa
 aaa
+anl
+aaa
+aaa
+anl
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -100993,19 +101398,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anl
+aht
+aht
+anl
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 aIp
 aJq
 aFj
@@ -101250,10 +101655,10 @@ aaa
 aaa
 aaa
 aaa
+anl
 aaa
 aaa
-aaa
-aaa
+anl
 aaa
 aaa
 aaa
@@ -101507,10 +101912,10 @@ aaa
 aaa
 aaa
 aaa
+anl
 aaa
 aaa
-aaa
-aaa
+anl
 aaa
 aaa
 aaa
@@ -101764,10 +102169,10 @@ aaa
 aaa
 aaa
 aaa
+anl
 aaa
 aaa
-aaa
-aaa
+anl
 aaa
 aaa
 aaa
@@ -102021,10 +102426,10 @@ aaa
 aaa
 aaa
 aaa
+anl
 aaa
 aaa
-aaa
-aaa
+anl
 aaa
 aaa
 aaa
@@ -102281,7 +102686,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aaa
 aaa
 aaa
@@ -102321,8 +102726,8 @@ aht
 aht
 aht
 cdm
-aaa
-aaa
+aht
+aht
 vgm
 uSW
 ybX
@@ -102347,7 +102752,7 @@ fKj
 lWy
 lWy
 bwm
-aed
+abI
 aaa
 aht
 aaa
@@ -102356,7 +102761,7 @@ aaa
 aed
 aaa
 aaa
-cFB
+aaa
 aaa
 aaa
 aaa
@@ -102538,7 +102943,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+anl
 aaa
 aaa
 aaa
@@ -102579,7 +102984,7 @@ aaa
 aaa
 cdm
 aaa
-aaa
+aht
 vgm
 uSW
 fNv
@@ -102604,8 +103009,8 @@ bwm
 bwm
 lWy
 bwm
-aby
-aht
+abI
+tHo
 aby
 aby
 aby
@@ -102836,7 +103241,7 @@ aaa
 aaa
 cdm
 aaa
-aaa
+aht
 vgm
 uSW
 bfM
@@ -102861,7 +103266,7 @@ bwm
 hXt
 lWy
 rNB
-aby
+abI
 aaa
 aed
 aaa
@@ -103092,8 +103497,8 @@ aht
 aaa
 aaa
 cdm
-aaa
-aaa
+aht
+aht
 vgm
 uSW
 ybX
@@ -103118,7 +103523,7 @@ bwm
 bwm
 lWy
 bwm
-aed
+abI
 aaa
 aaa
 aaa
@@ -103130,7 +103535,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -104146,7 +104551,7 @@ rNB
 bwm
 bwm
 bwm
-aht
+aaa
 aaa
 aaa
 aaa
@@ -104338,17 +104743,17 @@ aaa
 aaa
 aaa
 aaa
-aby
-aby
-aby
-aby
-aby
-aht
-aht
-aht
-aht
-aht
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 vek
 aht
 aht
@@ -104402,8 +104807,8 @@ bwm
 aaa
 aht
 aaa
-aaa
 aht
+aaa
 aaa
 aaa
 aaa
@@ -104596,13 +105001,13 @@ aaa
 aaa
 aaa
 aby
-aht
-aht
-aht
 aby
-aaa
-aaa
-aaa
+aby
+aby
+aby
+anl
+anl
+anl
 aaa
 aaa
 aaa
@@ -104630,7 +105035,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 bbP
@@ -104658,9 +105063,9 @@ bwm
 bwm
 aaa
 aby
-aht
+aaa
 aed
-aby
+aaa
 aaa
 aaa
 aaa
@@ -104857,7 +105262,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -104887,7 +105292,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 bbP
@@ -105144,7 +105549,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 bbP
@@ -105401,9 +105806,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
 bbP
 xbX
 eTw
@@ -105658,7 +106063,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 bbP
@@ -105915,7 +106320,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 bbP
@@ -106172,7 +106577,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 bbP
@@ -106197,7 +106602,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aby
 aaa
@@ -106429,9 +106834,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
 bbP
 gDQ
 bbP
@@ -106453,8 +106858,8 @@ bkF
 aht
 aed
 aht
+aht
 aby
-aaa
 aaa
 aed
 aaa
@@ -106686,17 +107091,17 @@ aaa
 aaa
 aaa
 aaa
+aht
+aaa
+aaa
+aht
+aaa
+aht
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
 aaa
 bkF
 cBO
@@ -106710,8 +107115,8 @@ bkF
 aaa
 aby
 aaa
-aht
 aaa
+aht
 aaa
 aby
 aaa
@@ -106943,18 +107348,18 @@ aaa
 aaa
 aaa
 aaa
+tXE
+aht
+aht
+tXE
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tXE
+aht
+aht
+aht
+aht
+tXE
+aht
 xKc
 cBO
 cBO
@@ -106967,8 +107372,8 @@ xKc
 aaa
 aby
 aaa
-aht
 aaa
+aht
 aaa
 aht
 aaa
@@ -107224,9 +107629,9 @@ bkF
 aaa
 aed
 aaa
-aby
+aaa
 aht
-aht
+aaa
 aht
 aaa
 aaa
@@ -107478,13 +107883,13 @@ xKc
 bkF
 bkF
 bkF
-aaa
+aht
 aby
-aaa
+aed
 aby
-aaa
-aaa
-aaa
+aby
+aht
+aht
 aaa
 aaa
 aaa
@@ -107737,8 +108142,8 @@ aaa
 aaa
 aaa
 bHI
-aht
-aed
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -107995,7 +108400,7 @@ aby
 aht
 aby
 aaa
-aht
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27243,10 +27243,6 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"cpX" = (
-/turf/open/floor/plating/airless,
-/turf/open/space/basic,
-/area/space/nearstation)
 "cpY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -86483,9 +86479,9 @@ aaa
 aht
 aaa
 mVM
-cpX
+mVM
 aht
-cpX
+mVM
 aht
 aaa
 aht
@@ -86739,7 +86735,7 @@ aht
 aaa
 aht
 aaa
-cpX
+mVM
 aht
 aht
 aht
@@ -87253,7 +87249,7 @@ adX
 aaa
 aht
 aaa
-cpX
+mVM
 aht
 mVM
 aht


### PR DESCRIPTION

> [!NOTE]
> This PR is almost an exact copy of [#1239](https://github.com/fulpstation/fulpstation/pull/1239), which I chose to close due to a particularly difficult merge conflict. Most of the map changes in this new PR are exactly the same though I have adjusted a few more things here and there.
## About The Pull Request
This PR attempts to improve Pubby Station's exterior a bit (mostly but not exclusively by moving around, adding, and deleting lattices/grilles.) The primary changes of note made in this PR include the following:

1. Adding a space basketball court: 
![Space_Basketball](https://github.com/user-attachments/assets/6cc39980-4ff2-4b58-bd9b-91eacdb55126)

2. Adding a small asteroid debris cloud near Pubby's bomb testing asteroid: 
![Small_Asteroid_Debris_Area](https://github.com/user-attachments/assets/0e73f087-45e8-40ad-adf9-2cd70a00bb3e)

3. Giving Pubby's telecomms sat a bit more exterior breathing room: 
![Redetailed_Telecomms](https://github.com/user-attachments/assets/3c377f47-f607-4ede-8f56-4dceeda684aa)

<sup>(Also I added a singular tile that was missing under a door near Pubby's mining shuttle dock.)</sup>
## Why It's Good For The Game
These changes hopefully make Pubby Station look better on the outside.
## Changelog
:cl:
add: Added more details to Pubby Station's exterior
/:cl: