### PR TITLE
Players can now start a shuttle vote 2 hours into the round

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -606,3 +606,8 @@ UPLOAD_LIMIT 524288
 
 ## Restricts admin client uploads to the server, defined in bytes, default is 5MB
 UPLOAD_LIMIT_ADMIN 5242880
+
+## HERE BE FULP FEATURES
+
+## Time, in minutes, before all players are allowed to start a vote to end the round. -1 will disable the feature.
+PUBLIC_SHUTTLE_VOTE 0

--- a/fulp_modules/fulp_world/fulp_config.dm
+++ b/fulp_modules/fulp_world/fulp_config.dm
@@ -1,3 +1,7 @@
+/datum/config_entry/number/public_shuttle_vote
+	default = 120 // Two hours
+	min_val = -1 // -1 will disable it.
+
 /datum/config_entry/string/servercaption // Caption name (goes next to server name in BYOND hub)
 
 /datum/config_entry/string/discordurl

--- a/fulp_modules/fulp_world/public_restart_vote.dm
+++ b/fulp_modules/fulp_world/public_restart_vote.dm
@@ -56,8 +56,8 @@
 		\n\
 		Biometrics data shows morale has decayed beyond profitable limits. A mandatory crew rotation will now take place. \
 		Crew remaining on site after the end of their shift may expect recovery in approximately six business weeks \
-		and are encouraged to apply for a Nanowage Overtime Plan Acclimated Yearly\n\
-		\n\Glory to Nanotrasen")
+		and are encouraged to apply for a Nanowage Overtime Plan Acclimated Yearly.\n\
+		\nGlory to Nanotrasen")
 		SSshuttle.emergency_no_recall = TRUE
 		log_game("Shuttle call forced by successful public vote.")
 		return

--- a/fulp_modules/fulp_world/public_restart_vote.dm
+++ b/fulp_modules/fulp_world/public_restart_vote.dm
@@ -56,7 +56,7 @@
 		\n\
 		S.M.I.L.E. telemetry shows that crew morale has decayed beyond profitable limits. \
 		A mandatory crew rotation will take place, and janitorial staff have been dispatched to prepare the facilities for the next shift.\n\
-		Glory to NT.")
+		/n/Glory to Nanotrasen")
 		SSshuttle.emergency_no_recall = TRUE
 		log_game("Shuttle call forced by successful public vote.")
 		return

--- a/fulp_modules/fulp_world/public_restart_vote.dm
+++ b/fulp_modules/fulp_world/public_restart_vote.dm
@@ -1,0 +1,67 @@
+#define CHOICE_RESTART "Call the shuttle"
+#define CHOICE_CONTINUE "Continue Playing"
+
+/datum/vote/public_shuttle_vote
+	name = "Shuttle call"
+	default_choices = list(
+		CHOICE_RESTART,
+		CHOICE_CONTINUE,
+	)
+	default_message = "Vote to call the shuttle and end the ongoing round."
+	var/last_held = 0
+
+/datum/vote/public_shuttle_vote/toggle_votable()
+	var/datum/config_entry/CE = /datum/config_entry/number/public_shuttle_vote
+	if(CONFIG_GET(number/public_shuttle_vote) == -1)
+		var/time_requirement = input(usr, "How many minutes should the round last before the vote can be called?", "Enabling restart vote", initial(CE.default)) as num
+		CONFIG_SET(number/public_shuttle_vote, time_requirement)
+	else
+		CONFIG_SET(number/public_shuttle_vote, -1)
+
+/datum/vote/public_shuttle_vote/is_config_enabled()
+	return  CONFIG_GET(number/public_shuttle_vote) != -1
+
+/datum/vote/public_shuttle_vote/create_vote()
+	last_held = world.time
+	. = ..()
+
+/datum/vote/public_shuttle_vote/get_vote_result()
+	. = ..()
+
+/datum/vote/public_shuttle_vote/can_be_initiated(forced)
+	var/time_remaining = CONFIG_GET(number/public_shuttle_vote) MINUTES - (world.time - SSticker.round_start_time)
+	var/can_evac = SSshuttle.canEvac()
+	var/cooldown = last_held ? (last_held + 20 MINUTES) - world.time : 0 // Always 0 if we haven't had a vote yet
+
+	. = ..()
+	if(. != VOTE_AVAILABLE)
+		return .
+	if(can_evac != TRUE)
+		return can_evac // Despite the name, it's either 'TRUE' OR a string describing why the shuttle can't be called.
+	if(forced)
+		return VOTE_AVAILABLE
+	if(time_remaining > 0)
+		return "Cannot be called until [DisplayTimeText(CONFIG_GET(number/public_shuttle_vote) MINUTES)] after the start of the round.\n\
+				([DisplayTimeText(time_remaining)] left)"
+	if(cooldown > 0)
+		return "A shuttle vote has already been called. Another will be available in [DisplayTimeText(cooldown)]."
+	return VOTE_AVAILABLE
+
+/datum/vote/public_shuttle_vote/finalize_vote(winning_option)
+	if(winning_option == CHOICE_CONTINUE)
+		return
+
+	if(winning_option == CHOICE_RESTART)
+		SSshuttle.emergency.request(reason = "\n\
+		\n\
+		S.M.I.L.E. telemetry shows morale has decayed beyond profitable limits. \
+		A mandatory crew rotation will take place, and janitorial staff have been dispatched to prepare the facilities for the next shift.\n\
+		Glory to NT.")
+		SSshuttle.emergency_no_recall = TRUE
+		log_game("Shuttle call forced by successful public vote.")
+		return
+
+	CRASH("[type] wasn't passed a valid winning choice. (Got: [winning_option || "null"])")
+
+#undef CHOICE_RESTART
+#undef CHOICE_CONTINUE

--- a/fulp_modules/fulp_world/public_restart_vote.dm
+++ b/fulp_modules/fulp_world/public_restart_vote.dm
@@ -54,7 +54,7 @@
 	if(winning_option == CHOICE_RESTART)
 		SSshuttle.emergency.request(reason = "\n\
 		\n\
-		A mandatory crew rotation will now take place. \
+		Biometrics data shows morale has decayed beyond profitable limits. A mandatory crew rotation will now take place. \
 		Crew remaining on site after the end of their shift may expect recovery in approximately six business weeks \
 		and are encouraged to apply for a Nanowage Overtime Plan Acclimated Yearly\n\
 		/n/Glory to Nanotrasen")

--- a/fulp_modules/fulp_world/public_restart_vote.dm
+++ b/fulp_modules/fulp_world/public_restart_vote.dm
@@ -54,7 +54,7 @@
 	if(winning_option == CHOICE_RESTART)
 		SSshuttle.emergency.request(reason = "\n\
 		\n\
-		S.M.I.L.E. telemetry shows morale has decayed beyond profitable limits. \
+		S.M.I.L.E. telemetry shows that crew morale has decayed beyond profitable limits. \
 		A mandatory crew rotation will take place, and janitorial staff have been dispatched to prepare the facilities for the next shift.\n\
 		Glory to NT.")
 		SSshuttle.emergency_no_recall = TRUE

--- a/fulp_modules/fulp_world/public_restart_vote.dm
+++ b/fulp_modules/fulp_world/public_restart_vote.dm
@@ -55,7 +55,7 @@
 		SSshuttle.emergency.request(reason = "\n\
 		\n\
 		S.M.I.L.E. telemetry shows that crew morale has decayed beyond profitable limits. \
-		A mandatory crew rotation will take place, and janitorial staff have been dispatched to prepare the facilities for the next shift.\n\
+		A mandatory crew rotation will now take place. Janitorial staff have been dispatched to prepare station facilities for the next shift.\n\
 		/n/Glory to Nanotrasen")
 		SSshuttle.emergency_no_recall = TRUE
 		log_game("Shuttle call forced by successful public vote.")

--- a/fulp_modules/fulp_world/public_restart_vote.dm
+++ b/fulp_modules/fulp_world/public_restart_vote.dm
@@ -55,7 +55,7 @@
 		SSshuttle.emergency.request(reason = "\n\
 		\n\
 		S.M.I.L.E. telemetry shows that crew morale has decayed beyond profitable limits. \
-		A mandatory crew rotation will now take place. Janitorial staff have been dispatched to prepare station facilities for the next shift.\n\
+		A mandatory crew rotation will now take place, and janitorial staff have been dispatched to prepare station facilities for the next shift.\n\
 		/n/Glory to Nanotrasen")
 		SSshuttle.emergency_no_recall = TRUE
 		log_game("Shuttle call forced by successful public vote.")

--- a/fulp_modules/fulp_world/public_restart_vote.dm
+++ b/fulp_modules/fulp_world/public_restart_vote.dm
@@ -57,7 +57,7 @@
 		Biometrics data shows morale has decayed beyond profitable limits. A mandatory crew rotation will now take place. \
 		Crew remaining on site after the end of their shift may expect recovery in approximately six business weeks \
 		and are encouraged to apply for a Nanowage Overtime Plan Acclimated Yearly\n\
-		/n/Glory to Nanotrasen")
+		\n\Glory to Nanotrasen")
 		SSshuttle.emergency_no_recall = TRUE
 		log_game("Shuttle call forced by successful public vote.")
 		return

--- a/fulp_modules/fulp_world/public_restart_vote.dm
+++ b/fulp_modules/fulp_world/public_restart_vote.dm
@@ -54,8 +54,9 @@
 	if(winning_option == CHOICE_RESTART)
 		SSshuttle.emergency.request(reason = "\n\
 		\n\
-		S.M.I.L.E. telemetry shows that crew morale has decayed beyond profitable limits. \
-		A mandatory crew rotation will now take place, and janitorial staff have been dispatched to prepare station facilities for the next shift.\n\
+		A mandatory crew rotation will now take place. \
+		Crew remaining on site after the end of their shift may expect recovery in approximately six business weeks \
+		and are encouraged to apply for a Nanowage Overtime Plan Acclimated Yearly\n\
 		/n/Glory to Nanotrasen")
 		SSshuttle.emergency_no_recall = TRUE
 		log_game("Shuttle call forced by successful public vote.")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6562,6 +6562,7 @@
 #include "fulp_modules\fulp_world\fulp_config.dm"
 #include "fulp_modules\fulp_world\fulp_preferences.dm"
 #include "fulp_modules\fulp_world\fulp_world.dm"
+#include "fulp_modules\fulp_world\public_restart_vote.dm"
 #include "fulp_modules\mapping\areas\areas.dm"
 #include "fulp_modules\mapping\deathmatch\code\deathmatch_loadouts.dm"
 #include "fulp_modules\mapping\deathmatch\code\deathmatch_maps.dm"


### PR DESCRIPTION
## About The Pull Request

After 2 hours* have elapsed, players will be able to host a Shuttle Vote. If it passes, the shuttle will be called with no possibility of recalling. If it fails, it can be rerun every 20 minutes.

Sample:

https://github.com/user-attachments/assets/a96a7dbf-e9c3-466d-b88e-edd854afe123

![image](https://github.com/user-attachments/assets/e13149dc-689b-4b15-8bed-eaa217a632c8)

It behaves like a standard vote, in that all players (dead or alive) can vote in and start it.

(*The actual value is based on config. A sample of how config.txt will need to be changed is provided in the PR.)
## Why It's Good For The Game

Avoids situations where the round drags on due power problems, consoles being broken, everyone being dead, etc.
Two hours is a reasonably long time for a round, and so this should rarely cut a good round short. Meanwhile, it will cut through plenty of tedious waits for an admin to call it, or for someone to break into the bridge.
## Changelog
:cl:
add: Players can now host a public shuttle vote after the 2 hour mark.
/:cl:
