### PR TITLE
Bloodsucker Bite Ability Bug Fix

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
@@ -88,6 +88,7 @@
 	owner.balloon_alert(owner, "feeding off [feed_target]...")
 	if(!do_after(owner, feed_timer, feed_target, NONE, TRUE))
 		owner.balloon_alert(owner, "feed stopped")
+		target_ref = null
 		DeactivatePower()
 		return
 	if(owner.pulling == feed_target && owner.grab_state >= GRAB_AGGRESSIVE)


### PR DESCRIPTION

## About The Pull Request
This PR implements a quick fix for a bug that renders the Bloodsucker Bite ability unusable. The bug seems to be caused by the improper clearing of the 'target_ref' variable upon the ability's failure to initiate.
## Why It's Good For The Game
This fixes [this](https://github.com/fulpstation/fulpstation/issues/1313) issue.
## Changelog
:cl:
fix: Fixed a bug involving the Bloodsucker Bite ability.
/:cl:
