### PR TITLE
Fixes non-standard mapping in Govyadina Station, the Beefman Research Outpost and the Syndicate Engineering Outpost

### DIFF
--- a/fulp_modules/_maps/RandomRuins/IceRuins/beef_cytology.dmm
+++ b/fulp_modules/_maps/RandomRuins/IceRuins/beef_cytology.dmm
@@ -63,10 +63,8 @@
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "cp" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/ruin/powered/beefcyto)
 "cP" = (
@@ -177,7 +175,7 @@
 "jx" = (
 /obj/machinery/door/airlock/vault{
 	id_tag = "migo door";
-	name = "migo door"
+	name = "Migo Chamber"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/fans/tiny,
@@ -205,7 +203,7 @@
 "kI" = (
 /obj/machinery/door/airlock/vault{
 	id_tag = "carp door";
-	name = "carp door"
+	name = "Carp Chamber"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/fans/tiny,
@@ -486,7 +484,7 @@
 /area/ruin/powered/beefcyto)
 "wf" = (
 /obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder/constructed,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "wn" = (
@@ -509,7 +507,7 @@
 "xA" = (
 /obj/machinery/door/airlock/vault{
 	id_tag = "blobbernaut door";
-	name = "blobbernaut door"
+	name = "Blobbernaut Chamber"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/fans/tiny,
@@ -725,9 +723,7 @@
 /area/ruin/powered/beefcyto)
 "Ek" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "Em" = (
@@ -843,7 +839,7 @@
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "Kz" = (
-/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/grass,
 /area/ruin/powered/beefcyto)
 "Lo" = (
@@ -920,7 +916,7 @@
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "Pc" = (
-/obj/structure/window,
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/ruin/powered/beefcyto)
 "Pg" = (
@@ -1051,9 +1047,7 @@
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "Vc" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/ruin/powered/beefcyto)
 "Vk" = (
@@ -1085,9 +1079,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/powered/beefcyto)
 "Yo" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window/left/directional/east,
 /turf/open/floor/grass,
 /area/ruin/powered/beefcyto)
 "YC" = (

--- a/fulp_modules/_maps/RandomRuins/SpaceRuins/beef_station.dmm
+++ b/fulp_modules/_maps/RandomRuins/SpaceRuins/beef_station.dmm
@@ -312,9 +312,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "el" = (
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/eighties,
 /area/ruin/space/has_grav/powered/beef)
 "em" = (
@@ -1400,11 +1398,9 @@
 	dir = 1
 	},
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/door/window{
-	dir = 4
-	},
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/door/window/left/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "we" = (
@@ -1790,10 +1786,8 @@
 	dir = 1
 	},
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/door/window{
-	dir = 4
-	},
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/door/window/left/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "DZ" = (
@@ -2174,9 +2168,7 @@
 	color = "#4a4a4a";
 	dir = 4
 	},
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/eighties,
 /area/ruin/space/has_grav/powered/beef)
 "Ke" = (
@@ -2334,15 +2326,6 @@
 "NG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/carpet/orange,
-/area/ruin/space/has_grav/powered/beef)
-"NJ" = (
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
-/turf/open/floor/eighties,
 /area/ruin/space/has_grav/powered/beef)
 "NL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -4447,7 +4430,7 @@ fC
 xi
 CE
 Pa
-NJ
+el
 jb
 bZ
 NL

--- a/fulp_modules/_maps/RandomRuins/SpaceRuins/beef_station.dmm
+++ b/fulp_modules/_maps/RandomRuins/SpaceRuins/beef_station.dmm
@@ -1,15 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ae" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/powered/beef)
 "ao" = (
-/obj/structure/window,
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/beef)
 "aq" = (
@@ -26,10 +22,8 @@
 /turf/open/floor/light,
 /area/ruin/space/has_grav/powered/beef)
 "aI" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/structure/bookcase,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/powered/beef)
 "aK" = (
@@ -151,7 +145,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "cF" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/beef)
 "cJ" = (
@@ -265,11 +259,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/powered/beef)
 "dG" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /mob/living/basic/butterfly,
 /obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/powered/beef)
 "dJ" = (
@@ -307,9 +299,7 @@
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/powered/beef)
 "ed" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/powered/beef)
 "ei" = (
@@ -678,10 +668,8 @@
 /area/ruin/space/has_grav/powered/beef/atmos)
 "jN" = (
 /mob/living/basic/cow,
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
 /obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/powered/beef)
 "jW" = (
@@ -729,9 +717,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/beef)
 "kD" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window/left/directional/east,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/beef)
 "kF" = (
@@ -790,9 +776,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "ls" = (
-/obj/structure/window{
-	dir = 1
-	},
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -801,6 +784,7 @@
 	color = "#2e2e2e";
 	dir = 4
 	},
+/obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "lt" = (
@@ -810,11 +794,6 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/powered/beef)
-"lv" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/turf/closed/indestructible/reinforced,
-/area/ruin/space/has_grav/powered/beef/atmos)
 "lH" = (
 /obj/machinery/light{
 	dir = 4
@@ -832,8 +811,8 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/powered/beef)
 "lQ" = (
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/beef)
 "mh" = (
@@ -854,14 +833,11 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/powered/beef/atmos)
 "mw" = (
+/obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/beef)
 "mN" = (
-/obj/structure/window{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 8
@@ -869,14 +845,13 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/structure/window{
-	dir = 1
-	},
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
 	},
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "nf" = (
@@ -927,9 +902,6 @@
 /area/ruin/space/has_grav/powered/beef)
 "nM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/window{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -937,6 +909,7 @@
 	color = "#2e2e2e";
 	dir = 4
 	},
+/obj/machinery/door/window/left/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "oa" = (
@@ -1016,10 +989,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/beef/atmos)
 "pJ" = (
-/obj/structure/window{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/eighties,
 /area/ruin/space/has_grav/powered/beef)
 "pS" = (
@@ -1052,9 +1023,6 @@
 /turf/open/floor/eighties,
 /area/ruin/space/has_grav/powered/beef)
 "qq" = (
-/obj/structure/window{
-	dir = 8
-	},
 /obj/structure/table/glass,
 /obj/item/surgery_tray/full,
 /obj/effect/turf_decal/tile/neutral{
@@ -1070,6 +1038,7 @@
 	dir = 8
 	},
 /obj/item/reagent_containers/spray/cleaner,
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "qr" = (
@@ -1099,14 +1068,11 @@
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/powered/beef)
 "qy" = (
-/obj/structure/window,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/beef)
 "qz" = (
-/obj/structure/window{
-	dir = 8
-	},
 /obj/structure/table/glass,
 /obj/item/storage/medkit/o2,
 /obj/item/storage/medkit/toxin,
@@ -1121,13 +1087,11 @@
 	color = "#2e2e2e";
 	dir = 8
 	},
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "qD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/window{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -1135,6 +1099,7 @@
 	color = "#2e2e2e";
 	dir = 4
 	},
+/obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "qH" = (
@@ -1182,9 +1147,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "rw" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 8
 	},
@@ -1193,6 +1155,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/machinery/door/window/left/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "rA" = (
@@ -1214,9 +1177,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/beef/atmos)
 "sk" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/machinery/vending/hydronutrients{
 	default_price = null;
 	extra_price = null;
@@ -1229,6 +1189,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "sw" = (
@@ -1236,20 +1197,16 @@
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/powered/beef)
 "sM" = (
-/obj/structure/window{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
 	},
-/obj/structure/window{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/structure/window/spawner/directional/north,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "sX" = (
@@ -1435,12 +1392,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/powered/beef)
 "vW" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
@@ -1452,6 +1403,8 @@
 /obj/machinery/door/window{
 	dir = 4
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "we" = (
@@ -1501,12 +1454,6 @@
 /turf/open/floor/eighties,
 /area/ruin/space/has_grav/powered/beef)
 "xp" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/machinery/vending/hydroseeds{
 	default_price = null;
 	extra_price = null;
@@ -1519,6 +1466,8 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "xv" = (
@@ -1594,9 +1543,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/beef/atmos)
 "yJ" = (
-/obj/structure/window/spawner{
-	dir = 8
-	},
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/light,
 /area/ruin/space/has_grav/powered/beef)
 "yN" = (
@@ -1606,9 +1553,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "yP" = (
-/obj/structure/window{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
@@ -1621,6 +1565,7 @@
 	color = "#2e2e2e";
 	dir = 8
 	},
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "yS" = (
@@ -1652,9 +1597,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/window/right/directional/north{
-	dir = 8
-	},
+/obj/machinery/door/window/right/directional/west,
 /turf/open/floor/light,
 /area/ruin/space/has_grav/powered/beef)
 "Ah" = (
@@ -1683,9 +1626,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "AM" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window/left/directional/east,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/powered/beef)
 "AQ" = (
@@ -1724,9 +1665,6 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/beef)
 "Ce" = (
-/obj/structure/window{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1";
 	dir = 1
@@ -1735,6 +1673,7 @@
 	color = "#2e2e2e";
 	dir = 8
 	},
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "Co" = (
@@ -1792,7 +1731,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/beef)
 "Dr" = (
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -1805,6 +1743,7 @@
 	dir = 8;
 	pixel_x = 5
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "DB" = (
@@ -1843,9 +1782,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "DY" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
@@ -1857,6 +1793,7 @@
 /obj/machinery/door/window{
 	dir = 4
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "DZ" = (
@@ -1882,9 +1819,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "EF" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/powered/beef)
 "EH" = (
@@ -1943,11 +1878,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/beef/atmos)
-"Fy" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/turf/closed/indestructible/reinforced,
-/area/ruin/space/has_grav/powered/beef)
 "Fz" = (
 /turf/open/floor/mineral/silver,
 /area/ruin/space/has_grav/powered/beef)
@@ -1994,9 +1924,6 @@
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/powered/beef)
 "Gu" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
@@ -2005,6 +1932,7 @@
 	dir = 1
 	},
 /obj/machinery/hydroponics/constructable,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "GB" = (
@@ -2048,9 +1976,6 @@
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/powered/beef)
 "Hd" = (
-/obj/machinery/door/window{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -2058,6 +1983,7 @@
 	color = "#2e2e2e";
 	dir = 8
 	},
+/obj/machinery/door/window/right/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "Hg" = (
@@ -2071,22 +1997,18 @@
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/powered/beef)
 "Hl" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/structure/easel,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/powered/beef)
 "Hu" = (
-/obj/structure/window{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
 	},
 /obj/machinery/stasis,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "Hv" = (
@@ -2133,10 +2055,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/powered/beef)
 "Ik" = (
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/beef)
 "Il" = (
@@ -2146,11 +2068,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/beef/atmos)
 "Is" = (
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/window,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/window/spawner/directional/east,
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/beef)
 "Iu" = (
@@ -2161,13 +2081,9 @@
 /area/ruin/space/has_grav/powered/beef)
 "Iz" = (
 /mob/living/basic/chick,
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/powered/beef)
 "IB" = (
@@ -2191,8 +2107,8 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/beef)
 "IT" = (
+/obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/beef)
 "Jb" = (
@@ -2303,11 +2219,6 @@
 "Ld" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/powered/beef/atmos)
-"Lk" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/grille,
-/turf/closed/indestructible/reinforced,
-/area/ruin/space/has_grav/powered/beef)
 "Ly" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/engine,
@@ -2443,9 +2354,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "NT" = (
-/obj/structure/window{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
@@ -2457,6 +2365,7 @@
 /obj/machinery/computer/operating{
 	dir = 1
 	},
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "NU" = (
@@ -2473,9 +2382,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/powered/beef)
 "Oj" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "Or" = (
@@ -2512,9 +2419,6 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/powered/beef)
 "OR" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
 /obj/structure/table/glass,
 /obj/item/storage/bag/plants,
 /obj/machinery/light,
@@ -2523,6 +2427,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "OV" = (
@@ -2578,8 +2483,8 @@
 /turf/open/floor/mineral/silver,
 /area/ruin/space/has_grav/powered/beef)
 "Qk" = (
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/decal/cleanable/blood/old,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/beef)
 "Qm" = (
@@ -2652,9 +2557,7 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/beef)
 "RE" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/powered/beef)
 "RN" = (
@@ -2671,14 +2574,12 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "RU" = (
-/obj/structure/window{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
 	},
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "RY" = (
@@ -2710,7 +2611,7 @@
 /turf/open/floor/eighties,
 /area/ruin/space/has_grav/powered/beef)
 "Sy" = (
-/mob/living/simple_animal/bot/vibebot,
+/mob/living/basic/bot/vibebot,
 /turf/open/floor/light,
 /area/ruin/space/has_grav/powered/beef)
 "SH" = (
@@ -2732,9 +2633,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "ST" = (
-/obj/structure/window{
-	dir = 4
-	},
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/beef)
 "SU" = (
@@ -2781,9 +2680,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "Tm" = (
-/obj/structure/window{
-	dir = 4
-	},
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/eighties,
 /area/ruin/space/has_grav/powered/beef)
 "Tr" = (
@@ -2826,9 +2723,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/powered/beef)
 "Uh" = (
-/obj/structure/window{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1";
@@ -2838,6 +2732,7 @@
 	color = "#2e2e2e";
 	dir = 8
 	},
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "Ui" = (
@@ -2996,9 +2891,6 @@
 /turf/open/floor/mineral/gold,
 /area/ruin/space/has_grav/powered/beef)
 "XV" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
@@ -3006,6 +2898,7 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/item/reagent_containers/cup/bucket,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "Yb" = (
@@ -3103,24 +2996,17 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 "ZO" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window/left/directional/east,
 /turf/open/floor/eighties,
 /area/ruin/space/has_grav/powered/beef)
 "ZP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/window{
-	dir = 8
-	},
+/obj/machinery/door/window/left/directional/west,
 /turf/open/floor/light,
 /area/ruin/space/has_grav/powered/beef)
 "ZY" = (
-/obj/structure/window{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -3128,6 +3014,7 @@
 	color = "#2e2e2e";
 	dir = 4
 	},
+/obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/beef)
 
@@ -3251,7 +3138,7 @@ uq
 Tg
 Tg
 Tg
-lv
+Tg
 uq
 uq
 uq
@@ -3392,7 +3279,7 @@ uq
 Tg
 eD
 wG
-lv
+Tg
 uq
 uq
 uq
@@ -3983,7 +3870,7 @@ uq
 uq
 uq
 uq
-Fy
+YA
 YA
 YA
 YA
@@ -4547,7 +4434,7 @@ uq
 uq
 uq
 uq
-Fy
+YA
 YA
 YA
 YA
@@ -4782,10 +4669,10 @@ uq
 uq
 uq
 uq
-Lk
-Lk
-Lk
-Lk
+YA
+YA
+YA
+YA
 YA
 uq
 uq
@@ -4970,7 +4857,7 @@ uq
 uq
 uq
 uq
-Fy
+YA
 YA
 YA
 YA

--- a/fulp_modules/_maps/RandomRuins/SpaceRuins/syndicate_engineer.dmm
+++ b/fulp_modules/_maps/RandomRuins/SpaceRuins/syndicate_engineer.dmm
@@ -157,10 +157,8 @@
 /area/ruin/has_grav/prototype/Captain)
 "aB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/fruit_bowl{
-	pixel_y = 32
-	},
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
+/obj/structure/sign/poster/official/fruit_bowl/directional/north,
 /turf/open/floor/iron/cafeteria/airless,
 /area/ruin/has_grav/prototype/kitchen)
 "aC" = (
@@ -250,7 +248,7 @@
 "aP" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/security/glass{
-	name = "Prison cell"
+	name = "Prison Cell"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -312,11 +310,6 @@
 /turf/open/floor/iron/cafeteria/airless,
 /area/ruin/has_grav/prototype/kitchen)
 "aX" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right"
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -324,6 +317,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/door/window/left/directional/east,
 /turf/open/floor/iron/cafeteria/airless,
 /area/ruin/has_grav/prototype/kitchen)
 "aZ" = (
@@ -436,7 +430,7 @@
 "bu" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/hatch{
-	name = "Shuttle door"
+	name = "Shuttle Door"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered)
@@ -1023,9 +1017,6 @@
 /area/ruin/has_grav/prototype/engineering)
 "dJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/build{
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -1041,6 +1032,7 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 50
 	},
+/obj/structure/sign/poster/official/build/directional/north,
 /turf/open/floor/iron/airless,
 /area/ruin/has_grav/prototype/engineering)
 "dK" = (
@@ -1369,14 +1361,12 @@
 /turf/open/floor/plating/airless,
 /area/ruin/has_grav/prototype/engineering)
 "eS" = (
-/obj/machinery/door/window{
-	name = "Botany"
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/door/window/left/directional/south,
 /turf/open/floor/iron/airless,
 /area/ruin/has_grav/prototype/botany)
 "eT" = (


### PR DESCRIPTION

## About The Pull Request

By "non-standard mapping", I'm referring to things not allowed by linters. This includes the use of dir in a non-directional spawner instead of using the directional prefabs, improper capitalization of door names, grilles and windows accidentally placed twice over the same tile, etc.
## Why It's Good For The Game

Fixes the issues that #1290 will bring to light, as it will allow map tests to be run on these maps too.
## Changelog
Nothing player-facing
