### PR TITLE
Adds the Bonfire Burning Sound Loop to Braziers

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -546,10 +546,7 @@
 
 //Quieter burning sound loop based off of 'code\datums\looping_sounds\burning.dm'
 /datum/looping_sound/burning/brazier
-	mid_sounds = 'sound/effects/comfyfire.ogg'
-	mid_length = 5 SECONDS
 	volume = 15
-	vary = TRUE
 	ignore_walls = FALSE
 
 /// Blood Throne - Allows Bloodsuckers to remotely speak with their Vassals. - Code (Mostly) stolen from comfy chairs (armrests) and chairs (layers)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_crypt.dm
@@ -528,12 +528,29 @@
 	vamp_desc = "You alone can toggle this from afar by <b>ctrl-clicking</b> it."
 	vassal_desc = "You can toggle this by <b>clicking</b> it."
 
+	/// Our slightly quieter looping burn sound effect; copied over from 'bonfire.dm'
+	var/datum/looping_sound/burning/brazier/burning_loop
+
+/obj/structure/bloodsucker/lighting/brazier/Initialize()
+	. = ..()
+	burning_loop = new(src)
+
 /obj/structure/bloodsucker/lighting/brazier/toggle(mob/user)
 	. = ..()
 	if(lit)
 		particles = new /particles/brazier
+		burning_loop.start()
 	else
 		QDEL_NULL(particles)
+		burning_loop.stop()
+
+//Quieter burning sound loop based off of 'code\datums\looping_sounds\burning.dm'
+/datum/looping_sound/burning/brazier
+	mid_sounds = 'sound/effects/comfyfire.ogg'
+	mid_length = 5 SECONDS
+	volume = 15
+	vary = TRUE
+	ignore_walls = FALSE
 
 /// Blood Throne - Allows Bloodsuckers to remotely speak with their Vassals. - Code (Mostly) stolen from comfy chairs (armrests) and chairs (layers)
 /obj/structure/bloodsucker/bloodthrone


### PR DESCRIPTION

## About The Pull Request
This PR adds a quieter version of the burning sound loop used by bonfires to bloodsucker braziers. 
## Why It's Good For The Game
This small aesthetic detail might add to the general ambience of bloodsucker lairs.
## Changelog
:cl:
add: Added the bonfire burning sound loop to braziers.
/:cl:
