### PR TITLE
Conglomerated Bloodsucker Bug Fixing and General Balancing

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -54,6 +54,10 @@
 	var/frenzy_threshold = FRENZY_MINIMUM_THRESHOLD_ENTER
 	///If we are currently in a Frenzy
 	var/frenzied = FALSE
+	///If we are currently in Torpor
+	///Set on entering and exiting Torpor, but not practically used much otherwise.
+	///Originally implemented to fix a bug.
+	var/torpored = FALSE
 
 	///ALL Powers currently owned
 	var/list/datum/action/cooldown/bloodsucker/powers = list()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -196,6 +196,7 @@
 		.["Add Clan"] = CALLBACK(src, PROC_REF(admin_set_clan))
 
 ///Called when you get the antag datum, called only ONCE per antagonist.
+///The signals registered with the sol subsystem here are reregistered on mind transfer.
 /datum/antagonist/bloodsucker/on_gain()
 	RegisterSignal(SSsunlight, COMSIG_SOL_RANKUP_BLOODSUCKERS, PROC_REF(sol_rank_up))
 	RegisterSignal(SSsunlight, COMSIG_SOL_NEAR_START, PROC_REF(sol_near_start))
@@ -273,6 +274,20 @@
 
 	//Give the datum the blood volume of its new body.
 	bloodsucker_blood_volume = new_body.blood_volume
+
+	//Sol-related signals are typically removed when 'FinalDeath()' is called,
+	//so we'll check for them here and reregister them if they don't exist.
+	var/sol_signals = FALSE
+	for(var/target in _signal_procs)
+		if(istype(target, /datum/controller/subsystem/sunlight))
+			sol_signals = TRUE
+			break
+	if(!sol_signals)
+		RegisterSignal(SSsunlight, COMSIG_SOL_RANKUP_BLOODSUCKERS, PROC_REF(sol_rank_up))
+		RegisterSignal(SSsunlight, COMSIG_SOL_NEAR_START, PROC_REF(sol_near_start))
+		RegisterSignal(SSsunlight, COMSIG_SOL_END, PROC_REF(on_sol_end))
+		RegisterSignal(SSsunlight, COMSIG_SOL_RISE_TICK, PROC_REF(handle_sol))
+		RegisterSignal(SSsunlight, COMSIG_SOL_WARNING_GIVEN, PROC_REF(give_warning))
 
 /datum/antagonist/bloodsucker/greet()
 	. = ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -271,6 +271,9 @@
 		old_body.remove_traits(bloodsucker_traits, BLOODSUCKER_TRAIT)
 	new_body.add_traits(bloodsucker_traits, BLOODSUCKER_TRAIT)
 
+	//Give the datum the blood volume of its new body.
+	bloodsucker_blood_volume = new_body.blood_volume
+
 /datum/antagonist/bloodsucker/greet()
 	. = ..()
 	var/fullname = return_full_name()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_datum.dm
@@ -275,19 +275,19 @@
 	//Give the datum the blood volume of its new body.
 	bloodsucker_blood_volume = new_body.blood_volume
 
-	//Sol-related signals are typically removed when 'FinalDeath()' is called,
-	//so we'll check for them here and reregister them if they don't exist.
-	var/sol_signals = FALSE
-	for(var/target in _signal_procs)
-		if(istype(target, /datum/controller/subsystem/sunlight))
-			sol_signals = TRUE
-			break
-	if(!sol_signals)
-		RegisterSignal(SSsunlight, COMSIG_SOL_RANKUP_BLOODSUCKERS, PROC_REF(sol_rank_up))
-		RegisterSignal(SSsunlight, COMSIG_SOL_NEAR_START, PROC_REF(sol_near_start))
-		RegisterSignal(SSsunlight, COMSIG_SOL_END, PROC_REF(on_sol_end))
-		RegisterSignal(SSsunlight, COMSIG_SOL_RISE_TICK, PROC_REF(handle_sol))
-		RegisterSignal(SSsunlight, COMSIG_SOL_WARNING_GIVEN, PROC_REF(give_warning))
+	//Enter or exit Frenzy depending on our new blood volume
+	if(bloodsucker_blood_volume >= frenzy_threshold)
+		owner.current.remove_status_effect(/datum/status_effect/frenzy)
+	else
+		owner.current.apply_status_effect(/datum/status_effect/frenzy)
+
+	//Sol-related signals are removed when 'FinalDeath()' is called,
+	//so we'll reregister them here.
+	RegisterSignal(SSsunlight, COMSIG_SOL_RANKUP_BLOODSUCKERS, PROC_REF(sol_rank_up), TRUE)
+	RegisterSignal(SSsunlight, COMSIG_SOL_NEAR_START, PROC_REF(sol_near_start), TRUE)
+	RegisterSignal(SSsunlight, COMSIG_SOL_END, PROC_REF(on_sol_end), TRUE)
+	RegisterSignal(SSsunlight, COMSIG_SOL_RISE_TICK, PROC_REF(handle_sol), TRUE)
+	RegisterSignal(SSsunlight, COMSIG_SOL_WARNING_GIVEN, PROC_REF(give_warning), TRUE)
 
 /datum/antagonist/bloodsucker/greet()
 	. = ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
@@ -41,7 +41,7 @@
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum
 
 /datum/status_effect/frenzy/get_examine_text()
-	return span_notice("They seem inhuman and feral!")
+	return span_cult_italic("They seem inhuman and feral!")
 
 /atom/movable/screen/alert/status_effect/masquerade/MouseEntered(location,control,params)
 	desc = initial(desc)
@@ -69,6 +69,7 @@
 	var/obj/cuffs = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
 	var/obj/legcuffs = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
 	if(user.handcuffed || user.legcuffed)
+		playsound(get_turf(user), 'sound/effects/grillehit.ogg', 80, 1, -1)
 		user.clear_cuffs(cuffs, TRUE)
 		user.clear_cuffs(legcuffs, TRUE)
 	bloodsuckerdatum.frenzied = TRUE
@@ -94,3 +95,12 @@
 	if(!bloodsuckerdatum.frenzied)
 		return
 	user.adjustFireLoss(1.5 + (bloodsuckerdatum.humanity_lost / 10))
+	if(prob(30))
+		user.do_jitter_animation(300)
+		return
+	if(prob(10))
+		user.emote("tremble")
+		return
+	if(prob(5))
+		user.emote("screech")
+		return

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
@@ -39,6 +39,9 @@
 	var/was_tooluser = FALSE
 	/// The stored Bloodsucker antag datum
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum
+	///Boolean indicating whether or not the owner is part of the Brujah clan
+	///Used in passive burn damage calculation
+	var/brujah = FALSE
 
 /datum/status_effect/frenzy/get_examine_text()
 	return span_cult_italic("They seem inhuman and feral!")
@@ -73,6 +76,10 @@
 		user.clear_cuffs(cuffs, TRUE)
 		user.clear_cuffs(legcuffs, TRUE)
 	bloodsuckerdatum.frenzied = TRUE
+
+	// Determine if the owner is part of the Brujah clan
+	if(istype(bloodsuckerdatum.my_clan, /datum/bloodsucker_clan/brujah))
+		brujah = TRUE
 	return ..()
 
 /datum/status_effect/frenzy/on_remove()
@@ -94,7 +101,10 @@
 	var/mob/living/carbon/human/user = owner
 	if(!bloodsuckerdatum.frenzied)
 		return
-	user.adjustFireLoss(1.5 + (bloodsuckerdatum.humanity_lost / 10))
+	//Passively accumulate burn damage (Bloodsuckers can't survive on low blood forever).
+	//Humanity loss is supposed to be a bad thing for Bloodsuckers so it adds to this damage.
+	//Brujah Bloodsuckers start with a lot of lost humanity so we give them a bit of leeway.
+	user.adjustFireLoss(1.5 + (brujah ? 1 : (bloodsuckerdatum.humanity_lost / 10)))
 	if(prob(30))
 		user.do_jitter_animation(300)
 		return

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -296,6 +296,10 @@
 	if(unique_death & DONT_DUST)
 		return
 
+	// Properly exit Frenzy if Frenzying
+	if(frenzied)
+		owner.current.remove_status_effect(/datum/status_effect/frenzy)
+
 	// Elders get dusted, Fledglings get gibbed.
 	if(bloodsucker_level >= 4)
 		user.visible_message(

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_moodlets.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_moodlets.dm
@@ -9,7 +9,7 @@
 	timeout = 3 MINUTES
 
 /datum/mood_event/drankblood_dead
-	description = span_boldwarning("I drank dead blood. I am better than this.")
+	description = span_boldwarning("I drank blood from the dead. I am better than this.")
 	mood_change = -7
 	timeout = 8 MINUTES
 
@@ -19,7 +19,7 @@
 	timeout = 8 MINUTES
 
 /datum/mood_event/drankkilled
-	description = span_boldwarning("I fed off of a dead person. I feel... less human.")
+	description = span_boldwarning("I fed off of someone until their death. I feel... less human.")
 	mood_change = -15
 	timeout = 10 MINUTES
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_sol.dm
@@ -147,6 +147,9 @@
 		torpor_begin()
 
 /datum/antagonist/bloodsucker/proc/check_end_torpor()
+	//We can't end Torpor if we're not actually in Torpor...
+	if(!torpored)
+		return FALSE
 	var/mob/living/carbon/user = owner.current
 	var/total_brute = user.getBruteLoss_nonProsthetic()
 	var/total_burn = user.getFireLoss_nonProsthetic()
@@ -172,6 +175,8 @@
 	owner.current.set_timed_status_effect(0 SECONDS, /datum/status_effect/jitter, only_if_higher = TRUE)
 	// Disable ALL Powers
 	DisableAllPowers()
+	// Set this var to TRUE.
+	torpored = TRUE
 
 /datum/antagonist/bloodsucker/proc/torpor_end()
 	owner.current.grab_ghost()
@@ -181,3 +186,4 @@
 		ADD_TRAIT(owner.current, TRAIT_SLEEPIMMUNE, BLOODSUCKER_TRAIT)
 	heal_vampire_organs()
 	SEND_SIGNAL(src, BLOODSUCKER_EXIT_TORPOR)
+	torpored = FALSE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
@@ -50,7 +50,8 @@
 
 /datum/action/cooldown/bloodsucker/feed/DeactivatePower()
 	var/mob/living/user = owner
-	var/mob/living/feed_target = target_ref.resolve()
+	if(target_ref)
+		var/mob/living/feed_target = target_ref.resolve()
 	if(isnull(feed_target))
 		log_combat(user, user, "fed on blood (target not found)", addition="(and took [blood_taken] blood)")
 	else

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
@@ -50,8 +50,9 @@
 
 /datum/action/cooldown/bloodsucker/feed/DeactivatePower()
 	var/mob/living/user = owner
+	var/mob/living/feed_target
 	if(target_ref)
-		var/mob/living/feed_target = target_ref.resolve()
+		feed_target = target_ref.resolve()
 	if(isnull(feed_target))
 		log_combat(user, user, "fed on blood (target not found)", addition="(and took [blood_taken] blood)")
 	else

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
@@ -18,7 +18,7 @@
 	purchase_flags = BLOODSUCKER_CAN_BUY|BLOODSUCKER_DEFAULT_POWER
 	bloodcost = 0
 	cooldown_time = 15 SECONDS
-	///Amount of blood taken, reset after each Feed. Used for logging.
+	///Amount of blood taken, reset after each Feed. Used (mostly) for logging.
 	var/blood_taken = 0
 	///The amount of Blood a target has since our last feed, this loops and lets us not spam alerts of low blood.
 	var/warning_target_bloodvol = BLOOD_VOLUME_MAX_LETHAL
@@ -56,7 +56,7 @@
 	else
 		log_combat(user, feed_target, "fed on blood", addition="(and took [blood_taken] blood)")
 		to_chat(user, span_notice("You slowly release [feed_target]."))
-		if(feed_target.stat == DEAD)
+		if(feed_target.stat == DEAD && blood_taken > 0)
 			user.add_mood_event("drankkilled", /datum/mood_event/drankkilled)
 			bloodsuckerdatum_power.AddHumanityLost(10)
 
@@ -79,6 +79,12 @@
 		DeactivatePower()
 		feed_target.death()
 		return
+
+	if(feed_target.blood_volume <= 0)
+		owner.balloon_alert(owner, "no blood!")
+		DeactivatePower()
+		return
+
 	var/feed_timer = clamp(round(FEED_DEFAULT_TIMER / (1.25 * (level_current || 1))), 1, FEED_DEFAULT_TIMER)
 	if(bloodsuckerdatum_power.frenzied)
 		feed_timer = 2 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes a decent number of Bloodsucker bugs and makes a few minor adjustments for the sake of balance/quality of life (changes of all of the aforementioned types are described below.)

### Bug fixes:

1. Makes Bloodsuckers unable to lose Humanity by attempting to drain bloodless corpses.
2. Fixes a runtime error caused by the `DeactivatePower()` proc on `/datum/action/cooldown/bloodsucker/feed`.
3. Fixes a bug which caused Bloodsuckers to constantly receive a message indicating that they had exited Torpor during Frenzy.
4. Makes Bloodsuckers receive the blood volume of bodies their brain is transferred to.
5. Ensures that Bloodsuckers continue to be affected by the sol subsystem (day/night cycle) even after body transfer.
6. Ensures that Bloodsuckers will no longer halfway retain their Frenzying status on body transfer if they died during Frenzy.

### Balancing:

1. Makes Brujah Bloodsuckers receive less passive burn damage during Frenzy. (Currently they receive an excessive amount of burn damage due to their innate Humanity loss.)

### Quality of life:

1. Rewords a couple of moodlets related to Bloodsuckers draining blood from the dead so as to better differentiate them. (One applies when Bloodsuckers actively kill people by draining blood from them and the other applies when Bloodsuckers merely drink from dead bodies.)
2. Makes the textual description add-on given to Bloodsuckers during Frenzy use `span_cult_italic` instead of `span_notice` (so it's dark red and italicized now).
3. Makes Bloodsuckers occasionally "*tremble", "*screech", and jitter during Frenzy.
4. Makes the Brawn cuff-breaking sound effect play if Bloodsuckers break their cuffs upon entering Frenzy.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently a lot of bugs occur whenever Bloodsuckers have their brains transferred to other bodies. This PR hopefully fixes most of those bugs, and in general it aims to make Bloodsuckers a bit more mechanically polished overall.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Made Bloodsucker Frenzying more visually apparent; also reworded a couple of Bloodsuckers moodlets to clarify their cause.
balance: Lowered the (currently excessive) amount of burn damage passively accumulated by Brujah Bloodsuckers during Frenzy.
fix: Fixed a number of Bloodsucker bugs (most were related to errors caused on Bloodsucker body transfer), see associated GitHub PR for exact details.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
