### PR TITLE
Fixes/Simplifies the "Cateorize" Admin Smite

### DIFF
--- a/fulp_modules/features/admin_chicanery/smites/catification.dm
+++ b/fulp_modules/features/admin_chicanery/smites/catification.dm
@@ -1,72 +1,9 @@
 /// Catification smite
-/// Allows an admin to spawn a cateor near a target and direct it at them.
+/// Allows an admin to spawn a cat meteor at a target's location and instantly hit them with it.
 /datum/smite/catify
 	name = "Cateorize"
 
-	/// Boolean indicating whether or not we stun the target before launching a cateor at them.
-	var/stun_target = TRUE
-	/// Boolean indicating whether or not the user has accepted the smite's disclaimer.
-	var/warning_accepted = FALSE
-
-/datum/smite/catify/configure(client/user)
-	. = ..()
-	/// Warn the admin about the exact function of the smite.
-	warning_accepted = input(user,
-						"This smite will spawn a cateor at a random point within a roughly three \
-						tile range of its target. The cateor doesn't have perfect homing, and it is \
-						liable to hit any mob between it and the target. Please ensure that no mobs \
-						are present near the target unless you wish to risk hitting them.",
-						"DISCLAIMER",
-						FALSE) in list("ACCEPT DISCLAIMER", "ABORT")
-	if(warning_accepted == "ACCEPT DISCLAIMER")
-		warning_accepted = TRUE
-	if(warning_accepted == "ABORT")
-		warning_accepted = FALSE
-		should_log = FALSE
-		return FALSE
-
-	/// Optional stunning
-	stun_target = input(user,
-						"Stun target once the cat meteor is launched? (Please keep the cateor's \
-						imperfect homing in mind.)",
-						"Stun Configuration",
-						TRUE) in list("Yes", "No")
-	if(stun_target == "Yes")
-		stun_target = TRUE
-	if(stun_target == "No")
-		stun_target = FALSE
-
 /datum/smite/catify/effect(client/user, mob/living/target)
 	. = ..()
-	if(warning_accepted == FALSE) //We should've returned FALSE on 'configure()', but just in case...
-		return
-
-	if(stun_target)
-		if(iscarbon(target))
-			var/mob/living/carbon/victim = target
-			victim.Immobilize(10 SECONDS, TRUE)
-		else
-			var/launch_anyways
-			launch_anyways = input(user,
-			"Can't stun a non-carbon mob, launch cateor anyways?",
-			"Launch Anyways?",
-			FALSE) in list("Yes", "No")
-			if(launch_anyways == "Yes")
-				launch_anyways = TRUE
-			if(launch_anyways == "No")
-				launch_anyways = FALSE
-			if(!launch_anyways)
-				return
-
-	var/turf/T = get_turf(target)
-	var/list/valid_turfs = list()
-	/// Copied over with adjustment from 'pandora.dm', gets a spawnpoint for our cateor at a certain
-	/// distance from the target.
-	for(var/t in spiral_range_turfs(3, T))
-		if(get_dist(t, T) > 1)
-			valid_turfs.Add(t)
-
-	/// Spawn the cateor and launch it.
-	var/obj/effect/meteor/cateor/new_cateor = new /obj/effect/meteor/cateor(pick(valid_turfs), get_turf(target))
-	addtimer(CALLBACK(new_cateor, PROC_REF(Destroy)), 5 SECONDS)
-	new_cateor.chase_target(get_turf(target), home = TRUE)
+	var/obj/effect/meteor/cateor/new_cateor = new /obj/effect/meteor/cateor(get_turf(target), NONE)
+	new_cateor.Bump(target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes the (currently nonfunctional) "cateorize" smite by simplifying it. Previously the smite worked by spawning a cateor near a target and directing it towards them, but with this PR it'll function by spawning a cateor _at_ a target to instantaneously hit them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The cateorize smite isn't working for some reason, and I understand neither why that is nor what has caused it. It seems to be something involving an error in what I could only vaguely (and perhaps nonsensically) describe as "movement loop override logic". My brief attempts at debugging the issue have failed, and this solution will fix it while also making the smite much more reliable overall.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Fixed the cateorize smite by simplifying it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
