### PR TITLE
Heliostation vault edits

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -12886,7 +12886,7 @@
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "bkO" = (
-/turf/open/floor/circuit,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "bkR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12956,7 +12956,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "blc" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 10
+	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "bld" = (
@@ -13412,8 +13414,9 @@
 /area/station/commons/toilet)
 "bmD" = (
 /obj/machinery/nuclearbomb/selfdestruct,
-/obj/structure/cable,
-/turf/open/floor/circuit/green,
+/turf/open/floor/circuit/green{
+	luminosity = 2
+	},
 /area/station/ai_monitored/command/nuke_storage)
 "bmE" = (
 /obj/structure/disposalpipe/segment{
@@ -15057,9 +15060,7 @@
 /turf/closed/wall/r_wall,
 /area/station/security/checkpoint/escape)
 "bsr" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 1
-	},
+/obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -18731,9 +18732,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bOo" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
+/obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
@@ -23846,13 +23845,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cJG" = (
-/obj/effect/turf_decal/siding/dark_blue/corner,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
-	},
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "cJH" = (
@@ -23860,22 +23854,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "cJI" = (
-/obj/effect/turf_decal/siding/dark_blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/command/nuke_storage)
-"cJJ" = (
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 8
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 4
-	},
-/obj/item/toy/plush/nukeplushie,
-/obj/structure/closet/crate/silvercrate,
-/turf/open/floor/iron/dark,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "cJK" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -26262,11 +26247,12 @@
 /turf/open/floor/plating,
 /area/station/cargo/lobby)
 "cVX" = (
-/obj/effect/turf_decal/siding/dark_blue,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 9
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "cWb" = (
 /obj/effect/decal/cleanable/glass,
@@ -31152,6 +31138,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
+"eRS" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 6
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/command/nuke_storage)
 "eSi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair,
@@ -31939,6 +31931,11 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
+"flS" = (
+/obj/structure/table/reinforced,
+/obj/item/piggy_bank/vault,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/command/nuke_storage)
 "flY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 4
@@ -34608,6 +34605,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"gsh" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/command/nuke_storage)
 "gsj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Cooling Loop Bypass"
@@ -35606,14 +35610,12 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/prison)
 "gNi" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Cargo - Vault";
 	network = list("ss13","vault")
 	},
-/obj/structure/cable,
-/obj/item/piggy_bank/vault,
-/turf/open/floor/circuit,
+/obj/structure/closet/crate/goldcrate,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "gNl" = (
 /obj/machinery/duct,
@@ -36507,9 +36509,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
 "hej" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -36627,6 +36626,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/bridge)
+"hfN" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/command/nuke_storage)
 "hfS" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 4
@@ -37444,13 +37450,13 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar/directional/west,
-/obj/item/toy/plush/phos{
-	pixel_y = 5
-	},
 /obj/item/newspaper{
 	pixel_y = 7
 	},
+/obj/item/toy/plush/phos{
+	pixel_y = 5
+	},
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "hvz" = (
@@ -44020,7 +44026,7 @@
 /area/station/ai_monitored/command/storage/eva)
 "jVd" = (
 /obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/circuit,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "jVk" = (
 /obj/structure/reflector/double/anchored{
@@ -44186,9 +44192,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "jYd" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 9
-	},
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/reagent_containers/cup/glass/bottle/cognac{
 	pixel_x = -7;
@@ -45882,9 +45885,7 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "kHG" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 1
-	},
+/obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -48208,9 +48209,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port)
 "lGN" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 1
-	},
+/obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -51339,9 +51338,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/bridge)
 "mRu" = (
-/obj/effect/turf_decal/siding/dark_blue/end,
-/obj/structure/closet/crate/silvercrate,
 /obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "mRA" = (
@@ -57151,9 +57151,7 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/command/gateway)
 "oZu" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 1
-	},
+/obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -59057,9 +59055,6 @@
 /obj/item/reagent_containers/cup/glass/bottle/vodka/badminka,
 /obj/item/gun/ballistic/revolver/russian,
 /obj/item/ammo_box/a357,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "pNb" = (
@@ -62968,6 +62963,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"rmd" = (
+/obj/structure/closet/crate/silvercrate,
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/command/nuke_storage)
 "rmj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -63541,7 +63541,7 @@
 "rwz" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/ore_silo,
-/turf/open/floor/circuit,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "rwA" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -65425,8 +65425,10 @@
 /turf/open/floor/plastic,
 /area/station/commons/toilet/auxiliary)
 "spW" = (
-/obj/effect/turf_decal/siding/dark_blue/end,
 /obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "sqp" = (
@@ -65482,11 +65484,11 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "sra" = (
-/obj/effect/turf_decal/siding/dark_blue,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 5
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "srm" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -68586,7 +68588,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/plasmaman)
 "txr" = (
-/obj/structure/rack,
 /obj/item/poster/random_contraband{
 	pixel_y = 6
 	},
@@ -69203,9 +69204,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "tHB" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 1
-	},
+/obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -71714,6 +71713,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/lab)
+"uJM" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/command/nuke_storage)
 "uJP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76944,8 +76947,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "wOw" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 1
+/obj/structure/chair/comfy/brown{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
@@ -80665,9 +80668,7 @@
 /turf/open/floor/plating,
 /area/station/security/prison/visit)
 "yly" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 1
-	},
+/obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -116324,7 +116325,7 @@ cVV
 cHW
 wOw
 cVX
-bkO
+hfN
 blc
 jVd
 ykc
@@ -116582,7 +116583,7 @@ sBl
 hej
 cJI
 bmD
-blc
+uJM
 rwz
 ykc
 aaa
@@ -116836,10 +116837,10 @@ cVV
 cVV
 cVV
 cHW
-wOw
+flS
 sra
-bkO
-bkO
+gsh
+eRS
 bkO
 ykc
 aaa
@@ -117094,9 +117095,9 @@ aaa
 aaa
 ykc
 pMF
-cJJ
-mRu
 bkO
+mRu
+rmd
 tnw
 ykc
 aaa

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -15060,7 +15060,9 @@
 /turf/closed/wall/r_wall,
 /area/station/security/checkpoint/escape)
 "bsr" = (
-/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -18732,7 +18734,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bOo" = (
-/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
@@ -45885,7 +45889,9 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "kHG" = (
-/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -48209,7 +48215,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port)
 "lGN" = (
-/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -57151,7 +57159,9 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/command/gateway)
 "oZu" = (
-/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -69204,7 +69214,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "tHB" = (
-/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -80668,7 +80680,9 @@
 /turf/open/floor/plating,
 /area/station/security/prison/visit)
 "yly" = (
-/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},


### PR DESCRIPTION
## About The Pull Request
This PR edits Heliostation's vault a bit by adding a previously missing gold crate to it and making it look like this:
<details><summary>Expand for image of new vault appearance shown in StrongDMM</summary>


![image](https://github.com/user-attachments/assets/d332672e-12cc-4612-b34c-de7a0a0a3131)

</details>
(Also this PR attempts to fix two other minor mapping errors, including a tile with two racks and an improperly layered plush in the bar.)

## Why It's Good For The Game
Heliostation's vault currently lacks a gold crate, which is a rather essential feature of any station vault (especially on low-pop rounds where gold is necessary to build positronic brains and AI shells.)
## Changelog
:cl:
fix: added a previously missing gold crate to Heliostation's vault and changed up its appearance a bit
/:cl:
