### PR TITLE
Corrects one missing mail splitter in TheiaStation

### DIFF
--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -59744,9 +59744,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig/hallway)
 "vxg" = (
-/obj/structure/disposalpipe/junction/flip{
+/obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/mail_sorting/service/dormitories,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "vxh" = (

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -62,3 +62,6 @@ endmap
 
 map runtimestation
 endmap
+
+map theiastation
+endmap

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -62,6 +62,3 @@ endmap
 
 map runtimestation
 endmap
-
-map theiastation
-endmap


### PR DESCRIPTION

## About The Pull Request

Unfortunately, our last proposal worked exactly as advertised, if you read the fine print. A single destination, Dormitories, did not work properly. Now it does.
## Why It's Good For The Game

Bugfix
## Changelog
:cl:
map: Packages addressed to "Dormitories" now arrive correctly on Theiastation
/:cl:
