### PR TITLE
Makes Bloodsucker Abilities Part of a Tab on the Status Panel

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
@@ -7,6 +7,7 @@
 	button_icon_state = "power_feed"
 	buttontooltipstyle = "cult"
 	transparent_when_unavailable = TRUE
+	panel = "Bloodsucker"
 
 	/// Cooldown you'll have to wait between each use, decreases depending on level.
 	cooldown_time = 2 SECONDS
@@ -53,6 +54,14 @@
 	bloodsuckerdatum_power = null
 	return ..()
 
+/datum/action/cooldown/bloodsucker/set_statpanel_format()
+	. = ..()
+	if(!islist(.))
+		return
+
+	if(active)
+		.[PANEL_DISPLAY_STATUS] = "ACTIVE"
+
 /datum/action/cooldown/bloodsucker/IsAvailable(feedback = FALSE)
 	return next_use_time <= world.time
 
@@ -74,6 +83,7 @@
 	if(!(power_flags & BP_AM_TOGGLE) || !active)
 		DeactivatePower()
 	return TRUE
+
 
 /datum/action/cooldown/bloodsucker/proc/can_pay_cost()
 	if(!owner || !owner.mind)


### PR DESCRIPTION

## About The Pull Request
This PR gives bloodsucker abilities their own action subpanel/tab as part of the typical SS13/BYOND status panel (the one that's always on the side of the screen and has a lot of clickable text commands). This functions in much the same way as it does with spells (the tab is only given to people who receive the particular abilities associated with it, et cetera).
## Why It's Good For The Game
These changes allow bloodsuckers to use their abilities even if their ability HUD buttons cease to function for whatever reason. 
## Changelog
:cl:
qol: Bloodsucker actions are now part of a subpanel/tab within the standard BYOND game status panel.
/:cl:
