### PR TITLE
Minor Pubby Cargo Fixes Following Recent Improvements

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1156,11 +1156,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/status_display/supply{
-	dir = 4;
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "afe" = (
@@ -13941,7 +13938,7 @@
 	},
 /obj/machinery/status_display/supply{
 	dir = 4;
-	pixel_x = 33
+	pixel_x = 32
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
@@ -30612,7 +30609,7 @@
 "ech" = (
 /obj/machinery/conveyor{
 	dir = 10;
-	id = "ShuttleLoad"
+	id = "ShuttleUnload"
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
@@ -32625,12 +32622,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "fER" = (
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
+/obj/machinery/status_display/supply{
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "fEU" = (
@@ -42352,7 +42351,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
 /area/station/cargo/storage)
 "nNN" = (
 /obj/structure/disposaloutlet{
@@ -50172,12 +50173,13 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
 	dir = 8
+	},
+/obj/machinery/status_display/supply{
+	dir = 4;
+	pixel_x = 32
 	},
 /turf/open/floor/iron/edge{
 	dir = 8
@@ -56165,6 +56167,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
+"xQB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "xQM" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets,
@@ -96868,7 +96878,7 @@ gUJ
 euT
 tbz
 euT
-anQ
+xQB
 qXb
 udR
 lGJ

--- a/_maps/shuttles/cargo_pubby.dmm
+++ b/_maps/shuttles/cargo_pubby.dmm
@@ -34,14 +34,11 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "k" = (
-/obj/machinery/door/poddoor{
-	id = "cargoload";
-	name = "Supply Dock Loading Door"
-	},
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "ShuttleLoad"
 	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "m" = (
@@ -57,10 +54,6 @@
 "s" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
-/obj/machinery/button/door/directional/west{
-	id = "cargoload";
-	name = "Loading Doors"
-	},
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
@@ -145,28 +138,16 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "J" = (
-/obj/machinery/door/poddoor{
-	id = "cargounload";
-	name = "Supply Dock Loading Door"
-	},
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "ShuttleUnload"
 	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "K" = (
 /turf/open/floor/iron/chapel{
 	dir = 1
-	},
-/area/shuttle/supply)
-"O" = (
-/obj/machinery/button/door/directional/west{
-	id = "cargounload";
-	name = "Loading Doors"
-	},
-/turf/open/floor/iron/chapel{
-	dir = 8
 	},
 /area/shuttle/supply)
 "Q" = (
@@ -231,7 +212,7 @@ s
 X
 w
 K
-O
+X
 t
 T
 a


### PR DESCRIPTION

## About The Pull Request
This PR fixes a few things that were missed in #1325 (mainly the incorrect ID-ing of one conveyor belt, a few improperly styled tiles, and the lack of airtight flaps on Pubby's cargo shuttle).
## Why It's Good For The Game
These changes correct a few things that were missed in a recent PR.
## Changelog
:cl:
map: Fixes a few things that were overlooked in a recent edit of Pubby Station's cargo bay.
/:cl:
