### PR TITLE
Improves body camera quality of life

### DIFF
--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -26,10 +26,10 @@
 
 /obj/item/bodycam_upgrade/examine_more(mob/user)
 	. = ..()
-	. += list(span_notice("Use [src] on any valid vest to quickly install."))
+	. += list(span_notice("Use [src] on any valid vest to instantaneously install"))
 	. += list(span_notice("Use a [span_bold("screwdriver")] to remove it."))
-	. += list(span_notice("While equipped, use your ID card on the vest to activate/deactivate the camera."))
-	. += list(span_notice("Unequipping the vest will immediately deactivate the camera."))
+	. += list(span_notice("Once installed, the camera will activate/deactivate whenever its associated vest is worn/removed."))
+	. += list(span_notice("You can also use your ID card on the vest to toggle its camera manually."))
 
 /obj/item/bodycam_upgrade/Destroy()
 	if(builtin_bodycamera)
@@ -41,11 +41,18 @@
 		return FALSE
 	return TRUE
 
-/obj/item/bodycam_upgrade/proc/turn_on(mob/user, obj/item/card/id/id_card)
+/obj/item/bodycam_upgrade/proc/turn_on(mob/living/user, obj/item/card/id/id_card)
+	if(!id_card)
+		var/obj/item/card/id/card = user.get_idcard()
+		if(card)
+			id_card = card
 	builtin_bodycamera = new(user)
 	builtin_bodycamera.internal_light = FALSE
 	builtin_bodycamera.network = list("ss13")
-	builtin_bodycamera.c_tag = "-Body Camera: [(id_card.registered_name)] ([id_card.assignment])"
+	if(id_card)
+		builtin_bodycamera.c_tag = "-Body Camera: [(id_card.registered_name)] ([id_card.assignment])"
+	else
+		builtin_bodycamera.c_tag = "-Body Camera: [(user.name)]"
 	playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
 	if(user)
 		user.balloon_alert(user, "bodycamera activated")
@@ -73,11 +80,13 @@
 	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attackby))
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(on_examine_more))
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER), PROC_REF(on_screwdriver_act))
+	RegisterSignal(parent, COMSIG_ITEM_POST_EQUIPPED, PROC_REF(on_parent_equipped))
 
 /datum/component/bodycamera_holder/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER))
 	UnregisterSignal(parent, COMSIG_ATOM_ATTACKBY)
 	UnregisterSignal(parent, COMSIG_ATOM_EXAMINE)
+	UnregisterSignal(parent, COMSIG_ITEM_POST_EQUIPPED)
 	QDEL_NULL(bodycamera_installed)
 	return ..()
 
@@ -88,6 +97,15 @@
 /datum/component/bodycamera_holder/proc/turn_camera_off(mob/living/user)
 	UnregisterSignal(parent, COMSIG_ITEM_POST_UNEQUIP)
 	bodycamera_installed.turn_off(user)
+
+/// When the camera holder is equipped
+/datum/component/bodycamera_holder/proc/on_parent_equipped(mob/living/source, force, atom/newloc, no_move, invdrop, silent)
+	SIGNAL_HANDLER
+	if(bodycamera_installed)
+		var/obj/item/clothing/parent_item = parent
+		var/mob/living/equipper = isliving(parent_item.loc) ? parent_item.loc : null
+		if(equipper && equipper.get_item_by_slot(clothingtype_required) == parent)
+			turn_camera_on(equipper)
 
 /// When the camera holder is unequipped
 /datum/component/bodycamera_holder/proc/on_unequip(mob/living/source, force, atom/newloc, no_move, invdrop, silent)
@@ -115,6 +133,8 @@
 			item.forceMove(source)
 			bodycamera_installed = item
 			playsound(source, 'sound/items/drill_use.ogg', item.get_clamped_volume(), TRUE, -1)
+			if(user.get_item_by_slot(clothingtype_required) == parent)
+				turn_camera_on(user)
 		return
 
 	if(!bodycamera_installed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes security body cameras automatically enable when installed on a worn vest or installed on a vest that is then worn. They can still be toggled manually with an ID, and if they are unable to get a person's name/job from their ID slot then they'll just use the person's (possibly fake) name for their camera's network tag.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This eliminates the tedious task of constantly having to remember to activate body cameras whenever you want to use them. Besides, anyone who actively chooses to buy a body camera and install it on a vest probably wants it on anyways.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Body cameras now automatically enable when installed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
