### PR TITLE
Adds more escape pods to Pubby Station

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -52077,7 +52077,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "vMx" = (
 /obj/structure/disposalpipe/segment{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -29189,7 +29189,7 @@
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/structure/cable,
-/turf/open/space/basic,
+/turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "cWk" = (
 /turf/open/floor/iron,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -30311,7 +30311,7 @@
 /area/station/engineering/supermatter/room)
 "dXd" = (
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "dXv" = (
 /obj/machinery/door/airlock/medical{
@@ -32875,7 +32875,7 @@
 "gcd" = (
 /obj/docking_port/stationary/random{
 	name = "lavaland";
-	shuttle_id = "pod_3_lavaland"
+	shuttle_id = "pod_4_lavaland"
 	},
 /turf/open/space/basic,
 /area/space)
@@ -33179,7 +33179,7 @@
 /obj/docking_port/stationary/random{
 	dir = 4;
 	name = "lavaland";
-	shuttle_id = "pod_lavaland"
+	shuttle_id = "pod_3_lavaland"
 	},
 /turf/open/space/basic,
 /area/space)
@@ -33992,6 +33992,9 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"gYp" = (
+/turf/open/floor/plating/airless,
+/area/space)
 "gYR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68658,7 +68661,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gYp
 aaa
 aaa
 aaa
@@ -80529,7 +80532,7 @@ aaa
 aaa
 aaa
 aaa
-kFR
+aaa
 kFR
 kFR
 kFR
@@ -80786,8 +80789,8 @@ aaa
 aaa
 aaa
 aaa
-kFR
 aaa
+kFR
 aaa
 aaa
 aaa
@@ -81043,8 +81046,8 @@ aaa
 aaa
 aaa
 aaa
-kFR
 aaa
+kFR
 aaa
 aaa
 aaa
@@ -81300,8 +81303,8 @@ aaa
 aaa
 aaa
 aaa
-kFR
 aaa
+kFR
 aaa
 aaa
 aaa
@@ -81557,8 +81560,8 @@ aaa
 aaa
 aaa
 aaa
-kFR
 aaa
+kFR
 aaa
 bvX
 aaa
@@ -81814,8 +81817,8 @@ aaa
 aaa
 aaa
 aaa
-kFR
 aaa
+kFR
 aaa
 aaa
 aaa
@@ -82071,8 +82074,8 @@ aaa
 aaa
 aaa
 aaa
-kFR
 aaa
+kFR
 aaa
 aaa
 aaa
@@ -82328,8 +82331,8 @@ aaa
 aaa
 aaa
 aaa
-kFR
 aaa
+kFR
 aaa
 aaa
 aaa
@@ -82585,7 +82588,7 @@ aaa
 aaa
 aaa
 aaa
-kFR
+aaa
 kFR
 kFR
 kFR

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -17983,6 +17983,13 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"bvX" = (
+/obj/docking_port/stationary/random{
+	name = "lavaland";
+	shuttle_id = "pod_2_lavaland"
+	},
+/turf/open/space/basic,
+/area/space)
 "bvZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -19856,6 +19863,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
+"bDO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/sign/warning/docking/directional/north,
+/obj/machinery/camera/directional/north,
+/turf/open/floor/plating,
+/area/station/service/chapel/asteroid/monastery)
 "bDQ" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
@@ -20868,6 +20883,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/psychology,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"bJB" = (
+/obj/structure/sign/warning/pods/directional/north,
+/turf/open/floor/engine,
+/area/station/science/lab)
 "bJD" = (
 /obj/structure/sign/departments/engineering/directional/south,
 /obj/machinery/door/firedoor,
@@ -26748,7 +26767,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/directional/north,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plastic,
 /area/station/security/lockers)
 "cnP" = (
@@ -26758,8 +26776,13 @@
 /turf/open/floor/plastic,
 /area/station/security/lockers)
 "cnQ" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/bot,
+/obj/machinery/button/door/directional/north{
+	id = "Equipment Room";
+	name = "Space Shutters Control"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plastic,
 /area/station/security/lockers)
 "cnT" = (
@@ -30590,6 +30613,8 @@
 "ekt" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plastic,
 /area/station/security/lockers)
 "ekU" = (
@@ -30760,6 +30785,16 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"eqG" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod One";
+	space_dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/service/chapel/asteroid/monastery)
 "ery" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -30991,6 +31026,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"eCc" = (
+/obj/structure/flora/bush/ferny/style_random,
+/obj/structure/sign/warning/pods/directional/east,
+/turf/open/misc/asteroid,
+/area/station/service/chapel/asteroid/monastery)
 "eCB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -31084,6 +31124,12 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"eGc" = (
+/obj/docking_port/stationary/escape_pod{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "eGF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -31957,6 +32003,10 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"foa" = (
+/turf/closed/wall,
+/turf/open/space/basic,
+/area/station/service/chapel/asteroid/monastery)
 "fom" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -32752,6 +32802,13 @@
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"fWX" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/sign/warning/pods/directional/north,
+/turf/open/floor/plastic,
+/area/station/security/lockers)
 "fXP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -32815,6 +32872,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"gcd" = (
+/obj/docking_port/stationary/random{
+	name = "lavaland";
+	shuttle_id = "pod_3_lavaland"
+	},
+/turf/open/space/basic,
+/area/space)
 "gcn" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet,
@@ -33111,6 +33175,14 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"gqp" = (
+/obj/docking_port/stationary/random{
+	dir = 4;
+	name = "lavaland";
+	shuttle_id = "pod_lavaland"
+	},
+/turf/open/space/basic,
+/area/space)
 "gqx" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -33600,6 +33672,13 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"gIn" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/iron,
+/area/station/service/chapel/asteroid/monastery)
 "gIC" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -33800,6 +33879,9 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
+"gTh" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/station/service/chapel/asteroid/monastery)
 "gTq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -34163,6 +34245,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"hls" = (
+/turf/closed/wall,
+/turf/open/floor/plating,
+/area/station/service/chapel/asteroid/monastery)
 "hlQ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment,
@@ -36225,6 +36311,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
+"jno" = (
+/obj/machinery/door/airlock/external{
+	name = "Security Escape Pod";
+	space_dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/station/security/lockers)
 "jnp" = (
 /obj/structure/table,
 /obj/item/nanite_remote,
@@ -36510,11 +36604,8 @@
 /area/station/hallway/primary/central/aft)
 "jzI" = (
 /obj/item/radio/intercom/directional/east,
-/obj/machinery/fax{
-	fax_name = "Security Office";
-	name = "Security Office Fax Machine"
-	},
-/obj/structure/table,
+/obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plastic,
 /area/station/security/lockers)
 "jzX" = (
@@ -36643,6 +36734,20 @@
 	dir = 9
 	},
 /turf/closed/wall,
+/area/station/maintenance/department/science/central)
+"jIb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/warning/pods/directional/north,
+/turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "jIy" = (
 /obj/structure/lattice/catwalk,
@@ -36820,6 +36925,13 @@
 "jOB" = (
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency/starboard)
+"jOF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/iron,
+/area/station/service/chapel/asteroid/monastery)
 "jOI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37934,6 +38046,17 @@
 /obj/effect/mapping_helpers/requests_console/supplies,
 /turf/open/floor/wood,
 /area/station/service/bar)
+"kFR" = (
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
+"kGj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/security/lockers)
 "kGE" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/light/directional/south,
@@ -38933,12 +39056,6 @@
 /obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"lvE" = (
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plastic,
-/area/station/security/lockers)
 "lwO" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
@@ -41164,6 +41281,17 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"nte" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod One";
+	space_dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/landmark/navigate_destination/dockescpod1,
+/turf/open/floor/plating,
+/area/station/service/chapel/asteroid/monastery)
 "nts" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41554,6 +41682,14 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
+"nMQ" = (
+/obj/structure/table,
+/obj/machinery/fax{
+	fax_name = "Security Office";
+	name = "Security Office Fax Machine"
+	},
+/turf/open/floor/plastic,
+/area/station/security/lockers)
 "nNk" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -43693,6 +43829,15 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"puM" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/obj/structure/sign/warning/docking/directional/west,
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating,
+/area/station/security/lockers)
 "puW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -43827,6 +43972,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"pCg" = (
+/obj/effect/turf_decal/bot,
+/obj/vehicle/ridden/secway,
+/obj/item/key/security,
+/turf/open/floor/plastic,
+/area/station/security/lockers)
 "pCY" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance"
@@ -44453,6 +44604,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/sign/warning/pods/directional/north,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "pYw" = (
@@ -45613,6 +45765,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/cargo/bitrunning/den)
+"qXo" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/iron,
+/area/station/service/chapel/asteroid/monastery)
 "qXq" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -46356,11 +46513,11 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "rAE" = (
-/obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/sign/warning/pods/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "rAP" = (
@@ -46819,6 +46976,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"rTb" = (
+/obj/docking_port/stationary/escape_pod,
+/turf/open/space/basic,
+/area/space)
 "rTy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -46840,6 +47001,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"rUo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/service/chapel/asteroid/monastery)
 "rUS" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -47748,6 +47915,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/range)
+"sHp" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/security/lockers)
 "sHy" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Holodeck Control";
@@ -47874,6 +48048,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"sNJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/service/chapel/asteroid/monastery)
 "sOB" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -49792,6 +49973,14 @@
 "ufo" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"ugd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/sign/warning/docking/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "ugv" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -50389,6 +50578,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/structure/sign/warning/pods/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uAg" = (
@@ -51856,6 +52046,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"vNc" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "vNl" = (
 /obj/structure/cable,
 /turf/open/floor/grass,
@@ -52583,6 +52783,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"wlk" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "wlr" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -52745,11 +52950,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/processing/cremation)
 "wtp" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/bot,
-/obj/machinery/button/door/directional/north{
-	id = "Equipment Room";
-	name = "Space Shutters Control"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plastic,
 /area/station/security/lockers)
@@ -53176,6 +53378,14 @@
 	dir = 4
 	},
 /area/station/commons/fitness)
+"wLh" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod One";
+	space_dir = 8
+	},
+/obj/effect/landmark/navigate_destination/dockescpod3,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "wLx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -53324,6 +53534,11 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"wQe" = (
+/obj/structure/flora/bush/style_random,
+/obj/structure/sign/warning/pods/directional/east,
+/turf/open/misc/asteroid,
+/area/station/service/chapel/asteroid/monastery)
 "wQy" = (
 /obj/structure/chair/sofa/left/brown,
 /obj/item/radio/intercom/directional/north,
@@ -54334,6 +54549,17 @@
 	dir = 4
 	},
 /area/station/security/prison/workout)
+"xvo" = (
+/obj/machinery/door/airlock/external{
+	name = "Security Escape Pod";
+	space_dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/landmark/navigate_destination/dockescpod2,
+/turf/open/floor/plating,
+/area/station/security/lockers)
 "xvx" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -54405,6 +54631,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plastic,
 /area/station/security/lockers)
 "xxO" = (
@@ -55171,6 +55398,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"yeK" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/station/security/lockers)
 "yeL" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -73224,11 +73454,11 @@ ahi
 bNs
 bOw
 bOw
-bUC
-bOw
-bOw
-bOw
-bSm
+eCc
+qXo
+jOF
+gIn
+wQe
 bOw
 bQg
 cfm
@@ -73481,11 +73711,11 @@ ahi
 bNs
 bNs
 bNs
+hls
 bNs
+nte
 bNs
-bNs
-bNs
-bNs
+hls
 bNs
 bNs
 cfm
@@ -73736,15 +73966,15 @@ abI
 abI
 ahi
 bLs
-crO
-crO
-crO
-crO
-crO
-crO
-crO
-crO
-crO
+arF
+arF
+caS
+bDO
+rUo
+sNJ
+foa
+arF
+arF
 cfN
 cfN
 whJ
@@ -73995,11 +74225,11 @@ cdm
 aht
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+caS
+bNs
+eqG
+bNs
+caS
 aaa
 aaa
 aaa
@@ -74252,11 +74482,11 @@ cdm
 aht
 aaa
 aaa
+caS
 aaa
+eGc
 aaa
-aaa
-aaa
-aaa
+caS
 aaa
 aaa
 aaa
@@ -74509,11 +74739,11 @@ cdm
 aht
 aaa
 aaa
+caS
 aaa
 aaa
 aaa
-aaa
-aaa
+caS
 aaa
 aaa
 aaa
@@ -74764,17 +74994,17 @@ aht
 aht
 cdm
 aht
+aht
+aht
+gTh
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gTh
+aht
+aht
+aht
+aht
 whJ
 whJ
 wIX
@@ -75282,7 +75512,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gqp
 aaa
 aaa
 aaa
@@ -79532,7 +79762,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -79541,7 +79771,7 @@ aaa
 aKw
 ahd
 mWQ
-aiq
+pCg
 fcK
 aio
 kTl
@@ -80047,7 +80277,7 @@ aaa
 aaa
 aaa
 aaa
-cFB
+aaa
 aaa
 aaa
 aby
@@ -80055,7 +80285,7 @@ aaa
 aKw
 ahd
 aeB
-aiq
+nMQ
 aiq
 oWx
 kTl
@@ -80299,17 +80529,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kFR
+kFR
+kFR
+kFR
+kFR
+kFR
+kFR
+kFR
 aby
 abI
-dAa
+aKw
 cnN
 aeB
 cnT
@@ -80556,6 +80786,7 @@ aaa
 aaa
 aaa
 aaa
+kFR
 aaa
 aaa
 aaa
@@ -80564,12 +80795,11 @@ aaa
 aaa
 aaa
 aaa
-aby
 aaa
-aKw
+dAa
 ahd
 aeB
-aiq
+air
 fQN
 aip
 kTl
@@ -80813,17 +81043,17 @@ aaa
 aaa
 aaa
 aaa
+kFR
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aby
-aaa
-aKw
+yeK
+dAa
+dAa
+dAa
+dAa
+dAa
 cnP
 aeB
 lkX
@@ -81070,6 +81300,7 @@ aaa
 aaa
 aaa
 aaa
+kFR
 aaa
 aaa
 aaa
@@ -81077,10 +81308,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aby
-aaa
-aKw
+dAa
+puM
+dAa
 cnQ
 ahN
 cnV
@@ -81327,21 +81557,21 @@ aaa
 aaa
 aaa
 aaa
+kFR
+aaa
+aaa
+bvX
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aed
-aaa
-dAa
+rTb
+jno
+kGj
+xvo
 wtp
 anf
 tCJ
-lvE
+aiq
 jzI
 kTl
 ajr
@@ -81584,6 +81814,7 @@ aaa
 aaa
 aaa
 aaa
+kFR
 aaa
 aaa
 aaa
@@ -81591,11 +81822,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aby
-abI
 dAa
-air
+sHp
+dAa
+fWX
 anf
 tCJ
 abx
@@ -81841,16 +82071,16 @@ aaa
 aaa
 aaa
 aaa
+kFR
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-anl
-aaa
+yeK
+dAa
+dAa
+dAa
+dAa
 vRp
 vRp
 ecV
@@ -82098,6 +82328,7 @@ aaa
 aaa
 aaa
 aaa
+kFR
 aaa
 aaa
 aaa
@@ -82106,7 +82337,6 @@ aaa
 aaa
 aaa
 aaa
-anl
 aaa
 vRp
 aWA
@@ -82355,16 +82585,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kFR
+kFR
+kFR
+kFR
+kFR
+kFR
+kFR
+kFR
 anl
-aaa
+aht
 vRp
 xsw
 wIg
@@ -97849,7 +98079,7 @@ gvM
 pBg
 yet
 iSi
-nJI
+bJB
 bky
 bky
 lAR
@@ -98106,7 +98336,7 @@ gvM
 pBg
 gvM
 iSi
-bky
+nJI
 bpo
 bpo
 bqx
@@ -98617,7 +98847,7 @@ aaa
 aaa
 aaa
 gvM
-pBg
+jIb
 gvM
 iSi
 iSi
@@ -99899,7 +100129,7 @@ gvM
 iiy
 uSW
 gvM
-uSW
+rAE
 lEn
 uwb
 bjB
@@ -101691,9 +101921,9 @@ iIB
 aTy
 glb
 baG
-cxg
-aaa
-aaa
+rWE
+aht
+aht
 gvM
 eZA
 tDn
@@ -101948,9 +102178,9 @@ dUZ
 xdb
 glb
 baG
-rWE
-aht
-aht
+cxg
+aaa
+aaa
 gvM
 vzT
 gUb
@@ -102464,7 +102694,7 @@ glb
 baG
 cxg
 aaa
-aaa
+aht
 gvM
 gvM
 gvM
@@ -102722,11 +102952,11 @@ lLS
 rWE
 aht
 aht
-aht
-aht
-cdm
-aht
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
 vgm
 uSW
 ybX
@@ -102979,14 +103209,14 @@ aaa
 aaa
 aaa
 aht
+gcd
 aaa
 aaa
-cdm
 aaa
-aht
-vgm
+rTb
+wLh
 uSW
-fNv
+vNc
 iSi
 bnh
 blX
@@ -103238,9 +103468,9 @@ aaa
 aht
 aaa
 aaa
-cdm
 aaa
-aht
+aaa
+aaa
 vgm
 uSW
 bfM
@@ -103495,11 +103725,11 @@ aaa
 aht
 aaa
 aaa
-cdm
-aht
-aht
-vgm
-uSW
+gvM
+gvM
+gvM
+gvM
+ugd
 ybX
 iSi
 kdb
@@ -103754,9 +103984,9 @@ aht
 aht
 cdm
 gvM
-gvM
-gvM
-rAE
+wlk
+yet
+uSW
 fNv
 iSi
 bnh

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -38297,6 +38297,7 @@
 	name = "Escape Pod Three"
 	},
 /obj/effect/landmark/navigate_destination/dockescpod3,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "kSD" = (
@@ -52072,6 +52073,9 @@
 "vMw" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/space/basic,
 /area/station/maintenance/department/science/xenobiology)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -32003,10 +32003,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
-"foa" = (
-/turf/closed/wall,
-/turf/open/space/basic,
-/area/station/service/chapel/asteroid/monastery)
 "fom" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -33992,9 +33988,6 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"gYp" = (
-/turf/open/floor/plating/airless,
-/area/space)
 "gYR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34248,10 +34241,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"hls" = (
-/turf/closed/wall,
-/turf/open/floor/plating,
-/area/station/service/chapel/asteroid/monastery)
 "hlQ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment,
@@ -68661,7 +68650,7 @@ aaa
 aaa
 aaa
 aaa
-gYp
+aaa
 aaa
 aaa
 aaa
@@ -73714,11 +73703,11 @@ ahi
 bNs
 bNs
 bNs
-hls
+caS
 bNs
 nte
 bNs
-hls
+caS
 bNs
 bNs
 cfm
@@ -73975,7 +73964,7 @@ caS
 bDO
 rUo
 sNJ
-foa
+caS
 arF
 arF
 cfN

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -20403,7 +20403,6 @@
 /area/station/science/ordnance)
 "bGB" = (
 /obj/structure/flora/bush/flowers_br/style_random,
-/obj/machinery/light/directional/south,
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
@@ -29190,7 +29189,7 @@
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/space/basic,
 /area/station/service/janitor)
 "cWk" = (
 /turf/open/floor/iron,
@@ -29778,6 +29777,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"dxL" = (
+/obj/docking_port/stationary/escape_pod{
+	dir = 2
+	},
+/turf/open/space/basic,
+/area/space)
 "dye" = (
 /obj/structure/closet/secure_closet/freezer/meat/open,
 /obj/structure/sign/departments/science/directional/north,
@@ -29798,6 +29803,14 @@
 	dir = 1
 	},
 /area/station/service/chapel)
+"dzt" = (
+/obj/docking_port/stationary/random{
+	dir = 2;
+	name = "lavaland";
+	shuttle_id = "pod_3_lavaland"
+	},
+/turf/open/space/basic,
+/area/space)
 "dAa" = (
 /turf/closed/wall/r_wall,
 /area/station/security/lockers)
@@ -30336,6 +30349,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"dXW" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "dYh" = (
 /turf/closed/wall,
 /area/station/medical/treatment_center)
@@ -30477,6 +30495,11 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"edQ" = (
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/space,
+/area/space/nearstation)
 "edZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -32868,13 +32891,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"gcd" = (
-/obj/docking_port/stationary/random{
-	name = "lavaland";
-	shuttle_id = "pod_4_lavaland"
-	},
-/turf/open/space/basic,
-/area/space)
 "gcn" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet,
@@ -33175,7 +33191,7 @@
 /obj/docking_port/stationary/random{
 	dir = 4;
 	name = "lavaland";
-	shuttle_id = "pod_3_lavaland"
+	shuttle_id = "pod_1_lavaland"
 	},
 /turf/open/space/basic,
 /area/space)
@@ -33801,6 +33817,7 @@
 /area/station/maintenance/department/chapel/monastery)
 "gOV" = (
 /mob/living/carbon/human/species/monkey,
+/obj/machinery/light/directional/south,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "gQa" = (
@@ -35110,6 +35127,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel/monastery)
+"idC" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "idH" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -35471,6 +35493,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"ivF" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "ivQ" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/machinery/airalarm/directional/east,
@@ -36564,6 +36590,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"jxD" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "jyJ" = (
 /obj/structure/closet/secure_closet/medical1{
 	pixel_x = -3
@@ -36726,20 +36758,6 @@
 	dir = 9
 	},
 /turf/closed/wall,
-/area/station/maintenance/department/science/central)
-"jIb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/sign/warning/pods/directional/north,
-/turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "jIy" = (
 /obj/structure/lattice/catwalk,
@@ -36951,6 +36969,10 @@
 "jQh" = (
 /obj/item/stack/sheet/animalhide/xeno,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/sign/warning/pods/directional/south,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "jRB" = (
@@ -36963,6 +36985,7 @@
 /area/station/hallway/secondary/exit)
 "jRG" = (
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "jRZ" = (
@@ -38269,6 +38292,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"kSf" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Three"
+	},
+/obj/effect/landmark/navigate_destination/dockescpod3,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "kSD" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -38587,6 +38617,13 @@
 /obj/structure/secure_safe/caps_spare,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"ldZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/warning/pods/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "lem" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -39166,6 +39203,7 @@
 "lDw" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/carbon/human/species/monkey,
+/obj/structure/sign/warning/pods/directional/south,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "lEn" = (
@@ -42345,8 +42383,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ooI" = (
@@ -42356,6 +42392,7 @@
 /area/station/hallway/primary/central/fore)
 "ops" = (
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/sign/warning/pods/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "opz" = (
@@ -44596,7 +44633,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/sign/warning/pods/directional/north,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "pYw" = (
@@ -45557,6 +45593,11 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
+"qNa" = (
+/obj/effect/spawner/random/structure/crate,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "qNy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/south{
@@ -45802,6 +45843,7 @@
 /area/station/medical/morgue)
 "qYn" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/pods/directional/south,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "qYA" = (
@@ -45928,6 +45970,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"rdN" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "rdU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -46504,14 +46551,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
-"rAE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/sign/warning/pods/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "rAP" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/light_switch/directional/east,
@@ -46972,6 +47011,11 @@
 /obj/docking_port/stationary/escape_pod,
 /turf/open/space/basic,
 /area/space)
+"rTl" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "rTy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -48723,6 +48767,9 @@
 /obj/machinery/power/tracker,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/ai)
+"tkV" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/station/maintenance/department/science/xenobiology)
 "tla" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -49965,14 +50012,6 @@
 "ufo" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"ugd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/sign/warning/docking/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "ugv" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -51836,6 +51875,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/toilet)
+"vDs" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "vDH" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron/airless,
@@ -52025,6 +52069,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"vMw" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Three"
+	},
+/turf/open/space/basic,
+/area/station/maintenance/department/science/xenobiology)
 "vMx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -52249,6 +52299,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"vSK" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "vSL" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Pharmacy Maintenance"
@@ -52900,6 +52954,11 @@
 /obj/item/binoculars,
 /turf/open/space/basic,
 /area/space/nearstation)
+"wrQ" = (
+/obj/structure/sign/warning/docking/directional/south,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "wrU" = (
 /obj/machinery/photocopier,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -53370,14 +53429,6 @@
 	dir = 4
 	},
 /area/station/commons/fitness)
-"wLh" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod One";
-	space_dir = 8
-	},
-/obj/effect/landmark/navigate_destination/dockescpod3,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "wLx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -54305,6 +54356,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"xlR" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/warning/pods/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "xmg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55406,6 +55469,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/toilet)
+"ygj" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "ygx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -98839,7 +98906,7 @@ aaa
 aaa
 aaa
 gvM
-jIb
+pBg
 gvM
 iSi
 iSi
@@ -99349,7 +99416,7 @@ pHf
 enf
 khX
 kjA
-khX
+xlR
 dSK
 enf
 khX
@@ -100121,7 +100188,7 @@ gvM
 iiy
 uSW
 gvM
-rAE
+uSW
 lEn
 uwb
 bjB
@@ -100657,7 +100724,7 @@ qdg
 uvq
 bFx
 bGB
-rKi
+uzx
 lWy
 bwm
 aht
@@ -100914,7 +100981,7 @@ xan
 dfm
 llS
 lDw
-uzx
+rKi
 uug
 bwm
 aht
@@ -102693,7 +102760,7 @@ gvM
 gvM
 gvM
 gvM
-rAE
+uSW
 bfM
 iSi
 blX
@@ -102944,12 +103011,12 @@ lLS
 rWE
 aht
 aht
-aaa
-aaa
-aaa
-aaa
-aaa
-vgm
+aht
+aht
+cdm
+aht
+aht
+gvM
 uSW
 ybX
 iSi
@@ -102972,14 +103039,14 @@ lWy
 fKj
 lWy
 lWy
-bwm
+rNB
 abI
 aaa
-aht
 aaa
 aht
 aaa
-aed
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -103201,12 +103268,12 @@ aaa
 aaa
 aaa
 aht
-gcd
 aaa
 aaa
+cdm
 aaa
-rTb
-wLh
+aht
+gvM
 uSW
 vNc
 iSi
@@ -103229,14 +103296,14 @@ lWy
 bwm
 bwm
 lWy
-bwm
+rNB
 abI
-tHo
-aby
-aby
-aby
-aby
-aby
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -103460,10 +103527,10 @@ aaa
 aht
 aaa
 aaa
+cdm
 aaa
-aaa
-aaa
-vgm
+aht
+gvM
 uSW
 bfM
 iSi
@@ -103486,12 +103553,12 @@ sAK
 bwm
 hXt
 lWy
-rNB
+bwm
 abI
 aaa
-aed
 aaa
-aed
+aht
+aaa
 aaa
 aaa
 aaa
@@ -103717,11 +103784,11 @@ aaa
 aht
 aaa
 aaa
+cdm
 gvM
 gvM
 gvM
-gvM
-ugd
+uSW
 ybX
 iSi
 kdb
@@ -103744,11 +103811,11 @@ bwm
 bwm
 lWy
 bwm
-abI
-aaa
-aaa
-aaa
-aaa
+bwm
+bwm
+bwm
+bwm
+tkV
 aaa
 aaa
 aaa
@@ -103999,10 +104066,10 @@ efU
 efU
 uug
 uug
-lWy
+wrQ
 bwm
+rTl
 bwm
-aaa
 aaa
 aaa
 aaa
@@ -104236,7 +104303,7 @@ vgm
 bnl
 yet
 uSW
-kSG
+ldZ
 iSi
 bni
 blX
@@ -104252,19 +104319,19 @@ blX
 blX
 blX
 rKi
+rdN
 efU
-efU
 uug
 uug
-uug
-jDA
-rNB
+dXW
+kSf
+vSK
+vMw
+dxL
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+dzt
 aaa
 aaa
 aaa
@@ -104509,14 +104576,14 @@ rKi
 rKi
 rKi
 rKi
-efU
-bwm
+idC
+ivF
 jFw
 lWy
 jQh
 bwm
+jxD
 bwm
-aaa
 aaa
 aaa
 aaa
@@ -104762,21 +104829,21 @@ btF
 gIC
 bwn
 vRi
-uug
-uug
-lWy
+vDs
+vDs
+ygj
 jRG
-lWy
+ygj
+bwm
 bwm
 rNB
 bwm
 bwm
 bwm
-aaa
-aaa
-aaa
-aaa
-aaa
+bwm
+bwm
+bwm
+tkV
 aaa
 aaa
 aaa
@@ -105019,7 +105086,7 @@ faA
 qYn
 rKi
 oon
-jFw
+qNa
 rSQ
 qVi
 lWy
@@ -105032,7 +105099,7 @@ aht
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -105283,15 +105350,15 @@ vtl
 bwm
 bwm
 aaa
-aby
+edQ
 aaa
 aed
 aaa
+aht
 aaa
+aht
 aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -105540,16 +105607,16 @@ lWy
 rui
 bwm
 aht
-aby
+edQ
+kFR
+edQ
+kFR
+kFR
+kFR
+kFR
+kFR
+kFR
 aht
-aby
-aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -105797,15 +105864,15 @@ hSM
 bwm
 bwm
 aaa
-aby
+edQ
 aaa
-aby
+edQ
 aaa
+kFR
 aaa
+kFR
 aaa
-aaa
-aaa
-aaa
+kFR
 aaa
 aaa
 aaa
@@ -106054,16 +106121,16 @@ ahi
 ahi
 aht
 aht
-aby
+edQ
 aht
-aed
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+edQ
+kFR
+kFR
+kFR
+kFR
+aht
+kFR
+aht
 aaa
 aaa
 aaa
@@ -106311,15 +106378,15 @@ aaa
 aaa
 aht
 aaa
-aed
+edQ
 aaa
-aby
+edQ
 aaa
+kFR
 aaa
+kFR
 aaa
-aaa
-aaa
-aaa
+kFR
 aaa
 aaa
 aaa
@@ -106568,16 +106635,16 @@ aaa
 aaa
 aby
 aht
-aby
+edQ
+kFR
+edQ
+kFR
+kFR
+kFR
+kFR
+kFR
+kFR
 aht
-aby
-aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -106829,11 +106896,11 @@ aby
 aaa
 aed
 aaa
+aht
 aaa
+aht
 aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request
This pull request adds a total of three new escape pods to Pubby Station. One is located at security, another at the monastery, and the last one is near disposals in science/cargo maintenance.
<details><summary>Images of the new escape pods</summary>

![image](https://github.com/user-attachments/assets/04e15e5c-5fbe-495d-bb58-9801cfc74e21)
![image](https://github.com/user-attachments/assets/06f562be-f96d-4656-a7aa-c8303668d6b2)
![image](https://github.com/user-attachments/assets/01505a39-0985-4dbc-95b4-f8c6d6e10c03)
</details>

## Why It's Good For The Game

Currently Pubby Station only has one escape pod, and the fact that it even is an escape pod is fairly unintuitive (since it's the public mining shuttle.) This PR fixes that by adding three new ones. (This also means that the budget/luxury escape pod station perks can now work on Pubby Station.)
## Changelog
:cl:
add: Added more escape pods to Pubby Station
/:cl:
