### PR TITLE
Theia Station Engineering Fuel Tank Fix

### DIFF
--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -644,6 +644,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/gravity_generator)
+"all" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "alo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -1730,7 +1735,8 @@
 	dir = 8
 	},
 /obj/machinery/shower/directional/east,
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/bot,
+/obj/structure/fluff/shower_drain,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "aDy" = (
@@ -4658,6 +4664,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/storage)
+"bCS" = (
+/obj/effect/spawner/random/trash/moisture,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "bDd" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -11303,6 +11313,10 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
+"dWo" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "dWr" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /turf/closed/wall/r_wall,
@@ -26517,6 +26531,12 @@
 /obj/item/reagent_containers/condiment/enzyme,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
+"jqQ" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "jqV" = (
 /turf/open/floor/iron/dark/herringbone,
 /area/station/commons/lounge)
@@ -26804,6 +26824,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/surgery/aft)
+"jwU" = (
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "jwW" = (
 /obj/effect/spawner/random/engineering/material_cheap,
 /obj/effect/decal/cleanable/dirt,
@@ -27090,6 +27114,7 @@
 /area/station/security/prison/rec)
 "jBp" = (
 /obj/effect/turf_decal/tile/yellow/diagonal_centre,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "jBu" = (
@@ -28904,6 +28929,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/drone_bay)
+"kgn" = (
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "kgD" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -31143,7 +31174,7 @@
 /area/station/cargo/miningdock)
 "kXP" = (
 /obj/effect/spawner/random/trash/food_packaging,
-/obj/effect/decal/cleanable/fuel_pool,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "kXU" = (
@@ -37478,7 +37509,6 @@
 /area/station/hallway/secondary/exit/escape_pod)
 "noa" = (
 /obj/machinery/duct,
-/obj/effect/decal/cleanable/fuel_pool/hivis,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "nob" = (
@@ -38308,6 +38338,7 @@
 /area/station/engineering/storage/tech)
 "nDw" = (
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "nDK" = (
@@ -40795,10 +40826,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/bitrunning/den)
-"owY" = (
-/obj/effect/decal/cleanable/fuel_pool/hivis,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "oxc" = (
 /obj/effect/turf_decal/siding/thinplating_new/corner,
 /obj/structure/disposalpipe/segment,
@@ -42666,6 +42693,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos/pumproom)
+"pgR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "pgU" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/green/half{
@@ -43752,10 +43785,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"pCr" = (
-/obj/effect/decal/cleanable/fuel_pool,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "pCy" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44381,7 +44410,8 @@
 /turf/open/floor/carpet/purple,
 /area/station/service/lawoffice)
 "pNQ" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/effect/spawner/random/trash/graffiti,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "pNT" = (
@@ -57409,10 +57439,6 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
 /area/station/hallway/primary/central/aft)
-"uFB" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "uFN" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -59825,7 +59851,8 @@
 	},
 /obj/structure/sign/poster/official/moth_delam/directional/west,
 /obj/machinery/shower/directional/east,
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/bot,
+/obj/structure/fluff/shower_drain,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "vyN" = (
@@ -61416,7 +61443,6 @@
 "wbu" = (
 /obj/effect/spawner/random/trash/bacteria,
 /obj/machinery/duct,
-/obj/effect/decal/cleanable/fuel_pool,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "wbv" = (
@@ -65435,7 +65461,7 @@
 /turf/open/floor/iron/checker,
 /area/station/hallway/secondary/exit/escape_pod/secondary)
 "xxZ" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -66948,7 +66974,6 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/hfr_room)
 "yav" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
@@ -84431,8 +84456,8 @@ jlz
 ndi
 txX
 qvs
-txX
-txX
+pgR
+kgn
 cfg
 iZz
 rzp
@@ -84686,10 +84711,10 @@ kvN
 oTP
 uVb
 cfg
-iZz
-iZz
-iZz
-txX
+jwU
+bCS
+pgR
+dWo
 cfg
 cfg
 lDx
@@ -84945,12 +84970,12 @@ lDi
 cfg
 pNQ
 yav
-iZz
-txX
-txX
-txX
-txX
-pCq
+jqQ
+jqQ
+pgR
+pgR
+pgR
+all
 pCq
 pCq
 cfg
@@ -85208,7 +85233,7 @@ cfg
 kna
 iZz
 kXP
-pCr
+iZz
 cfg
 cfg
 gcO
@@ -85465,7 +85490,7 @@ cfg
 mhg
 wbu
 noa
-owY
+iZz
 cfg
 oDv
 vfV
@@ -85720,7 +85745,7 @@ iSA
 ppc
 cfg
 sSK
-kXP
+iZz
 noa
 aSQ
 cfg
@@ -87519,7 +87544,7 @@ vny
 cYO
 jlV
 xKE
-uFB
+qPn
 qPn
 jJB
 jlV


### PR DESCRIPTION

## About The Pull Request
In PR #1249 I put a handful of welding fuel decals under a high capacity fuel tank in Theia Station's engineering maintenance area. This turned out to be a very bad idea. I understood that the decals could trigger an explosion if ignited, but I underestimated the overall probability of them igniting on any given round. 

I later reduced the number of welding fuel pools in PR #1252, but that didn't really help much. Given the benefit of hindsight, I now realize that the entire concept is inherently flawed. This PR removes all of the aforementioned welding fuel pools and moves a couple of fuel tanks away from each other to make chain reaction explosions less likely.
## Why It's Good For The Game
Having welding tanks explode every four rounds or so due to a very poor mapping decision is a bad thing. This PR rectifies that mistake.
## Changelog
:cl:
map: A particular group of welding tanks in Theia Station's engineering maintenance area should now be much less likely to explode.
/:cl:
