### PR TITLE
Incredibly broad Theia Station improvements

### DIFF
--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -1027,10 +1027,10 @@
 	},
 /area/station/medical/morgue)
 "atG" = (
-/obj/machinery/rnd/production/techfab/department/cargo,
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/machinery/autolathe,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "atL" = (
@@ -3659,8 +3659,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "bsM" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/chair/office{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bsR" = (
@@ -7613,12 +7614,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
-"cYw" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
 "cYO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -7884,6 +7879,10 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"deJ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/closed/wall,
+/area/station/maintenance/aft/lesser)
 "deL" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -12614,6 +12613,10 @@
 /area/station/cargo/storage)
 "eVN" = (
 /obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/structure/ore_box,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "eVX" = (
@@ -13794,6 +13797,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"fsy" = (
+/obj/machinery/firealarm/directional/east,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "fsC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -17050,10 +17063,10 @@
 /area/station/ai_monitored/security/armory)
 "gHR" = (
 /obj/effect/landmark/start/cargo_technician,
-/obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gHV" = (
@@ -17619,10 +17632,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/bar)
-"gSz" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "gSG" = (
 /obj/structure/chair/comfy/beige,
 /obj/item/toy/plush/lizard_plushie/space,
@@ -18087,9 +18096,8 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "haa" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hab" = (
@@ -29087,7 +29095,8 @@
 /area/station/security/prison/mess)
 "lBB" = (
 /obj/machinery/mineral/ore_redemption{
-	dir = 1
+	input_dir = 2;
+	output_dir = 1
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/north{
@@ -30151,6 +30160,15 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"man" = (
+/obj/machinery/computer/cargo{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "mar" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
@@ -31759,8 +31777,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mJB" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "mJC" = (
@@ -34595,6 +34616,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"nSp" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "nSq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37074,16 +37103,18 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "oRf" = (
-/obj/machinery/computer/cargo{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/machinery/light/small/directional/south,
+/obj/item/folder/yellow,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "oRu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/requests_console/directional/south,
+/obj/machinery/requests_console/directional/south{
+	name = "Engineering Requests Console";
+	department = "Engineering"
+	},
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/information,
@@ -42611,6 +42642,12 @@
 "rkT" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
+"rkW" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "rla" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -43580,6 +43617,8 @@
 	network = list("ss13","cargo")
 	},
 /obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/machinery/rnd/production/techfab/department/cargo,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rEf" = (
@@ -58459,9 +58498,15 @@
 /area/station/maintenance/starboard/aft)
 "xPZ" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/requests_console/directional/south,
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/machinery/requests_console/directional/east{
+	department = "Cargo"
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xQi" = (
@@ -58561,11 +58606,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "xRR" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xSp" = (
@@ -83921,8 +83964,8 @@ lIf
 gHR
 cgl
 cgl
-cgl
 jum
+rkW
 qab
 rFt
 aaL
@@ -84174,7 +84217,7 @@ mMP
 mMP
 xEF
 lIf
-gSz
+lIf
 haa
 rDK
 atG
@@ -84433,7 +84476,7 @@ iBG
 lIf
 bsM
 oRf
-rEy
+deJ
 rEy
 rEy
 rEy
@@ -84688,8 +84731,8 @@ dRk
 mMP
 eVN
 xPZ
-rEy
-rEy
+man
+fsy
 rEy
 vTT
 hDF
@@ -84946,8 +84989,8 @@ mMP
 rEy
 rEy
 rEy
-doq
-cYw
+rEy
+rEy
 doq
 doq
 doq
@@ -85205,7 +85248,7 @@ mdF
 nod
 doq
 rEy
-rEy
+nSp
 rEy
 bwv
 wDa

--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -1416,7 +1416,6 @@
 "aBt" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "aBw" = (
@@ -82302,7 +82301,7 @@ vQV
 vQV
 vQV
 nri
-pkh
+qxV
 qxV
 qxV
 qxV

--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -1,12 +1,19 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaf" = (
-/obj/structure/closet,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "ToiletA";
+	name = "Bolt Control - Toilet A";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_x = 6
+	},
+/obj/machinery/light/small/directional/west,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/auxiliary)
 "aag" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/modular_computer/preset/id,
@@ -23,9 +30,11 @@
 /area/station/maintenance/starboard/aft)
 "aai" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/engineering/transit_tube)
 "aaI" = (
@@ -101,7 +110,6 @@
 "abp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -109,6 +117,7 @@
 	codes_txt = "patrol;next_patrol=cargo2";
 	location = "cargo1"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "abs" = (
@@ -196,6 +205,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"acF" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "acP" = (
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
@@ -268,9 +282,8 @@
 "aet" = (
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
@@ -312,6 +325,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"afM" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "afY" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/chair{
@@ -488,6 +506,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "ajl" = (
@@ -556,7 +575,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "akZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/gravity_generator)
@@ -567,11 +586,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "alp" = (
-/obj/structure/reflector/double,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_10k,
-/turf/open/floor/plating,
+/obj/structure/reflector/single,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "als" = (
 /obj/structure/cable,
@@ -635,11 +654,14 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "amw" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/item/reagent_containers/cup/glass/bottle/whiskey,
 /obj/item/storage/fancy/cigarettes/cigars/havana,
 /obj/structure/cable,
 /obj/machinery/keycard_auth,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
 "ann" = (
@@ -656,15 +678,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"anC" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "anF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -804,6 +817,12 @@
 /obj/machinery/fishing_portal_generator,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/hallway/primary/central/aft)
+"apA" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "apG" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -922,7 +941,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain/private)
 "asq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -968,6 +987,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"atg" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "ath" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -985,6 +1008,14 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
+"atn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "atz" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/closet/crate/coffin,
@@ -1076,6 +1107,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/commons/fitness)
+"avo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L11"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "avv" = (
 /obj/structure/table/wood,
 /obj/item/pen/fountain,
@@ -1151,12 +1191,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
-"awf" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L8"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "awj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1389,10 +1423,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
-"aBy" = (
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "aBJ" = (
 /turf/open/floor/iron/dark/herringbone,
 /area/station/command/bridge)
@@ -1414,7 +1444,6 @@
 /area/station/security/checkpoint/science)
 "aCm" = (
 /obj/effect/decal/cleanable/oil,
-/obj/structure/reflector/box,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "aCn" = (
@@ -1427,7 +1456,6 @@
 /area/station/commons/fitness/recreation)
 "aCp" = (
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -1444,6 +1472,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/library)
+"aCz" = (
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "aCF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 10
@@ -1584,6 +1617,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"aEp" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "aEH" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
@@ -1613,6 +1651,10 @@
 /obj/machinery/computer/security/telescreen/rd/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"aEY" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "aFk" = (
 /obj/effect/decal/cleanable/vomit/purple,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1807,7 +1849,8 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/rag,
 /obj/item/reagent_containers/cup/glass/bottle/tequila,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/tile,
 /area/station/maintenance/department/engine)
 "aIg" = (
 /obj/machinery/airalarm/directional/east,
@@ -1817,6 +1860,7 @@
 "aIh" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/sign/directions/dorms/directional/west,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "aIk" = (
@@ -1838,6 +1882,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "aJq" = (
@@ -1861,6 +1906,10 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/carpet/purple,
 /area/station/service/lawoffice)
+"aKh" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "aKz" = (
 /obj/structure/chair{
 	dir = 1
@@ -2079,7 +2128,7 @@
 /area/station/security/detectives_office)
 "aPv" = (
 /obj/structure/chair/office,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "aPA" = (
 /obj/item/storage/medkit/brute{
@@ -2128,12 +2177,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"aQF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark/arrow_ccw,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "aQM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2250,12 +2293,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aSa" = (
-/obj/item/storage/box/shipping,
-/obj/item/toner,
-/obj/item/stack/wrapping_paper,
-/obj/item/hand_labeler,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "aSd" = (
@@ -2314,6 +2354,7 @@
 /area/station/cargo/miningdock)
 "aSQ" = (
 /obj/structure/reagent_dispensers/fueltank/large,
+/obj/effect/decal/cleanable/fuel_pool,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "aSX" = (
@@ -2404,10 +2445,11 @@
 "aVT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "aVV" = (
@@ -2418,6 +2460,11 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"aWl" = (
+/obj/structure/grille/broken,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "aWn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -2517,6 +2564,14 @@
 "aZy" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/nuke_storage)
+"aZz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
+"aZI" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "bac" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2579,6 +2634,12 @@
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"bbD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "bbK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2{
 	dir = 9
@@ -2607,9 +2668,8 @@
 /area/station/science/lobby)
 "bcd" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/engineering/transit_tube)
@@ -2859,6 +2919,9 @@
 /obj/machinery/portable_atmospherics/pipe_scrubber,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos/pumproom)
+"bge" = (
+/turf/open/floor/iron/dark,
+/area/station/security/execution)
 "bgi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2916,11 +2979,15 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bhd" = (
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/machinery/light/directional/south,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bhh" = (
@@ -2930,7 +2997,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/white,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/execution)
 "bhl" = (
 /obj/structure/chair/pew/right{
@@ -3083,6 +3150,7 @@
 /obj/structure/fluff/beach_towel,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bjW" = (
@@ -3128,12 +3196,31 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"bkq" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "bkx" = (
 /obj/effect/turf_decal/trimline/green/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"bkB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
+"bkG" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "bkJ" = (
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/iron,
@@ -3178,6 +3265,7 @@
 /obj/structure/chair/stool/bar/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "blD" = (
@@ -3245,12 +3333,12 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bmF" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
+	},
+/obj/structure/cable,
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
@@ -3288,6 +3376,9 @@
 /area/station/medical/medbay/central)
 "bnE" = (
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/power/emitter{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "bnU" = (
@@ -3586,7 +3677,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/security/office)
 "bto" = (
@@ -3732,9 +3822,6 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L11"
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "bwf" = (
@@ -3752,6 +3839,9 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
+"bwv" = (
+/turf/closed/wall/rust,
+/area/station/maintenance/aft/lesser)
 "bwH" = (
 /obj/structure/chair/wood,
 /obj/effect/landmark/start/hangover,
@@ -3764,19 +3854,6 @@
 /mob/living/simple_animal/bot/secbot/beepsky,
 /turf/open/floor/iron,
 /area/station/security/brig)
-"bwS" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/engine,
-/area/station/security/mechbay)
-"bxj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/storage_shared)
 "bxk" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -3864,8 +3941,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/closet/toolcloset,
-/obj/item/lightreplacer,
+/obj/item/clothing/head/cone{
+	pixel_x = -7;
+	pixel_y = -4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "byA" = (
@@ -3981,10 +4060,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/toilet)
 "bBa" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/camera/directional/east,
+/obj/effect/landmark/start/hangover,
+/obj/item/soap/nanotrasen,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/auxiliary)
 "bBi" = (
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot_red,
@@ -4126,12 +4208,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
-"bEx" = (
-/obj/structure/cable,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/four,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
 "bEM" = (
 /obj/structure/chair/pew{
 	dir = 8
@@ -4245,6 +4321,7 @@
 /obj/item/chair/stool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bGS" = (
@@ -4268,15 +4345,6 @@
 "bHd" = (
 /turf/closed/wall,
 /area/station/service/hydroponics)
-"bHs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "bHu" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -4290,6 +4358,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bHE" = (
@@ -4320,11 +4389,6 @@
 "bHP" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/hop)
-"bHT" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/light,
-/area/station/ai_monitored/command/storage/eva)
 "bIn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/arrow_cw,
@@ -4342,6 +4406,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
@@ -4416,10 +4483,11 @@
 /area/station/security/prison/rec)
 "bJo" = (
 /obj/machinery/holopad/secure,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "bJu" = (
 /obj/structure/rack,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bJy" = (
@@ -4441,8 +4509,10 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "bJW" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 4
+	},
 /area/station/maintenance/aft/upper)
 "bJX" = (
 /obj/structure/closet/radiation,
@@ -4466,6 +4536,8 @@
 "bKg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "bKv" = (
@@ -4561,6 +4633,15 @@
 "bLO" = (
 /turf/closed/wall,
 /area/station/commons/fitness/recreation/entertainment)
+"bLW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "bMf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4636,20 +4717,17 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"bNa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/grey{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "bNE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"bNT" = (
+/obj/item/clothing/shoes/clown_shoes,
+/obj/effect/decal/cleanable/blood,
+/obj/item/bodypart/leg/left,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "bOh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -4863,18 +4941,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"bSI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L9"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "bSJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -4903,9 +4969,6 @@
 /area/station/hallway/secondary/command)
 "bTa" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/power/emitter{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "bTc" = (
@@ -4924,6 +4987,7 @@
 	codes_txt = "patrol;next_patrol=hall1";
 	location = "hall8"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bTF" = (
@@ -4981,6 +5045,10 @@
 	dir = 4
 	},
 /area/station/science/lab)
+"bUL" = (
+/obj/effect/spawner/random/structure/chair_maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "bUM" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/blue/anticorner,
@@ -4997,11 +5065,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "bUY" = (
-/obj/structure/closet/wardrobe/orange,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/closet/wardrobe/orange,
 /turf/open/floor/iron/dark,
 /area/station/security/brig/hallway)
 "bVh" = (
@@ -5277,15 +5345,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
-"cbj" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 9
-	},
-/obj/structure/chair/sofa/bench/solo{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+"caN" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "cbq" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
@@ -5440,6 +5503,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "cfg" = (
@@ -5558,7 +5622,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "ciw" = (
-/obj/structure/cable,
+/obj/structure/chair/sofa/bench/left{
+	dir = 1
+	},
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ciA" = (
@@ -5582,6 +5649,7 @@
 /obj/structure/sign/directions/evac/directional/east{
 	dir = 9
 	},
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "ciW" = (
@@ -5593,10 +5661,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ciX" = (
-/obj/machinery/status_display/evac/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 5
 	},
@@ -5606,10 +5670,21 @@
 /obj/effect/turf_decal/trimline/dark_blue/mid_joiner{
 	dir = 4
 	},
+/obj/machinery/button/door/directional/east{
+	req_access = list("teleporter");
+	id = "teleshutter";
+	name = "Teleporter Shutter Control";
+	pixel_y = 6
+	},
+/obj/machinery/light_switch/directional/east{
+	pixel_x = 25;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/textured_large,
 /area/station/command/teleporter)
 "cjf" = (
 /obj/machinery/status_display/ai/directional/north,
+/obj/structure/reflector/box,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "cjr" = (
@@ -5618,8 +5693,9 @@
 /obj/machinery/door/airlock{
 	name = "Evac Lounge Supply Closet"
 	},
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/auxiliary)
 "cjt" = (
 /obj/structure/table/wood/fancy,
 /obj/item/gun/ballistic/revolver/russian,
@@ -5627,6 +5703,7 @@
 /area/station/commons/lounge)
 "cju" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "cjw" = (
@@ -5774,7 +5851,8 @@
 /area/station/ai_monitored/security/armory)
 "cnW" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/plating,
+/obj/structure/reflector/single,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "coa" = (
 /obj/structure/table,
@@ -5856,7 +5934,6 @@
 "coX" = (
 /obj/item/hand_tele,
 /obj/structure/table/reinforced,
-/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 9
 	},
@@ -5943,10 +6020,6 @@
 /obj/effect/turf_decal/tile/prison/half,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
-"cqI" = (
-/obj/effect/spawner/random/trash/moisture_trap,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "cqM" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/office)
@@ -6013,7 +6086,12 @@
 "crt" = (
 /obj/item/construction/rcd,
 /obj/structure/rack,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/window/spawner/directional/west,
+/obj/machinery/door/window/left/directional/north{
+	req_access = list("engineering")
+	},
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "crC" = (
 /obj/effect/turf_decal/bot,
@@ -6192,6 +6270,10 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
+"cwj" = (
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "cwk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6265,6 +6347,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "cxD" = (
@@ -6281,6 +6364,10 @@
 	dir = 8
 	},
 /area/station/engineering/atmos)
+"cxN" = (
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "cxR" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -6377,7 +6464,6 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "cAD" = (
-/obj/structure/table,
 /obj/machinery/camera/directional/east{
 	c_tag = "Securtiy Mech Bay";
 	name = "camera"
@@ -6385,6 +6471,10 @@
 /obj/machinery/light/cold/no_nightlight/directional/east,
 /turf/open/floor/engine,
 /area/station/security/mechbay)
+"cAO" = (
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "cBq" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 8
@@ -6764,6 +6854,18 @@
 /obj/structure/sign/directions/evac/directional/north{
 	dir = 2
 	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/trimline/neutral/arrow_cw{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/arrow_cw{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "cIq" = (
@@ -6800,6 +6902,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"cIL" = (
+/obj/machinery/light/small/broken/directional/north,
+/turf/open/floor/iron/white/smooth_half,
+/area/station/maintenance/aft/upper)
 "cJm" = (
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -6823,7 +6929,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cJz" = (
@@ -6877,6 +6982,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"cJM" = (
+/obj/effect/spawner/random/trash/bacteria,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "cKc" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/structure/disposalpipe/segment,
@@ -6899,6 +7008,13 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
+"cKC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "cKG" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6954,9 +7070,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "cLG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/closet,
 /obj/item/clothing/under/dress/wedding_dress,
 /obj/item/clothing/head/costume/weddingveil,
@@ -6981,14 +7094,22 @@
 /turf/closed/wall,
 /area/station/security/detectives_office)
 "cMv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering - Front Desk";
 	name = "engineering camera";
 	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -7;
+	pixel_y = -8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
@@ -7049,20 +7170,21 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
-"cNM" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "cOb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
+"cOe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "cOk" = (
 /obj/item/stock_parts/power_store/cell/potato,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "cOo" = (
@@ -7123,8 +7245,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "cQc" = (
 /obj/structure/cable,
@@ -7178,10 +7302,12 @@
 /area/station/maintenance/department/cargo)
 "cRg" = (
 /obj/effect/decal/cleanable/oil,
-/obj/structure/reflector/single,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/power/emitter{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "cRj" = (
 /obj/structure/chair/office{
@@ -7347,6 +7473,13 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/aft/lesser)
+"cVu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cVx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/dark/full,
@@ -7374,6 +7507,10 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"cWe" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "cWi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7439,8 +7576,8 @@
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
 "cXx" = (
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
+/obj/vehicle/sealed/mecha/ripley/paddy/preset,
 /turf/open/floor/engine,
 /area/station/security/mechbay)
 "cXF" = (
@@ -7456,8 +7593,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "cYc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/office,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "cYq" = (
@@ -7471,6 +7608,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"cYw" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "cYO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -7560,13 +7703,6 @@
 /obj/item/clothing/shoes/laceup,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"dbi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "dbp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7589,6 +7725,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"dbR" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "dcn" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/directional/east,
@@ -7630,8 +7770,8 @@
 /area/station/science/robotics/mechbay)
 "dcS" = (
 /obj/structure/rack,
-/obj/item/soap/syndie,
 /obj/item/stack/medical/suture/emergency,
+/obj/effect/spawner/random/trash/soap,
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
@@ -7711,9 +7851,9 @@
 	},
 /area/station/medical/storage)
 "dek" = (
-/obj/effect/decal/cleanable/blood,
 /obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "dev" = (
@@ -7765,11 +7905,14 @@
 /turf/open/floor/iron/textured_large,
 /area/station/science/ordnance/testlab)
 "deV" = (
-/obj/item/storage/briefcase/secure,
-/obj/structure/rack,
-/obj/item/ammo_box/magazine/toy/smg,
-/obj/item/gun/ballistic/automatic/toy,
-/turf/open/floor/plating,
+/obj/item/clothing/head/costume/griffin,
+/obj/item/clothing/under/costume/griffin,
+/obj/item/clothing/shoes/griffin,
+/obj/item/clothing/suit/toggle/owlwings/griffinwings,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/closet,
+/turf/open/floor/iron/white/smooth_corner,
 /area/station/maintenance/aft/upper)
 "dfb" = (
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -7792,6 +7935,16 @@
 /obj/effect/spawner/random/medical/medkit,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"dfN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/spawner/random/trash/moisture,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "dfZ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
@@ -7830,11 +7983,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "dgw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "dgC" = (
@@ -7961,6 +8114,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
+"djk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "djp" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Gallery"
@@ -7972,6 +8132,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
+"djP" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "djU" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/siding/wood,
@@ -7988,7 +8152,6 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -8037,7 +8200,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "dlh" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -8149,7 +8311,10 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/shaker,
 /obj/item/food/grown/rainbow_flower,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood/tile,
 /area/station/maintenance/department/engine)
 "dnr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8179,9 +8344,12 @@
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "dnE" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/item/aicard,
 /obj/item/assembly/flash,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
 "dnJ" = (
@@ -8242,7 +8410,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "doF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -8367,6 +8535,16 @@
 "drb" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"drk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "drl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -8479,6 +8657,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"dsU" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/aisat/exterior)
 "dti" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8488,15 +8673,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"dtu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "dtz" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -8607,6 +8783,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"dvr" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "dvB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8660,6 +8840,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"dwr" = (
+/obj/effect/spawner/random/structure/girder,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "dwz" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
@@ -8717,13 +8902,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/exit/departure_lounge)
-"dxM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random/trash/moisture,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
 "dxO" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
@@ -8753,7 +8931,7 @@
 	},
 /obj/structure/rack,
 /obj/item/storage/bag/trash,
-/obj/item/storage/box/mousetraps,
+/obj/effect/spawner/random/trash/janitor_supplies,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
@@ -8761,6 +8939,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/textured_large,
 /area/station/command/teleporter)
 "dyQ" = (
@@ -9051,10 +9230,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "dER" = (
-/obj/machinery/space_heater,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
+/obj/structure/closet/wardrobe/orange,
 /turf/open/floor/iron/dark,
 /area/station/security/brig/hallway)
 "dEU" = (
@@ -9288,6 +9467,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"dJT" = (
+/obj/effect/spawner/random/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "dKd" = (
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
@@ -9328,8 +9512,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "dKD" = (
-/obj/vehicle/sealed/mecha/ripley/paddy/preset,
-/turf/open/floor/engine,
+/turf/closed/wall,
 /area/station/security/mechbay)
 "dKI" = (
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -9412,6 +9595,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"dNj" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "dNn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -9681,6 +9869,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
+"dTE" = (
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "dTP" = (
 /turf/closed/wall/r_wall,
 /area/station/command/corporate_showroom)
@@ -9877,6 +10074,7 @@
 "dXY" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "dYe" = (
@@ -9963,6 +10161,9 @@
 "dZx" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/hallway/secondary/command)
 "dZB" = (
@@ -10028,6 +10229,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/science/ordnance/office)
+"ebO" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/fuel_pool,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
+"eco" = (
+/obj/effect/spawner/random/trash/moisture,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "ecr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -10043,7 +10253,6 @@
 /area/station/medical/virology)
 "ecJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/security/mechbay)
 "ecO" = (
@@ -10210,14 +10419,15 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/open/space/basic,
 /area/space/nearstation)
+"efM" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/lattice,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/space/basic,
+/area/space/nearstation)
 "efN" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"efZ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/space/basic,
-/area/space/nearstation)
 "egk" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/corner{
@@ -10245,9 +10455,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "ehh" = (
-/obj/machinery/power/emitter{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - SM Reflector Room";
@@ -10255,6 +10462,9 @@
 	network = list("ss13","engineering")
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/machinery/power/emitter{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "ehz" = (
@@ -10417,8 +10627,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/hallway/primary/central/aft)
+"ekI" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/emergency/starboard)
 "ekW" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "elj" = (
@@ -10433,7 +10651,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "eln" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -10680,6 +10897,10 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/window/brigdoor/left/directional/west{
+	name = "Command Deliveries";
+	req_access = list("command")
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/command/bridge)
 "epO" = (
@@ -10785,6 +11006,7 @@
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "esB" = (
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "esH" = (
@@ -10830,6 +11052,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "etT" = (
@@ -10990,12 +11213,7 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
 "ewl" = (
-/obj/item/clothing/under/costume/griffin,
-/obj/item/clothing/suit/toggle/owlwings/griffinwings,
-/obj/item/clothing/shoes/griffin,
-/obj/item/clothing/head/costume/griffin,
-/obj/structure/closet,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white/smooth_half,
 /area/station/maintenance/aft/upper)
 "ewt" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -11062,7 +11280,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain/private)
 "exE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2{
@@ -11109,6 +11327,7 @@
 "eyB" = (
 /obj/item/storage/toolbox/emergency,
 /obj/structure/rack,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "eyC" = (
@@ -11128,7 +11347,6 @@
 /area/station/cargo/warehouse)
 "eyU" = (
 /obj/machinery/light/directional/south,
-/obj/structure/sign/departments/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -11141,6 +11359,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"ezc" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
+	},
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "ezi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11311,6 +11536,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/chapel)
+"eCB" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/execution)
 "eCT" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -11564,7 +11793,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark/arrow_ccw,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "eHR" = (
@@ -11613,13 +11844,14 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
+/obj/effect/turf_decal/trimline/neutral/filled/mid_joiner{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
@@ -11728,6 +11960,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"eKl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "eKo" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
@@ -11997,7 +12241,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "eQi" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -12018,6 +12262,18 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library/printer)
+"eQw" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/folder/yellow{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage_shared)
 "eQy" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes{
@@ -12159,6 +12415,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "eSY" = (
@@ -12211,6 +12468,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/auxlab/firing_range)
+"eTQ" = (
+/obj/item/reagent_containers/cup/glass/bottle/ritual_wine,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/reagent_containers/blood/random,
+/turf/open/floor/wood,
+/area/station/maintenance/aft/lesser)
 "eTU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
@@ -12291,6 +12554,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"eVd" = (
+/obj/effect/spawner/random/trash/bin,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "eVf" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
@@ -12301,8 +12568,18 @@
 	},
 /area/station/science/xenobiology)
 "eVg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "eVt" = (
 /obj/effect/turf_decal/trimline/dark/filled/line{
@@ -12400,7 +12677,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "eWY" = (
-/obj/structure/cable,
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -12518,6 +12794,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"eZK" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "eZS" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/turf_decal/tile/purple/full,
@@ -12645,6 +12925,10 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"fbU" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "fbV" = (
 /mob/living/basic/frog,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -12659,6 +12943,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"fcw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "fdc" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -12833,6 +13121,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/processing)
+"fgt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "fgA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -12954,11 +13249,20 @@
 "fiG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
 /turf/open/floor/iron/edge,
 /area/station/commons/storage/primary)
+"fiJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "fiN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
@@ -12990,6 +13294,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"fjH" = (
+/obj/structure/sign/departments/security/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "fjJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13141,16 +13450,11 @@
 	dir = 8
 	},
 /area/station/science/xenobiology)
-"fnl" = (
-/obj/item/chair/stool/bar{
-	pixel_y = -8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "fny" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/structure/reflector/box,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "fnB" = (
@@ -13218,9 +13522,20 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos/pumproom)
 "for" = (
-/obj/structure/closet/wardrobe/mixed,
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "ToiletB";
+	name = "Bolt Control - Toilet B";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_x = 6
+	},
+/obj/machinery/light/small/directional/west,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/auxiliary)
 "fox" = (
 /obj/structure/railing{
 	dir = 8
@@ -13246,7 +13561,6 @@
 /area/station/ai_monitored/command/storage/eva)
 "foW" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "foY" = (
@@ -13261,7 +13575,7 @@
 /obj/structure/transit_tube/station/dispenser{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/command/teleporter)
 "fpm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -13307,6 +13621,18 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"fpI" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "teleshutter";
+	name = "Teleporter Access Shutter"
+	},
+/turf/open/floor/iron/large,
+/area/station/command/teleporter)
 "fpN" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -13376,6 +13702,11 @@
 /obj/structure/fireaxecabinet/mechremoval/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"fqO" = (
+/obj/effect/spawner/random/trash/mess,
+/obj/effect/spawner/random/trash/mopbucket,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "fqR" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -13593,16 +13924,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"fva" = (
-/obj/structure/sink/kitchen/directional/east,
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "fvg" = (
 /obj/structure/chair/sofa/bench,
 /turf/open/floor/iron,
@@ -13651,6 +13972,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
+"fwh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "fww" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "Pure to Ports"
@@ -13684,13 +14012,23 @@
 	},
 /area/station/science/xenobiology)
 "fxx" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/machinery/computer/security/wooden_tv{
 	pixel_x = 1;
 	pixel_y = 6
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
+"fyf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "fyl" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/sign/warning/electric_shock/directional/north,
@@ -13729,7 +14067,6 @@
 /area/station/medical/treatment_center)
 "fyw" = (
 /obj/machinery/newscaster/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -13834,10 +14171,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
-"fBd" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "fBh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13921,7 +14254,10 @@
 "fBQ" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/dark/fourcorners,
-/obj/machinery/power/port_gen/pacman,
+/obj/structure/rack,
+/obj/item/wirecutters,
+/obj/item/wrench,
+/obj/item/crowbar,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fBU" = (
@@ -14126,6 +14462,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"fFS" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "fGh" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/storage/gas)
@@ -14225,13 +14567,32 @@
 	dir = 1
 	},
 /area/station/medical/morgue)
+"fJj" = (
+/obj/structure/sign/directions/evac/directional/north{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/neutral/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "fJI" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/tile/green/half,
 /turf/open/floor/iron/edge,
 /area/station/service/hydroponics/kitchen)
 "fJR" = (
-/turf/open/floor/glass/reinforced,
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/chair/sofa/bench/corner{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/glass/reinforced/plasma,
 /area/station/hallway/primary/starboard)
 "fJT" = (
 /turf/closed/wall,
@@ -14270,6 +14631,7 @@
 /obj/item/cigbutt/roach,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "fLj" = (
@@ -14288,7 +14650,14 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "fLw" = (
-/obj/effect/landmark/blobstart,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/mug/britcup{
+	pixel_x = 4
+	},
+/obj/machinery/reagentgrinder{
+	pixel_x = -5;
+	pixel_y = 11
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "fLL" = (
@@ -14549,6 +14918,10 @@
 	dir = 4
 	},
 /area/station/security/prison/rec)
+"fQw" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/purple,
+/area/station/maintenance/starboard)
 "fQz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -14609,7 +14982,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain/private)
 "fSj" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -14626,6 +14999,12 @@
 /obj/structure/marker_beacon/olive,
 /turf/open/space/basic,
 /area/space/nearstation)
+"fSx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "fSD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -14696,9 +15075,10 @@
 /area/station/cargo/warehouse)
 "fUO" = (
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/head/utility/welding,
+/obj/item/stack/cable_coil/five,
 /turf/open/floor/engine,
 /area/station/security/mechbay)
 "fUS" = (
@@ -14784,12 +15164,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"fXk" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "fXu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
@@ -14871,6 +15245,15 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"fYG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L14"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "fYJ" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
@@ -14891,6 +15274,12 @@
 	dir = 4
 	},
 /area/station/science/xenobiology)
+"fYQ" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fYW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/effect/turf_decal/siding/thinplating_new/corner{
@@ -15012,7 +15401,6 @@
 /turf/closed/wall/r_wall,
 /area/station/security/prison/mess)
 "gbe" = (
-/obj/structure/cable,
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/camera/directional/south{
 	c_tag = "Aft Central Hall - Port"
@@ -15241,10 +15629,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/security/execution)
+"gfo" = (
+/turf/open/floor/glass/reinforced/plasma,
+/area/station/hallway/primary/starboard)
 "gfq" = (
 /obj/machinery/light/small/directional/north,
-/obj/structure/sign/departments/aiupload/directional/west,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/command/teleporter)
 "gfs" = (
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -15257,7 +15647,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark/arrow_ccw,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -15521,6 +15910,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"glR" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "glX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15602,9 +15995,6 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/janitor_closet,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L13"
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "gnM" = (
@@ -15681,9 +16071,18 @@
 /turf/open/floor/iron/textured_large,
 /area/station/command/teleporter)
 "gpg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/closet/crate,
+/obj/item/toner,
+/obj/item/pen/red{
+	pixel_x = 8;
+	pixel_y = 8
 	},
+/obj/item/pen,
+/obj/item/pen{
+	pixel_x = 5
+	},
+/obj/item/pen,
+/obj/item/pen,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "gpo" = (
@@ -15744,6 +16143,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating_new,
+/obj/structure/railing/corner/end{
+	dir = 3
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "gqs" = (
@@ -15777,7 +16182,7 @@
 /turf/open/space/basic,
 /area/space)
 "gqM" = (
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/command/teleporter)
 "grd" = (
 /obj/machinery/door/airlock{
@@ -15790,10 +16195,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
-"grf" = (
-/obj/structure/transit_tube/diagonal,
-/turf/open/space/basic,
-/area/space/nearstation)
 "grs" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/turf_decal/delivery,
@@ -15948,6 +16349,12 @@
 /obj/item/reagent_containers/blood/o_minus,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"gui" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "gux" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -16060,18 +16467,16 @@
 	dir = 8
 	},
 /area/station/science/xenobiology)
+"gwy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "gwS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"gxj" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "gxk" = (
 /obj/machinery/vending/games,
 /turf/open/floor/wood,
@@ -16225,19 +16630,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"gzC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "gzG" = (
 /obj/structure/sign/map/fulp/directions/star{
 	pixel_x = -32
@@ -16296,7 +16688,7 @@
 /obj/structure/transit_tube/horizontal,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/command/teleporter)
 "gAh" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -16527,9 +16919,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
+/turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
 "gEd" = (
 /obj/machinery/light/small/directional/south,
@@ -16616,6 +17006,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"gGt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "gGv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -16683,6 +17080,7 @@
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "gIA" = (
@@ -16751,14 +17149,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"gJG" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/brig)
 "gJM" = (
 /obj/structure/hoop{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gJV" = (
@@ -16972,11 +17367,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"gNY" = (
-/obj/structure/firepit,
-/obj/structure/cable,
-/turf/open/misc/beach/sand,
-/area/station/maintenance/department/engine)
 "gOw" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/defibrillator/loaded,
@@ -17049,6 +17439,16 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/captain/private)
+"gPv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "gPF" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
@@ -17065,7 +17465,14 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "gQk" = (
-/obj/structure/closet/toolcloset,
+/obj/item/flatpack{
+	board = /obj/item/circuitboard/machine/flatpacker;
+	pixel_x = -5
+	},
+/obj/structure/rack,
+/obj/item/multitool{
+	pixel_x = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "gQl" = (
@@ -17113,11 +17520,6 @@
 "gQP" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
-"gQS" = (
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "gQV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17271,8 +17673,11 @@
 /turf/open/floor/iron/white/textured_edge,
 /area/station/command/heads_quarters/cmo)
 "gUz" = (
-/obj/structure/reagent_dispensers/plumbed,
-/turf/open/floor/plating,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "gUA" = (
 /obj/structure/cable,
@@ -17555,6 +17960,15 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/medical/virology)
+"gYl" = (
+/obj/effect/turf_decal/trimline/neutral/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "gYo" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -17635,7 +18049,8 @@
 "gZo" = (
 /obj/structure/closet/crate/medical/department,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/rust,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/white,
 /area/station/maintenance/starboard/fore)
 "gZE" = (
 /obj/effect/turf_decal/tile/purple/half{
@@ -17734,6 +18149,7 @@
 	codes_txt = "patrol;next_patrol=cargo3";
 	location = "cargo2"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "hbt" = (
@@ -17842,7 +18258,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/duct,
 /obj/structure/sign/departments/evac/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -17893,6 +18308,12 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/cargo/storage)
+"heb" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L5"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "hem" = (
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/aft/lesser)
@@ -17923,6 +18344,12 @@
 	dir = 8
 	},
 /area/station/engineering/atmos/office)
+"heW" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L1"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "heX" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -18041,13 +18468,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"hgJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "hgY" = (
 /obj/effect/turf_decal/trimline/brown/arrow_ccw{
 	dir = 5
@@ -18206,6 +18626,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"hjL" = (
+/obj/effect/spawner/random/structure/girder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "hkg" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -18413,6 +18838,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
 	},
@@ -18458,7 +18884,7 @@
 /turf/closed/wall,
 /area/station/medical/surgery/aft)
 "hpm" = (
-/obj/structure/table,
+/obj/structure/table/reinforced,
 /obj/item/clothing/shoes/magboots{
 	pixel_x = 4;
 	pixel_y = -3
@@ -18834,6 +19260,9 @@
 /area/station/engineering/atmos)
 "hxB" = (
 /obj/machinery/computer/communications,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
 "hxW" = (
@@ -19093,6 +19522,7 @@
 /area/station/service/chapel)
 "hFg" = (
 /obj/item/toy/plush/narplush,
+/obj/structure/marker_beacon/burgundy,
 /turf/open/floor/cult,
 /area/station/maintenance/aft/upper)
 "hFp" = (
@@ -19418,7 +19848,10 @@
 	pixel_x = -1;
 	pixel_y = 2
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "hMX" = (
 /obj/structure/disposalpipe/segment{
@@ -19434,12 +19867,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hNd" = (
-/obj/item/toy/basketball,
-/obj/structure/rack,
-/obj/item/toy/basketball,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
+/obj/machinery/door/airlock{
+	id_tag = "ToiletB";
+	name = "Toilet B"
+	},
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/auxiliary)
 "hNe" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -19509,16 +19943,6 @@
 	dir = 5
 	},
 /area/station/engineering/main)
-"hOg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/textured_large,
-/area/station/security/execution)
 "hOn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Starboard Maintenance"
@@ -19643,13 +20067,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"hQO" = (
-/obj/structure/sign/warning/pods/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "hRz" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/xenobio,
@@ -19778,10 +20195,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/main)
-"hUn" = (
-/obj/structure/reflector/double,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "hUy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20063,6 +20476,10 @@
 /obj/machinery/light/small/blacklight/directional/north,
 /turf/open/floor/mineral/titanium/tiled,
 /area/station/ai_monitored/command/nuke_storage)
+"ibj" = (
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "ibk" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -20158,6 +20575,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
+"icO" = (
+/obj/item/circuitboard/machine/chem_master,
+/obj/structure/frame/machine,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "icX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -20180,6 +20602,7 @@
 	codes_txt = "patrol;next_patrol=security4";
 	location = "security3"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "idE" = (
@@ -20248,9 +20671,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
+/turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
 "ieL" = (
 /obj/machinery/griddle,
@@ -20264,16 +20685,16 @@
 "ifk" = (
 /turf/closed/wall,
 /area/station/engineering/atmos/storage/gas)
-"ifm" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
 "ifv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"ifH" = (
+/obj/structure/table/wood,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ifR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 5
@@ -20293,6 +20714,9 @@
 /area/station/maintenance/aft/lesser)
 "ifX" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/hallway/secondary/command)
 "igb" = (
@@ -20353,7 +20777,10 @@
 "igU" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "ihe" = (
 /obj/machinery/biogenerator,
@@ -20396,6 +20823,12 @@
 /obj/effect/turf_decal/tile/prison/anticorner,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
+"iiz" = (
+/obj/machinery/space_heater,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "iiQ" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/vacuum,
@@ -20460,10 +20893,10 @@
 /area/station/command/meeting_room)
 "ikX" = (
 /obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
 "ila" = (
@@ -20475,6 +20908,11 @@
 /obj/effect/spawner/random/armory/rubbershot,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"ill" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "ilR" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -20521,6 +20959,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
+"imU" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/white/smooth_half{
+	dir = 8
+	},
+/area/station/maintenance/aft/upper)
 "ina" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
@@ -20982,12 +21426,17 @@
 "ixQ" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
-"iyi" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restroom"
-	},
-/turf/open/floor/iron,
+"iya" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/item/toy/basketball,
+/turf/open/floor/wood,
 /area/station/hallway/secondary/exit/departure_lounge)
+"iyi" = (
+/turf/closed/wall,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard)
 "iyj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -20996,13 +21445,13 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "iyB" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "iyE" = (
@@ -21063,20 +21512,26 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "izO" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "izV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"izX" = (
+/obj/effect/spawner/random/trash/moisture,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "izZ" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable,
@@ -21161,11 +21616,6 @@
 "iCC" = (
 /turf/closed/wall/r_wall,
 /area/station/command/gateway)
-"iCD" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
 "iCJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -21526,6 +21976,7 @@
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iJR" = (
@@ -21769,10 +22220,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "iOD" = (
-/obj/structure/table,
-/obj/item/clothing/head/utility/welding,
-/obj/item/stack/cable_coil/five,
-/obj/item/storage/toolbox/mechanical,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/engine,
 /area/station/security/mechbay)
 "iOH" = (
@@ -21847,10 +22297,6 @@
 	dir = 8
 	},
 /area/station/science/lab)
-"iPy" = (
-/obj/item/storage/toolbox/fishing,
-/turf/open/misc/beach/sand,
-/area/station/maintenance/department/engine)
 "iPP" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/modular_computer/preset/cargochat/cargo{
@@ -21904,12 +22350,6 @@
 /obj/structure/sign/poster/official/moth_delam/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/main)
-"iQn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
 "iQu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/newscaster/directional/south,
@@ -21992,10 +22432,6 @@
 "iSl" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/machinery/door/window/right/directional/east{
-	name = "Research Delivery";
-	req_access = list("science")
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
@@ -22172,10 +22608,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "iXo" = (
-/obj/structure/fluff/beach_towel,
-/obj/item/fishing_rod,
-/obj/item/cigarette/rollie/cannabis,
-/turf/open/floor/plating,
+/obj/structure/firepit,
+/turf/open/misc/beach/sand,
 /area/station/maintenance/department/engine)
 "iXu" = (
 /obj/structure/rack,
@@ -22236,7 +22670,7 @@
 "iXV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "iYk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22275,8 +22709,16 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "iZc" = (
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/engineering/flashlight,
+/obj/structure/closet/crate/secure/gear{
+	desc = "Contains the most important part of any Chef.";
+	name = "chef crate"
+	},
+/obj/item/storage/box/evidence{
+	pixel_x = -5
+	},
+/obj/item/storage/box/deputy{
+	pixel_x = 5
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "iZd" = (
@@ -22331,6 +22773,13 @@
 /obj/machinery/door/window/right/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"jaU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "jaV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue,
@@ -22482,6 +22931,16 @@
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
+"jev" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Gallery"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/turf/open/floor/wood/tile,
+/area/station/command/corporate_showroom)
 "jeD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22536,6 +22995,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"jfU" = (
+/obj/effect/spawner/random/maintenance,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "jgh" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Gallery"
@@ -22562,9 +23026,6 @@
 /turf/closed/wall/r_wall,
 /area/station/science/cytology)
 "jgB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -22655,6 +23116,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
+"jiO" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "jiS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -22727,8 +23193,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/dark/arrow_ccw,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "jki" = (
@@ -22756,7 +23223,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "jkR" = (
-/obj/structure/table,
+/obj/structure/table/reinforced,
 /obj/item/tank/jetpack/carbondioxide{
 	pixel_x = 4;
 	pixel_y = -1
@@ -22823,16 +23290,6 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/carpet/blue,
 /area/station/service/library)
-"jlG" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/siding/grey{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "jlV" = (
 /turf/closed/wall,
 /area/station/maintenance/department/engine)
@@ -22861,11 +23318,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/port)
-"jmG" = (
-/obj/structure/cable,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
 "jmM" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
@@ -22875,15 +23327,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/service/bar)
 "jnn" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Permabrig Hallway - Fore";
 	network = list("ss13","prison")
 	},
+/obj/structure/chair{
+	dir = 8
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/hallway)
@@ -23029,10 +23481,6 @@
 /obj/structure/displaycase/forsale,
 /turf/open/floor/wood/large,
 /area/station/service/library)
-"jqd" = (
-/obj/effect/turf_decal/trimline/dark/arrow_ccw,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "jqf" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -23160,6 +23608,11 @@
 /obj/structure/cable,
 /turf/closed/wall,
 /area/station/security/brig/hallway)
+"jtO" = (
+/obj/effect/spawner/random/structure/shipping_container,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jtV" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -23241,6 +23694,9 @@
 "jve" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/chair/sofa/bench,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jvk" = (
@@ -23347,6 +23803,7 @@
 "jxm" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/rack,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "jxt" = (
@@ -23384,6 +23841,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"jxW" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard)
 "jxZ" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/morgue)
@@ -23565,6 +24027,12 @@
 /obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
+"jBu" = (
+/obj/machinery/grill/unwrenched,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "jBv" = (
 /obj/structure/displaycase/captain,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -23578,7 +24046,7 @@
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "jBV" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/command/bridge)
@@ -23621,6 +24089,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
+"jDa" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "jDe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23638,9 +24110,12 @@
 /turf/open/floor/carpet,
 /area/station/security/processing)
 "jDp" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/item/folder/blue,
 /obj/effect/spawner/random/entertainment/lighter,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
 "jDs" = (
@@ -23655,6 +24130,13 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/cargo/storage)
+"jDu" = (
+/obj/item/chair/plastic,
+/obj/effect/spawner/random/structure/furniture_parts,
+/obj/item/chair/plastic,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "jDB" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
@@ -23870,11 +24352,23 @@
 /obj/machinery/door/window/right/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"jHM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/carpet/purple,
+/area/station/maintenance/starboard)
 "jHP" = (
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"jHR" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L7"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "jIb" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -23910,6 +24404,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "jIH" = (
@@ -23947,8 +24442,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jJA" = (
-/obj/structure/fluff/beach_umbrella/engine,
-/turf/open/floor/plating,
+/obj/item/storage/toolbox/fishing,
+/obj/item/fishing_rod,
+/turf/open/misc/beach/sand,
+/turf/open/misc/beach/sand,
 /area/station/maintenance/department/engine)
 "jJB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24025,6 +24522,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"jLh" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "jLm" = (
 /obj/structure/table/bronze,
 /obj/item/flashlight/flare/candle,
@@ -24101,6 +24608,11 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"jMS" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "jMU" = (
 /obj/item/target/syndicate,
 /obj/effect/decal/cleanable/dirt,
@@ -24249,6 +24761,11 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"jPJ" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/eight,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "jPK" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -24366,13 +24883,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/aft/upper)
-"jRJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "jRR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -24463,7 +24973,6 @@
 /turf/open/floor/wood,
 /area/station/service/chapel)
 "jSC" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -24566,7 +25075,10 @@
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
 /area/station/maintenance/department/engine)
 "jUn" = (
 /obj/machinery/status_display/evac/directional/north,
@@ -24579,7 +25091,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "jUt" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/machinery/recharger,
 /obj/item/restraints/handcuffs,
 /obj/structure/cable,
@@ -24776,11 +25288,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"jYA" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "jYT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24830,6 +25337,7 @@
 /area/station/hallway/secondary/entry)
 "jZH" = (
 /obj/machinery/light_switch/directional/north,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/security/mechbay)
 "jZL" = (
@@ -24951,6 +25459,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"kcv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/chair/sofa/bench/right,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "kcB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25093,14 +25609,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/science/auxlab/firing_range)
-"keA" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/stake,
-/obj/item/clothing/suit/costume/dracula,
-/obj/item/clothing/under/costume/draculass,
-/obj/item/storage/box/halloween/edition_21/alucard,
-/turf/open/floor/wood,
-/area/station/maintenance/aft/lesser)
 "keC" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron,
@@ -25162,8 +25670,20 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/robotics/lab)
 "kfV" = (
-/obj/structure/sign/poster/contraband/the_griffin/directional/east,
-/turf/open/floor/plating,
+/obj/item/gps{
+	pixel_y = 3
+	},
+/obj/item/radio{
+	pixel_y = 5
+	},
+/obj/item/toy/talking/griffin{
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/fancy/royalblack,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 8
+	},
 /area/station/maintenance/aft/upper)
 "kgb" = (
 /obj/structure/cable,
@@ -25266,6 +25786,11 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/half,
 /area/station/hallway/primary/central/aft)
+"khZ" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "kip" = (
 /obj/machinery/modular_computer/preset/id,
 /obj/machinery/light/directional/north,
@@ -25286,6 +25811,11 @@
 	dir = 4
 	},
 /area/station/command/heads_quarters/cmo)
+"kiQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "kjk" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 4
@@ -25318,20 +25848,12 @@
 /obj/effect/turf_decal/tile/dark_green/full,
 /turf/open/floor/iron/large,
 /area/station/service/bar/backroom)
-"kjM" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "kjW" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "kka" = (
@@ -25502,9 +26024,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L7"
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "knF" = (
@@ -25628,10 +26147,10 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
 	},
-/obj/structure/sign/departments/restroom/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "kqJ" = (
@@ -25864,9 +26383,7 @@
 "kup" = (
 /obj/structure/fluff/beach_towel,
 /obj/item/instrument/guitar,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/misc/beach/sand,
 /area/station/maintenance/department/engine)
 "kuq" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -25973,7 +26490,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kwu" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating_new/corner,
 /obj/structure/sign/poster/random/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -25993,6 +26509,7 @@
 /area/station/engineering/atmos/hfr_room)
 "kxf" = (
 /obj/effect/spawner/random/structure/crate_loot,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "kxo" = (
@@ -26096,10 +26613,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/ordnance)
-"kzf" = (
-/obj/item/reagent_containers/cup/soda_cans/canned_laughter,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
 "kzl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -26121,11 +26634,7 @@
 /turf/open/floor/wood,
 /area/station/command/bridge)
 "kAc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/corner,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "kAd" = (
@@ -26275,7 +26784,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 8
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "kCU" = (
@@ -26286,6 +26794,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kCZ" = (
@@ -26297,6 +26806,13 @@
 "kDg" = (
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"kDm" = (
+/obj/structure/railing,
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
+	},
+/turf/open/floor/glass/reinforced/plasma,
+/area/station/hallway/primary/starboard)
 "kDv" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "medbay_entrance";
@@ -26518,6 +27034,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"kIa" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/engineering/transit_tube)
 "kIl" = (
 /obj/structure/cable,
 /obj/machinery/nuclearbomb/selfdestruct,
@@ -26600,6 +27123,7 @@
 "kKr" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "kKF" = (
@@ -27112,6 +27636,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "kVO" = (
@@ -27138,6 +27665,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "kWh" = (
@@ -27147,6 +27675,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
+"kWB" = (
+/obj/effect/spawner/random/trash/crushed_can,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "kWT" = (
 /mob/living/basic/cow,
 /obj/machinery/airalarm/directional/west,
@@ -27155,6 +27688,9 @@
 "kXn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/engineering/transit_tube)
@@ -27167,6 +27703,7 @@
 /area/station/cargo/miningdock)
 "kXP" = (
 /obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/decal/cleanable/fuel_pool,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "kYe" = (
@@ -27242,6 +27779,9 @@
 	location = "minisat"
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "kZX" = (
@@ -27502,6 +28042,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "leC" = (
@@ -27514,6 +28057,8 @@
 /area/station/cargo/sorting)
 "leD" = (
 /obj/machinery/space_heater,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "leL" = (
@@ -27540,15 +28085,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
-"lfg" = (
-/obj/structure/chair/sofa/bench/solo{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "lfm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/window/left/directional/north{
@@ -27619,6 +28155,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/blue,
 /area/station/service/library)
+"lhK" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "lig" = (
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
@@ -27989,88 +28532,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"lqP" = (
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/utility/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/utility/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/utility/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/utility/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/utility/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/structure/closet/crate/internals,
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow,
-/turf/open/floor/iron/large,
-/area/station/commons/storage/primary)
 "lqV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -28126,6 +28587,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"lrI" = (
+/obj/effect/spawner/random/trash/bucket,
+/obj/effect/spawner/random/trash/caution_sign,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "lrO" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/tile/neutral{
@@ -28156,11 +28623,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/bitrunning/den)
 "lsJ" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/sign/departments/telecomms/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lsV" = (
@@ -28171,6 +28640,13 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
+"ltc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "ltK" = (
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 4
@@ -28205,9 +28681,15 @@
 /turf/open/floor/iron/white/corner,
 /area/station/medical/treatment_center)
 "ltZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "evashutters";
+	name = "E.V.A. Storage Shutters";
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/station/ai_monitored/command/storage/eva)
 "luc" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -28330,7 +28812,6 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "lwL" = (
-/obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -28338,7 +28819,10 @@
 	c_tag = "Escape Lounge Emergency Atmos";
 	name = "camera"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "lwX" = (
 /obj/structure/displaycase,
@@ -28685,9 +29169,17 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/service/library)
+"lDr" = (
+/obj/structure/railing,
+/obj/structure/chair/sofa/bench{
+	dir = 1
+	},
+/turf/open/floor/glass/reinforced/plasma,
+/area/station/hallway/primary/starboard)
 "lDx" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "lDA" = (
@@ -28696,10 +29188,8 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "lDI" = (
-/obj/structure/chair/comfy{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/chair/comfy,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/command/bridge)
 "lDT" = (
 /obj/machinery/holopad,
@@ -28885,7 +29375,7 @@
 "lJw" = (
 /obj/structure/fluff/beach_umbrella,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/misc/beach/sand,
 /area/station/maintenance/department/engine)
 "lJE" = (
 /obj/machinery/status_display/evac/directional/east,
@@ -28895,15 +29385,25 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"lJH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "lKp" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "lKs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L9"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "lKL" = (
@@ -28935,6 +29435,9 @@
 /obj/machinery/requests_console/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"lLD" = (
+/turf/open/floor/iron,
+/area/station/maintenance/starboard)
 "lLE" = (
 /turf/closed/wall/mineral/silver{
 	name = "padded wall"
@@ -28950,6 +29453,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
+"lMc" = (
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/station/hallway/secondary/exit/departure_lounge)
 "lMq" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room"
@@ -28985,6 +29493,10 @@
 "lNw" = (
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/secondary/construction)
+"lNx" = (
+/turf/closed/wall/r_wall,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/escape)
 "lNy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -29040,6 +29552,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/crystallizer)
+"lPb" = (
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "lPo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -29074,11 +29591,7 @@
 /area/station/security/execution)
 "lPY" = (
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/station/hallway/primary/central/fore)
 "lQc" = (
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -29150,7 +29663,8 @@
 /area/station/hallway/primary/central/fore)
 "lRb" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/airlock/welded,
+/turf/open/floor/iron/white/textured,
 /area/station/maintenance/aft/upper)
 "lRo" = (
 /obj/structure/table,
@@ -29184,12 +29698,28 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"lSi" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/item/knife/kitchen,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard)
 "lSq" = (
 /obj/machinery/computer/teleporter,
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
+"lSs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "lSv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29251,6 +29781,7 @@
 "lTm" = (
 /obj/item/clothing/shoes/sandal,
 /obj/effect/landmark/event_spawn,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "lTA" = (
@@ -29348,10 +29879,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/plate,
+/obj/item/food/cakeslice/berry_chocolate_cake,
 /turf/open/floor/iron/dark,
-/area/space/nearstation)
+/area/station/ai_monitored/aisat/exterior)
 "lVm" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
@@ -29399,9 +29932,6 @@
 "lVW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "lWh" = (
@@ -29503,6 +30033,8 @@
 /area/station/hallway/primary/aft)
 "lXS" = (
 /mob/living/basic/cockroach,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "lXU" = (
@@ -29548,6 +30080,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"lYX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
+"lYY" = (
+/obj/item/kirbyplants/random/fullysynthetic,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "lYZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -29612,13 +30158,15 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/ordnance)
 "mau" = (
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "mav" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "max" = (
@@ -29635,12 +30183,18 @@
 "maN" = (
 /obj/structure/transit_tube,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer/command)
 "mbc" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/engine,
 /area/station/security/mechbay)
+"mbi" = (
+/obj/structure/mirror/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/smooth_half,
+/area/station/maintenance/aft/upper)
 "mbs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/closed/wall/r_wall,
@@ -29885,6 +30439,14 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"mfE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/left,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "mfR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -29951,6 +30513,7 @@
 /obj/machinery/plumbing/synthesizer{
 	reagent_id = /datum/reagent/water
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "mhh" = (
@@ -29963,7 +30526,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "mhi" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/herringbone,
@@ -29983,13 +30546,9 @@
 /obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/genetics)
-"mhB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "mhJ" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "mid" = (
@@ -30139,6 +30698,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/service/theater)
+"mlX" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "mmd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30161,6 +30724,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
+"mmq" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sec-departures"
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/escape)
 "mmA" = (
 /obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/plating,
@@ -30233,6 +30817,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/fulp/floor_directions/aft,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "moq" = (
@@ -30271,6 +30857,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
+"mph" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "mpB" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -30485,16 +31077,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/main)
-"mtl" = (
-/obj/structure/cable,
-/obj/machinery/door/window/brigdoor/left/directional/east{
-	name = "Command Desk";
-	req_access = list("command")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/herringbone,
-/area/station/command/bridge)
 "mtn" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -30538,6 +31120,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/prison/rec)
+"mtQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/station/command/bridge)
 "mtT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -30631,6 +31225,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"mwM" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "mwV" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /obj/item/radio/intercom/directional/north,
@@ -30709,6 +31307,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"mye" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "myL" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8
@@ -30768,11 +31370,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"mAf" = (
+/obj/item/flashlight/lantern,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood,
+/area/station/maintenance/aft/lesser)
 "mAs" = (
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
 /area/station/holodeck/rec_center)
+"mAt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/captain)
 "mAA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30836,6 +31449,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "mCu" = (
@@ -30860,6 +31474,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library/artgallery)
+"mCQ" = (
+/obj/structure/aquarium,
+/turf/open/misc/beach/sand,
+/area/station/maintenance/department/engine)
 "mCW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -30918,7 +31536,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/hallway)
@@ -31190,8 +31808,12 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "mKF" = (
-/obj/structure/mirror/directional/north,
-/turf/open/floor/plating,
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/toy,
+/obj/item/ammo_box/magazine/toy/smg,
+/obj/item/storage/briefcase/secure,
+/obj/structure/sign/poster/contraband/the_griffin/directional/north,
+/turf/open/floor/iron/white/smooth_half,
 /area/station/maintenance/aft/upper)
 "mKJ" = (
 /obj/effect/turf_decal/tile/purple/full,
@@ -31254,11 +31876,23 @@
 /obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"mMa" = (
+/obj/structure/closet,
+/obj/item/storage/box/halloween/edition_20/princess/wonderland,
+/obj/item/clothing/glasses/monocle,
+/obj/item/clothing/head/costume/crown,
+/obj/item/storage/box/halloween/edition_20/princess/beauty,
+/obj/item/clothing/neck/beads,
+/obj/item/clothing/neck/beads,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "mME" = (
-/obj/effect/turf_decal/trimline/dark/arrow_ccw{
-	dir = 8
+/obj/machinery/camera/directional/south{
+	c_tag = "Arrivals Hallway - Aft"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -31326,9 +31960,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "mOf" = (
-/obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/structure/sign/poster/official/random/directional/east,
-/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "mOk" = (
@@ -31358,6 +31990,17 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/cryo)
+"mOx" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "mOC" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/effect/turf_decal/tile/neutral{
@@ -31424,6 +32067,12 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"mQx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/storage/emergency/starboard)
 "mQG" = (
 /obj/machinery/camera/directional/north{
 	name = "AI Chamber - North"
@@ -31478,9 +32127,14 @@
 "mRe" = (
 /turf/closed/wall,
 /area/station/medical/surgery/fore)
+"mRf" = (
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/cult,
+/area/station/maintenance/aft/upper)
 "mRh" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/mug/britcup,
+/obj/item/modular_computer/laptop/preset/civilian,
+/obj/structure/sign/poster/official/periodic_table/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "mRr" = (
@@ -31603,15 +32257,9 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/security/execution)
 "mTS" = (
-/obj/item/storage/box/halloween/edition_20/princess/beauty,
-/obj/item/clothing/head/costume/crown,
-/obj/item/clothing/neck/beads,
-/obj/item/clothing/neck/beads,
-/obj/item/clothing/glasses/monocle,
-/obj/structure/closet,
-/obj/item/storage/box/halloween/edition_20/princess/wonderland,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "mUF" = (
@@ -31793,8 +32441,13 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/large,
 /area/station/medical/morgue)
+"mYc" = (
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "mYs" = (
 /obj/machinery/nuclearbomb/beer,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "mYt" = (
@@ -31842,13 +32495,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "mYU" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/machinery/airalarm/directional/west,
 /obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/security/lockers)
+/turf/closed/wall,
+/area/station/maintenance/starboard/aft)
 "mYX" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
@@ -31865,9 +32514,18 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/command/bridge)
 "mZB" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"mZC" = (
+/obj/effect/spawner/random/trash/grime,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "mZG" = (
 /obj/effect/turf_decal/tile/purple/full,
 /obj/effect/turf_decal/stripes/white/line{
@@ -31962,6 +32620,7 @@
 /area/station/cargo/storage)
 "nbh" = (
 /obj/machinery/space_heater,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "nbs" = (
@@ -32075,7 +32734,6 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "ncT" = (
-/obj/structure/cable,
 /obj/machinery/camera/directional/west{
 	c_tag = "Escape Lounge - Fore";
 	name = "camera"
@@ -32083,6 +32741,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/sign/departments/restroom/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ndi" = (
@@ -32144,7 +32803,8 @@
 "nee" = (
 /obj/item/chair/plastic,
 /obj/item/chair/plastic,
-/obj/item/chair/plastic,
+/obj/effect/spawner/random/structure/furniture_parts,
+/obj/structure/rack,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "nez" = (
@@ -32322,6 +32982,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
+"nhw" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "nhM" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/engine,
@@ -32561,6 +33226,7 @@
 /area/station/maintenance/disposal/incinerator)
 "noa" = (
 /obj/machinery/duct,
+/obj/effect/decal/cleanable/fuel_pool/hivis,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "nob" = (
@@ -32657,6 +33323,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
+"npZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "nqj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32762,6 +33435,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"nsX" = (
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "ntc" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -32910,6 +33587,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"nwY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "nxf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -32999,6 +33680,12 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
+"nzu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "nzE" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -33033,11 +33720,6 @@
 /obj/machinery/air_sensor/incinerator_tank,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
-"nzR" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/security/mechbay)
 "nzU" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -33102,12 +33784,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "nAL" = (
-/obj/structure/table,
+/obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/machinery/camera/directional/south{
 	c_tag = "EVA Storage"
 	},
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/engine,
 /area/station/ai_monitored/command/storage/eva)
 "nAN" = (
@@ -33169,6 +33852,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/hoop,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nCa" = (
@@ -33180,10 +33864,14 @@
 	},
 /area/station/service/hydroponics)
 "nCe" = (
-/obj/item/bodypart/head,
 /obj/effect/decal/cleanable/blood,
-/obj/item/clothing/mask/gas/sexyclown,
 /obj/structure/table/wood/fancy/red,
+/obj/item/flashlight/lantern/lit_lantern{
+	pixel_x = 4;
+	pixel_y = 13
+	},
+/obj/item/bodypart/head,
+/obj/item/clothing/mask/gas/sexyclown,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "nCf" = (
@@ -33247,6 +33935,10 @@
 /obj/effect/spawner/random/techstorage/service_all,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"nDw" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "nDM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -33303,8 +33995,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "nFh" = (
-/obj/machinery/grill/unwrenched,
-/turf/open/floor/plating,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "nFu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33393,11 +34088,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
+"nHg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/herringbone,
+/area/station/engineering/transit_tube)
 "nHj" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/pharmacy)
+"nHX" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_half,
+/area/station/maintenance/aft/upper)
 "nIb" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -33427,6 +34134,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sec-departures"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
@@ -33465,6 +34175,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"nIZ" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "nJu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -33477,9 +34191,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "nJz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
@@ -33517,6 +34228,9 @@
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=depart6";
 	location = "depart5"
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -33568,7 +34282,8 @@
 "nLE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/reflector/double,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "nLF" = (
 /obj/effect/turf_decal/tile/purple/diagonal_centre,
@@ -33712,6 +34427,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"nPe" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "nPf" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Command - Bridge Fore";
@@ -33739,6 +34461,11 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/starboard/aft)
+"nPN" = (
+/obj/effect/spawner/random/structure/crate_abandoned,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "nPP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -33816,11 +34543,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
-"nQW" = (
-/obj/item/cigarette/rollie/cannabis,
-/mob/living/basic/crab,
-/turf/open/misc/beach/sand,
-/area/station/maintenance/department/engine)
 "nRg" = (
 /mob/living/basic/mouse,
 /turf/open/floor/plating,
@@ -33828,7 +34550,6 @@
 "nRh" = (
 /obj/item/toy/beach_ball,
 /obj/structure/fluff/beach_towel,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "nRp" = (
@@ -33870,6 +34591,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/command)
+"nRP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "nSq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34030,6 +34755,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
 "nVb" = (
@@ -34143,11 +34869,6 @@
 /obj/effect/turf_decal/siding/thinplating,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"nWv" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "nWO" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 8
@@ -34265,7 +34986,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/thinplating_new,
-/obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nZf" = (
@@ -34373,10 +35094,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ocj" = (
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "ocm" = (
@@ -34471,7 +35188,6 @@
 /turf/closed/wall,
 /area/station/hallway/secondary/entry)
 "oew" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
@@ -34489,7 +35205,7 @@
 /turf/open/floor/circuit/green/telecomms,
 /area/station/tcommsat/server)
 "ofk" = (
-/obj/structure/table,
+/obj/structure/table/reinforced,
 /obj/machinery/recharger{
 	pixel_x = 6;
 	pixel_y = 3
@@ -34523,6 +35239,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"ofS" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "ofT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -34568,6 +35288,7 @@
 /area/station/engineering/atmos)
 "ohl" = (
 /obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "ohp" = (
@@ -34671,22 +35392,6 @@
 /obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"oiu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen{
-	pixel_x = 5
-	},
-/obj/item/pen/red{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/structure/closet/crate,
-/obj/item/toner,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
 "oiz" = (
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 8
@@ -34744,6 +35449,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 8
 	},
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -34884,6 +35590,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/fore)
+"omC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "omH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
@@ -34894,12 +35606,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"omP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/brig)
 "oni" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/laser/practice{
@@ -34993,10 +35699,10 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/pharmacy)
 "opC" = (
-/obj/structure/reflector/single,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/reflector/double,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "opG" = (
 /obj/machinery/holopad,
@@ -35097,10 +35803,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "ort" = (
-/obj/structure/closet/firecloset/full,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/auxiliary)
 "orz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
@@ -35168,11 +35874,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"osH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "osL" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -35220,6 +35921,11 @@
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit/green/telecomms,
 /area/station/tcommsat/server)
+"otB" = (
+/obj/effect/spawner/random/structure/crate_loot,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "otD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
@@ -35228,6 +35934,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"otI" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/aisat/exterior)
 "otK" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35349,6 +36060,7 @@
 /area/station/science/xenobiology)
 "owt" = (
 /obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "owu" = (
@@ -35389,6 +36101,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/bitrunning/den)
+"owY" = (
+/obj/effect/decal/cleanable/fuel_pool/hivis,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "oxc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -35545,13 +36261,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"ozl" = (
-/obj/effect/spawner/random/trash/moisture_trap,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "ozu" = (
 /obj/machinery/door/airlock/medical{
 	name = "Paramedic Dispatch"
@@ -35605,6 +36314,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"oAD" = (
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "oAE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35685,6 +36399,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"oBE" = (
+/obj/structure/fluff/beach_towel,
+/turf/open/misc/beach/sand,
+/area/station/maintenance/department/engine)
 "oBR" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
@@ -35732,14 +36450,6 @@
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker;
-	pixel_x = -5
-	},
-/obj/item/multitool{
-	pixel_x = 8
-	},
-/obj/structure/rack,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "oDx" = (
@@ -35780,6 +36490,9 @@
 "oEd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "oEu" = (
@@ -35797,7 +36510,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "oEI" = (
-/obj/structure/reflector/double,
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
 	},
@@ -35842,7 +36554,6 @@
 /obj/structure/displaycase,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/corporate_showroom)
 "oFa" = (
@@ -35871,7 +36582,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "oGd" = (
 /obj/structure/cable,
@@ -36068,6 +36779,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"oKx" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "oKE" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -36390,6 +37107,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/item/chair/stool/bar{
+	pixel_y = -8
+	},
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "oSC" = (
@@ -36426,10 +37147,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "oTu" = (
-/obj/structure/sign/departments/aisat/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/south,
+/obj/structure/sign/departments/telecomms/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "oTA" = (
@@ -36461,15 +37183,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
-"oUe" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/public/glass{
-	name = "Gallery"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/tile,
-/area/station/command/corporate_showroom)
 "oUA" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Fore Maintenance"
@@ -36594,7 +37307,6 @@
 /area/station/maintenance/port/fore)
 "oWs" = (
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -36623,7 +37335,6 @@
 "oXJ" = (
 /obj/item/key,
 /obj/item/kirbyplants/organic/plant21,
-/obj/structure/cable,
 /obj/machinery/camera/directional/south{
 	c_tag = "Escape Lounge - Aft";
 	name = "camera"
@@ -36633,18 +37344,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"oXP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L5"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "oXR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36733,7 +37432,7 @@
 	c_tag = "AI Upload- Command Tube"
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/command/teleporter)
 "oZS" = (
 /turf/open/floor/iron/dark/textured_large,
@@ -36799,15 +37498,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 8
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=depart2";
 	location = "depart1"
 	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L8"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"pbB" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "pbD" = (
 /obj/effect/turf_decal/tile/purple/full,
 /obj/effect/turf_decal/stripes/white/line{
@@ -36961,6 +37664,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "per" = (
@@ -36977,6 +37681,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"peJ" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced/plasma,
+/area/station/hallway/primary/starboard)
 "pfh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/closed/wall/r_wall,
@@ -37000,6 +37713,7 @@
 	req_access = list("minisat");
 	pixel_y = -23
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "pga" = (
@@ -37120,6 +37834,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"pho" = (
+/obj/item/reagent_containers/cup/glass/bottle/beer/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "phw" = (
 /obj/effect/turf_decal/siding/thinplating_new/end{
 	dir = 4
@@ -37146,7 +37865,6 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "pig" = (
 /obj/effect/spawner/random/trash/bin,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
@@ -37234,12 +37952,9 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/engineering/transit_tube)
 "pjG" = (
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
-"pka" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "pkh" = (
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -37269,11 +37984,15 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "pkK" = (
-/obj/structure/urinal/directional/north,
-/obj/structure/mirror/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
+"pkZ" = (
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "plj" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -37287,7 +38006,7 @@
 "plB" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/carpet/red,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/command/bridge)
 "plI" = (
 /obj/effect/decal/cleanable/confetti,
@@ -37364,6 +38083,7 @@
 "pmS" = (
 /obj/machinery/shower/directional/south,
 /obj/structure/curtain,
+/obj/effect/spawner/random/trash/soap,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "pnv" = (
@@ -37460,7 +38180,7 @@
 /obj/machinery/power/emitter/welded{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/execution)
 "ppq" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -37497,6 +38217,7 @@
 	codes_txt = "patrol;next_patrol=hall6";
 	location = "cargo7"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "pqa" = (
@@ -37543,7 +38264,7 @@
 	name = "decommissioned sleeper"
 	},
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/maintenance/starboard/fore)
 "pqP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37627,6 +38348,7 @@
 /area/station/commons/fitness/recreation/entertainment)
 "psD" = (
 /obj/effect/spawner/random/trash/moisture_trap,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "psJ" = (
@@ -37898,6 +38620,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"pyj" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/grime,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "pyw" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/tile/neutral{
@@ -37934,7 +38662,7 @@
 /area/station/security/checkpoint/supply)
 "pzi" = (
 /obj/machinery/vending/boozeomat/all_access,
-/turf/open/floor/plating,
+/turf/open/floor/wood/tile,
 /area/station/maintenance/department/engine)
 "pzO" = (
 /obj/machinery/vending/hydronutrients,
@@ -37966,6 +38694,16 @@
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/hallway/secondary/service)
+"pAt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "pAu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -38001,6 +38739,10 @@
 /area/station/cargo/lobby)
 "pCq" = (
 /obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
+"pCr" = (
+/obj/effect/decal/cleanable/fuel_pool,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "pCy" = (
@@ -38067,7 +38809,10 @@
 "pEm" = (
 /obj/item/reagent_containers/cup/bowl,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/purple,
 /area/station/maintenance/starboard)
 "pEz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -38076,8 +38821,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "pEH" = (
-/obj/machinery/field/generator,
 /obj/effect/turf_decal/bot,
+/obj/machinery/field/generator,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/storage)
 "pEK" = (
@@ -38225,6 +38970,12 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/lab)
+"pHC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "pHZ" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser{
@@ -38300,6 +39051,15 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"pJG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "pJW" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restroom"
@@ -38344,7 +39104,15 @@
 "pLy" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light/small/directional/north,
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/light_switch/directional/north{
+	pixel_y = 24
+	},
+/obj/machinery/button/door/directional/north{
+	id = "evashutters";
+	name = "E.V.A. Shutters";
+	req_access = list("command");
+	pixel_x = 9
+	},
 /turf/open/floor/light,
 /area/station/ai_monitored/command/storage/eva)
 "pLD" = (
@@ -38422,12 +39190,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"pME" = (
+/obj/effect/turf_decal/tile/dark/fourcorners,
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "pMF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -38702,6 +39472,11 @@
 /obj/effect/turf_decal/tile/red/full,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"pSW" = (
+/obj/structure/cable,
+/obj/structure/chair/comfy,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/command/bridge)
 "pTr" = (
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /obj/effect/turf_decal/bot,
@@ -38720,6 +39495,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/auxlab/firing_range)
+"pTz" = (
+/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"pUj" = (
+/obj/structure/sign/departments/aiupload/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/engine,
+/area/station/command/teleporter)
 "pUp" = (
 /obj/structure/bed/dogbed/lia,
 /mob/living/basic/carp/pet/lia,
@@ -38728,13 +39515,14 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "pUq" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/trimline/neutral/line{
-	dir = 9
+	dir = 1
 	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/mid_joiner,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "pVc" = (
@@ -38811,8 +39599,16 @@
 /area/station/hallway/primary/fore)
 "pXx" = (
 /obj/machinery/space_heater/improvised_chem_heater,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"pXO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "pXX" = (
 /obj/effect/turf_decal/siding/thinplating_new/corner{
 	dir = 4
@@ -38914,7 +39710,6 @@
 /obj/item/toy/plush/beefplushie,
 /obj/structure/displaycase,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/corporate_showroom)
@@ -38923,19 +39718,20 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "qan" = (
-/obj/structure/sign/directions/evac/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Arrivals Hallway - Aft"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/sign/departments/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "qaE" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
+"qaS" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "qaX" = (
 /obj/structure/table/glass,
 /obj/item/food/deadmouse,
@@ -38947,8 +39743,10 @@
 "qba" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
+/obj/structure/mirror/directional/west,
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/auxiliary)
 "qbc" = (
 /turf/closed/wall,
 /area/station/science/lobby)
@@ -39058,6 +39856,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"qcr" = (
+/obj/effect/spawner/random/trash/moisture,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "qcs" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -39209,13 +40011,6 @@
 /obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"qgJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/reflector/single,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "qgO" = (
 /turf/closed/wall/r_wall,
 /area/station/security/medical)
@@ -39265,7 +40060,7 @@
 "qhp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "qhs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
@@ -39313,10 +40108,17 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
+"qiH" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/security/execution)
 "qiP" = (
 /obj/machinery/telecomms/server/presets/science,
 /turf/open/floor/circuit/red/telecomms,
 /area/station/tcommsat/server)
+"qiR" = (
+/turf/closed/wall/rust,
+/area/station/maintenance/aft/upper)
 "qjp" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -39345,6 +40147,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/chapel)
+"qjF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/departments/aisat/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qjG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39356,6 +40165,9 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/office)
+"qjJ" = (
+/turf/closed/wall,
+/area/station/commons/toilet/auxiliary)
 "qjU" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
@@ -39396,7 +40208,9 @@
 /turf/open/floor/grass,
 /area/station/commons/fitness/recreation/entertainment)
 "qle" = (
-/obj/structure/cable,
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/station/security/mechbay)
 "qln" = (
@@ -39562,7 +40376,8 @@
 /obj/item/storage/box/cups,
 /obj/item/reagent_containers/condiment/saltshaker,
 /obj/item/food/grown/rainbow_flower,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/tile,
 /area/station/maintenance/department/engine)
 "qoi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39707,6 +40522,8 @@
 "qqP" = (
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/structure/closet/crate/wooden/toy,
+/obj/item/stamp/clown,
 /turf/open/floor/iron/diagonal,
 /area/station/service/theater)
 "qrF" = (
@@ -39739,7 +40556,6 @@
 /area/station/maintenance/disposal)
 "qss" = (
 /obj/item/kirbyplants/organic/plant21,
-/obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -39830,6 +40646,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"qtW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "qug" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/beaker/cryoxadone{
@@ -39892,6 +40715,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/security/brig/hallway)
+"qwu" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L13"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "qwv" = (
 /obj/structure/cable,
 /obj/structure/chair/sofa/bench{
@@ -39913,10 +40742,9 @@
 "qwF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "qwG" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -40039,12 +40867,6 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "qzD" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Desk"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
@@ -40069,10 +40891,8 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "qAe" = (
-/obj/structure/urinal/directional/east,
 /obj/structure/closet/crate,
 /obj/structure/sign/poster/random/directional/south,
-/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "qAg" = (
@@ -40080,8 +40900,21 @@
 /obj/item/storage/medkit/emergency,
 /obj/structure/rack,
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/window/spawner/directional/east,
+/obj/machinery/door/window/right/directional/north{
+	req_access = list("engineering")
+	},
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
+"qAA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "qAN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40162,6 +40995,7 @@
 /area/station/engineering/lobby)
 "qBM" = (
 /obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "qBR" = (
@@ -40485,6 +41319,7 @@
 	codes_txt = "patrol;next_patrol=command1";
 	location = "hall 6"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "qJm" = (
@@ -40500,9 +41335,17 @@
 /obj/machinery/smartfridge/drying,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"qJr" = (
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qJt" = (
 /obj/structure/grille/broken,
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "qJA" = (
@@ -40530,6 +41373,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"qKe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/directions/dorms/directional/west{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "qKf" = (
 /obj/machinery/camera/directional/north,
 /obj/machinery/power/smes/engineering,
@@ -40639,11 +41492,6 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain/private)
-"qNc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "qNg" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/effect/landmark/start/depsec/science,
@@ -40672,6 +41520,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"qNX" = (
+/obj/effect/spawner/random/structure/crate_loot,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "qOl" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -40745,6 +41597,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"qPe" = (
+/obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "qPh" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/spawner/random/trash/bin,
@@ -40810,9 +41667,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qQi" = (
-/obj/effect/turf_decal/siding/grey{
-	dir = 1
-	},
+/obj/machinery/door/airlock/multi_tile/public/glass,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qQk" = (
@@ -40939,7 +41795,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -40952,11 +41807,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qTs" = (
-/obj/item/toy/talking/griffin,
-/obj/structure/rack,
-/obj/item/radio,
-/obj/item/gps,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/smooth_half,
 /area/station/maintenance/aft/upper)
 "qTu" = (
 /obj/effect/turf_decal/box/white{
@@ -40990,11 +41842,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
-"qUb" = (
-/obj/structure/marker_beacon/bronze,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
 "qUl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -41022,6 +41869,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qVh" = (
@@ -41243,12 +42091,19 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"qZx" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "raf" = (
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/half{
 	dir = 8
 	},
 /area/station/hallway/secondary/command)
+"ram" = (
+/turf/open/floor/iron/white/smooth_corner,
+/area/station/maintenance/aft/upper)
 "ran" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -41295,14 +42150,9 @@
 /obj/structure/chair/stool/bar/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"rbh" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "rbj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41391,11 +42241,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/courtroom)
-"rdm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
 "reg" = (
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -41416,9 +42261,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"rff" = (
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 1
+	},
+/area/station/maintenance/aft/upper)
 "rfp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/grille,
@@ -41426,6 +42275,8 @@
 /area/station/engineering/atmos)
 "rft" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "rfC" = (
@@ -41558,7 +42409,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "rhC" = (
-/obj/structure/closet/firecloset,
 /obj/machinery/firealarm/directional/west,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/herringbone,
@@ -41568,9 +42418,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L1"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -41618,18 +42465,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"riI" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "riJ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -41779,7 +42614,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "rlk" = (
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L3"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "rlp" = (
@@ -41830,12 +42667,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"rmg" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/aisat/exterior)
 "rmk" = (
 /obj/machinery/door/window/brigdoor/left/directional/south{
 	req_access = list("genetics")
 	},
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"rmC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "rmQ" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
@@ -41901,14 +42750,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
-"rng" = (
-/obj/effect/turf_decal/tile/dark/fourcorners,
-/obj/structure/rack,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/wirecutters,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "rnL" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -41977,7 +42818,10 @@
 /area/station/commons/fitness/recreation)
 "rom" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "ros" = (
 /obj/effect/spawner/random/maintenance/three,
@@ -42056,9 +42900,6 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms)
 "rqs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/closet,
 /obj/item/clothing/neck/tie/black,
 /obj/item/clothing/under/suit/black,
@@ -42152,6 +42993,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"rsh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/item/flashlight/lantern/lit_lantern,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "rsv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/layer3,
@@ -42185,6 +43033,8 @@
 /area/station/science/robotics/mechbay)
 "rte" = (
 /obj/effect/spawner/random/trash/bacteria,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "rty" = (
@@ -42498,7 +43348,10 @@
 /area/station/cargo/lobby)
 "rAV" = (
 /obj/structure/cat_house,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/carpet/purple,
 /area/station/maintenance/starboard)
 "rAW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -42654,7 +43507,7 @@
 /area/station/engineering/atmos/pumproom)
 "rCU" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/carpet/red,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/command/bridge)
 "rDg" = (
 /obj/effect/turf_decal/siding/wood{
@@ -42669,16 +43522,14 @@
 /area/station/service/library)
 "rDj" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -4
-	},
-/obj/item/pen{
-	pixel_x = -4
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/desk_bell{
 	pixel_x = 8;
 	pixel_y = 9
+	},
+/obj/machinery/door/window/right/directional/north{
+	name = "Engineering Desk";
+	req_access = list("engineering")
 	},
 /turf/open/floor/iron/half{
 	dir = 8
@@ -42791,13 +43642,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"rFA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
 "rFC" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
@@ -42807,10 +43651,11 @@
 	},
 /area/station/science/xenobiology)
 "rFE" = (
-/obj/structure/urinal/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "rFJ" = (
@@ -42849,6 +43694,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
+"rHh" = (
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "rHq" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/rack,
@@ -42991,6 +43843,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"rKr" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/hallway)
 "rKv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43011,7 +43869,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "rKH" = (
 /obj/structure/closet/secure_closet/detective,
@@ -43027,6 +43885,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
+"rLd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "rLi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -43095,6 +43960,12 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"rNl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/station/maintenance/department/engine)
 "rNn" = (
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
@@ -43162,18 +44033,8 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
-"rOk" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "rOm" = (
 /obj/effect/spawner/random/maintenance/two,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
@@ -43335,7 +44196,7 @@
 /area/station/security/prison/toilet)
 "rRr" = (
 /obj/structure/reflector/single,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "rSh" = (
 /obj/effect/turf_decal/stripes/line{
@@ -43346,6 +44207,12 @@
 	dir = 1
 	},
 /area/station/engineering/main)
+"rSs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "rSw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -43373,6 +44240,10 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/fitness/recreation)
+"rSF" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "rSR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43410,11 +44281,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"rTT" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
+"rTQ" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/herringbone,
+/area/station/hallway/secondary/command)
 "rTX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -43449,10 +44321,18 @@
 /turf/open/floor/wood,
 /area/station/service/library/private)
 "rVb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/machinery/door/airlock/command{
+	name = "MiniSat Access"
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/tile/command/opposingcorners,
+/obj/effect/landmark/navigate_destination/minisat_access_ai,
+/obj/effect/landmark/navigate_destination/minisat_access_tcomms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/engineering/transit_tube)
 "rVN" = (
 /obj/effect/turf_decal/tile/yellow/half{
@@ -43477,7 +44357,6 @@
 	},
 /area/station/medical/pharmacy)
 "rWm" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -43601,16 +44480,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"rZe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "rZj" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
@@ -43739,9 +44608,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"sca" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "sci" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/red/telecomms,
@@ -43788,6 +44660,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured_large,
 /area/station/science/ordnance)
+"scF" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "scI" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -43808,11 +44684,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"scQ" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/wood,
-/area/station/maintenance/aft/lesser)
 "scS" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 6
@@ -43869,12 +44740,9 @@
 /area/station/security/checkpoint/escape)
 "see" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "sef" = (
@@ -43995,18 +44863,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
-"sgP" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "sgQ" = (
-/obj/structure/closet/wardrobe/pjs,
-/obj/machinery/camera/directional/north{
-	c_tag = "Escape Lounge Storage";
-	name = "camera"
+/obj/machinery/door/airlock{
+	id_tag = "ToiletB";
+	name = "Toilet B"
 	},
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/auxiliary)
 "shq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -44118,6 +44981,11 @@
 "sjZ" = (
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"skc" = (
+/mob/living/basic/crab,
+/obj/item/cigarette/rollie/cannabis,
+/turf/open/misc/beach/sand,
+/area/station/maintenance/department/engine)
 "ski" = (
 /obj/machinery/teleport/hub,
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner{
@@ -44160,6 +45028,10 @@
 	},
 /obj/effect/turf_decal/trimline/dark_blue/mid_joiner{
 	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/command/teleporter)
@@ -44257,8 +45129,13 @@
 /area/station/commons/fitness)
 "snn" = (
 /obj/item/toy/plush/ratplush,
+/obj/structure/marker_beacon/bronze,
 /turf/open/floor/bronze/filled,
 /area/station/maintenance/aft/upper)
+"snu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "soa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination/atmos,
@@ -44438,6 +45315,7 @@
 "sta" = (
 /obj/item/coin/twoheaded,
 /obj/effect/spawner/random/maintenance/eight,
+/obj/structure/rack,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "stt" = (
@@ -44447,16 +45325,11 @@
 /turf/open/floor/carpet/blue,
 /area/station/hallway/secondary/command)
 "stw" = (
-/obj/structure/sink/directional/south{
-	dir = 8;
-	pixel_x = 14;
-	pixel_y = 0
-	},
-/obj/structure/mirror/directional/east,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "stx" = (
@@ -44595,6 +45468,8 @@
 /area/station/maintenance/starboard/fore)
 "swE" = (
 /obj/machinery/status_display/evac/directional/south,
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/medkit/regular,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/command/bridge)
 "swN" = (
@@ -44699,10 +45574,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
-"syp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "syq" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
@@ -44974,7 +45845,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "sDL" = (
@@ -45005,13 +45875,6 @@
 /obj/item/toy/plush/pico,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"sDX" = (
-/obj/structure/closet/wardrobe/orange,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/hallway)
 "sDY" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
@@ -45068,9 +45931,8 @@
 /turf/closed/wall,
 /area/station/security/brig)
 "sEu" = (
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/maintenance/aft/lesser)
 "sEF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45196,9 +46058,6 @@
 /turf/open/space/basic,
 /area/space)
 "sGU" = (
-/obj/structure/chair/sofa/bench{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -45207,6 +46066,7 @@
 	name = "camera"
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/sign/warning/vacuum/external/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "sGX" = (
@@ -45234,7 +46094,7 @@
 /area/station/science/lobby)
 "sHl" = (
 /obj/item/storage/cans/sixbeer,
-/turf/open/floor/plating,
+/turf/open/misc/beach/sand,
 /area/station/maintenance/department/engine)
 "sHt" = (
 /obj/structure/chair/bronze{
@@ -45280,16 +46140,6 @@
 /obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
-"sIu" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "sIy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/oxygen_output,
 /turf/open/floor/engine/o2,
@@ -45395,6 +46245,11 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/machinery/door/window/right/directional/west{
+	name = "Research Delivieries";
+	req_access = list("robotics")
+	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "sKC" = (
@@ -45407,6 +46262,11 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 4
 	},
+/obj/item/storage/box/shipping,
+/obj/item/hand_labeler,
+/obj/item/stack/wrapping_paper,
+/obj/item/toner,
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
 /turf/open/floor/iron/corner{
 	dir = 1
 	},
@@ -45551,11 +46411,14 @@
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "sNy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/engineering/transit_tube)
+"sOg" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "sOm" = (
 /obj/machinery/computer/operating,
 /obj/effect/turf_decal/tile/blue/full,
@@ -45623,6 +46486,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"sPw" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "sPJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -45751,6 +46618,16 @@
 "sSh" = (
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
+"sSm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "sSn" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/iron/dark,
@@ -45790,6 +46667,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"sTl" = (
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "sTD" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/light/no_nightlight/directional/north,
@@ -45875,14 +46757,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L14"
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "sUN" = (
 /obj/machinery/status_display/evac/directional/west,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -45897,11 +46775,17 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/upper)
+"sUU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "sUW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "sUZ" = (
 /obj/machinery/status_display/evac/directional/north,
@@ -46004,14 +46888,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
-"sYu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/grille/broken,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "sYx" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -46141,12 +47017,6 @@
 /obj/effect/turf_decal/trimline/brown/warning,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"tcz" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/cup/glass/bottle/ritual_wine,
-/turf/open/floor/wood,
-/area/station/maintenance/aft/lesser)
 "tcC" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 4
@@ -46167,6 +47037,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"tcQ" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "tcU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46217,12 +47091,8 @@
 /area/station/cargo/lobby)
 "tdP" = (
 /obj/effect/spawner/random/vending/snackvend,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -46250,6 +47120,13 @@
 "tdV" = (
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"tdW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "tee" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue{
@@ -46260,6 +47137,11 @@
 /obj/item/toy/figure/lawyer,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
+"ten" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "teo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46293,11 +47175,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"teR" = (
-/obj/structure/table/glass,
-/obj/item/storage/medkit/regular,
-/turf/open/floor/iron/dark/herringbone,
-/area/station/command/bridge)
 "tfs" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/east,
@@ -46536,10 +47413,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"tjZ" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
 "tkj" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
@@ -46552,12 +47425,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/storage)
 "tkM" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/showroomfloor,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard)
 "tkT" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -46812,7 +47683,6 @@
 "tqO" = (
 /obj/structure/displaycase,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/corporate_showroom)
 "tqR" = (
@@ -47068,6 +47938,10 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"txJ" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "txR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47123,6 +47997,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/explab)
+"tyK" = (
+/turf/open/floor/wood/tile,
+/area/station/maintenance/department/engine)
 "tyY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47192,12 +48069,12 @@
 /area/station/engineering/atmos)
 "tAT" = (
 /obj/structure/table/wood,
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 8
+	},
 /obj/item/clipboard{
 	pixel_x = 4;
 	pixel_y = -4
-	},
-/obj/effect/turf_decal/siding/thinplating_new/corner{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -47259,6 +48136,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"tDI" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "tDL" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -47311,10 +48192,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
-"tFd" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/maintenance/aft/lesser)
 "tFh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -47358,6 +48235,11 @@
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /turf/open/floor/iron/diagonal,
 /area/station/service/theater)
+"tFH" = (
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "tFJ" = (
 /obj/structure/sign/departments/xenobio/directional/north,
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -47426,6 +48308,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "tHq" = (
@@ -47440,14 +48323,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
-"tHS" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_half,
-/area/station/hallway/primary/central/aft)
 "tIc" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -47539,7 +48414,7 @@
 "tJG" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/command/teleporter)
 "tJI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47580,13 +48455,15 @@
 	},
 /turf/open/floor/iron/textured_corner,
 /area/station/engineering/atmos/office)
+"tKy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/carpet/purple,
+/area/station/maintenance/starboard)
 "tKU" = (
 /turf/open/floor/iron/textured_large,
 /area/station/science/ordnance)
-"tKY" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
 "tKZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47733,6 +48610,7 @@
 /area/station/ai_monitored/security/armory)
 "tOf" = (
 /obj/structure/tank_holder/extinguisher,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "tOh" = (
@@ -47755,6 +48633,18 @@
 /obj/machinery/vending/clothing,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"tOy" = (
+/obj/effect/turf_decal/trimline/neutral/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "tOK" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -47923,9 +48813,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "tRI" = (
-/obj/item/bodypart/leg/left,
-/obj/effect/decal/cleanable/blood,
-/obj/item/clothing/shoes/clown_shoes,
+/obj/effect/spawner/random/structure/girder,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "tSc" = (
@@ -47934,6 +48823,8 @@
 "tSf" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/structure/closet/toolcloset,
+/obj/item/lightreplacer,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "tSi" = (
@@ -47995,7 +48886,7 @@
 "tUg" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/command/teleporter)
 "tUB" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -48023,10 +48914,6 @@
 /obj/machinery/computer/security/telescreen/ordnance/directional/south,
 /turf/open/floor/iron,
 /area/station/science/ordnance/office)
-"tUY" = (
-/obj/item/clothing/shoes/costume_2021/alucard_shoes,
-/turf/open/floor/wood,
-/area/station/maintenance/aft/lesser)
 "tVe" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -48062,7 +48949,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "tVy" = (
-/turf/open/floor/plating,
+/obj/structure/reflector/double,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "tVz" = (
 /obj/structure/disposalpipe/segment,
@@ -48180,6 +49068,7 @@
 /area/station/service/kitchen)
 "tYu" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "tYz" = (
@@ -48188,6 +49077,7 @@
 /area/station/security/prison/rec)
 "tYB" = (
 /obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
 "tYK" = (
@@ -48250,6 +49140,18 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/ordnance)
+"ubO" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
+"ubP" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/chair/sofa/bench,
+/turf/open/floor/glass/reinforced/plasma,
+/area/station/hallway/primary/starboard)
 "ubQ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -48289,17 +49191,27 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
+"ucG" = (
+/obj/effect/spawner/random/trash/graffiti,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
+"ucH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "ucQ" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/machinery/recharger,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
-"ucR" = (
-/obj/structure/aquarium,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "udo" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -48424,13 +49336,13 @@
 "ufg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ufo" = (
@@ -48446,12 +49358,6 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/medical/cryo)
-"ufB" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "ufO" = (
 /obj/machinery/modular_computer/preset/engineering{
 	dir = 4
@@ -48473,6 +49379,13 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
+"ugb" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "ugm" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -48498,7 +49411,10 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
-/turf/open/floor/glass/reinforced,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced/plasma,
 /area/station/hallway/primary/starboard)
 "ugM" = (
 /obj/machinery/light/small/directional/north,
@@ -48623,7 +49539,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /obj/machinery/duct,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain/private)
 "ujm" = (
 /obj/effect/turf_decal/trimline/purple/line{
@@ -48782,8 +49698,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
-/obj/machinery/duct,
-/turf/open/floor/plating,
+/turf/open/floor/iron/textured,
 /area/station/commons/storage/emergency/starboard)
 "umx" = (
 /obj/machinery/door/airlock/maintenance,
@@ -48819,8 +49734,15 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"unc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "unf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48849,6 +49771,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"unz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "unP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48906,9 +49835,15 @@
 	dir = 1
 	},
 /area/station/cargo/miningdock)
+"upy" = (
+/obj/structure/rack,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "upO" = (
 /obj/structure/sign/directions/dorms{
-	dir = 1
+	dir = 8;
+	pixel_y = 08
 	},
 /turf/closed/wall,
 /area/station/maintenance/aft/lesser)
@@ -48958,15 +49893,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "uqC" = (
-/obj/structure/closet/crate/secure/gear{
-	desc = "Contains the most important part of any Chef.";
-	name = "chef crate"
-	},
-/obj/item/storage/box/deputy,
-/obj/item/storage/box/evidence{
-	pixel_x = -5;
-	pixel_y = 12
-	},
+/obj/effect/spawner/random/engineering/flashlight,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "uqW" = (
@@ -49140,11 +50068,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
-"uvy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "uvZ" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood,
@@ -49195,6 +50118,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "uxg" = (
@@ -49273,6 +50197,17 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/pharmacy)
+"uxB" = (
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "uxJ" = (
 /obj/structure/cable,
 /obj/structure/cable/layer3,
@@ -49359,7 +50294,7 @@
 /area/station/solars/starboard/aft)
 "uAq" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "uAt" = (
 /obj/machinery/door/firedoor,
@@ -49399,11 +50334,11 @@
 /area/station/security/prison/garden)
 "uCa" = (
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /obj/structure/sign/departments/restroom/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "uCh" = (
@@ -49473,15 +50408,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"uDj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+"uDf" = (
+/obj/effect/spawner/random/structure/girder,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "uDq" = (
 /obj/machinery/camera/directional/north{
 	name = "AI Sat - Antechamber"
@@ -49536,8 +50467,7 @@
 	},
 /area/station/hallway/primary/central/aft)
 "uFp" = (
-/obj/structure/cable,
-/obj/structure/grille/broken,
+/obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "uFt" = (
@@ -49601,8 +50531,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
-/obj/structure/reflector/box,
-/turf/open/floor/plating,
+/obj/structure/reflector/double,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "uGW" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -49834,10 +50764,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "uKT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "uLe" = (
@@ -49895,9 +50827,12 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "uLQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/sofa/bench{
 	dir = 8
 	},
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "uMb" = (
@@ -50011,6 +50946,17 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/solars/starboard)
+"uOE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "evashutters";
+	name = "E.V.A. Storage Shutters"
+	},
+/turf/open/floor/engine,
+/area/station/ai_monitored/command/storage/eva)
 "uOG" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
@@ -50048,7 +50994,6 @@
 /area/station/hallway/primary/port)
 "uPo" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/structure/cable,
 /obj/structure/sign/departments/rndserver/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -50260,7 +51205,8 @@
 /area/station/maintenance/disposal/incinerator)
 "uTm" = (
 /obj/structure/safe,
-/obj/item/stack/spacecash/c100,
+/obj/item/stack/spacecash/c1000,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "uTv" = (
@@ -50275,6 +51221,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 8
 	},
+/obj/item/flashlight,
+/obj/item/flashlight,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -50346,18 +51294,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"uUq" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "uUs" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -50458,6 +51394,15 @@
 	dir = 4
 	},
 /area/station/service/hydroponics/kitchen)
+"uWK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/emergency/starboard)
 "uWL" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -50535,17 +51480,9 @@
 /area/station/science/xenobiology)
 "uYn" = (
 /obj/structure/transit_tube/curved,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"uYu" = (
-/obj/effect/turf_decal/siding/grey{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "uYD" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
@@ -50595,6 +51532,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"uZp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "uZv" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -50681,9 +51624,9 @@
 /turf/open/floor/iron/white,
 /area/station/security/execution)
 "vcf" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/edge,
 /area/station/commons/storage/primary)
 "vct" = (
@@ -50800,10 +51743,6 @@
 	},
 /turf/open/floor/carpet/neon/simple/black/nodots,
 /area/station/command/meeting_room)
-"vdV" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
 "vea" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50835,13 +51774,6 @@
 	dir = 8
 	},
 /area/station/science/xenobiology)
-"ven" = (
-/obj/structure/railing/corner,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "veB" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
@@ -51084,12 +52016,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"vjg" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "vjG" = (
 /obj/machinery/suit_storage_unit/hos,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -51143,6 +52069,10 @@
 /obj/machinery/computer/security/telescreen/vault/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"vkT" = (
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "vkV" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /mob/living/basic/chicken,
@@ -51224,24 +52154,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"vnf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/escape)
 "vnl" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51284,8 +52196,14 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/security/office)
+"vnU" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "voo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51294,6 +52212,10 @@
 /obj/machinery/duct,
 /turf/open/floor/wood/large,
 /area/station/medical/morgue)
+"vop" = (
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "vos" = (
 /obj/machinery/door/airlock/command{
 	name = "Teleport Access"
@@ -51315,6 +52237,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"voD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/station/command/bridge)
 "voJ" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Pharmacy"
@@ -51323,6 +52257,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"voY" = (
+/obj/structure/curtain/bounty/start_closed,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "vpc" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/airalarm/directional/east,
@@ -51401,7 +52340,7 @@
 /area/station/maintenance/disposal)
 "vqR" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/execution)
 "vrk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -51484,6 +52423,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"vsS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "vtq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -51491,6 +52437,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"vud" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/field/generator,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/engineering/storage)
 "vuo" = (
 /obj/machinery/door/airlock/external{
 	name = "External Solar Access"
@@ -51538,6 +52490,14 @@
 /obj/structure/window/spawner/directional/north,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
+"vvl" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/storage/box/halloween/edition_21/alucard,
+/obj/item/clothing/under/costume/draculass,
+/obj/item/clothing/suit/costume/dracula,
+/obj/item/clothing/shoes/costume_2021/alucard_shoes,
+/turf/open/floor/wood,
+/area/station/maintenance/aft/lesser)
 "vvu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -51757,7 +52717,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "vAv" = (
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -51793,6 +52752,13 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/mineral/titanium/tiled,
 /area/station/ai_monitored/command/nuke_storage)
+"vBh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/floor,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/auxiliary)
 "vBk" = (
 /turf/closed/wall,
 /area/station/security/execution)
@@ -51933,6 +52899,20 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/pharmacy)
+"vDn" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard)
+"vDq" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/emergency/starboard)
 "vDr" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
@@ -52075,11 +53055,6 @@
 /obj/effect/mapping_helpers/mail_sorting/service/theater,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/hallway/secondary/service)
-"vHp" = (
-/obj/structure/closet/crate,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
 "vHt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -52159,6 +53134,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"vJs" = (
+/obj/effect/spawner/random/trash/graffiti,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "vJx" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/icecream_vat,
@@ -52236,6 +53216,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"vKA" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "vKF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/east,
@@ -52255,6 +53240,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
+"vKR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "vLb" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
@@ -52356,6 +53348,9 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "vMK" = (
@@ -52453,6 +53448,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
+"vNV" = (
+/obj/effect/mapping_helpers/engraving,
+/turf/closed/wall,
+/area/station/maintenance/department/engine/atmos)
 "vNY" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
@@ -52530,7 +53529,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "vQg" = (
 /obj/machinery/door/poddoor/preopen{
@@ -52627,16 +53629,37 @@
 "vRQ" = (
 /obj/item/target/clown,
 /obj/item/target/clown,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "vRY" = (
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
+"vSa" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "vSe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
+"vSw" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "vSG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -52661,8 +53684,8 @@
 	chamber_id = "ordnanceburn"
 	},
 /obj/effect/mapping_helpers/airalarm/tlv_no_checks,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/ordnance)
@@ -52698,6 +53721,7 @@
 /obj/item/stack/tile/eighties{
 	amount = 15
 	},
+/obj/item/stack/sheet/mineral/bananium,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "vUd" = (
@@ -52737,6 +53761,7 @@
 /area/station/science/lobby)
 "vUQ" = (
 /obj/effect/turf_decal/tile/dark/fourcorners,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "vUT" = (
@@ -52761,16 +53786,21 @@
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "vWI" = (
 /obj/structure/door_assembly/door_assembly_cult/unruned,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "vWJ" = (
 /obj/effect/spawner/random/maintenance/two,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "vWP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/station/security/mechbay)
 "vWR" = (
@@ -52797,15 +53827,16 @@
 	pixel_x = 2;
 	pixel_y = -2
 	},
-/obj/machinery/light/directional/north,
 /obj/machinery/button/door/directional/south{
 	id = "atmoshfr";
 	name = "Radiation Shutters Control"
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "vXi" = (
-/obj/structure/closet/crate/trashcart/laundry,
+/obj/machinery/space_heater,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "vXl" = (
@@ -53027,6 +54058,7 @@
 "wbu" = (
 /obj/effect/spawner/random/trash/bacteria,
 /obj/machinery/duct,
+/obj/effect/decal/cleanable/fuel_pool,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "wbv" = (
@@ -53208,6 +54240,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"wdP" = (
+/obj/machinery/light/directional/south,
+/obj/structure/sign/departments/evac/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "wdY" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/space,
@@ -53275,6 +54312,10 @@
 /obj/machinery/biogenerator,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden/monastery)
+"wfN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard)
 "wgg" = (
 /obj/structure/mannequin/skeleton,
 /obj/effect/decal/cleanable/dirt,
@@ -53300,6 +54341,8 @@
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "wgA" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "wgC" = (
@@ -53463,6 +54506,14 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
+"wkp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "wkr" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -53526,6 +54577,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
+"wlM" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/aisat/exterior)
 "wlY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53534,7 +54592,7 @@
 /area/station/science/auxlab/firing_range)
 "wmi" = (
 /obj/machinery/computer/communications,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "wmr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53548,7 +54606,6 @@
 "wna" = (
 /obj/structure/displaycase,
 /obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/corporate_showroom)
@@ -53610,23 +54667,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/office)
-"woc" = (
-/obj/effect/landmark/navigate_destination/minisat_access_ai,
-/obj/machinery/door/airlock/command{
-	name = "MiniSat Access"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/effect/turf_decal/tile/command/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/navigate_destination/minisat_access_tcomms,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/transit_tube)
 "wod" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green/diagonal_centre,
@@ -53737,6 +54777,11 @@
 	dir = 8
 	},
 /area/station/command/heads_quarters/cmo)
+"wqa" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/closet/crate,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wqj" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral{
@@ -53774,7 +54819,6 @@
 /turf/open/floor/iron/white,
 /area/station/security/checkpoint/science)
 "wrq" = (
-/obj/structure/cable,
 /mob/living/basic/parrot,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -53785,6 +54829,10 @@
 /obj/effect/landmark/navigate_destination/cargo,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"wrA" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "wrE" = (
 /obj/structure/table/glass,
 /obj/item/clothing/shoes/clown_shoes,
@@ -53922,6 +54970,13 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"wtV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wui" = (
 /obj/machinery/shower/directional/west,
 /obj/machinery/firealarm/directional/north,
@@ -54035,6 +55090,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
+"wws" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "wwu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -54157,6 +55221,7 @@
 /area/station/science/xenobiology)
 "wxs" = (
 /obj/structure/window/reinforced/tinted/fulltile,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/execution)
 "wxt" = (
@@ -54198,10 +55263,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wxY" = (
-/obj/machinery/power/emitter{
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/machinery/power/emitter{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -54355,6 +55420,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/storage/gas)
+"wAR" = (
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/obj/item/circuitboard/computer/security,
+/obj/item/stack/cable_coil/five,
+/obj/item/shard,
+/obj/item/shard{
+	icon_state = "small"
+	},
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 1
+	},
+/area/station/maintenance/aft/upper)
 "wBe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54376,11 +55455,6 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
 /area/station/security/office)
-"wCb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/entry)
 "wCf" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/watering_can,
@@ -54490,15 +55564,15 @@
 /area/station/ai_monitored/turret_protected/ai)
 "wDU" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -4
+	},
+/obj/item/pen{
+	pixel_x = -4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"wEc" = (
-/obj/item/reagent_containers/cup/soda_cans/random,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
 "wEd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
@@ -54552,13 +55626,18 @@
 /turf/open/floor/iron,
 /area/station/science/auxlab/firing_range)
 "wEF" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 1
+	},
+/obj/machinery/button/door/directional/south{
+	id = "evashutters";
+	name = "E.V.A. Shutters";
+	req_access = list("command");
+	pixel_x = 9
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -54607,7 +55686,10 @@
 "wGd" = (
 /mob/living/basic/pet/cat/kitten,
 /obj/item/toy/cattoy,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/carpet/purple,
 /area/station/maintenance/starboard)
 "wGf" = (
 /obj/structure/chair{
@@ -54657,9 +55739,12 @@
 /area/station/engineering/atmos)
 "wGQ" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/engineering/transit_tube)
 "wGS" = (
@@ -54706,11 +55791,8 @@
 /turf/open/floor/grass,
 /area/station/service/kitchen/abandoned)
 "wIa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/field/generator,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark/textured_large,
+/turf/closed/wall/r_wall,
 /area/station/engineering/storage)
 "wIj" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -54779,10 +55861,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "wJf" = (
-/obj/structure/cable,
 /obj/structure/sign/map/fulp/directions/star{
 	pixel_x = -32
 	},
+/obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "wJj" = (
@@ -54801,6 +55883,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"wJW" = (
+/obj/effect/spawner/random/maintenance/four,
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "wJZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54878,6 +55966,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "wLk" = (
@@ -54894,15 +55983,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"wLB" = (
-/obj/machinery/power/emitter{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "wLF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
@@ -54930,14 +56010,14 @@
 /area/station/security/brig)
 "wMv" = (
 /obj/item/toy/beach_ball,
-/turf/open/floor/plating,
+/obj/item/cigarette/rollie/cannabis,
+/turf/open/misc/beach/sand,
 /area/station/maintenance/department/engine)
 "wNf" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "wNC" = (
@@ -55072,7 +56152,15 @@
 /area/station/maintenance/port/fore)
 "wQa" = (
 /obj/structure/toilet,
-/turf/open/floor/iron,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/button/door/directional/east{
+	id = "halltoilet";
+	name = "Bolt Control - Single-Occupant Restroom";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/structure/sign/poster/official/moth_epi/directional/west,
+/turf/open/floor/iron/showroomfloor,
 /area/station/hallway/primary/port)
 "wQd" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -55114,7 +56202,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/closet/firecloset,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wRl" = (
@@ -55131,6 +56219,16 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
+"wSy" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/chair/sofa/bench/corner{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/glass/reinforced/plasma,
+/area/station/hallway/primary/starboard)
 "wSz" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -55255,7 +56353,7 @@
 /area/station/security/medical)
 "wVJ" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "wVL" = (
@@ -55294,6 +56392,12 @@
 	name = "padded floor"
 	},
 /area/station/maintenance/aft/upper)
+"wXa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "wXh" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
@@ -55401,6 +56505,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/nuke_storage)
+"xaq" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/chair/sofa/bench/left,
+/turf/open/floor/glass/reinforced/plasma,
+/area/station/hallway/primary/starboard)
 "xar" = (
 /turf/closed/wall,
 /area/station/service/chapel/funeral)
@@ -55513,11 +56624,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"xbx" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "xbT" = (
 /turf/open/floor/carpet/blue,
 /area/station/hallway/secondary/command)
@@ -55592,6 +56698,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"xeg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
+"xev" = (
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "xeN" = (
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -55669,24 +56785,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
-"xgQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L3"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "xgS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "xgV" = (
 /turf/open/floor/engine/vacuum,
@@ -55795,6 +56899,9 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
@@ -55977,8 +57084,8 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/auxiliary)
 "xnm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -56007,6 +57114,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"xnB" = (
+/obj/machinery/space_heater,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "xnO" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wood{
@@ -56053,6 +57165,16 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/security/execution)
+"xoA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/chair/sofa/bench{
+	dir = 1
+	},
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "xoB" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /turf/open/floor/iron,
@@ -56149,12 +57271,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "xpy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
@@ -56386,13 +57508,6 @@
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /turf/open/floor/iron/diagonal,
 /area/station/security/courtroom)
-"xvu" = (
-/obj/structure/curtain/bounty/start_closed,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
 "xvv" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/silver,
@@ -56414,12 +57529,6 @@
 "xvz" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"xvD" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate,
-/turf/open/floor/iron,
-/area/station/maintenance/aft/upper)
 "xvE" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -56441,11 +57550,20 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "xvV" = (
-/obj/machinery/fishing_portal_generator,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"xvZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "xwg" = (
 /obj/machinery/computer/records/security{
 	dir = 1
@@ -56492,6 +57610,7 @@
 "xxk" = (
 /obj/structure/fluff/beach_towel,
 /obj/item/pizzabox/margherita,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "xxp" = (
@@ -56552,10 +57671,13 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/commons/lounge)
 "xyu" = (
-/obj/structure/chair/sofa/bench/right{
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
 	dir = 4
 	},
-/turf/open/floor/glass/reinforced,
+/turf/open/floor/glass/reinforced/plasma,
 /area/station/hallway/primary/starboard)
 "xyA" = (
 /turf/open/floor/iron/white,
@@ -56662,8 +57784,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xAJ" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood/tile,
 /area/station/maintenance/department/engine)
 "xAM" = (
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
@@ -56671,10 +57793,11 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/hallway/secondary/service)
 "xBa" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/machinery/duct,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "xBh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -56701,9 +57824,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/aft/lesser)
 "xBM" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /obj/machinery/cell_charger{
 	pixel_y = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
@@ -56974,6 +58100,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"xHN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "xIh" = (
 /obj/structure/filingcabinet/employment,
 /turf/open/floor/carpet/blue,
@@ -56990,12 +58122,86 @@
 	},
 /area/station/science/xenobiology)
 "xIH" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/camera/directional/west{
-	c_tag = "Primary Tool Storage"
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
 	},
-/turf/open/floor/iron/corner,
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/structure/closet/crate/internals,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "xIJ" = (
 /obj/structure/cable,
@@ -57050,6 +58256,14 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"xKQ" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "xLp" = (
 /obj/machinery/modular_computer/preset/id{
 	dir = 4
@@ -57153,7 +58367,7 @@
 /area/station/science/genetics)
 "xNp" = (
 /obj/structure/reflector/box,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "xNx" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -57298,7 +58512,6 @@
 "xRt" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
@@ -57321,6 +58534,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"xRO" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "xRR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -57429,11 +58646,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"xVq" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/mineral/bananium,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
+"xVn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "xVw" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -57456,6 +58675,7 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "xWt" = (
@@ -57480,20 +58700,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/auxlab/firing_range)
-"xWM" = (
-/obj/structure/closet/crate/engineering,
-/obj/item/clothing/head/utility/welding,
-/obj/item/weldingtool,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow,
-/turf/open/floor/iron/large,
-/area/station/commons/storage/primary)
 "xWO" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible{
 	dir = 4
@@ -57507,16 +58713,21 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "xWV" = (
-/obj/structure/table,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/storage/toolbox/mechanical,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
+/obj/structure/closet/crate/engineering,
+/obj/item/clothing/head/utility/welding,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/storage/belt/utility,
+/obj/item/weldingtool,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "xXb" = (
@@ -57738,11 +58949,23 @@
 /area/station/engineering/atmos/hfr_room)
 "yav" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"yaY" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
+"ybd" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/wood/tile,
+/area/station/maintenance/department/engine)
 "ybe" = (
 /obj/machinery/space_heater,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "ybr" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -57790,11 +59013,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "ycZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/vending/wallmed/directional/north{
 	use_power = 0
 	},
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/starboard)
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/auxiliary)
 "yda" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
@@ -57897,6 +59121,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"yeV" = (
+/obj/effect/spawner/random/structure/crate_loot,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "yeZ" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
@@ -57951,6 +59179,8 @@
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "yge" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
 "ygf" = (
@@ -57988,8 +59218,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "ygT" = (
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/maintenance{
+	id_tag = "halltoilet";
+	name = "Single-Occupant Restroom"
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/hallway/primary/port)
 "yhe" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -58079,7 +59312,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "yhY" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -58091,13 +59323,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"yhZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
 "yic" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -58171,6 +59396,10 @@
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"yjF" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "yjU" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -58242,6 +59471,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ykB" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/moisture,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "ykH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -58250,6 +59484,7 @@
 	codes_txt = "patrol;next_patrol=depart5";
 	location = "depart4"
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ykQ" = (
@@ -65676,11 +66911,11 @@ vQV
 vQV
 vQV
 vQV
-pkh
+vQV
 phf
 phf
 phf
-phf
+anu
 phf
 phf
 phf
@@ -65688,7 +66923,7 @@ phf
 pkh
 nri
 phf
-phf
+anu
 phf
 nri
 phf
@@ -65933,7 +67168,7 @@ vQV
 vQV
 vQV
 vQV
-pkh
+vQV
 nri
 tMM
 tMM
@@ -66464,7 +67699,7 @@ hmW
 lEr
 gsn
 mQH
-phf
+anu
 vQV
 vQV
 vQV
@@ -68010,12 +69245,12 @@ phf
 nri
 phf
 phf
-phf
+anu
 phf
 phf
 phf
 nri
-pkh
+anu
 phf
 phf
 phf
@@ -69052,7 +70287,7 @@ rbm
 lEr
 kuk
 mQH
-phf
+anu
 vQV
 vQV
 vQV
@@ -69567,7 +70802,7 @@ clO
 dgC
 mQH
 phf
-vQV
+iwm
 vQV
 vQV
 vQV
@@ -69822,9 +71057,9 @@ nam
 nam
 clO
 dgC
-hET
-phf
-vQV
+efM
+nri
+fYQ
 vQV
 vQV
 vQV
@@ -70077,11 +71312,11 @@ yeg
 nGi
 nam
 nam
-pkh
-dgC
+vnG
+fnV
+otI
 mQH
 phf
-vQV
 vQV
 vQV
 vQV
@@ -70308,7 +71543,7 @@ tYK
 esH
 esH
 jPi
-mjo
+lYY
 vbd
 lig
 kdq
@@ -70335,10 +71570,10 @@ dWb
 nam
 nam
 vnG
-dgC
+fnV
+wlM
 mQH
 phf
-vQV
 vQV
 vQV
 vQV
@@ -70594,8 +71829,8 @@ nam
 hAW
 fnV
 lUR
+mQH
 phf
-vQV
 vQV
 vQV
 vQV
@@ -70849,10 +72084,10 @@ aAj
 nam
 nam
 vnG
-dgC
-tzz
-nri
-vQV
+fnV
+dsU
+hET
+rtO
 vQV
 vQV
 vQV
@@ -71106,10 +72341,10 @@ nGi
 nam
 nam
 clO
-dgC
+fnV
+rmg
 mQH
 phf
-vQV
 vQV
 vQV
 vQV
@@ -71364,9 +72599,9 @@ nam
 nam
 vnG
 dgC
-mQH
+tzz
+nri
 phf
-vQV
 vQV
 vQV
 vQV
@@ -71623,7 +72858,7 @@ clO
 dgC
 mQH
 phf
-vQV
+iwm
 vQV
 vQV
 vQV
@@ -73148,7 +74383,7 @@ vQV
 vQV
 vQV
 phf
-phf
+anu
 phf
 pkh
 phf
@@ -73159,7 +74394,7 @@ phf
 pkh
 nri
 phf
-phf
+anu
 phf
 phf
 phf
@@ -73877,7 +75112,7 @@ syv
 wzg
 qWv
 qWv
-qWv
+djk
 wxt
 cfg
 nmi
@@ -73923,7 +75158,7 @@ vQV
 vQV
 vQV
 vQV
-sGH
+vQV
 vQV
 vQV
 vQV
@@ -74143,7 +75378,7 @@ wAj
 seW
 seW
 vFX
-jLf
+qjF
 iWb
 iWb
 iWb
@@ -74398,7 +75633,7 @@ jLf
 xFb
 jLf
 uzK
-hQO
+jLf
 pEe
 oTu
 iWb
@@ -74434,7 +75669,7 @@ vQV
 vQV
 vQV
 vQV
-vQV
+sGH
 vQV
 vQV
 vQV
@@ -74638,7 +75873,7 @@ cfg
 fuM
 iZz
 pew
-cfg
+vNV
 pCq
 cfg
 kCh
@@ -74651,16 +75886,16 @@ wQa
 ygT
 qmc
 non
-vUQ
-dYe
 pEe
-pEe
-pEe
+lJH
+xZx
+cKC
+lhK
 kZS
 lsJ
 rVb
 wGQ
-aLp
+nHg
 emA
 iWb
 iWb
@@ -74910,12 +76145,12 @@ eCo
 eJB
 bAC
 mav
-mav
-xZx
-rZe
-rZe
-gzC
-woc
+pEe
+pME
+gHV
+lQe
+gHV
+iWb
 aai
 ebj
 pjB
@@ -75153,7 +76388,7 @@ iZz
 rzp
 nLp
 cfg
-pCq
+aEp
 cfg
 suT
 pEz
@@ -75163,16 +76398,16 @@ byq
 eVg
 cMv
 kRh
-hwM
+gPv
 dcy
 bka
 tpw
 pEe
 vUQ
 gHV
-lQe
-gHV
-gHV
+drk
+jLh
+iWb
 sNy
 kXn
 aLp
@@ -75415,12 +76650,12 @@ cfg
 atj
 pEz
 pmm
-bxj
-bxj
+qzD
+qzD
 qzD
 cYc
 rDj
-hwM
+vSw
 dcy
 bka
 pEe
@@ -75429,13 +76664,13 @@ bhd
 gHV
 pUq
 eIO
-gHV
+iWb
 aIg
 bcd
+kIa
 iWb
-iWb
-iWb
-iWb
+vQV
+vQV
 vQV
 vQV
 vQV
@@ -75666,21 +76901,21 @@ txX
 txX
 txX
 pCq
-pCq
-pCq
+ebO
+ebO
 cfg
 vLA
 pEz
 pmm
 ocj
 gQk
-eVg
+eQw
 wDU
 jWY
-hwM
+vSa
 dYe
 bka
-rng
+pEe
 mOf
 fBQ
 gHV
@@ -75690,9 +76925,9 @@ jeO
 jeO
 jeO
 jeO
-xbx
-nWv
-nXM
+jeO
+jeO
+vQV
 vQV
 vQV
 vQV
@@ -75715,9 +76950,9 @@ vQV
 vQV
 vQV
 kpq
-ssX
-ssX
-ssX
+vJJ
+aWl
+bXd
 ePR
 fkR
 vQV
@@ -75892,7 +77127,7 @@ vQV
 vQV
 nri
 aOC
-tVy
+rRr
 xNp
 cnW
 rRr
@@ -75923,7 +77158,7 @@ cfg
 kna
 iZz
 kXP
-iZz
+pCr
 cfg
 cfg
 gcO
@@ -75936,7 +77171,7 @@ ogq
 ogq
 cgP
 qwz
-wLa
+mOx
 aqI
 gHV
 gHV
@@ -75944,11 +77179,11 @@ gHV
 lMq
 fuH
 jeO
-fbf
+vCa
 vWJ
 riw
-fbf
-fbf
+oAD
+nXM
 nXM
 nXM
 nXM
@@ -75972,9 +77207,9 @@ kpq
 kpq
 kpq
 kpq
-ejh
-sYu
-spY
+ssX
+ssX
+ssX
 fnD
 fkR
 fkR
@@ -76180,7 +77415,7 @@ cfg
 mhg
 wbu
 noa
-iZz
+owY
 cfg
 oDv
 vfV
@@ -76193,7 +77428,7 @@ uQp
 ogq
 vFX
 dYe
-gQV
+sSm
 akZ
 hYW
 hYW
@@ -76230,8 +77465,8 @@ ejh
 ejh
 ejh
 ejh
-vJJ
-spY
+unc
+vKR
 spY
 uKn
 fkR
@@ -76407,7 +77642,7 @@ nri
 nri
 aOC
 bnE
-oMV
+uae
 oMV
 oMV
 sVQ
@@ -76459,7 +77694,7 @@ kFS
 ydZ
 jeO
 xdx
-fbf
+nIZ
 nXM
 nXM
 nXM
@@ -76488,7 +77723,7 @@ qZw
 kpq
 kpq
 vJJ
-bXd
+ssX
 spY
 rOm
 fkR
@@ -76665,8 +77900,8 @@ aOC
 aOC
 ehh
 oMV
-uae
-uae
+oMV
+oMV
 sVQ
 vPr
 tSc
@@ -76707,7 +77942,7 @@ xMM
 ogq
 vFX
 dYe
-gQV
+sSm
 akZ
 kTQ
 wRU
@@ -76716,7 +77951,7 @@ ejI
 nLQ
 jeO
 xdx
-fbf
+ten
 nXM
 jzZ
 rUX
@@ -76736,7 +77971,7 @@ spY
 spY
 spY
 spY
-spY
+jaU
 spY
 spY
 kpq
@@ -76920,7 +78155,7 @@ aOC
 fYh
 oMV
 vPr
-wLB
+tbc
 tbc
 oEI
 tbc
@@ -76973,7 +78208,7 @@ jeO
 jeO
 jeO
 xdx
-fbf
+ibj
 nXM
 aWs
 dcD
@@ -77180,7 +78415,7 @@ feV
 bTa
 vfQ
 vfQ
-hUn
+vfQ
 bDj
 vPr
 tSc
@@ -77228,9 +78463,9 @@ frC
 mjx
 xdx
 xdx
+tdW
 xdx
-xdx
-fbf
+cwj
 nXM
 blD
 qpl
@@ -77245,7 +78480,7 @@ qQc
 nXM
 nXM
 spY
-ssX
+rSF
 fkR
 wEJ
 gPo
@@ -77483,8 +78718,8 @@ bxU
 xdx
 xdx
 kCZ
-qQE
-fwU
+acF
+iiz
 nXM
 nXM
 nXM
@@ -78012,8 +79247,8 @@ nXM
 nXM
 nXM
 wHn
-fkR
-fkR
+ssX
+jDa
 fkR
 mSt
 xnm
@@ -78207,7 +79442,7 @@ nri
 aOC
 uGQ
 sUW
-qgJ
+sUW
 sUW
 sUW
 aOC
@@ -78269,7 +79504,7 @@ gSG
 nTd
 fkR
 wHn
-fkR
+ssX
 uTm
 fkR
 xFj
@@ -78526,8 +79761,8 @@ ntT
 imo
 fkR
 wHn
-fkR
 ssX
+nhw
 fkR
 tjQ
 gvw
@@ -78815,7 +80050,7 @@ tHe
 tkj
 iWg
 kUf
-iWg
+fcw
 iWg
 pJW
 gAa
@@ -78997,7 +80232,7 @@ aOC
 aOC
 kvZ
 eSW
-aDI
+kvZ
 aDI
 fCV
 tkq
@@ -79022,8 +80257,8 @@ mKe
 tzl
 mXE
 nXM
-vCa
 fbf
+sca
 gtr
 bdL
 lNV
@@ -79253,10 +80488,10 @@ vQV
 hpo
 rqN
 tJA
-anq
-aDI
+wXa
+sTl
 wIa
-pEH
+vud
 pEH
 hgd
 xBS
@@ -79273,7 +80508,7 @@ sIr
 qCO
 aIb
 kvZ
-qPn
+bkq
 jlV
 eCs
 wVb
@@ -79511,9 +80746,9 @@ kvZ
 kvZ
 kvZ
 oqc
+ucG
 aDI
-aDI
-aDI
+pEH
 pEH
 nrT
 tQQ
@@ -79530,7 +80765,7 @@ pdR
 krg
 cqX
 kvZ
-qPn
+bkq
 jlV
 iAb
 dcy
@@ -79546,7 +80781,7 @@ pGe
 fkR
 uKn
 rHq
-ssX
+pyj
 cVA
 fkR
 wHn
@@ -79765,11 +81000,11 @@ rWz
 cNp
 vQV
 kvZ
-pPG
-dqr
+tFH
+pho
+fSx
 anq
-anq
-jYA
+kvZ
 kvZ
 kvZ
 kvZ
@@ -79842,7 +81077,7 @@ bdy
 ydT
 kJv
 hLf
-gJk
+bkG
 iWg
 ylx
 eyN
@@ -80023,10 +81258,10 @@ bsF
 vQV
 kvZ
 wMv
-nQW
-ohl
-jJB
-jJB
+bsd
+qPe
+bkB
+bkB
 lgi
 jJB
 jJB
@@ -80059,7 +81294,7 @@ fCT
 qnU
 fkR
 wHn
-ssX
+cJM
 ntc
 qRZ
 fkR
@@ -80279,10 +81514,10 @@ rWz
 cNp
 vQV
 kvZ
-qPn
-qPn
+mCQ
+bsd
 lJw
-jJB
+wkp
 bsd
 jlV
 qPn
@@ -80295,7 +81530,7 @@ jlV
 jlV
 jlV
 rvH
-jlV
+otB
 jlV
 jlV
 jlV
@@ -80525,7 +81760,7 @@ vQV
 vQV
 vQV
 vQV
-qxV
+hXj
 veP
 bsF
 veP
@@ -80536,11 +81771,11 @@ veP
 bsF
 vQV
 kvZ
-ucR
-qPn
+rjF
+skc
 kup
 xvV
-qPn
+nRP
 jlV
 xMn
 jJB
@@ -80552,9 +81787,9 @@ bPL
 vZf
 jlV
 rvH
+khZ
 jlV
 tql
-lqP
 xIH
 okl
 uTv
@@ -80795,11 +82030,11 @@ vQV
 kvZ
 jJA
 iXo
-rvH
+oBE
 mLI
-iPy
+bsd
 jlV
-qPn
+xev
 jJB
 jlV
 xyM
@@ -80809,9 +82044,9 @@ sTW
 loG
 jlV
 rvH
+uDf
 jlV
 brW
-xWM
 xgS
 nGr
 lUz
@@ -81039,22 +82274,22 @@ vQV
 vQV
 vQV
 vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
+hXj
+nri
+nri
+nri
+nri
+nri
+nri
+nri
+nri
+nri
 kvZ
 sHl
+bsd
 rjF
-rvH
-anq
-qPn
+bkB
+nRP
 jlV
 aRl
 jJB
@@ -81066,7 +82301,7 @@ xwi
 bsR
 jlV
 rvH
-jlV
+lPb
 jlV
 jlV
 jnS
@@ -81296,24 +82531,24 @@ vQV
 vQV
 vQV
 vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
+nri
+qxV
+qxV
+jtO
+qxV
+jtO
+qxV
+jtO
+qxV
+jtO
 kvZ
-qPn
+bsd
 lTm
-gNY
-anq
+nRP
+bkB
 rte
 jlV
-qPn
+aKh
 jJB
 jlV
 eyl
@@ -81553,24 +82788,24 @@ vQV
 vQV
 vQV
 vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
+nri
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
 kvZ
-qPn
+nRP
 ivl
-rvH
+nRP
 fLh
-qPn
+bkq
 jlV
-qPn
+sOg
 jJB
 jlV
 puI
@@ -81810,16 +83045,16 @@ vQV
 vQV
 vQV
 vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
+nri
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
 kvZ
 lXS
 xxk
@@ -81827,7 +83062,7 @@ nRh
 bjP
 ohl
 jlV
-qPn
+mye
 jJB
 jlV
 iZV
@@ -82067,9 +83302,9 @@ vQV
 vQV
 vQV
 vQV
-vQV
-vQV
-vQV
+nri
+qxV
+wqa
 qsd
 qsd
 qsd
@@ -82078,13 +83313,13 @@ qsd
 qsd
 qsd
 jlV
-gQS
-rvH
+dqr
+qPn
 wrq
-anq
+jJB
 qPI
 jlV
-qPn
+nDw
 jJB
 jlV
 puh
@@ -82331,14 +83566,14 @@ qsd
 eWY
 sQW
 sQW
-sQW
+fwh
 sQW
 sQW
 sQW
 jJB
 bGQ
 rbg
-anq
+jJB
 qPn
 jlV
 jlV
@@ -82412,7 +83647,7 @@ ssg
 ufX
 rEy
 rEy
-rdm
+kjW
 rqs
 rEy
 rEy
@@ -82585,14 +83820,14 @@ pcM
 bFt
 cjY
 qsd
-ttG
-hsp
+jiO
+sQW
 qsd
 qsd
 qsd
 qsd
 qsd
-qPn
+rNl
 jUb
 dnn
 blu
@@ -82600,7 +83835,7 @@ qPn
 qPn
 jlV
 jJB
-qPn
+bkq
 jlV
 xsu
 kWT
@@ -82670,13 +83905,13 @@ ifU
 pDq
 sve
 dgw
-xvu
-doq
-rEy
+lko
+voY
+nwY
 vQV
 vQV
 vQV
-vQV
+nri
 vQV
 vQV
 vQV
@@ -82842,20 +84077,20 @@ bHu
 wpv
 dGr
 eFz
-osH
-hsp
+rEq
+sQW
 qsd
 vry
 egG
 xYa
 jlV
 xAJ
-qPn
+tyK
 qoh
 blu
-anq
-anq
-ufB
+jJB
+jJB
+lgi
 jJB
 pPG
 jlV
@@ -82933,7 +84168,7 @@ rEy
 vQV
 vQV
 vQV
-vQV
+nri
 vQV
 vQV
 vQV
@@ -83099,18 +84334,18 @@ dpz
 qVP
 wOQ
 qsd
-ttG
-hsp
+txJ
+sQW
 qsd
 aQE
 wzy
 mEx
 jlV
 pzi
-qPn
+ybd
 aIf
 oSv
-fnl
+qPn
 qPn
 jlV
 rvH
@@ -83190,7 +84425,7 @@ vQV
 vQV
 vQV
 vQV
-vQV
+nri
 vQV
 vQV
 vQV
@@ -83356,8 +84591,8 @@ hdq
 hdq
 hdq
 qsd
-ttG
-hsp
+yjF
+sQW
 qsd
 sdw
 vde
@@ -83441,13 +84676,13 @@ wso
 wDa
 qST
 lSB
-rEy
+nwY
 vQV
 vQV
 vQV
 vQV
 vQV
-vQV
+nri
 vQV
 vQV
 vQV
@@ -83614,7 +84849,7 @@ vQV
 nri
 qsd
 ttG
-hsp
+sQW
 qsd
 qil
 ljN
@@ -83625,7 +84860,7 @@ uqt
 riB
 jlV
 qPn
-cqI
+qPn
 jlV
 jlV
 rvH
@@ -83685,9 +84920,9 @@ rEy
 rEy
 rEy
 doq
-tEJ
-xVq
-hDF
+cYw
+doq
+doq
 doq
 wDa
 kip
@@ -83697,14 +84932,14 @@ fll
 aNy
 wDa
 qST
-dxM
+lSB
 rEy
 vQV
 vQV
 vQV
 vQV
 vQV
-vQV
+nri
 vQV
 vQV
 vQV
@@ -83881,8 +85116,8 @@ rbe
 ddk
 glf
 jlV
-qPn
-qPn
+bkq
+qcr
 qPn
 jlV
 rvH
@@ -83914,7 +85149,7 @@ oUT
 xVI
 fkR
 wHn
-fkR
+jDa
 fkR
 fkR
 fkR
@@ -83945,7 +85180,7 @@ doq
 rEy
 rEy
 rEy
-rEy
+bwv
 wDa
 wDa
 wDa
@@ -83961,7 +85196,7 @@ rEy
 rEy
 rEy
 vQV
-vQV
+nri
 vQV
 vQV
 vQV
@@ -84138,11 +85373,11 @@ bjE
 tSn
 yiG
 jlV
-nqn
+qPn
 qPn
 mYs
 jlV
-nqn
+apA
 rvH
 jlV
 lkZ
@@ -84212,8 +85447,8 @@ dph
 dph
 dse
 kkX
-gVl
-gVl
+qAA
+qKe
 dph
 pMl
 rEy
@@ -84395,11 +85630,11 @@ rfU
 ebB
 vpE
 jlV
-qPn
-qPn
+nqn
+ubO
 bhX
 jlV
-qPn
+uDf
 rvH
 jlV
 iLi
@@ -84645,7 +85880,7 @@ gdO
 qsd
 hsp
 ggj
-nTN
+xnB
 qsd
 qsd
 wkX
@@ -84988,9 +86223,9 @@ vmu
 rEy
 sta
 rEy
-rEy
+vkT
 tIZ
-doq
+snu
 wDa
 rla
 xNU
@@ -85244,8 +86479,8 @@ gVu
 ods
 tEJ
 doq
-doq
 rEy
+djP
 xgo
 haS
 vXQ
@@ -85454,10 +86689,10 @@ jQm
 gBO
 oxQ
 qVc
-rOk
+ryJ
 mbT
 mCl
-wgA
+mbT
 gFC
 gFC
 gFC
@@ -85502,7 +86737,7 @@ rEy
 rEy
 qJN
 rEy
-rEy
+aCz
 xgo
 doq
 wDa
@@ -85708,14 +86943,14 @@ gQt
 gQt
 gQt
 gQt
-gQt
+wtV
 qJd
 mnC
-jRJ
-bWf
+xvZ
+xvZ
 abp
 wgA
-gFC
+jev
 yge
 tYB
 tYB
@@ -85760,7 +86995,7 @@ doq
 qJN
 rEy
 jgB
-dse
+dfN
 doq
 wDa
 rxk
@@ -85954,9 +87189,9 @@ gJn
 dYK
 dYK
 dYK
-ven
-anC
-sIu
+dYK
+dYK
+dKj
 sOy
 gBc
 aei
@@ -85966,13 +87201,13 @@ oAj
 oAj
 qfa
 xWo
-kJT
-wgA
+sOy
+atg
 kAc
 lKp
 see
-bHO
-oUe
+uzt
+gFC
 aet
 oEZ
 qaj
@@ -85981,9 +87216,9 @@ wna
 ikX
 dTP
 nri
-nri
-nri
-nri
+vQV
+vQV
+vQV
 nri
 xvz
 xvz
@@ -86016,9 +87251,9 @@ mhc
 wQx
 qJN
 rEy
-xgo
-wDa
-wDa
+atn
+xeg
+yeV
 wDa
 lQD
 lQD
@@ -86223,7 +87458,7 @@ xas
 yhx
 uFb
 umX
-cNM
+ken
 kYV
 kYV
 ltZ
@@ -86273,10 +87508,10 @@ doq
 doq
 iOH
 rEy
-xgo
+fyf
+xeg
+mlX
 rEy
-vQV
-vQV
 vQV
 vQV
 nri
@@ -86482,7 +87717,7 @@ jgk
 hoB
 gbe
 kYV
-bHT
+jdk
 kkb
 icb
 ptj
@@ -86491,10 +87726,10 @@ lBv
 wuC
 ixQ
 aYb
-pkh
-pkh
-pkh
-pkh
+nri
+nri
+nri
+nri
 tqo
 tqo
 tqo
@@ -86531,9 +87766,9 @@ doq
 bik
 rEy
 xgo
+xeg
+djP
 rEy
-vQV
-vQV
 vQV
 vQV
 vQV
@@ -86736,7 +87971,7 @@ cxD
 iTZ
 aUk
 vhJ
-tHS
+mLD
 wEF
 kYV
 pLy
@@ -86748,9 +87983,9 @@ lBv
 ixQ
 aJq
 aYb
-pkh
-pkh
-pkh
+nri
+vQV
+nri
 uYn
 maN
 rOG
@@ -86782,7 +88017,7 @@ nlB
 pgn
 rEy
 evN
-doq
+eco
 doq
 rEy
 rEy
@@ -87005,10 +88240,10 @@ lBv
 ixQ
 hPh
 aYb
-pkh
-pkh
-grf
-pkh
+nri
+nri
+spm
+nri
 kZz
 dpy
 mtq
@@ -87029,19 +88264,19 @@ dnK
 vSG
 gdJ
 mYK
+cPM
+cPM
+cPM
 fMF
+xlX
 fMF
-xlX
-xlX
-xlX
-rFA
 reK
 nZN
 rEy
 vLw
 gfz
 doq
-rEy
+tEJ
 haS
 haS
 kkX
@@ -87262,10 +88497,10 @@ lBv
 aJq
 ixQ
 aYb
-pkh
+nri
 gIo
-pkh
-pkh
+nri
+vQV
 tqo
 tqo
 tqo
@@ -87286,11 +88521,11 @@ twD
 vMG
 lni
 tVe
-tjZ
+nlB
 pig
 xLE
 uCa
-stw
+pXO
 stw
 jSC
 eln
@@ -87298,7 +88533,7 @@ rEy
 aNv
 doq
 doq
-tEJ
+rEy
 haS
 xMQ
 rEy
@@ -87519,13 +88754,13 @@ lBv
 lwX
 txh
 aYb
-qxV
+tMM
 aMA
-qxV
-pkh
-pkh
-pkh
-pkh
+nri
+nri
+nri
+nri
+nri
 xvz
 jBM
 rLl
@@ -87554,7 +88789,7 @@ xRt
 rEy
 rEy
 rEy
-doq
+rEy
 rEy
 haS
 rEy
@@ -87768,7 +89003,7 @@ vRL
 wEP
 kYV
 kYV
-ltZ
+uOE
 kYV
 kYV
 kYV
@@ -87776,9 +89011,9 @@ lBv
 lBv
 lBv
 lBv
-ogV
+pUj
 gAf
-efZ
+hET
 lYI
 lYI
 lYI
@@ -87807,11 +89042,11 @@ kKf
 iHz
 leL
 kRT
-rTT
+fpu
 uFp
-scQ
-rEy
-rEy
+gJA
+eTQ
+vvl
 rEy
 yil
 rEy
@@ -88025,7 +89260,7 @@ bAv
 qdL
 qdL
 ifX
-ksF
+rTQ
 dZx
 drm
 coX
@@ -88035,7 +89270,7 @@ ipO
 ogV
 gfq
 tUg
-efZ
+hET
 lYI
 loe
 oWk
@@ -88064,11 +89299,11 @@ sdF
 kRT
 kRT
 kRT
-iCD
+fpu
 rEy
-tFd
-tcz
-keA
+gJA
+hem
+gJA
 rEy
 haS
 rEy
@@ -88292,7 +89527,7 @@ wBA
 tJG
 gqM
 fph
-efZ
+hET
 lYI
 hWL
 loe
@@ -88323,9 +89558,9 @@ leL
 kRT
 fpu
 rEy
-tFd
+gJA
 sEu
-tFd
+gJA
 wVJ
 haS
 rEy
@@ -88541,7 +89776,7 @@ stt
 uzS
 bzK
 qdL
-drm
+fpI
 ciX
 skQ
 vXP
@@ -88549,7 +89784,7 @@ sRz
 ogV
 gqM
 oZH
-efZ
+hET
 lYI
 ftD
 mlS
@@ -88580,10 +89815,10 @@ kRT
 kRT
 fpu
 rEy
-tUY
 gJA
+hem
 gJA
-upO
+rEy
 haS
 rEy
 qha
@@ -88819,7 +90054,7 @@ mUR
 sHt
 bcM
 bcM
-bcM
+xRO
 mUR
 eIM
 cxj
@@ -88837,7 +90072,7 @@ pCL
 kRT
 gIA
 rEy
-eqC
+mAf
 luZ
 eqC
 rEy
@@ -89075,8 +90310,8 @@ nri
 mUR
 bLv
 bcM
-bcM
-qUb
+scF
+tmq
 iEL
 tmq
 cxj
@@ -89330,11 +90565,11 @@ rAZ
 lYI
 nri
 mUR
-mUR
+qiR
 qJt
 vWI
 dXY
-mUR
+qiR
 kCO
 xsV
 mUR
@@ -89506,7 +90741,7 @@ sJj
 qsd
 bOS
 qsd
-bJu
+upy
 sQW
 vzz
 qQN
@@ -89577,7 +90812,7 @@ sdy
 iez
 huC
 rKB
-uHK
+mAt
 oFM
 sqS
 kiy
@@ -89589,9 +90824,9 @@ nri
 mUR
 gud
 xGj
-bcM
-tmq
-fUT
+xRO
+ill
+mRf
 mUR
 xsV
 mUR
@@ -89763,7 +90998,7 @@ sJj
 btU
 xAz
 qsd
-bJu
+jPJ
 sQW
 vzz
 jFN
@@ -91371,7 +92606,7 @@ jSr
 lDI
 rCU
 ucQ
-aIQ
+voD
 xBM
 wle
 cpA
@@ -91400,7 +92635,7 @@ mUR
 iYI
 uui
 mhf
-xvD
+fDI
 nra
 cMy
 gmC
@@ -91625,7 +92860,7 @@ xVj
 aSz
 nri
 jSr
-veI
+pSW
 plB
 amw
 aIQ
@@ -92139,7 +93374,7 @@ lJb
 aSz
 nri
 jSr
-aBJ
+lDI
 rCU
 fxx
 aIQ
@@ -92399,7 +93634,7 @@ jSr
 lDI
 rCU
 jDp
-aIQ
+mtQ
 dnE
 wle
 cpA
@@ -92685,7 +93920,7 @@ mAs
 mAs
 mAs
 mUR
-bEx
+uui
 uui
 yiW
 hlW
@@ -92942,8 +94177,8 @@ mAs
 mAs
 mAs
 mUR
-bcM
-bcM
+wJW
+mZC
 yiW
 mUR
 afK
@@ -93424,8 +94659,8 @@ pqK
 aSz
 hiW
 edx
-mtl
-teR
+bpY
+aBJ
 dnJ
 vZz
 dnJ
@@ -93654,7 +94889,7 @@ oIl
 ylY
 fMI
 kHo
-aoo
+unz
 fiF
 jmM
 lba
@@ -93692,7 +94927,7 @@ nys
 jKd
 dnJ
 nri
-pkh
+nri
 nri
 nri
 nri
@@ -93715,7 +94950,7 @@ mAs
 hJr
 nri
 mUR
-yiW
+lSs
 mUR
 ooa
 ooa
@@ -93949,7 +95184,7 @@ ePE
 mUF
 dnJ
 nri
-nri
+mUR
 mUR
 mUR
 mUR
@@ -94167,7 +95402,7 @@ mHA
 lwu
 rQT
 fMI
-kHo
+bLW
 kCU
 fiF
 irt
@@ -94207,7 +95442,7 @@ lyQ
 dnJ
 nri
 mUR
-mUR
+mph
 yiW
 yiW
 yiW
@@ -94397,7 +95632,7 @@ ncr
 ncr
 ncr
 ncr
-ncr
+ugb
 ncr
 ncr
 ncr
@@ -94422,9 +95657,9 @@ cNA
 bTX
 tuv
 lwu
-dYK
+xVn
 bTz
-uDj
+gea
 lPY
 fiF
 cqv
@@ -94465,7 +95700,7 @@ dnJ
 nri
 mUR
 yiW
-yiW
+bcM
 eIM
 mUR
 mUR
@@ -94484,7 +95719,7 @@ xxp
 mAs
 mAs
 mUR
-nri
+mUR
 mUR
 yiW
 mUR
@@ -94646,7 +95881,7 @@ gWU
 gWU
 kkR
 gWU
-bZq
+sPw
 mLi
 vJg
 eeK
@@ -94679,10 +95914,10 @@ mhv
 iCV
 bTX
 lwu
-dKj
-gcc
-gea
-oUL
+dYK
+fMI
+kHo
+fgt
 fiF
 fiF
 fiF
@@ -94722,12 +95957,12 @@ dnJ
 hab
 mUR
 yiW
-rft
 bcM
+uxN
 mUR
 fRB
 tmq
-kzf
+cWe
 gpg
 mUR
 mUR
@@ -94741,8 +95976,8 @@ mUR
 hJr
 hJr
 mUR
-nri
-mUR
+yaY
+bcM
 yiW
 mUR
 ooa
@@ -94962,7 +96197,7 @@ tmO
 tmO
 tmO
 fQg
-vOI
+xKQ
 dfi
 tmO
 tmO
@@ -94977,15 +96212,15 @@ dDE
 dDE
 dkI
 hab
-bcM
+scF
 yiW
+mwM
+qiR
 mUR
-mUR
-mUR
+cWe
+tmq
 bcM
-tmq
-tmq
-oiu
+bcM
 fLw
 mRh
 onJ
@@ -94998,9 +96233,9 @@ hJr
 dLF
 eJQ
 mUR
-mUR
-mUR
-yhZ
+fFS
+cWe
+yiW
 mUR
 ooa
 ooa
@@ -95234,18 +96469,18 @@ pwR
 dDE
 kec
 hab
-eIM
+caN
 yiW
 bcM
-uxN
+vKA
 mUR
 sDp
-wEc
+tmq
 esB
+pTz
 bcM
 bcM
-bcM
-bcM
+dbR
 mUR
 qnY
 cAp
@@ -95256,7 +96491,7 @@ fDn
 hrr
 mUR
 tRI
-mUR
+izX
 yiW
 mUR
 ooa
@@ -95390,7 +96625,7 @@ vQV
 vQV
 vQV
 vQV
-nri
+vQV
 nri
 nri
 vQV
@@ -95491,17 +96726,17 @@ dDE
 dDE
 ktf
 hab
-bcM
+dJT
 yiW
-jmG
-rft
+xRO
+dNj
 mUR
 tFA
 iMp
 cOk
 faM
 pXx
-bcM
+icO
 qBM
 mUR
 kqT
@@ -95512,8 +96747,8 @@ mUR
 mUR
 mUR
 mUR
-mUR
-mUR
+vJs
+bcM
 yiW
 mUR
 ooa
@@ -95648,7 +96883,7 @@ vQV
 vQV
 vQV
 nri
-vQV
+nri
 vQV
 vQV
 dUf
@@ -95762,7 +96997,7 @@ mUR
 mUR
 sfS
 gPb
-xcP
+jIf
 jIf
 bkp
 fwf
@@ -95989,9 +97224,9 @@ irQ
 irQ
 nfS
 fpq
-fJR
-ugK
+wSy
 xyu
+peJ
 gqh
 ugK
 xyu
@@ -96019,19 +97254,19 @@ bjc
 diD
 pay
 drb
-xcP
-dbi
+jIf
+jcI
 tQC
 hab
 mUR
 mUR
 hSe
-hab
-hab
-hab
-hab
-hab
-hab
+qiR
+wbJ
+aEY
+mUR
+mUR
+mUR
 mUR
 oOh
 oOh
@@ -96246,13 +97481,13 @@ ghW
 irQ
 cXh
 nyR
-fJR
-fJR
+ubP
+gfo
 iTz
 hPf
 xFi
-fJR
-fJR
+gfo
+lDr
 iut
 cRv
 kAf
@@ -96275,7 +97510,7 @@ kAf
 kAf
 bHA
 cfa
-xcP
+jIf
 idt
 dlh
 bob
@@ -96284,11 +97519,11 @@ owt
 bcM
 yiW
 mUR
-bcM
-bcM
-bcM
-bcM
-bcM
+hab
+hab
+hab
+hab
+hab
 mUR
 vQV
 vQV
@@ -96503,13 +97738,13 @@ aKd
 irQ
 kqT
 fpq
-fJR
-cbj
+xaq
+iTz
 kAj
-drb
+ifH
 tAT
-lfg
-fJR
+xFi
+kDm
 iut
 lne
 drb
@@ -97050,7 +98285,7 @@ aPu
 rKH
 mUR
 deV
-bcM
+imU
 bJW
 mUR
 yiW
@@ -97190,7 +98425,7 @@ vQV
 vQV
 vQV
 nri
-vQV
+nri
 vQV
 vQV
 dUf
@@ -97219,7 +98454,7 @@ oGC
 uCR
 mCd
 sYi
-sYi
+gaY
 mCd
 nfb
 mFv
@@ -97307,8 +98542,8 @@ uPR
 hsq
 mUR
 mKF
-bcM
-mUR
+ram
+rff
 mUR
 yiW
 mUR
@@ -97446,7 +98681,7 @@ vQV
 vQV
 vQV
 vQV
-nri
+vQV
 nri
 nri
 vQV
@@ -97485,7 +98720,7 @@ bmo
 tHk
 xLv
 iJM
-oZz
+cOe
 cxn
 oZz
 jHi
@@ -97552,7 +98787,7 @@ igA
 dht
 kgj
 hab
-bcM
+yaY
 bcM
 mUR
 cPw
@@ -97563,10 +98798,10 @@ hwb
 uPR
 wyi
 mUR
-bcM
+mbi
 ewl
 mUR
-oTA
+mUR
 yiW
 mUR
 lLE
@@ -97711,7 +98946,7 @@ nri
 nri
 nri
 nri
-nri
+vQV
 vQV
 dUf
 sms
@@ -97742,8 +98977,8 @@ uPo
 eKt
 oew
 gsK
-qNc
-qlz
+cBu
+cxn
 cBu
 uTb
 joc
@@ -97820,17 +99055,17 @@ hYv
 hYv
 dqR
 mUR
-bcM
+cIL
 qTs
 mUR
-lpk
+oTA
 yiW
 mUR
-bcM
-bcM
-bcM
-bcM
-bcM
+hab
+hab
+hab
+hab
+hab
 mUR
 vQV
 vQV
@@ -98077,10 +99312,10 @@ blY
 cRj
 dGn
 mUR
-tKY
-bcM
+ewl
+nHX
 mUR
-eIM
+lpk
 yiW
 mUR
 mUR
@@ -98324,7 +99559,7 @@ pWU
 fsU
 tuE
 hab
-bcM
+mYc
 mUR
 wKJ
 oTT
@@ -98335,9 +99570,9 @@ lQB
 qcm
 mUR
 kfV
-bcM
+wAR
 mUR
-bcM
+eIM
 yiW
 mUR
 vQV
@@ -98760,7 +99995,7 @@ mCd
 bse
 bse
 bse
-ozl
+sYi
 sYi
 sYi
 sYi
@@ -98810,7 +100045,7 @@ xYX
 bPX
 cwk
 jDe
-gJG
+rbw
 vQA
 rbw
 rbw
@@ -99019,9 +100254,9 @@ eJx
 bse
 eoZ
 bse
+dvr
 gaY
-gaY
-gaY
+qaS
 cGz
 cCO
 gaY
@@ -99067,7 +100302,7 @@ dOf
 dOf
 dOf
 aVT
-omP
+eme
 uin
 eme
 eme
@@ -99313,9 +100548,9 @@ vmw
 jLc
 wJf
 mrY
-vHp
 efN
 efN
+pbB
 efN
 gzG
 jLc
@@ -99365,7 +100600,7 @@ mgl
 rRg
 oJu
 mgl
-oJu
+eVd
 qoi
 mgl
 vQV
@@ -99565,14 +100800,14 @@ lbm
 fRm
 kLq
 rhD
-fXk
+qqh
 eRO
 aIZ
-ndo
-efN
-ndo
+jMS
 ndo
 ndo
+ndo
+ykB
 ndo
 ndo
 vje
@@ -99620,7 +100855,7 @@ gbZ
 vQV
 mgl
 oJu
-oJu
+bNT
 mgl
 mgl
 qoi
@@ -99821,17 +101056,17 @@ nZy
 qIu
 fRm
 kLq
-xgQ
-vjg
+rhD
+qqh
 pOZ
 jLc
 cju
+dwr
 efN
 efN
 efN
-vdV
 efN
-efN
+fqO
 jLc
 pwM
 efN
@@ -99882,7 +101117,7 @@ rKh
 mgl
 qoi
 oJu
-oJu
+lrI
 cIH
 bxr
 fwg
@@ -100078,15 +101313,15 @@ bYA
 qIu
 jOY
 jdy
-oXP
-rbh
+gCV
+qqh
 phL
 dOf
 dOf
 dOf
 dOf
 dOf
-efN
+bUL
 efN
 efN
 jLc
@@ -100138,8 +101373,8 @@ oJu
 oJu
 kKr
 qoi
-fBd
-fBd
+oJu
+oJu
 cIH
 tjd
 twN
@@ -100336,14 +101571,14 @@ gCl
 ssU
 gHg
 knx
-awf
+qqh
 vna
 iCC
 hAT
 nAp
 gOU
 iCC
-efN
+wrA
 efN
 efN
 efN
@@ -100394,8 +101629,8 @@ oJu
 rKh
 rKh
 mgl
-uvy
-pka
+qoi
+jJF
 jJF
 aah
 kdP
@@ -100592,8 +101827,8 @@ ssU
 ssU
 ssU
 lxy
-bSI
-gxj
+gCV
+qqh
 pVT
 iCC
 sLr
@@ -100607,7 +101842,7 @@ jLc
 efN
 jLc
 vQV
-vQV
+nri
 vuI
 aAk
 csr
@@ -100651,9 +101886,9 @@ mgl
 mgl
 mgl
 mgl
-uvy
+qoi
 oJu
-fBd
+oJu
 cIH
 xKn
 hNO
@@ -100859,7 +102094,7 @@ kcM
 eWl
 dOf
 rAV
-efN
+tKy
 jLc
 efN
 jLc
@@ -100909,8 +102144,8 @@ mgl
 qoi
 qoi
 qoi
-fBd
-fBd
+oJu
+oqv
 cIH
 twN
 twN
@@ -101088,7 +102323,7 @@ ktr
 rkT
 jPK
 jPK
-jyl
+rmC
 qln
 qln
 qln
@@ -101116,9 +102351,9 @@ oCN
 bTc
 dOf
 pEm
-efN
+fQw
 oEd
-efN
+pkZ
 jLc
 vQV
 nri
@@ -101343,8 +102578,8 @@ bAI
 tKU
 hDv
 rkT
-xvK
 swz
+xvK
 jyl
 qln
 pqO
@@ -101372,7 +102607,7 @@ cEK
 umz
 sYN
 dOf
-efN
+jHM
 wGd
 jLc
 efN
@@ -101888,11 +103123,11 @@ nAp
 fyT
 dOf
 nee
-efN
+aZI
 efN
 jLc
 vQV
-vQV
+nri
 vQV
 vQV
 vuI
@@ -102136,7 +103371,7 @@ wgm
 wgm
 vCj
 glX
-jqd
+qLB
 jrS
 vgF
 sxt
@@ -102144,13 +103379,13 @@ pIp
 hIB
 qlo
 dOf
+jDu
 efN
 efN
-efN
 jLc
-jLc
-jLc
-jLc
+nri
+nri
+nri
 nri
 nri
 nri
@@ -102191,7 +103426,7 @@ qoi
 qoi
 qoi
 qoi
-qoi
+rLd
 mgl
 bYP
 jeu
@@ -102393,7 +103628,7 @@ wTt
 wTt
 iJp
 glX
-jqd
+qLB
 jrS
 qqz
 lJE
@@ -102401,13 +103636,13 @@ jxt
 tbU
 xef
 dOf
-cju
 uUT
 efN
 efN
-efN
-efN
 jLc
+vQV
+vQV
+vQV
 vQV
 vQV
 vQV
@@ -102443,11 +103678,11 @@ mgl
 luc
 mgl
 mgl
-mgl
+oOC
 oJu
 oJu
 oJu
-fBd
+oJu
 bKg
 xPq
 kNt
@@ -102631,7 +103866,7 @@ eLa
 nri
 qln
 jyl
-jPK
+qZx
 jdz
 qln
 qln
@@ -102647,10 +103882,10 @@ hVA
 hVA
 hVA
 chL
-aBy
+qLB
 iLn
 glX
-aQF
+wgm
 wxa
 iCC
 iCC
@@ -102703,8 +103938,8 @@ mYU
 mgl
 mgl
 mgl
+afM
 oJu
-epx
 mTS
 mgl
 uKy
@@ -102903,26 +104138,26 @@ khz
 qVh
 khz
 oMU
-wCb
+hVA
 tdP
 rXf
 kkD
 gfw
 tXq
 ury
-gDR
+qjJ
 aaf
-ifm
+qjJ
 for
-gDR
-uAq
+qjJ
+vDq
 igU
-vPI
+uWK
 lwL
 vPI
 oLm
 lgo
-lgo
+ltc
 lgo
 lgo
 lgo
@@ -102960,9 +104195,9 @@ jIz
 gwb
 tLs
 mgl
-oOC
-epx
 mgl
+oJu
+nzu
 mgl
 mgl
 mgl
@@ -103163,25 +104398,25 @@ aiN
 chL
 chL
 cIm
-kSQ
-eHL
+jZF
+nSq
 qLB
 eyU
-gDR
+qjJ
 sgQ
-iQn
+qjJ
 hNd
-gDR
+qjJ
+ekI
 uAq
-uAq
-vPI
+mQx
 mau
 crt
 jLc
-eWR
+vDn
 nFh
-efN
-efN
+aZI
+lSi
 lgo
 jLc
 vQV
@@ -103217,14 +104452,14 @@ qOP
 hUP
 dDH
 mgl
+mMa
 oJu
 epx
 epx
 epx
 epx
-epx
-epx
-epx
+vsS
+vsS
 epx
 epx
 oJu
@@ -103419,26 +104654,26 @@ qYv
 noA
 wRl
 dCa
-wTt
-jZF
+gYl
+heW
 eHL
-qLB
-ago
-gDR
+xHN
+npZ
+qjJ
 ycZ
 qba
 xnl
-gDR
+qjJ
 rom
 mau
-vPI
+mQx
 mau
 qAg
 jLc
-jLc
-jLc
-jLc
-jLc
+jBu
+wfN
+lLD
+gwy
 lgo
 jLc
 vQV
@@ -103477,10 +104712,10 @@ mgl
 mgl
 mgl
 mgl
+oKx
 oJu
-fNb
-oJu
-oJu
+aZz
+ucH
 mgl
 ntA
 cis
@@ -103676,26 +104911,26 @@ qYv
 aiN
 chL
 chL
-rlk
+tOy
 rlk
 jkd
-rlk
-hgJ
-gDR
+qLB
+ago
+qjJ
 bBa
-qba
+vBh
 ort
-gDR
+qjJ
 hMq
 ybe
 cQa
 xBa
 gUz
-mIl
-tkM
-mIl
-tkM
 jLc
+tkM
+aZI
+efN
+jxW
 lgo
 jLc
 jLc
@@ -103735,9 +104970,9 @@ fUO
 mbc
 mgl
 mgl
-mgl
 oJu
-oJu
+rSs
+eZK
 mgl
 cBW
 lWu
@@ -103933,28 +105168,28 @@ qYv
 aiN
 hVA
 noE
-euW
-qLB
-eHL
+fiJ
+heb
+lYX
 qLB
 qan
-gDR
-gDR
+qjJ
+qjJ
 cjr
-gDR
-gDR
+qjJ
+qjJ
 gDR
 gDR
 umt
 gDR
 gDR
-mIl
+jLc
 iyi
-mIl
+jLc
 iyi
 jLc
 lgo
-lgo
+ltc
 lgo
 lgo
 lgo
@@ -103992,9 +105227,9 @@ vWP
 ecJ
 cXx
 dKD
-mgl
+aZz
 oJu
-oJu
+nPN
 mgl
 cax
 uhZ
@@ -104181,7 +105416,7 @@ qln
 vFf
 fuK
 qLB
-ago
+gGt
 hVA
 qYv
 aiN
@@ -104189,24 +105424,24 @@ qVh
 qYv
 aiN
 hVA
-qLB
-qLB
-qLB
+tcQ
+gYl
+jHR
 pbz
+qLB
 mME
-mME
-uYu
+mIl
 cQT
-jve
+sVE
 ncT
 sUN
 kwu
 djX
 kCT
 hdv
-fva
-kqC
 vQr
+kqC
+uxB
 cyM
 bFc
 jLc
@@ -104248,10 +105483,10 @@ kjw
 jZH
 qFV
 qle
-bwS
-mgl
-oJu
-oJu
+dKD
+kWB
+glR
+qNX
 mgl
 lHE
 mLb
@@ -104447,15 +105682,15 @@ qYv
 aiN
 hVA
 vSM
-dVd
+eKl
 lKs
 nKj
 qLB
 qLB
 qQi
 iqI
-jve
-ciw
+sVE
+iqI
 iqI
 arL
 oBk
@@ -104463,7 +105698,7 @@ riU
 oBk
 oBk
 oBk
-oBk
+dxJ
 cUK
 pZX
 jLc
@@ -104504,11 +105739,11 @@ jHq
 kjw
 iOD
 cAD
-nzR
 bxk
-mgl
+dKD
 oJu
-fNb
+glR
+kiQ
 mgl
 uZN
 nls
@@ -104690,7 +105925,7 @@ szx
 vYM
 mZG
 rkT
-jPK
+cAO
 qln
 lgn
 fuK
@@ -104704,29 +105939,29 @@ qYv
 aiN
 chL
 chL
-cIm
-dVd
-nSq
-qLB
-qLB
-qQi
-iqI
-jve
+fJj
+avo
+pJG
+bbD
+omC
+cVu
+sUU
+sVE
 ciw
-iqI
+kcv
 arL
 oBk
 riU
 oBk
 oBk
 oBk
-oBk
+dxJ
 cUK
 dAF
 jLc
 rrA
 ppq
-efN
+gwy
 wDw
 xUJ
 jLc
@@ -104763,9 +105998,9 @@ mgl
 mgl
 mgl
 mgl
-mgl
 oJu
-oJu
+aZz
+vnU
 mgl
 jRx
 mLb
@@ -104961,21 +106196,21 @@ qYv
 noA
 wRl
 eNN
+dTE
+qwu
+fYG
+gui
 qLB
-qLB
-nSq
-nSq
-nSq
-bNa
+mIl
+iqI
 sVE
-sVE
-sVE
+xoA
 jve
 nYU
 nBK
 riU
-wNV
-oBk
+iya
+lMc
 oBk
 gJM
 cUK
@@ -104984,7 +106219,7 @@ jLc
 lVn
 ppq
 efN
-efN
+ofS
 jLc
 jLc
 cIs
@@ -105016,13 +106251,13 @@ cdZ
 cdZ
 cdZ
 cdZ
+vop
 oJu
-oJu
-oJu
-oJu
-oJu
-oJu
-oJu
+aZz
+aZz
+aZz
+aZz
+hjL
 mgl
 xoJ
 lYZ
@@ -105222,15 +106457,15 @@ qLB
 dVd
 nSq
 qLB
-qLB
-qQi
-iqI
-iqI
-sVE
-iqI
+wdP
+mIl
+tDI
+pHC
+ezc
+mfE
 arL
 oBk
-dxJ
+oBk
 riU
 dxJ
 dxJ
@@ -105250,7 +106485,7 @@ lgo
 lgo
 lgo
 lgo
-lgo
+qtW
 lgo
 lgo
 fkx
@@ -105265,21 +106500,21 @@ kAd
 bYg
 lEz
 oJu
-rRg
+jfU
 oqv
 psD
 oJu
+nsX
 oJu
 oJu
+fbU
 oJu
-oJu
-oJu
-mgl
-mgl
-mgl
-mgl
-mgl
-mgl
+rsh
+eZK
+cxN
+aZz
+aZz
+uZp
 mgl
 xoJ
 oVu
@@ -105478,12 +106713,12 @@ euW
 ago
 qLB
 cWi
-mhB
+omC
 dVd
-jlG
+mIl
 iqI
-syp
-sVE
+pHC
+iqI
 iqI
 arL
 oBk
@@ -105496,7 +106731,7 @@ cUK
 oXJ
 jLc
 dAR
-efN
+gwy
 aFm
 efN
 jLc
@@ -105523,21 +106758,21 @@ mgl
 mmB
 oJu
 oJu
-sgP
+oJu
 oJu
 oJu
 fNb
 jxm
 vXi
-oJu
-oJu
 mgl
-vQV
-vQV
-vQV
-vQV
-vQV
-uZN
+fjH
+aZz
+aZz
+aZz
+aZz
+mgl
+mgl
+mgl
 xoJ
 kLi
 hgj
@@ -105734,19 +106969,19 @@ hVA
 dVd
 dVd
 dVd
-kFc
+epe
 kNp
 kFc
 epe
 bcD
+wws
 nga
-bHs
 ykH
 jnI
 jDB
 jDB
 jVG
-dtu
+jDB
 jDB
 jDB
 dpG
@@ -105788,10 +107023,10 @@ cIH
 cIH
 cIH
 cIH
-qsI
-qsI
-qsI
-qsI
+lAM
+lAM
+lAM
+lAM
 lAM
 vQV
 uZN
@@ -105988,22 +107223,22 @@ qVh
 qYv
 aiN
 gbF
-epe
 kFc
 pJq
 kFc
+epe
 qFH
 jZx
+lNx
 kFc
+mmq
 kFc
-kFc
-vnf
-wbg
+kKY
 nga
 iqI
 mZB
 uLQ
-iqI
+pAt
 iqI
 iqI
 iqI
@@ -106246,8 +107481,8 @@ qYv
 aiN
 gbF
 wNf
-tSQ
 uRq
+tSQ
 vaF
 meb
 viG
@@ -106258,13 +107493,13 @@ nJz
 wbg
 nga
 iqI
+qJr
+rHh
+nPe
 iqI
 iqI
 iqI
-iqI
-iqI
-iqI
-kjM
+cQT
 jLc
 jLc
 jLc
@@ -106515,9 +107750,9 @@ xpy
 wbg
 nga
 nga
-uUq
+nga
 sGU
-riI
+nga
 nga
 iqI
 nga
@@ -106547,7 +107782,7 @@ vYQ
 fhI
 ttk
 mDX
-cTB
+rKr
 cTB
 sOs
 xjp
@@ -106767,9 +108002,9 @@ gOC
 joj
 epe
 kFc
-kFc
+epe
 lKL
-wbg
+kKY
 cyZ
 efx
 efx
@@ -106797,13 +108032,13 @@ hoZ
 geX
 oCm
 bhP
-oCm
+eCB
 vqR
-rxJ
+bge
 bhP
 vQV
 svk
-sDX
+svk
 jnn
 bUY
 dER
@@ -107052,14 +108287,14 @@ bhP
 vca
 tIN
 tmA
-hOg
+tmA
 wxs
-rxJ
+bge
 ppg
-oCm
+eCB
 bhP
 vQV
-svk
+vQV
 svk
 svk
 svk
@@ -107309,11 +108544,11 @@ bhP
 eeM
 rfO
 kpT
-oCm
+rxJ
 bhP
-rxJ
-pnS
-rxJ
+bge
+qiH
+bge
 bhP
 vQV
 vQV

--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -1413,6 +1413,12 @@
 /obj/machinery/gibber,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
+"aBt" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aBw" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -15274,12 +15280,6 @@
 	dir = 4
 	},
 /area/station/science/xenobiology)
-"fYQ" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
 "fYW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/effect/turf_decal/siding/thinplating_new/corner{
@@ -20590,6 +20590,10 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/corner,
 /area/station/service/hydroponics/kitchen)
+"idc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/station/commons/storage/emergency/starboard)
 "idg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -21433,10 +21437,6 @@
 /obj/item/toy/basketball,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/exit/departure_lounge)
-"iyi" = (
-/turf/closed/wall,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard)
 "iyj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -24444,7 +24444,6 @@
 "jJA" = (
 /obj/item/storage/toolbox/fishing,
 /obj/item/fishing_rod,
-/turf/open/misc/beach/sand,
 /turf/open/misc/beach/sand,
 /area/station/maintenance/department/engine)
 "jJB" = (
@@ -28822,6 +28821,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/starboard)
 "lwX" = (
@@ -29137,6 +29137,11 @@
 	dir = 8
 	},
 /area/station/science/lab)
+"lCu" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/spawner/random/structure/shipping_container,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lCv" = (
 /obj/structure/table,
 /obj/item/lightreplacer,
@@ -29493,10 +29498,6 @@
 "lNw" = (
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/secondary/construction)
-"lNx" = (
-/turf/closed/wall/r_wall,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/escape)
 "lNy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -41492,6 +41493,13 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain/private)
+"qNa" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qNg" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/effect/landmark/start/depsec/science,
@@ -45753,6 +45761,14 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/aft/lesser)
+"sCG" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/table/reinforced,
+/obj/item/paper/crumpled{
+	default_raw_text = "Delivery Notice: Shipping containers may be prone to...<i>The rest of the page has faded into unreadability due to stellar UV radiation.</i>"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "sCI" = (
 /obj/structure/mirror/directional/north,
 /obj/structure/sink{
@@ -47062,6 +47078,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"tdh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/emergency/starboard)
 "tdB" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -49115,13 +49137,6 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
-"uat" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "ubH" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom"
@@ -54779,7 +54794,8 @@
 /area/station/command/heads_quarters/cmo)
 "wqa" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/closet/crate,
+/obj/structure/table/reinforced,
+/obj/item/papercutter,
 /turf/open/space/basic,
 /area/space/nearstation)
 "wqj" = (
@@ -57729,6 +57745,13 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"xAa" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "xAd" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload"
@@ -59041,6 +59064,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/virology)
+"yde" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/table/reinforced,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ydf" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/engine/plasma,
@@ -71059,7 +71087,7 @@ clO
 dgC
 efM
 nri
-fYQ
+phf
 vQV
 vQV
 vQV
@@ -80484,7 +80512,7 @@ nXp
 rLo
 xmt
 cNp
-vQV
+nri
 hpo
 rqN
 tJA
@@ -80731,7 +80759,7 @@ vQV
 vQV
 vQV
 vQV
-vQV
+nri
 vYK
 rWz
 rWz
@@ -80741,7 +80769,7 @@ rWz
 rWz
 rWz
 bsF
-vQV
+nri
 kvZ
 kvZ
 kvZ
@@ -80988,7 +81016,7 @@ vQV
 vQV
 vQV
 vQV
-vQV
+nri
 veP
 rWz
 rWz
@@ -80998,7 +81026,7 @@ rWz
 rWz
 rWz
 cNp
-vQV
+nri
 kvZ
 tFH
 pho
@@ -81245,7 +81273,7 @@ vQV
 vQV
 vQV
 vQV
-vQV
+nri
 vYK
 rWz
 rWz
@@ -81255,7 +81283,7 @@ rWz
 rWz
 rWz
 bsF
-vQV
+nri
 kvZ
 wMv
 bsd
@@ -81502,17 +81530,17 @@ vQV
 vQV
 vQV
 vQV
-vQV
+nri
 veP
 rWz
 rWz
 rWz
 ciW
-rWz
+aBt
 rWz
 rWz
 cNp
-vQV
+nri
 kvZ
 mCQ
 bsd
@@ -81759,8 +81787,8 @@ vQV
 vQV
 vQV
 vQV
-vQV
-hXj
+nri
+qxV
 veP
 bsF
 veP
@@ -81769,7 +81797,7 @@ veP
 bsF
 veP
 bsF
-vQV
+qxV
 kvZ
 rjF
 skc
@@ -82016,17 +82044,17 @@ vQV
 vQV
 vQV
 vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
+nri
+qxV
+nri
+nri
+nri
+nri
+nri
+nri
+nri
+nri
+nri
 kvZ
 jJA
 iXo
@@ -82273,17 +82301,17 @@ vQV
 vQV
 vQV
 vQV
-vQV
-hXj
 nri
-nri
-nri
-nri
-nri
-nri
-nri
-nri
-nri
+pkh
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
+qxV
 kvZ
 sHl
 bsd
@@ -82530,13 +82558,13 @@ vQV
 vQV
 vQV
 vQV
-vQV
 nri
 qxV
 qxV
-jtO
 qxV
 jtO
+qxV
+lCu
 qxV
 jtO
 qxV
@@ -82787,8 +82815,8 @@ vQV
 vQV
 vQV
 vQV
-vQV
 nri
+qxV
 qxV
 qxV
 qxV
@@ -83044,10 +83072,10 @@ vQV
 vQV
 vQV
 vQV
-vQV
 nri
 qxV
-qxV
+xAa
+yde
 qxV
 qxV
 qxV
@@ -83301,9 +83329,9 @@ vQV
 vQV
 vQV
 vQV
-vQV
 nri
-qxV
+qNa
+sCG
 wqa
 qsd
 qsd
@@ -88201,7 +88229,7 @@ sQW
 sQW
 sQW
 sQW
-uat
+sQW
 sQW
 cqf
 nrD
@@ -104665,9 +104693,9 @@ qba
 xnl
 qjJ
 rom
-mau
+idc
 mQx
-mau
+tdh
 qAg
 jLc
 jBu
@@ -105184,9 +105212,9 @@ umt
 gDR
 gDR
 jLc
-iyi
 jLc
-iyi
+jLc
+jLc
 jLc
 lgo
 ltc
@@ -107229,7 +107257,7 @@ kFc
 epe
 qFH
 jZx
-lNx
+epe
 kFc
 mmq
 kFc

--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -1620,7 +1620,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "aEp" = (
 /obj/structure/cable,
@@ -1982,14 +1982,6 @@
 "aLp" = (
 /turf/open/floor/iron/dark/herringbone,
 /area/station/engineering/transit_tube)
-"aLC" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/captain,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
 "aLY" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/pants/jeans,
@@ -2133,7 +2125,7 @@
 /area/station/security/detectives_office)
 "aPv" = (
 /obj/structure/chair/office,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "aPA" = (
 /obj/item/storage/medkit/brute{
@@ -3256,6 +3248,13 @@
 	name = "padded floor"
 	},
 /area/station/maintenance/aft/upper)
+"blp" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy{
+	name = "landing marker"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "blt" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -3338,12 +3337,10 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bmF" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
 /obj/structure/cable,
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
@@ -4117,6 +4114,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
+"bCb" = (
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bCc" = (
 /obj/effect/turf_decal/tile/purple/half,
 /obj/structure/cable,
@@ -4250,6 +4253,7 @@
 	dir = 8
 	},
 /obj/structure/sign/warning/yes_smoking/circle/directional/south,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bFt" = (
@@ -4489,7 +4493,7 @@
 /area/station/security/prison/rec)
 "bJo" = (
 /obj/machinery/holopad/secure,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bJu" = (
 /obj/structure/rack,
@@ -4747,6 +4751,13 @@
 /obj/structure/cable,
 /turf/open/floor/eighties/red,
 /area/station/commons/fitness/recreation/entertainment)
+"bOI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/kirbyplants/organic/plant21,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bOS" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One";
@@ -5628,10 +5639,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "ciw" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/structure/window/reinforced/plasma/spawner/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ciA" = (
@@ -6510,6 +6520,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"cBy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/misc/hay,
+/area/station/command/heads_quarters/captain)
 "cBL" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room"
@@ -7224,6 +7240,16 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"cPe" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/escape)
 "cPg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -7743,10 +7769,14 @@
 /area/station/security/detectives_office)
 "dct" = (
 /obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 10
+	},
 /obj/item/disk/nuclear,
 /obj/item/pinpointer/nuke,
 /obj/item/reagent_containers/cup/glass/flask/gold,
-/turf/open/floor/wood,
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "dcy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9587,7 +9617,7 @@
 	req_access = list("captain")
 	},
 /obj/machinery/duct,
-/turf/open/floor/wood,
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "dMV" = (
 /turf/closed/wall,
@@ -10265,6 +10295,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"ecV" = (
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "edg" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -10557,7 +10593,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "eje" = (
-/obj/structure/toilet,
+/obj/item/lipstick/random,
+/obj/item/razor,
+/obj/item/soap/nanotrasen,
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain/private)
 "ejh" = (
@@ -10814,7 +10853,10 @@
 /turf/open/floor/wood,
 /area/station/service/chapel)
 "enN" = (
-/obj/structure/bed/dogbed,
+/obj/structure/bed/dogbed{
+	name = "horse bed";
+	desc = "More like an oddly shaped pillow than an actual bed given the size of its usual occupant."
+	},
 /turf/open/floor/wood/large,
 /area/station/maintenance/port/fore)
 "enO" = (
@@ -11354,6 +11396,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "ezb" = (
@@ -11364,10 +11409,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "ezc" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/structure/window/reinforced/plasma/spawner/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ezi" = (
@@ -11474,6 +11518,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"eBt" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/item/flashlight/lantern/lit_lantern,
+/turf/open/floor/grass,
+/area/station/command/heads_quarters/captain)
 "eBu" = (
 /turf/open/floor/engine,
 /area/station/science/explab)
@@ -12044,11 +12094,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Arrivals and Evac Lounges"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Arrivals Lounge"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -12345,7 +12395,7 @@
 /obj/machinery/status_display/evac/directional/north,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	name = "Arrivals and Evac Lounges"
+	name = "Arrivals Lounge"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -13242,6 +13292,12 @@
 /obj/effect/turf_decal/trimline/brown/mid_joiner,
 /turf/open/floor/iron/large,
 /area/station/cargo/storage)
+"fiu" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/misc/hay,
+/area/station/command/heads_quarters/captain)
 "fiE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13859,9 +13915,29 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "ftD" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/obj/structure/closet/crate/wooden{
+	name = "Apple Box"
+	},
+/obj/item/food/grown/apple{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/food/grown/apple{
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/obj/item/food/grown/apple{
+	pixel_y = -6;
+	pixel_x = 2
+	},
+/obj/item/food/grown/apple{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/misc/hay,
 /area/station/command/heads_quarters/captain)
 "ftK" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -14087,6 +14163,9 @@
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -14936,6 +15015,15 @@
 	dir = 4
 	},
 /area/station/security/prison/rec)
+"fQt" = (
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "fQw" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/purple,
@@ -15997,7 +16085,7 @@
 	dir = 4
 	},
 /obj/machinery/duct,
-/turf/open/floor/wood,
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "gnm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17282,10 +17370,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain/private)
-"gLA" = (
-/obj/item/food/grown/apple,
-/turf/open/floor/grass,
-/area/station/command/heads_quarters/captain)
 "gLD" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -17659,6 +17743,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"gTb" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gTB" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/cable,
@@ -19082,6 +19172,13 @@
 /obj/machinery/air_sensor/nitrous_tank,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"htX" = (
+/obj/structure/window/plasma/spawner/directional/east,
+/obj/structure/window/plasma/spawner/directional/south,
+/obj/structure/window/plasma/spawner/directional/west,
+/obj/structure/marker_beacon/violet,
+/turf/open/floor/iron/vaporwave,
+/area/station/hallway/secondary/exit/departure_lounge)
 "htZ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -19447,6 +19544,13 @@
 /obj/structure/cable,
 /turf/open/floor/mineral/titanium/tiled,
 /area/station/ai_monitored/command/nuke_storage)
+"hCB" = (
+/obj/structure/window/plasma/spawner/directional/north,
+/obj/structure/window/plasma/spawner/directional/east,
+/obj/structure/window/plasma/spawner/directional/west,
+/obj/structure/marker_beacon/violet,
+/turf/open/floor/iron/vaporwave,
+/area/station/hallway/secondary/exit/departure_lounge)
 "hCC" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
@@ -20236,6 +20340,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"hVc" = (
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "hVr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -20294,9 +20405,14 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "hWL" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/machinery/light/directional/north,
-/turf/open/floor/grass,
+/obj/structure/bed/dogbed{
+	name = "horse bed";
+	desc = "More like an oddly shaped pillow than an actual bed given the size of its usual occupant."
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/misc/hay,
 /area/station/command/heads_quarters/captain)
 "hXj" = (
 /obj/structure/lattice/catwalk,
@@ -21004,10 +21120,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
-"inL" = (
-/obj/machinery/keycard_auth,
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/captain/private)
 "ioc" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -21442,6 +21554,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/item/toy/basketball,
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/exit/departure_lounge)
 "iyj" = (
@@ -21520,14 +21633,8 @@
 /area/station/command/meeting_room)
 "izO" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "izV" = (
@@ -21759,7 +21866,7 @@
 	dir = 4
 	},
 /obj/machinery/duct,
-/turf/open/floor/wood,
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "iFp" = (
 /obj/machinery/suit_storage_unit/cmo,
@@ -22471,7 +22578,7 @@
 /area/station/maintenance/aft/lesser)
 "iTw" = (
 /obj/structure/closet/secure_closet/captains,
-/turf/open/floor/wood,
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "iTz" = (
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -23269,10 +23376,9 @@
 	},
 /area/station/tcommsat/server)
 "jlw" = (
-/obj/item/razor,
-/obj/structure/table/glass,
-/obj/item/lipstick/random,
-/obj/item/soap/nanotrasen,
+/obj/structure/curtain,
+/obj/machinery/shower/directional/south,
+/obj/item/bikehorn/rubberducky,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain/private)
 "jly" = (
@@ -23354,12 +23460,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"jnI" = (
-/obj/effect/turf_decal/siding/thinplating_new/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "jnS" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -23702,8 +23802,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/chair/sofa/bench,
-/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/effect/turf_decal/siding/thinplating_new,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jvk" = (
@@ -24046,7 +24145,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Command Captains Bedroom"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "jBM" = (
 /obj/machinery/porta_turret/ai,
@@ -24367,7 +24466,6 @@
 /area/station/maintenance/starboard)
 "jHP" = (
 /obj/structure/filingcabinet,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "jHR" = (
@@ -24728,6 +24826,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"jOH" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/item/flashlight/lantern/lit_lantern,
+/turf/open/floor/grass,
+/area/station/command/heads_quarters/captain)
 "jOY" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -25465,14 +25568,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
-"kcv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/chair/sofa/bench/right,
-/obj/structure/window/reinforced/plasma/spawner/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "kcB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25635,6 +25730,7 @@
 /area/station/command/heads_quarters/hos)
 "kfe" = (
 /obj/machinery/light/small/directional/east,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "kfu" = (
@@ -25648,6 +25744,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
+"kfx" = (
+/obj/structure/chair/sofa/bench/right,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "kfE" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
@@ -25742,8 +25842,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "khr" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "khu" = (
@@ -25803,9 +25902,14 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "kiy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/airlock/command/glass{
+	name = "Captain's Stable"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
 "kiJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26496,10 +26600,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kwu" = (
-/obj/effect/turf_decal/siding/thinplating_new/corner,
 /obj/structure/sign/poster/random/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -27184,11 +27290,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
-"kLM" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/machinery/light/directional/south,
-/turf/open/floor/grass,
-/area/station/command/heads_quarters/captain)
 "kLV" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
@@ -27444,8 +27545,6 @@
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "kQQ" = (
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "kQW" = (
@@ -27645,6 +27744,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "kVO" = (
@@ -27671,7 +27771,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "kWh" = (
@@ -28022,6 +28121,7 @@
 	c_tag = "Command - Captains Office";
 	name = "camera"
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "ldq" = (
@@ -28461,9 +28561,8 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "loe" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/misc/hay,
 /area/station/command/heads_quarters/captain)
 "lol" = (
 /obj/structure/table/reinforced,
@@ -29466,11 +29565,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
-"lMc" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/exit/departure_lounge)
 "lMq" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room"
@@ -29844,6 +29938,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
+"lUw" = (
+/obj/structure/chair/sofa/bench/left,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "lUz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -30457,14 +30555,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/security/brig)
-"mfE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/chair/sofa/bench/left,
-/obj/structure/window/reinforced/plasma/spawner/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "mfR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -30661,9 +30751,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "mkg" = (
-/obj/structure/curtain,
-/obj/item/bikehorn/rubberducky,
-/obj/machinery/shower/directional/west,
+/obj/structure/toilet{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain/private)
 "mkA" = (
@@ -31398,12 +31488,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/station/holodeck/rec_center)
-"mAt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/captain)
 "mAA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32420,6 +32504,12 @@
 	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/science/xenobiology)
+"mXf" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/escape)
 "mXg" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Execution Chamber - Fore";
@@ -32534,14 +32624,6 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/command/bridge)
-"mZB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/chair/sofa/bench/right{
-	dir = 8
-	},
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "mZC" = (
 /obj/effect/spawner/random/trash/grime,
 /obj/effect/decal/cleanable/dirt,
@@ -33349,6 +33431,9 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/chair/sofa/bench{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "nqj" = (
@@ -33869,13 +33954,6 @@
 /obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
-"nBK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/hoop,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/exit/departure_lounge)
 "nCa" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -34449,11 +34527,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "nPe" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 4
-	},
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/turf/open/floor/iron,
+/obj/structure/window/plasma/spawner/directional/east,
+/obj/structure/window/plasma/spawner/directional/west,
+/turf/open/floor/iron/vaporwave,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nPf" = (
 /obj/machinery/camera/directional/north{
@@ -35014,9 +35090,9 @@
 "nYU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/thinplating_new,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/hoop,
+/turf/open/floor/wood,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nZf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36445,6 +36521,10 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
+"oCp" = (
+/obj/structure/water_source/puddle,
+/turf/open/floor/grass,
+/area/station/command/heads_quarters/captain)
 "oCx" = (
 /obj/machinery/vending/assist,
 /obj/machinery/airalarm/directional/north,
@@ -36607,11 +36687,21 @@
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "oFM" = (
-/obj/machinery/computer/security/wooden_tv,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/wood/parquet,
+/obj/machinery/recharger{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/structure/table/wood,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/keycard_auth{
+	pixel_x = -9;
+	pixel_y = 3
+	},
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain)
 "oGd" = (
 /obj/structure/cable,
@@ -37309,6 +37399,7 @@
 "oWk" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
+/mob/living/basic/pony,
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/captain)
 "oWm" = (
@@ -37340,6 +37431,9 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -38726,13 +38820,9 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/hallway/secondary/service)
 "pAt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/chair/sofa/bench/left{
+/obj/structure/chair/sofa/bench{
 	dir = 8
 	},
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "pAu" = (
@@ -39753,6 +39843,9 @@
 	dir = 8
 	},
 /obj/structure/sign/departments/evac/directional/south,
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "qaE" = (
@@ -40548,7 +40641,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "qqP" = (
 /obj/machinery/newscaster/directional/east,
@@ -41366,13 +41459,6 @@
 /obj/machinery/smartfridge/drying,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"qJr" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 4
-	},
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "qJt" = (
 /obj/structure/grille/broken,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -41569,7 +41655,8 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/captain,
-/turf/open/floor/wood,
+/obj/item/hand_tele,
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain)
 "qOv" = (
 /obj/structure/lattice/catwalk,
@@ -41705,7 +41792,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qQi" = (
-/obj/machinery/door/airlock/multi_tile/public/glass,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Departures Lounge"
+	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -42066,22 +42155,21 @@
 /area/station/hallway/primary/starboard)
 "qXO" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -5;
-	pixel_y = 7
-	},
 /obj/machinery/requests_console/auto_name/directional/west,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
-/obj/item/stamp/denied,
 /obj/item/stamp/head/captain{
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/item/hand_tele,
-/obj/item/food/grown/apple,
-/turf/open/floor/wood,
+/obj/item/stamp/denied{
+	pixel_x = 8
+	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/item/storage/lockbox/medal,
+/obj/item/pen/fountain/captain,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain)
 "qYv" = (
 /turf/open/floor/iron/dark/textured_edge{
@@ -43408,11 +43496,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
-"rAZ" = (
-/mob/living/basic/pony,
-/obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
-/area/station/command/heads_quarters/captain)
 "rBj" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
 	dir = 4
@@ -43741,11 +43824,11 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "rHh" = (
-/obj/structure/chair/sofa/bench{
-	dir = 4
-	},
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/turf/open/floor/iron,
+/obj/structure/window/plasma/spawner/directional/east,
+/obj/structure/window/plasma/spawner/directional/west,
+/obj/item/statuebust,
+/obj/structure/marker_beacon/violet,
+/turf/open/floor/iron/vaporwave,
 /area/station/hallway/secondary/exit/departure_lounge)
 "rHq" = (
 /obj/effect/spawner/random/maintenance,
@@ -43915,7 +43998,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "rKH" = (
 /obj/structure/closet/secure_closet/detective,
@@ -44402,6 +44485,13 @@
 	dir = 1
 	},
 /area/station/medical/pharmacy)
+"rVS" = (
+/obj/item/flashlight/lantern/lit_lantern,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/misc/hay,
+/area/station/command/heads_quarters/captain)
 "rWm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -44776,8 +44866,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "sea" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
@@ -44846,6 +44934,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"seS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "seT" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
@@ -45297,15 +45392,20 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	name = "Captain's Desk";
+	req_access = list("captain")
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain)
 "sqW" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Arrivals and Evac Lounges"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Arrivals Lounge"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -46818,6 +46918,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/thinplating_new/corner,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "sUR" = (
@@ -47557,6 +47658,15 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/medical/cryo)
+"tlY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "tmq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -48198,6 +48308,7 @@
 /area/station/medical/medbay/lobby)
 "tDI" = (
 /obj/machinery/light/directional/north,
+/obj/structure/chair/sofa/bench,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tDL" = (
@@ -49592,7 +49703,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /obj/machinery/duct,
-/turf/open/floor/wood/large,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain/private)
 "ujm" = (
 /obj/effect/turf_decal/trimline/purple/line{
@@ -50125,6 +50236,12 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
+"uwF" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "uwG" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -50270,6 +50387,16 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"uxT" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/escape)
 "uyw" = (
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
@@ -50879,15 +51006,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
-"uLQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/sofa/bench{
-	dir = 8
-	},
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "uMb" = (
 /obj/effect/turf_decal/tile/purple/full,
 /obj/effect/turf_decal/stripes/white/line{
@@ -52356,8 +52474,8 @@
 	dir = 8
 	},
 /obj/machinery/door/window/brigdoor/left/directional/east{
-	name = "Command Desk";
-	req_access = list("command")
+	name = "Captain's Desk";
+	req_access = list("captain")
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/command/bridge)
@@ -53703,6 +53821,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
+"vSq" = (
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "vSw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -54347,6 +54471,13 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
+"wff" = (
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/obj/structure/marker_beacon/fuchsia,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "wfh" = (
 /obj/structure/table,
 /obj/item/bouquet/poppy,
@@ -54545,11 +54676,11 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/nuke_storage)
 "wjW" = (
-/obj/item/storage/lockbox/medal,
-/obj/structure/table/wood,
 /obj/machinery/newscaster/directional/west,
-/obj/item/pen/fountain/captain,
-/turf/open/floor/wood,
+/obj/machinery/computer/communications{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain)
 "wkd" = (
 /obj/effect/turf_decal/siding/wood{
@@ -54644,8 +54775,12 @@
 /turf/open/floor/iron,
 /area/station/science/auxlab/firing_range)
 "wmi" = (
-/obj/machinery/computer/communications,
-/turf/open/floor/wood/parquet,
+/obj/structure/table/wood,
+/obj/machinery/door/window/left/directional/north{
+	name = "Captain's Desk";
+	req_access = list("captain")
+	},
+/turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain)
 "wmr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56015,7 +56150,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms/laundry)
 "wLg" = (
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -56507,6 +56641,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
+"wZn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/captain)
 "wZv" = (
 /obj/machinery/computer/security/mining{
 	dir = 4
@@ -57223,10 +57363,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/chair/sofa/bench{
-	dir = 1
-	},
-/obj/structure/window/reinforced/plasma/spawner/directional/south,
+/obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xoB" = (
@@ -57236,7 +57373,7 @@
 "xoF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	name = "Arrivals and Evac Lounges"
+	name = "Arrivals Lounge"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -57326,12 +57463,10 @@
 /area/station/engineering/main)
 "xpy" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "xpN" = (
@@ -59555,6 +59690,9 @@
 	location = "depart4"
 	},
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ykQ" = (
@@ -89342,11 +89480,11 @@ gfq
 tUg
 hET
 lYI
-loe
-oWk
+rVS
+fiu
 ptx
 oZy
-bFV
+eBt
 lYI
 nri
 nri
@@ -89857,7 +89995,7 @@ oZH
 hET
 lYI
 ftD
-mlS
+cBy
 eKg
 oWk
 frW
@@ -90115,8 +90253,8 @@ lYI
 lYI
 lYI
 lYI
-oZy
-mlS
+arz
+oCp
 enw
 lYI
 nri
@@ -90371,10 +90509,10 @@ ldp
 lTk
 qXO
 wjW
-kiy
+lYI
 eKg
-bFV
-kLM
+jOH
+arz
 lYI
 nri
 mUR
@@ -90630,8 +90768,8 @@ wmi
 qOl
 kiy
 eKg
+oZy
 mlS
-rAZ
 lYI
 nri
 mUR
@@ -90882,10 +91020,10 @@ sdy
 iez
 huC
 rKB
-mAt
+uHK
 oFM
 sqS
-kiy
+wZn
 mlS
 bFV
 mlS
@@ -91142,10 +91280,10 @@ pJC
 kfe
 uHK
 kQQ
-aLC
-gLA
+lYI
+frW
 mlS
-bFV
+eBt
 lYI
 nri
 mUR
@@ -91396,7 +91534,7 @@ suX
 lYI
 jHP
 rLk
-inL
+xjj
 fRM
 xjj
 xjj
@@ -92175,7 +92313,7 @@ gLz
 whi
 xjj
 nri
-nri
+vQV
 nri
 mUR
 yiW
@@ -92432,7 +92570,7 @@ bPf
 qMY
 xjj
 nri
-nri
+vQV
 nri
 mUR
 yiW
@@ -92689,7 +92827,7 @@ lUH
 ttr
 xjj
 nri
-nri
+vQV
 nri
 mUR
 yiW
@@ -92946,7 +93084,7 @@ lUH
 gPt
 xjj
 nri
-nri
+vQV
 nri
 mUR
 yiW
@@ -104985,7 +105123,7 @@ tOy
 rlk
 jkd
 qLB
-ago
+tlY
 qjJ
 bBa
 vBh
@@ -105501,7 +105639,7 @@ pbz
 qLB
 mME
 mIl
-cQT
+bOI
 sVE
 ncT
 sUN
@@ -105761,8 +105899,8 @@ qQi
 iqI
 sVE
 iqI
-iqI
 arL
+oBk
 oBk
 riU
 oBk
@@ -106018,8 +106156,8 @@ cVu
 sUU
 sVE
 ciw
-kcv
 arL
+oBk
 oBk
 riU
 oBk
@@ -106272,15 +106410,15 @@ fYG
 gui
 qLB
 mIl
-iqI
+kfx
 sVE
 xoA
 jve
 nYU
-nBK
+riU
 riU
 iya
-lMc
+oBk
 oBk
 gJM
 cUK
@@ -106532,8 +106670,8 @@ mIl
 tDI
 pHC
 ezc
-mfE
 arL
+oBk
 oBk
 oBk
 riU
@@ -106786,11 +106924,11 @@ cWi
 omC
 dVd
 mIl
-iqI
+lUw
 pHC
 iqI
-iqI
 arL
+oBk
 oBk
 oBk
 wNV
@@ -107047,11 +107185,11 @@ bcD
 wws
 nga
 ykH
-jnI
 jDB
 jDB
+hVc
 jVG
-jDB
+fQt
 jDB
 jDB
 dpG
@@ -107305,11 +107443,11 @@ mmq
 kFc
 kKY
 nga
-iqI
-mZB
-uLQ
+uwF
 pAt
-iqI
+pAt
+pAt
+vSq
 iqI
 iqI
 fyw
@@ -107562,14 +107700,14 @@ uKT
 nJz
 wbg
 nga
-iqI
-qJr
+hCB
+nPe
 rHh
 nPe
+htX
 iqI
 iqI
-iqI
-cQT
+seS
 jLc
 jLc
 jLc
@@ -107819,14 +107957,14 @@ izO
 xpy
 wbg
 nga
-nga
-nga
-sGU
-nga
-nga
+ecV
+bCb
+wff
+bCb
+gTb
 iqI
-nga
-sOr
+iqI
+cQT
 mIl
 vQV
 vQV
@@ -108071,19 +108209,19 @@ kVr
 gOC
 joj
 epe
-kFc
-epe
-lKL
+cPe
+uxT
+mXf
 kKY
-cyZ
-efx
-efx
-kKY
-efx
-efx
-rTX
-efx
-rTX
+nga
+nga
+nga
+sGU
+nga
+nga
+iqI
+nga
+sOr
 mIl
 vQV
 vQV
@@ -108328,19 +108466,19 @@ epe
 kFc
 kFc
 epe
-vQV
 kFc
-wwl
-wbg
-iqI
+epe
+lKL
+kKY
+cyZ
 efx
-pkh
-pkh
-pkh
 efx
-iqI
+kKY
 efx
-xSp
+efx
+rTX
+efx
+rTX
 mIl
 nri
 nri
@@ -108587,17 +108725,17 @@ vQV
 nri
 vQV
 kFc
-jds
+wwl
 wbg
 iqI
 efx
-pkh
-pkh
-pkh
+vQV
+vQV
+vQV
 efx
 iqI
 efx
-iqI
+xSp
 mIl
 vQV
 vQV
@@ -108844,17 +108982,17 @@ rtO
 fSm
 vQV
 kFc
-vdF
+jds
 wbg
-feS
+iqI
 efx
-nri
-nri
-nri
+vQV
+vQV
+vQV
 efx
-feS
+iqI
 efx
-feS
+iqI
 mIl
 vQV
 vQV
@@ -109100,19 +109238,19 @@ vQV
 vQV
 vQV
 vQV
-vQV
-vQV
-vQV
-tjD
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
+kFc
+vdF
+wbg
+feS
+efx
+nri
+blp
+nri
+efx
+feS
+efx
+feS
+mIl
 vQV
 vQV
 vQV
@@ -109360,7 +109498,7 @@ vQV
 vQV
 vQV
 vQV
-vQV
+tjD
 vQV
 vQV
 vQV

--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -32508,6 +32508,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "mXg" = (


### PR DESCRIPTION

## About The Pull Request
This PR makes a wide number of improvements to Theia Station. Due to the fact that I didn't keep track of what I was doing as I did it the following list of changes is likely incomplete, but here it is nonetheless:

- Adds more dirty, burnt, and broken tiling to all maintenance areas for aesthetic purposes.
- Adds more random spawners to all maintenance areas.
- Adds more lightbulbs to all maintenance areas.
- Adds steam vents to all maintenance areas.
- Generally makes maintenance on Theia roomier (at least in appearance.)
- Gives the gravity generator's SMES a bit more room in order to keep its wiring sane.
- Replaces the gravity generator's reinforced glass windows with reinforced plasma-glass windows.
- Replaces the security lobby's reinforced glass flooring with reinforced plasma-glass flooring.
- Moves the security lobby's benches around.
- Adds shutters to the EVA and teleporter for ease of providing public access.
- Gives the clown's spawn room a toy box
-  The cake is no longer a lie.
- Separates departures from arrivals with a wall.
- Moves the Fulpstation logo to arrivals from the middle of a hall.
- Replaces the locker room in departures with a bathroom; removes the previously existing bathroom to give maintenance a bit more room.
- Adjusts the red carpeting in the center of the bridge.
- Gives the bridge reinforced glass tables instead of regular glass tables.
- Adds a row of randomized shipping containers to a portion of the station's exterior near engineering.
- Fixes a few random mapping errors that I encountered while working on all of the above.
## Why It's Good For The Game
Theia Station is still relatively new and lacks the polish that other maps have garnered through years of continuous development. This PR hopefully polishes it at least a bit more.
## Changelog
:cl:
add: Improved Theia Station in an incredibly broad number of ways
/:cl:
