### PR TITLE
Summon Dancefloor Bug Fixes 2

### DIFF
--- a/fulp_modules/features/spells/_spells.dm
+++ b/fulp_modules/features/spells/_spells.dm
@@ -39,7 +39,7 @@
 
 	funky_turfs = RANGE_TURFS(1, owner)
 	for(var/turf/closed/solid in funky_turfs)
-		to_chat(owner, span_warning("You're too close to a wall to case [src]."))
+		to_chat(owner, span_warning("You're too close to a wall to cast [src]."))
 		return SPELL_CANCEL_CAST
 
 /datum/action/cooldown/spell/summon_dancefloor/cast(atom/target)

--- a/fulp_modules/features/spells/_spells.dm
+++ b/fulp_modules/features/spells/_spells.dm
@@ -8,6 +8,7 @@
 	cooldown_time = 20 SECONDS //20 seconds, so the effects can't be spammed
 	invocation_type = INVOCATION_SHOUT
 	invocation = "DR'P TH' B'T!!!"
+	spell_max_level = 1
 
 	button_icon = 'icons/mob/actions/actions_minor_antag.dmi'
 	button_icon_state = "funk"
@@ -32,9 +33,13 @@
 
 /datum/action/cooldown/spell/summon_dancefloor/before_cast(atom/cast_on)
 	. = ..()
+	if(!isturf(owner.loc))
+		to_chat(owner, span_warning("You need to be on an open floor to cast [src]."))
+		return SPELL_CANCEL_CAST
+
 	funky_turfs = RANGE_TURFS(1, owner)
 	for(var/turf/closed/solid in funky_turfs)
-		to_chat(owner, span_warning("You're too close to a wall."))
+		to_chat(owner, span_warning("You're too close to a wall to case [src]."))
 		return SPELL_CANCEL_CAST
 
 /datum/action/cooldown/spell/summon_dancefloor/cast(atom/target)
@@ -103,6 +108,7 @@
 	for(var/i in 1 to 25)
 		if(i == 1)
 			central_sparkle = new /obj/effect/overlay/sparkles(target_turf)
+			sparkles += central_sparkle
 		var/obj/effect/overlay/sparkles/S = new /obj/effect/overlay/sparkles(target_turf)
 		sparkles += S
 		switch(i)

--- a/fulp_modules/features/spells/_spells.dm
+++ b/fulp_modules/features/spells/_spells.dm
@@ -33,11 +33,11 @@
 
 /datum/action/cooldown/spell/summon_dancefloor/before_cast(atom/cast_on)
 	. = ..()
-	if(!isturf(owner.loc))
-		to_chat(owner, span_warning("You need to be on an open floor to cast [src]."))
+	if(!get_turf(owner))
+		to_chat(owner, span_warning("You can't cast [src] here!"))
 		return SPELL_CANCEL_CAST
 
-	funky_turfs = RANGE_TURFS(1, owner)
+	funky_turfs = RANGE_TURFS(1, get_turf(owner))
 	for(var/turf/closed/solid in funky_turfs)
 		to_chat(owner, span_warning("You're too close to a wall to cast [src]."))
 		return SPELL_CANCEL_CAST


### PR DESCRIPTION
## About The Pull Request
In PR #1291 I attempted to fix some bugs involving the Summon Dancefloor spell. For the most part those fixes worked, but it seems I missed a few things. This PR makes the following additional fixes:

1. Summon Dancefloor can no longer be pointlessly upgraded by wizards.
2. Summon Dancefloor will function a bit more reliably if its user isn't directly on a tile.
3. The "sparkles" visual effect copied to Summon Dancefloor from dance machines now properly deletes itself in tandem with its dancefloor.
## Why It's Good For The Game
These changes make a Fulpstation spell a bit less buggy.
## Changelog
:cl:
fix: Fixed a few minor bugs involving the spell Summon Dancefloor.
/:cl:
