### PR TITLE
Cateor Bug Fixes 

### DIFF
--- a/fulp_modules/features/events/cateors/cateor.dm
+++ b/fulp_modules/features/events/cateors/cateor.dm
@@ -112,6 +112,11 @@
 			antennae.Remove(humanoid, special = TRUE)
 			qdel(antennae)
 
+		var/obj/item/organ/tail = humanoid.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+		if(tail)
+			tail.Remove(humanoid, special = TRUE)
+			qdel(tail)
+
 		purrbation_apply(humanoid, TRUE)
 
 		to_chat(humanoid, span_reallybig(span_hypnophrase("WOAW!~")))

--- a/fulp_modules/features/events/cateors/cateor.dm
+++ b/fulp_modules/features/events/cateors/cateor.dm
@@ -106,12 +106,25 @@
 
 		explosion(humanoid, light_impact_range = 1, explosion_cause = src)
 
-		//Remove moth antennae if present since 'purrbation_apply()' doesn't do that.
+		// Remove moth antennae if present since 'purrbation_apply()' doesn't do that.
 		var/obj/item/organ/spines/antennae = humanoid.get_organ_slot(ORGAN_SLOT_EXTERNAL_ANTENNAE)
 		if(antennae)
 			antennae.Remove(humanoid, special = TRUE)
 			qdel(antennae)
 
+		// Remove horns if present.
+		var/obj/item/organ/horns = humanoid.get_organ_slot(ORGAN_SLOT_EXTERNAL_HORNS)
+		if(horns)
+			horns.Remove(humanoid, special = TRUE)
+			qdel(horns)
+
+		// Remove frills if present.
+		var/obj/item/organ/frills = humanoid.get_organ_slot(ORGAN_SLOT_EXTERNAL_FRILLS)
+		if(frills)
+			frills.Remove(humanoid, special = TRUE)
+			qdel(frills)
+
+		// Remove tails if present.
 		var/obj/item/organ/tail = humanoid.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
 		if(tail)
 			tail.Remove(humanoid, special = TRUE)

--- a/fulp_modules/features/events/cateors/cateor.dm
+++ b/fulp_modules/features/events/cateors/cateor.dm
@@ -56,16 +56,15 @@
 	Bump(thing_that_touched_the_cateor)
 
 /// Called 1.25 decisecond after a cateor calls 'Bump()' on a target.
-/// Global because cateors will be deleted by the time this is called, so it can't be a proc belonging
-/// to cateors themselves.
+/// Global because cateors will be deleted by the time this is called,
+/// so it can't be a proc belonging to cateors themselves.
 /proc/cateor_hit_effects(mob/living/target)
 	target.extinguish() //Just in case it lit them on fire...
 	new /obj/effect/temp_visual/cateor_hit(get_turf(target))
 
 /**
- * 'purrbation_apply()' removes the external spines on mobs that it hits, but it
- * doesn't do so properly. Spines are also just one external organ of many that we
- * need to remove prior to giving our target cat organs.
+ * 'purrbation_apply()' removes the external spines on mobs that it hits, but spines are
+ * just one external organ of many that we "need" to remove prior to giving our target cat organs.
  *
  * This proc properly removes all relevant external organs from our cateor's target
  * using 'mob_remove()' rather than 'Remove()', which is used by 'purrbation_apply()'.
@@ -80,11 +79,6 @@
 	if(current_horns)
 		current_horns.mob_remove(target, special = TRUE)
 		qdel(current_horns)
-
-	var/obj/item/organ/frills/current_frilles = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_FRILLS)
-	if(current_frilles)
-		current_frilles.mob_remove(target, special = TRUE)
-		qdel(current_frilles)
 
 	var/obj/item/organ/tail/current_tail = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
 	if(current_tail)
@@ -127,12 +121,27 @@
 			qdel(src)
 			return
 
-	if(istype(target, /mob/living/carbon/human)) //Humanoids get lightly exploded and felinidified
+	if(istype(target, /mob/living/carbon/human)) //(Most) humanoids get lightly exploded and felinidified
 		var/mob/living/carbon/humanoid = target
-		if(isfelinid(target)) //Felinids just get stunned
+
+		//First we check to see if the target already has cat ears and a cat tail.
+		var/obj/item/organ/ears/possible_cat_ears = humanoid.get_organ_slot(ORGAN_SLOT_EARS)
+		var/cat_ears_confirmed = FALSE
+		var/obj/item/organ/tail/possible_cat_tail = humanoid.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+		var/cat_tail_confirmed = FALSE
+
+		if(possible_cat_ears && istype(possible_cat_ears, /obj/item/organ/ears/cat))
+			cat_ears_confirmed = TRUE
+
+		if(possible_cat_tail && istype(possible_cat_tail, /obj/item/organ/tail/cat))
+			cat_tail_confirmed = TRUE
+
+		 //Felinids/those already catified just get stunned.
+		if(isfelinid(target) || (cat_ears_confirmed && cat_tail_confirmed))
 			humanoid.emote("spin")
 			humanoid.Paralyze(10 SECONDS)
 			humanoid.Knockdown(15 SECONDS)
+			target.apply_status_effect(/datum/status_effect/drugginess, 15 SECONDS)
 			playsound(src.loc, 'fulp_modules/sounds/effects/anime_wow.ogg', 25)
 			to_chat(humanoid, (span_hypnophrase("The overwhelming smell of catnip permeates the air...")))
 			qdel(src)
@@ -141,6 +150,9 @@
 		explosion(humanoid, light_impact_range = 1, explosion_cause = src)
 
 		remove_relevant_organs(humanoid)
+		/// These next two lines are necessary, and I am not be able to explain why.
+		humanoid.dna.features["ears"] = "Cat"
+		humanoid.dna.features["tail_cat"] = "Cat"
 		purrbation_apply(humanoid, TRUE)
 
 		to_chat(humanoid, span_reallybig(span_hypnophrase("WOAW!~")))

--- a/fulp_modules/features/events/cateors/cateor.dm
+++ b/fulp_modules/features/events/cateors/cateor.dm
@@ -62,6 +62,40 @@
 	target.extinguish() //Just in case it lit them on fire...
 	new /obj/effect/temp_visual/cateor_hit(get_turf(target))
 
+/**
+ * 'purrbation_apply()' removes the external spines on mobs that it hits, but it
+ * doesn't do so properly. Spines are also just one external organ of many that we
+ * need to remove prior to giving our target cat organs.
+ *
+ * This proc properly removes all relevant external organs from our cateor's target
+ * using 'mob_remove()' rather than 'Remove()', which is used by 'purrbation_apply()'.
+*/
+/obj/effect/meteor/cateor/proc/remove_relevant_organs(mob/living/carbon/target)
+	var/obj/item/organ/spines/current_spines = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_SPINES)
+	if(current_spines)
+		current_spines.mob_remove(target, special = TRUE)
+		qdel(current_spines)
+
+	var/obj/item/organ/horns/current_horns = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_HORNS)
+	if(current_horns)
+		current_horns.mob_remove(target, special = TRUE)
+		qdel(current_horns)
+
+	var/obj/item/organ/frills/current_frilles = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_FRILLS)
+	if(current_frilles)
+		current_frilles.mob_remove(target, special = TRUE)
+		qdel(current_frilles)
+
+	var/obj/item/organ/tail/current_tail = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+	if(current_tail)
+		current_tail.mob_remove(target, special = TRUE)
+		qdel(current_tail)
+
+	var/obj/item/organ/antennae/current_antennae = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_ANTENNAE)
+	if(current_antennae)
+		current_antennae.mob_remove(target, special = TRUE)
+		qdel(current_antennae)
+
 /obj/effect/meteor/cateor/Bump(mob/living/target)
 	//Callback after 1.25 deciseconds to account for the possibility of explosion moving the target.
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(cateor_hit_effects), target), 1.25)
@@ -106,30 +140,7 @@
 
 		explosion(humanoid, light_impact_range = 1, explosion_cause = src)
 
-		// Remove moth antennae if present since 'purrbation_apply()' doesn't do that.
-		var/obj/item/organ/spines/antennae = humanoid.get_organ_slot(ORGAN_SLOT_EXTERNAL_ANTENNAE)
-		if(antennae)
-			antennae.Remove(humanoid, special = TRUE)
-			qdel(antennae)
-
-		// Remove horns if present.
-		var/obj/item/organ/horns = humanoid.get_organ_slot(ORGAN_SLOT_EXTERNAL_HORNS)
-		if(horns)
-			horns.Remove(humanoid, special = TRUE)
-			qdel(horns)
-
-		// Remove frills if present.
-		var/obj/item/organ/frills = humanoid.get_organ_slot(ORGAN_SLOT_EXTERNAL_FRILLS)
-		if(frills)
-			frills.Remove(humanoid, special = TRUE)
-			qdel(frills)
-
-		// Remove tails if present.
-		var/obj/item/organ/tail = humanoid.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
-		if(tail)
-			tail.Remove(humanoid, special = TRUE)
-			qdel(tail)
-
+		remove_relevant_organs(humanoid)
 		purrbation_apply(humanoid, TRUE)
 
 		to_chat(humanoid, span_reallybig(span_hypnophrase("WOAW!~")))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR does the following:

1. Fixes a bug/runtime error which caused cateors to not properly give cat organs to lizardpeople and (probably) a few other species. 
2. Makes cateors no longer explode people who have already been given cat ears and a cat tail.
3. Makes cateors give the "drugginess" status effect to felinids in addition to stunning them (because catnip).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These changes fix a couple of cateor bugs and generally just improve them a bit in terms of functionality/polish.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a bug which caused cateors to not properly "felinidify" certain species.
fix: Cateors no longer explode people who already have cat ears and a cat tail.
balance: Cateors now also give felinids the "drugginess" status effect in addition to stunning them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
