### PR TITLE
Body cameras are turned off by emp/jammers

### DIFF
--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -68,7 +68,7 @@
 		COMSIG_ATOM_EXAMINE_MORE,
 		COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER),
 		COMSIG_ITEM_GET_WORN_OVERLAYS,
-		COMSIG_ATOM_EMP_ACT
+		COMSIG_ATOM_EMP_ACT,
 	))
 	if(builtin_bodycamera) //retract the camera back in.
 		builtin_bodycamera.forceMove(src)

--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -74,7 +74,7 @@
 		builtin_bodycamera.forceMove(src)
 		builtin_bodycamera.network = list()
 	taking_from.cut_overlay(equipped_overlay)
-	forceMove(user.loc)
+	forceMove(user.drop_location())
 	turn_off()
 	user.put_in_hands(src)
 	if(user.get_item_by_slot(ITEM_SLOT_OCLOTHING) == taking_from)

--- a/fulp_modules/features/clothing/body_cameras/body_camera.dm
+++ b/fulp_modules/features/clothing/body_cameras/body_camera.dm
@@ -9,6 +9,9 @@
 	desc = "A body camera device attachable to most outerwear. There's an instructions tag if you look a little closer..."
 	icon = 'fulp_modules/icons/clothing/bodycamera.dmi'
 	icon_state = "bodycamera"
+
+	///The network we give to the builtin body camera while it's on and active.
+	var/list/network = list(CAMERANET_NETWORK_SS13)
 	///The camera itself, made when we need it and deleted on Destroy. Installed into the clothing item directly.
 	var/obj/machinery/camera/bodycamera/builtin_bodycamera
 	/**
@@ -53,6 +56,7 @@
 	RegisterSignal(installing_into, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(on_examine_more))
 	RegisterSignal(installing_into, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER), PROC_REF(on_screwdriver_act))
 	RegisterSignal(installing_into, COMSIG_ITEM_GET_WORN_OVERLAYS, PROC_REF(on_checked_overlays))
+	RegisterSignal(installing_into, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	if(user.get_item_by_slot(ITEM_SLOT_OCLOTHING) == installing_into)
 		user.update_worn_oversuit(update_obscured = FALSE)
 		turn_on(user)
@@ -64,9 +68,11 @@
 		COMSIG_ATOM_EXAMINE_MORE,
 		COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER),
 		COMSIG_ITEM_GET_WORN_OVERLAYS,
+		COMSIG_ATOM_EMP_ACT
 	))
 	if(builtin_bodycamera) //retract the camera back in.
 		builtin_bodycamera.forceMove(src)
+		builtin_bodycamera.network = list()
 	taking_from.cut_overlay(equipped_overlay)
 	forceMove(user.loc)
 	turn_off()
@@ -74,7 +80,7 @@
 	if(user.get_item_by_slot(ITEM_SLOT_OCLOTHING) == taking_from)
 		user.update_worn_oversuit(update_obscured = FALSE)
 
-///Turns the camera on.
+///Turns the camera on. Will be silent if 'user' is null.
 /obj/item/bodycam_upgrade/proc/turn_on(mob/living/user, obj/item/card/id/id_card)
 	if(!id_card)
 		var/obj/item/card/id/card = user.get_idcard()
@@ -86,16 +92,31 @@
 		builtin_bodycamera.c_tag = "-Body Camera: [(id_card.registered_name)] ([id_card.assignment])"
 	else
 		builtin_bodycamera.c_tag = "-Body Camera: [(user.name)]"
-	playsound(loc, 'sound/machines/beep/beep.ogg', get_clamped_volume(), TRUE, -1)
 	if(user)
 		user.balloon_alert(user, "bodycamera activated")
+		playsound(loc, 'sound/machines/beep/beep.ogg', get_clamped_volume(), TRUE, -1)
+	builtin_bodycamera.network = network //sync the network of the camera to us, the upgrade.
+	builtin_bodycamera.camera_enabled = TRUE
 
-///Turns the camera off.
+///Turns the camera off. Will be silent if 'user' is null.
 /obj/item/bodycam_upgrade/proc/turn_off(mob/user)
 	if(user)
 		user.balloon_alert(user, "bodycamera deactivated")
 		playsound(loc, 'sound/machines/beep/beep.ogg', get_clamped_volume(), TRUE, -1)
 	builtin_bodycamera.camera_enabled = FALSE
+
+/**
+ * on_emp_act
+ *
+ * Called when the body camera is EMPed.
+ * Will destroy the camera, regardless of whether it is equipped or not.
+ */
+/obj/item/bodycam_upgrade/proc/on_emp_act(atom/source, severity, protection)
+	SIGNAL_HANDLER
+	if(protection & EMP_PROTECT_SELF)
+		return
+	if(!isnull(builtin_bodycamera))
+		QDEL_NULL(builtin_bodycamera)
 
 /**
  * Examine more

--- a/fulp_modules/features/clothing/body_cameras/radio_jammer.dm
+++ b/fulp_modules/features/clothing/body_cameras/radio_jammer.dm
@@ -1,0 +1,4 @@
+/obj/item/jammer/disable_radios_on(atom/target)
+	. = ..()
+	for(var/obj/item/bodycam_upgrade/bodycamera in target.get_all_contents() + target)
+		bodycamera.turn_off()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6557,6 +6557,7 @@
 #include "fulp_modules\features\cargo\cargo.dm"
 #include "fulp_modules\features\clothing\body_cameras\body_camera.dm"
 #include "fulp_modules\features\clothing\body_cameras\camera.dm"
+#include "fulp_modules\features\clothing\body_cameras\radio_jammer.dm"
 #include "fulp_modules\features\clothing\neck\beefman_locket.dm"
 #include "fulp_modules\features\clothing\wintercoats\code\wintercoats.dm"
 #include "fulp_modules\features\events\bruhspace_anomaly.dm"


### PR DESCRIPTION
## About The Pull Request

Radio jammers being used in-hand or on someone with a body camera will now turn the camera off, making it static for anyone watching. EMP'ing someone with a camera will destroy it, removing it from the list of cameras. Either way it can be turned on immediately by swiping your ID on the suit, but both cases are silent so the user will have to find out that their gear is offline first.

Also fixes uninstalling cameras not taking them off the camera list.

## Why It's Good For The Game

Gives antags a way to disable body cameras using existing specific gear meant to target electronics. I never tried implementing this before because I didn't like how body cameras even existed, but with bodycams 3.0 I realized this would be an easy addition, so let's do it.