### PR TITLE
Replaces a Pole on Pubby Station

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -28741,6 +28741,7 @@
 "cBr" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
+/obj/effect/spawner/random/entertainment/gambling,
 /turf/open/floor/carpet,
 /area/station/service/abandoned_gambling_den)
 "cBs" = (
@@ -33399,7 +33400,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gna" = (
-/turf/open/floor/iron/stairs/medium,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/table/wood,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/abandoned_gambling_den)
 "gne" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -37944,8 +37953,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "klV" = (
-/obj/item/clothing/under/rank/civilian/clown/sexy,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/abandoned_gambling_den)
 "kmn" = (
 /turf/open/floor/iron/white,
@@ -41762,11 +41770,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "nnh" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/item/stack/spacecash/c10,
-/turf/open/floor/iron/dark,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/abandoned_gambling_den)
 "nnl" = (
 /obj/structure/table,
@@ -43676,7 +43681,15 @@
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/storage)
 "oMN" = (
-/turf/open/floor/iron/stairs/left,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/abandoned_gambling_den)
 "oMV" = (
 /obj/machinery/door/poddoor/shutters{
@@ -48321,14 +48334,8 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "sqh" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/structure/sign/poster/contraband/random/directional/east,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/abandoned_gambling_den)
 "sqi" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
@@ -49945,11 +49952,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "tvj" = (
-/obj/structure/festivus{
-	anchored = 1;
-	name = "pole"
+/obj/structure/chair/sofa/corner/maroon{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/abandoned_gambling_den)
 "tvq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -52434,14 +52440,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "vlF" = (
-/obj/item/coin/silver,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
 /obj/structure/light_construct/small{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/chair/sofa/left/maroon{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/abandoned_gambling_den)
 "vmo" = (
 /obj/machinery/camera/directional/west{
@@ -54940,7 +54945,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "xbJ" = (
-/turf/open/floor/iron/dark,
+/obj/structure/chair/sofa/right/maroon{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/abandoned_gambling_den)
 "xbX" = (
 /obj/machinery/conveyor{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -37476,10 +37476,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"jTL" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/space/basic,
-/area/space)
 "jTV" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/structure/table,
@@ -103808,7 +103804,7 @@ cxg
 bbG
 aVI
 bbG
-jTL
+bGI
 foE
 ech
 cxg


### PR DESCRIPTION
## About The Pull Request
This pull request replaces a pole in Pubby Station's abandoned gambling den (and also details the area around it just a bit). After making this PR I noticed that the CI Suite check for Pubbystation was failing due to a singular improperly area'd window near cargo, so that has been fixed as well.

<details><summary>Screenshot of the old (prior to the thing with the singular window ruining it) MapDiffBot check:</summary>

![image](https://github.com/user-attachments/assets/df5bfbb8-0ad5-40c9-83ee-2d9ab170f3ed)

</details>

## Why It's Good For The Game
The pole is an explicit reference which probably doesn't fit with Fulpstation's intentions as a server.
## Changelog
:cl:
map: Removed a pole from Pubby Station's abandoned gambling den.
/:cl:
