### PR TITLE
Pubby Station Medical Edits

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -7037,7 +7037,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
+/area/station/maintenance/department/medical)
 "azS" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Solar Access"

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3616,7 +3616,7 @@
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
 /obj/item/screwdriver,
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "anI" = (
@@ -6360,13 +6360,13 @@
 	c_tag = "Medbay Paramedic Dispatch";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "awX" = (
@@ -7029,19 +7029,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "azR" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "CMOCell";
-	name = "Personal Examination Room"
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/dark,
 /area/station/medical/abandoned)
 "azS" = (
@@ -8501,6 +8495,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
+/obj/structure/table/reinforced,
+/obj/item/stack/package_wrap,
+/obj/item/hand_labeler,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "aFc" = (
@@ -12369,7 +12366,7 @@
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Console";
 	pixel_x = 8;
-	pixel_y = 22;
+	pixel_y = 27;
 	req_access = list("virology")
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -12378,6 +12375,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aWI" = (
@@ -15389,7 +15387,7 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/flora/grass/jungle,
-/obj/machinery/light/directional/west,
+/obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
 "bjS" = (
@@ -15434,9 +15432,10 @@
 /area/station/medical/treatment_center)
 "bjV" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery/white,
 /obj/machinery/shower/directional/south,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/fluff/shower_drain,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "bjW" = (
@@ -15463,6 +15462,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "bka" = (
@@ -15491,18 +15491,18 @@
 /area/station/medical/paramedic)
 "bke" = (
 /obj/machinery/light/directional/north,
+/obj/machinery/shower/directional/east,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/fluff/shower_drain,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/shower/directional/east,
-/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bkf" = (
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin{
-	name = "Corpse Disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
@@ -15712,14 +15712,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"blb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/central)
 "blc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -15738,13 +15730,13 @@
 /area/station/medical/treatment_center)
 "bli" = (
 /obj/structure/bed/medical/emergency,
-/obj/machinery/newscaster/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "bll" = (
@@ -16025,10 +16017,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "bmn" = (
-/obj/machinery/computer/records/medical{
-	dir = 4
-	},
+/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/light/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "bmv" = (
@@ -16230,6 +16222,10 @@
 "bnD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -5;
+	pixel_y = -25
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "bnG" = (
@@ -16353,8 +16349,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bou" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Morgue"
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue Access"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16508,12 +16504,6 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/science/breakroom)
-"bpi" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "bpo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -16536,6 +16526,7 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/sign/departments/morgue/directional/west,
 /turf/open/floor/iron,
 /area/station/medical/cryo)
 "bpz" = (
@@ -16940,14 +16931,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "bqV" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/station/medical/morgue)
 "bqX" = (
 /obj/effect/turf_decal/stripes/line{
@@ -17011,10 +17004,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "brl" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
@@ -17355,11 +17345,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bsL" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/structure/chair/office/light{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "bsN" = (
@@ -17372,6 +17360,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/med_sec/directional/east,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "bsR" = (
@@ -17657,14 +17646,11 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "buk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/computer/security/telescreen/med_sec/directional/south,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "bun" = (
@@ -18176,8 +18162,12 @@
 /turf/open/floor/grass,
 /area/station/medical/medbay/central)
 "bwC" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
 /obj/structure/curtain,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -18226,7 +18216,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bwV" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bxa" = (
@@ -18667,10 +18657,10 @@
 	c_tag = "Medbay Main Hallway- CMO";
 	network = list("ss13","medbay")
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/bluespace_vendor/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "byw" = (
@@ -18683,10 +18673,9 @@
 	},
 /obj/item/construction/plumbing,
 /obj/item/construction/plumbing,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/chemistry)
 "byz" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -19093,49 +19082,41 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
-"bzK" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "bzO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/directional/east,
-/obj/structure/sign/eyechart/directional/east,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bzX" = (
-/obj/machinery/bluespace_vendor/directional/east,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bzZ" = (
-/obj/structure/table,
-/obj/machinery/airalarm/directional/west,
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/radio/off,
+/obj/structure/sign/poster/official/obey/directional/north,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "bAe" = (
 /obj/item/stack/cable_coil,
 /obj/item/storage/box/beakers,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/chemistry)
 "bAg" = (
 /obj/structure/table/glass,
@@ -19145,12 +19126,12 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bAh" = (
 /obj/machinery/chem_heater/withbuffer,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bAi" = (
@@ -19277,9 +19258,6 @@
 	c_tag = "Medbay Storage";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -19290,10 +19268,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
-"bAQ" = (
-/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "bAR" = (
@@ -19569,8 +19543,12 @@
 /turf/open/floor/grass,
 /area/station/medical/medbay/central)
 "bCg" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/structure/curtain,
 /turf/open/floor/iron/white,
@@ -19579,9 +19557,6 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Medbay Recovery Room";
 	network = list("ss13","medbay")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -19628,6 +19603,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/sign/departments/chemistry/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bCp" = (
@@ -19639,14 +19615,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bCr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/reagent_dispensers/wall/peppertank/directional/west,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/filingcabinet,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "bCv" = (
@@ -19658,10 +19632,8 @@
 /area/station/security/checkpoint/medical)
 "bCx" = (
 /obj/structure/closet/secure_closet/chemical,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/chemistry)
 "bCE" = (
 /obj/machinery/computer/robotics{
@@ -19821,7 +19793,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bDj" = (
-/obj/item/trash/candy,
+/obj/effect/spawner/random/trash/food_packaging,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -19854,11 +19826,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/fax{
-	fax_name = "Chief Medical Officer's Office";
-	name = "Chief Medical Officer's Fax Machine"
-	},
 /obj/structure/table/glass,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/item/computer_disk/medical,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bDy" = (
@@ -19867,10 +19838,9 @@
 /obj/item/clothing/head/utility/welding,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/sheet/iron/fifty,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/chemistry)
 "bDA" = (
 /obj/machinery/vending/cigarette,
@@ -20116,20 +20086,19 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/item/computer_disk/medical,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/fax{
+	fax_name = "Chief Medical Officer's Office";
+	name = "Chief Medical Officer's Fax Machine"
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bEI" = (
 /obj/structure/table/glass,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/chemistry)
 "bEN" = (
 /obj/structure/sign/poster/official/random/directional/west,
@@ -20248,7 +20217,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bFl" = (
-/obj/structure/filingcabinet,
 /obj/machinery/requests_console/directional/south{
 	department = "Security";
 	name = "Medical Post Requests Console"
@@ -20363,7 +20331,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -21135,11 +21103,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"bKq" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/warning/deathsposal,
-/turf/open/floor/plating,
-/area/station/medical/virology)
 "bKH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21326,7 +21289,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bLG" = (
-/obj/structure/girder,
+/obj/effect/spawner/random/structure/girder,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -21336,11 +21299,11 @@
 	c_tag = "Chemistry South";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bLM" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -21588,18 +21551,18 @@
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bMM" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bMN" = (
 /obj/machinery/chem_master,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -21832,7 +21795,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bNV" = (
-/obj/item/wrench/medical,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/random/trash/bin,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bNW" = (
@@ -22844,6 +22808,7 @@
 /obj/machinery/disposal/bin{
 	name = "Disposal To Space"
 	},
+/obj/structure/sign/warning/deathsposal/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bSq" = (
@@ -23686,6 +23651,10 @@
 "bVz" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
+"bVC" = (
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bVD" = (
@@ -24927,13 +24896,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
-"cbQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "cbS" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -27608,10 +27570,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"csl" = (
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "csn" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/cultpack,
@@ -28538,8 +28496,8 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "czJ" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron/dark,
+/obj/structure/table/optable,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "czK" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
@@ -28843,7 +28801,7 @@
 /area/station/security/prison)
 "cCd" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/frame/computer{
+/obj/machinery/computer/operating{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
@@ -28851,11 +28809,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "cCk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "cCl" = (
 /turf/closed/wall/r_wall,
@@ -29030,9 +28987,8 @@
 /obj/machinery/computer/records/medical/laptop,
 /obj/structure/table/glass,
 /obj/machinery/light/small/directional/north,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
+/area/station/maintenance/department/medical)
 "cIt" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -29392,7 +29348,7 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "dcN" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -29618,6 +29574,9 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/structure/table/glass,
+/obj/structure/reagent_dispensers/wall/virusfood{
+	pixel_y = 28
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "dpa" = (
@@ -29872,6 +29831,15 @@
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
+"dxA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "dxF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -30024,12 +29992,10 @@
 /area/station/commons/lounge)
 "dFn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/computer/operating{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/surgery_tray/full/morgue,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "dFK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -30177,8 +30143,12 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/science/xenobiology)
 "dMR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "dNr" = (
@@ -30464,9 +30434,9 @@
 /area/station/medical/treatment_center)
 "dYq" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/disposalpipe/segment,
 /obj/structure/bodycontainer/morgue/beeper_off,
-/turf/open/floor/iron/dark,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "dZb" = (
 /obj/effect/turf_decal/tile/blue{
@@ -30605,7 +30575,7 @@
 /area/station/cargo/office)
 "eeb" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "eel" = (
@@ -30937,9 +30907,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "erQ" = (
-/obj/structure/reagent_dispensers/wall/virusfood{
-	pixel_y = 28
-	},
 /obj/item/storage/box/monkeycubes,
 /obj/item/clothing/gloves/latex,
 /obj/item/stack/sheet/mineral/plasma{
@@ -30949,6 +30916,13 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/structure/table/glass,
+/obj/machinery/requests_console/directional/south{
+	department = "Virology";
+	name = "Virology Requests Console";
+	pixel_y = 30
+	},
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/ore_update,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "esz" = (
@@ -31052,7 +31026,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eyL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/eyechart/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ezk" = (
@@ -31367,7 +31344,6 @@
 /obj/item/scalpel{
 	pixel_y = 12
 	},
-/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
@@ -31853,16 +31829,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "fby" = (
-/obj/structure/sign/poster/official/no_erp/directional/east,
 /obj/structure/chair/office{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
+/area/station/maintenance/department/medical)
 "fcK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -31987,17 +31958,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "fgs" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/item/radio/off,
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
@@ -32050,7 +32016,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -32107,13 +32073,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
-"flq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "flQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32190,7 +32149,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "fpg" = (
@@ -32219,7 +32177,7 @@
 /area/station/commons/dorms)
 "frn" = (
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -32230,9 +32188,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "frF" = (
-/obj/structure/bed/medical/emergency,
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "frX" = (
 /obj/structure/chair{
@@ -32551,6 +32508,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency/starboard)
+"fFP" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "fGa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -33115,10 +33076,7 @@
 /area/station/hallway/secondary/command)
 "giC" = (
 /obj/structure/bodycontainer/morgue,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/station/medical/morgue)
 "giI" = (
 /obj/machinery/light/small/directional/north,
@@ -33218,8 +33176,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/shower/directional/south,
+/obj/structure/fluff/shower_drain,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "glf" = (
@@ -33542,6 +33500,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"gyD" = (
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/station/medical/morgue)
 "gyP" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/loading_area{
@@ -33720,6 +33684,14 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"gFf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "gFo" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/glass,
@@ -33971,22 +33943,13 @@
 /turf/closed/wall,
 /area/station/maintenance/department/medical/central)
 "gQM" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Morgue Waste Chute";
-	req_access = list("medical")
-	},
-/obj/machinery/door/window/right/directional/south{
-	name = "Morgue Waste Chute";
-	req_access = list("morgue_secure")
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/structure/filingcabinet,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "gQU" = (
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin{
-	name = "Corpse Disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
 	},
@@ -34282,6 +34245,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"hgq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "hgV" = (
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -34690,7 +34662,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "hBg" = (
-/obj/structure/girder,
+/obj/structure/rack,
+/obj/item/wrench/medical,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "hBn" = (
@@ -34799,9 +34772,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"hEC" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/abandoned)
 "hEX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -34917,6 +34887,16 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"hJn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "hJp" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -35056,6 +35036,7 @@
 	},
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/structure/table/glass,
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "hSM" = (
@@ -35128,9 +35109,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "hVJ" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/landmark/start/hangover,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "hVS" = (
@@ -35417,8 +35398,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "ijG" = (
-/obj/structure/table/optable,
-/turf/open/floor/iron/dark,
+/obj/structure/chair/office/tactical{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "ijU" = (
 /obj/structure/closet/crate,
@@ -35491,6 +35474,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
 /area/station/maintenance/department/engine)
+"inF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ioj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -35526,11 +35516,15 @@
 /obj/machinery/vending/wallmed{
 	pixel_y = 28
 	},
-/obj/structure/table/glass,
+/obj/structure/table_frame,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/folder/white,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/shard{
+	icon_state = "medium"
+	},
 /turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
+/area/station/maintenance/department/medical)
 "ipE" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -35793,6 +35787,7 @@
 /area/station/security/prison/workout)
 "iBY" = (
 /obj/machinery/space_heater,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "iCe" = (
@@ -35861,7 +35856,11 @@
 	name = "Coroner's Office";
 	req_access = list("morgue_secure")
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "iFA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35922,7 +35921,10 @@
 	c_tag = "Morgue"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/station/medical/morgue)
 "iIT" = (
 /turf/closed/wall/r_wall,
@@ -36048,7 +36050,9 @@
 /obj/item/crowbar,
 /obj/item/storage/box/bodybags,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
 /area/station/medical/morgue)
 "iMH" = (
 /obj/machinery/door/window/right/directional/south{
@@ -36060,6 +36064,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
+"iNc" = (
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "iNf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -36389,8 +36397,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "jfg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -36614,8 +36621,9 @@
 	idDoor = "virology_airlock_interior";
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Button";
-	pixel_x = -24;
-	req_access = list("virology")
+	pixel_x = -23;
+	req_access = list("virology");
+	pixel_y = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -36794,14 +36802,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"jxY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "jyJ" = (
 /obj/structure/closet/secure_closet/medical1{
 	pixel_x = -3
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/chemistry)
 "jze" = (
 /turf/closed/wall,
@@ -37020,11 +37033,11 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "jLT" = (
@@ -37404,7 +37417,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "kbi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "kbB" = (
@@ -37526,7 +37539,9 @@
 /area/station/engineering/supermatter/room)
 "kgz" = (
 /obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/station/medical/morgue)
 "kgR" = (
 /obj/structure/toilet{
@@ -37656,6 +37671,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"kkA" = (
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/chemistry)
 "kkF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38002,7 +38021,6 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "kvp" = (
@@ -38183,9 +38201,7 @@
 "kDS" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin{
-	name = "Corpse Disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
@@ -38206,6 +38222,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/structure/sign/poster/official/safety_eye_protection/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "kEy" = (
@@ -38319,10 +38336,25 @@
 /obj/item/paper_bin,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
+"kIr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kIy" = (
 /obj/machinery/atmospherics/components/tank/oxygen,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"kIW" = (
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "kJm" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow,
@@ -38490,6 +38522,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"kRk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kRq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -38568,8 +38610,9 @@
 "kUw" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/vending/wardrobe/coroner_wardrobe,
-/turf/open/floor/iron/dark,
+/obj/structure/bed/medical/emergency,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "kUH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -38818,6 +38861,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"ldv" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ldO" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 4
@@ -38897,7 +38947,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "lgK" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -38905,6 +38954,9 @@
 	},
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -38962,10 +39014,10 @@
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "liQ" = (
@@ -39006,7 +39058,6 @@
 /obj/item/scalpel{
 	pixel_y = 12
 	},
-/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
@@ -39091,7 +39142,7 @@
 	name = "Plumbing Shutter Control";
 	req_access = list("plumbing")
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -39143,7 +39194,7 @@
 /area/station/science/robotics/mechbay)
 "lou" = (
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -39194,9 +39245,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "lrb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -39225,6 +39273,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"lsm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lsr" = (
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze,
@@ -39401,7 +39455,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/station/medical/morgue)
 "lBJ" = (
 /obj/item/wrench,
@@ -39434,12 +39493,17 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"lDe" = (
+/obj/structure/bed/medical/emergency,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "lDw" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/carbon/human/species/monkey,
@@ -39466,7 +39530,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -39535,6 +39599,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"lJH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lJM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39812,6 +39886,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"lVf" = (
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/carpet,
+/area/station/medical/psychology)
 "lVR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -40259,6 +40337,10 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
+"mpi" = (
+/obj/effect/turf_decal/tile/medical,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "mpy" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
@@ -40275,7 +40357,7 @@
 /area/station/maintenance/department/engine)
 "mqg" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -40457,8 +40539,8 @@
 "mvW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/mannequin/skeleton,
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "mwg" = (
 /obj/structure/closet/crate{
@@ -40488,7 +40570,6 @@
 /area/station/tcommsat/computer)
 "mxV" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
@@ -40839,7 +40920,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -40986,6 +41067,14 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"mUZ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "mVK" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
@@ -41421,6 +41510,17 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"nmV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "nnh" = (
 /obj/structure/chair{
 	dir = 8
@@ -41494,7 +41594,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "npE" = (
-/obj/structure/bookcase/random/reference,
+/obj/structure/closet/secure_closet/psychology,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
 	},
@@ -41768,7 +41868,11 @@
 "nCP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/coroner,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "nCW" = (
 /obj/effect/landmark/start/hangover,
@@ -41943,8 +42047,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
-/obj/machinery/door/airlock/hatch{
-	name = "Morgue"
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue Access"
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/morgue)
@@ -42024,6 +42128,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"nOq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "nOt" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -42054,6 +42164,18 @@
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"nPO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "nQc" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -42079,6 +42201,12 @@
 /area/station/hallway/primary/central/fore)
 "nSe" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "nSz" = (
@@ -42153,14 +42281,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"nUb" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/bush/large/style_random,
-/obj/machinery/light/directional/east,
-/turf/open/floor/grass,
-/area/station/medical/treatment_center)
 "nUq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /turf/open/floor/iron,
@@ -42599,6 +42719,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"omB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "omR" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -43431,7 +43563,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/medical/morgue)
 "oRX" = (
 /obj/structure/closet,
@@ -43472,7 +43604,12 @@
 "oSq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/station/medical/morgue)
 "oSC" = (
 /obj/effect/turf_decal/bot_white,
@@ -43627,7 +43764,9 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/station/medical/morgue)
 "oXU" = (
 /obj/structure/disposalpipe/segment,
@@ -43856,14 +43995,8 @@
 /area/station/cargo/sorting)
 "phx" = (
 /obj/effect/landmark/blobstart,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
+/area/station/maintenance/department/medical)
 "pif" = (
 /obj/structure/hoop{
 	dir = 8
@@ -43909,9 +44042,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "pjB" = (
-/obj/machinery/disposal/bin{
-	name = "Corpse Disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -43927,7 +44058,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/medical/morgue)
 "pkj" = (
 /obj/structure/disposalpipe/segment,
@@ -43941,6 +44072,7 @@
 	},
 /obj/item/reagent_containers/cup/bottle/epinephrine,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "pkM" = (
@@ -44088,7 +44220,7 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/monastery)
 "prD" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "prO" = (
@@ -44271,7 +44403,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pAM" = (
-/obj/structure/chair/stool/bar/directional/west,
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "pBg" = (
@@ -44559,15 +44691,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
-"pKf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "pKg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -44663,10 +44786,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "pPN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "pQm" = (
@@ -45392,9 +45516,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "qqs" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "qqz" = (
@@ -45548,7 +45673,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "qwJ" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -45668,6 +45793,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"qCH" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qCS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/chair/sofa/bench/left{
@@ -45778,7 +45910,6 @@
 /area/station/commons/vacant_room/commissary)
 "qIl" = (
 /obj/machinery/computer/pandemic,
-/obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -46122,6 +46253,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/cargo/bitrunning/den)
+"qXl" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/station/medical/morgue)
 "qXo" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/sand/plating,
@@ -46163,7 +46302,7 @@
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 6
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/medical/morgue)
 "qYn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -46292,6 +46431,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "rdN" = (
@@ -46405,9 +46545,13 @@
 /area/station/cargo/storage)
 "rhJ" = (
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"rhN" = (
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "rie" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -46565,15 +46709,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"rpm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "rpu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -46593,12 +46728,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "rqv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/chair/office/tactical{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "rqB" = (
 /obj/machinery/conveyor{
@@ -46679,6 +46810,8 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "rtA" = (
@@ -46748,6 +46881,9 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "rut" = (
@@ -46767,9 +46903,10 @@
 /area/station/service/library)
 "rvH" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery/white,
 /obj/machinery/shower/directional/south,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/fluff/shower_drain,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "rvO" = (
@@ -46818,21 +46955,16 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/science/xenobiology)
 "ryC" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery/white,
 /obj/machinery/shower/directional/south,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/fluff/shower_drain,
 /turf/open/floor/iron,
 /area/station/medical/cryo)
 "ryR" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/reinforced,
-/obj/machinery/computer/records/medical/laptop{
-	dir = 4;
-	pixel_x = 3;
-	pixel_y = -1
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark,
+/obj/machinery/newscaster/directional/west,
+/obj/structure/mannequin/skeleton,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "ryS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -46934,17 +47066,11 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/requests_console/directional/south{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_y = 30
-	},
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/effect/mapping_helpers/requests_console/supplies,
 /obj/machinery/disposal/bin{
 	name = "Disposal To Space"
 	},
 /obj/effect/turf_decal/tile/green/fourcorners,
+/obj/structure/sign/warning/deathsposal/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "rCm" = (
@@ -47055,7 +47181,7 @@
 /area/station/cargo/bitrunning/den)
 "rIm" = (
 /obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -47079,6 +47205,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"rJP" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/sign/departments/psychology/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "rJS" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/structure/closet/secure_closet/freezer/kitchen,
@@ -47142,10 +47273,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
 "rLd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "rLi" = (
@@ -48200,6 +48334,7 @@
 /area/station/medical/surgery/theatre)
 "sCE" = (
 /obj/structure/reagent_dispensers/plumbed,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "sCQ" = (
@@ -48526,6 +48661,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "sSs" = (
@@ -48608,7 +48744,6 @@
 /area/station/engineering/supermatter/room)
 "sWH" = (
 /obj/machinery/chem_dispenser,
-/obj/structure/sign/poster/official/safety_eye_protection/directional/west,
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -48722,11 +48857,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/shower/directional/south,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 4
 	},
+/obj/structure/fluff/shower_drain,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "tan" = (
@@ -48786,18 +48921,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
-"tbQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "tbS" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Morgue"
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue Access"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -49370,11 +49496,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "tta" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ttA" = (
@@ -49501,8 +49627,7 @@
 /area/station/science/lab)
 "txm" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "txu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -49523,7 +49648,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -49584,6 +49709,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"tyP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/morgue)
 "tyT" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -49687,9 +49818,7 @@
 /area/station/service/library)
 "tCi" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/disposal/bin{
-	name = "Corpse Disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
@@ -49831,10 +49960,8 @@
 "tIx" = (
 /obj/structure/table/glass,
 /obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/chemistry)
 "tIQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -49979,18 +50106,18 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tQO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "tRc" = (
 /obj/structure/ore_box,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"tRT" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "tSK" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -50221,15 +50348,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
-"ucR" = (
-/obj/item/extinguisher,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/morgue)
 "udb" = (
 /obj/structure/sign/poster/random/directional/north,
 /obj/effect/turf_decal/tile/brown{
@@ -50299,7 +50417,7 @@
 	c_tag = "Chemistry East";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -50371,6 +50489,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "ufo" = (
@@ -50403,7 +50522,9 @@
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 9
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/medical/morgue)
 "uhk" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -50461,7 +50582,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -50509,6 +50630,7 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ukz" = (
@@ -50567,11 +50689,14 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "uly" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced,
-/obj/machinery/newscaster/directional/west,
-/obj/effect/spawner/surgery_tray/full/morgue,
-/turf/open/floor/iron/dark,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 4;
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "ulV" = (
 /obj/effect/landmark/event_spawn,
@@ -50579,15 +50704,14 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "umb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/medical/morgue)
 "umd" = (
 /obj/effect/spawner/random/trash/mess,
@@ -50682,14 +50806,13 @@
 /area/station/engineering/supermatter/room)
 "upW" = (
 /obj/machinery/space_heater,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "uqf" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/chemistry)
 "uqs" = (
 /obj/structure/flora/bush/large/style_random,
@@ -51180,12 +51303,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"uIo" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "uIv" = (
 /obj/structure/bookcase/random/adult,
 /obj/effect/decal/cleanable/dirt,
@@ -51248,10 +51365,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "uNc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "uNp" = (
 /obj/machinery/duct,
@@ -51346,7 +51464,7 @@
 /area/station/engineering/supermatter)
 "uRE" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -51566,10 +51684,10 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "uXp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "uXv" = (
@@ -51626,8 +51744,6 @@
 /area/station/maintenance/department/cargo)
 "uYF" = (
 /obj/machinery/light/small/directional/north,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
@@ -51790,9 +51906,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/disposal/bin{
-	name = "Corpse Disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
@@ -51807,8 +51921,9 @@
 "vgk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/station/medical/morgue)
 "vgm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -51916,9 +52031,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/disposal/bin{
-	name = "Corpse Disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
@@ -52143,7 +52256,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/station/medical/morgue)
 "vxg" = (
 /obj/structure/disposalpipe/segment{
@@ -52198,6 +52311,7 @@
 "vyL" = (
 /obj/machinery/stasis,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/defibrillator_mount/directional/east,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "vzg" = (
@@ -52398,14 +52512,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 5
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/medical/morgue)
 "vIU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -52551,7 +52664,6 @@
 /area/station/ai_monitored/turret_protected/aisat/solars)
 "vOB" = (
 /obj/effect/landmark/start/paramedic,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "vOQ" = (
@@ -52696,6 +52808,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "vSl" = (
@@ -52879,8 +52992,8 @@
 /obj/machinery/stasis{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/defibrillator_mount/directional/west,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "vZJ" = (
@@ -52923,12 +53036,22 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/defibrillator_mount/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "wbb" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"wbq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "wbs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -52990,6 +53113,7 @@
 "wcx" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/defibrillator_mount/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "wcP" = (
@@ -53140,7 +53264,9 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
 /area/station/medical/morgue)
 "whH" = (
 /obj/structure/chair/wood,
@@ -53198,6 +53324,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"wjD" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "wjK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -53359,14 +53491,13 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wqC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/medical/morgue)
 "wrO" = (
 /obj/structure/lattice/catwalk,
@@ -53899,15 +54030,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"wNG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "wNI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -54017,7 +54139,6 @@
 "wQy" = (
 /obj/structure/chair/sofa/left/brown,
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/light_switch/directional/east,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "wQE" = (
@@ -54413,7 +54534,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/medical/morgue)
 "xcR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
@@ -54803,6 +54924,9 @@
 "xmg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "xmE" = (
@@ -54971,15 +55095,6 @@
 	luminosity = 2
 	},
 /area/station/maintenance/department/science/xenobiology)
-"xsT" = (
-/obj/structure/closet/wardrobe/red,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
-"xsZ" = (
-/obj/structure/chair,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "xte" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -55234,10 +55349,10 @@
 "xBk" = (
 /obj/structure/bed/medical/emergency,
 /obj/machinery/iv_drip,
-/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "xBB" = (
@@ -55561,14 +55676,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xOm" = (
-/obj/machinery/disposal/delivery_chute{
-	dir = 4;
-	name = "Morgue Waste Chute";
-	pixel_x = -7
+/obj/machinery/computer/operating{
+	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "xOq" = (
 /obj/effect/turf_decal/tile/blue{
@@ -55706,6 +55817,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "xUX" = (
@@ -55820,7 +55932,6 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
 "ybu" = (
-/obj/effect/turf_decal/plaque,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
@@ -55897,6 +56008,11 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"ydo" = (
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/chemistry)
 "ydu" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
@@ -55931,6 +56047,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"yfK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "yfO" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
@@ -55949,7 +56072,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ygW" = (
@@ -77300,14 +77423,14 @@ bva
 bHT
 bJi
 bva
-bsn
+bVC
 bME
 bva
 qvx
 bHT
 bNQ
 xtI
-xtI
+hJn
 xtI
 olY
 bDi
@@ -78312,7 +78435,7 @@ ryR
 dYq
 giC
 bnu
-bnu
+gyD
 eLG
 bws
 apD
@@ -78574,7 +78697,7 @@ nKU
 cXd
 cXd
 foA
-ucR
+cXd
 xhs
 bDj
 pEI
@@ -79076,8 +79199,8 @@ eBf
 omu
 qUe
 bjK
-czJ
-csl
+rhN
+txm
 txm
 iFm
 kUw
@@ -79101,7 +79224,7 @@ sEN
 sEN
 ltE
 und
-bKq
+bKn
 bKn
 bEr
 bEr
@@ -79335,7 +79458,7 @@ bjK
 bjK
 vwu
 rMy
-rMy
+tyP
 oSq
 lBu
 lrb
@@ -79343,7 +79466,7 @@ iNf
 pjV
 tqC
 bwu
-gFD
+bye
 kbi
 fDf
 bAO
@@ -79847,7 +79970,7 @@ ptL
 ptL
 biO
 biY
-whr
+qXl
 oXp
 whr
 biY
@@ -79858,8 +79981,8 @@ biY
 tqC
 feU
 bwv
-bAQ
-bzG
+bye
+omB
 bye
 bBZ
 bjc
@@ -80115,14 +80238,14 @@ imE
 tqC
 tqC
 bwx
-bye
+gFD
 bzG
 uCe
 bCa
 bjc
 kZq
 uWC
-boN
+rJP
 sOB
 uYF
 pDZ
@@ -80886,7 +81009,7 @@ iTf
 qRO
 xLa
 koW
-bzK
+koW
 lgK
 btV
 anG
@@ -81144,7 +81267,7 @@ htK
 rtD
 tWt
 pPN
-cKQ
+kIW
 cKQ
 suU
 gZl
@@ -81389,8 +81512,8 @@ xPQ
 bik
 nmF
 gQI
-blb
 bml
+mUZ
 vtX
 gQI
 ryC
@@ -81404,13 +81527,13 @@ qma
 duu
 qma
 lOK
-flq
+qma
 esz
 qma
 bHY
 sOB
 wQy
-bpz
+lVf
 aJY
 bNO
 uOA
@@ -82194,7 +82317,7 @@ bDi
 umd
 xbD
 bDi
-bsn
+bVC
 bDi
 sWN
 uVK
@@ -82427,7 +82550,7 @@ kVN
 bua
 bvi
 tcm
-tcm
+lDe
 bub
 bub
 bub
@@ -82443,7 +82566,7 @@ bva
 bNR
 pHN
 fAE
-bsn
+bVC
 kTn
 bva
 sZP
@@ -83463,11 +83586,11 @@ xyI
 bJb
 bJb
 sVp
-bJb
+wjD
 bJb
 bJb
 bLG
-bpi
+bJb
 bJb
 tHl
 lRN
@@ -83720,12 +83843,12 @@ lRN
 bEz
 upW
 oxA
-hBg
+fFP
 hBg
 fbb
 fbb
 oPH
-xsZ
+oXV
 eMp
 lRN
 pQm
@@ -83962,7 +84085,7 @@ iDT
 vyL
 pku
 qib
-nUb
+bjQ
 anB
 anD
 hMt
@@ -84240,7 +84363,7 @@ uik
 txK
 bMK
 lRN
-eMp
+hgq
 lRN
 bQp
 ptK
@@ -84482,17 +84605,17 @@ xte
 bIy
 uOn
 bvm
-uOn
 oXU
+uOn
 gKB
 tli
 peY
 bCp
 jfg
-egX
+wbq
 bsK
-tcX
-egX
+bsK
+yfK
 bsK
 bsK
 ygx
@@ -84746,10 +84869,10 @@ bIi
 wLW
 bCp
 jfg
-tbQ
-qwJ
-cbQ
-tbQ
+egX
+bsK
+bsK
+tcX
 bsK
 bwV
 bMM
@@ -85003,8 +85126,8 @@ qnJ
 bja
 bja
 jfg
-uXp
-xqq
+jxY
+dMR
 dMR
 uXp
 bsK
@@ -85254,16 +85377,16 @@ brh
 brh
 bvl
 bwO
-yat
+bja
 bzZ
 bsJ
 bCr
 bja
 tta
-uXp
-xqq
-dMR
-uXp
+lJH
+tRT
+tRT
+gFf
 bsK
 bAg
 lRN
@@ -85516,11 +85639,11 @@ fgs
 xmg
 buk
 bja
-jfg
-uXp
-xqq
-dMR
-uXp
+qCH
+lJH
+tRT
+tRT
+gFf
 bsK
 bLL
 lRN
@@ -85773,9 +85896,9 @@ brl
 bsL
 bFl
 bja
-pKf
-uXp
-xqq
+jfg
+nPO
+dMR
 dMR
 rLd
 bsK
@@ -86028,13 +86151,13 @@ cqs
 yat
 hjy
 nSe
-xsT
-yat
+buk
+bja
 qqs
-uXp
+kRk
 xqq
-dMR
 xqq
+kIr
 bsK
 prD
 lRN
@@ -86286,12 +86409,12 @@ yat
 brm
 bsN
 bCv
-yat
-qqs
-uXp
+bja
+ldv
+kRk
 xqq
-dMR
 xqq
+kIr
 bsK
 bLM
 bMN
@@ -86545,10 +86668,10 @@ bja
 bja
 bja
 uRE
-uXp
-xqq
+dxA
 dMR
-xqq
+dMR
+inF
 bsK
 ezC
 jCw
@@ -86802,11 +86925,11 @@ uqf
 bCx
 byw
 dcN
-wNG
-uIo
-rpm
-uIo
-bwV
+egX
+bsK
+bsK
+tcX
+mpi
 qwJ
 bAh
 lRN
@@ -87054,15 +87177,15 @@ ouo
 xHJ
 bwT
 eBd
+kkA
+kkA
+kkA
+ydo
+bsK
+nOq
 bsK
 bsK
-bsK
-bsK
-bsK
-bsK
-bsK
-bsK
-bsK
+lsm
 prD
 byz
 ooh
@@ -87567,9 +87690,9 @@ bwT
 qHa
 pxw
 dRj
-hEC
-hEC
-hEC
+lRN
+lRN
+lRN
 lRN
 lRN
 lRN
@@ -87824,7 +87947,7 @@ kEb
 bun
 lnl
 fEU
-hEC
+lRN
 ipu
 phx
 azR
@@ -88081,7 +88204,7 @@ lRN
 lRN
 vSL
 lRN
-hEC
+lRN
 cIe
 fby
 oJj
@@ -88333,7 +88456,7 @@ aDm
 dhy
 bmB
 oJj
-oPH
+iNc
 oPH
 oPH
 eMp
@@ -88596,7 +88719,7 @@ gVk
 gVk
 gVk
 gVk
-gVk
+nmV
 gVk
 uQB
 oWN


### PR DESCRIPTION

## About The Pull Request
This PR makes a number of light alterations to Pubby Station's medical bay. One of the primary changes of note is the removal of the (currently nonfunctional and generally confusing) corpse disposal system. Defibrillator wall mounts have also been added where needed, and the 3x3 "abandoned medbay" area has been integrated into medical maintenance due to its insufficient "abandoned mebday"-ness. Images may be found in the results of the MapDiffBot check on this PR as per always.
## Why It's Good For The Game
Pubby Station's medical bay currently has a few functional/aesthetic faults, and this PR addresses them while also improving the appearance of the area overall. (Also most of the disposal units in the medical bay were labeled as "corpse disposal" units even though 75% of them don't actually lead to the morgue.)
## Changelog
:cl:
map: Edited Pubby Station's medical bay and fixed a few things within it.
/:cl:
