### PR TITLE
Theia Station Telecomms Power Fix

### DIFF
--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -545,7 +545,10 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/full{
+	output_level = 100000;
+	input_level = 110000
+	},
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "aiN" = (


### PR DESCRIPTION

## About The Pull Request
This PR slightly adjusts the values on a singular AI satellite SMES in order to ensure that telecomms is powered properly at round start. 
## Why It's Good For The Game
As part of PR #1318 I slightly edited Theia Station's AI satellite power network in order to make it slightly more station-independent. In doing so I accidentally overlooked the fact that the satellite has three SMES units, and the main station-to-ai-sat SMES needs to power two others.
## Changelog
:cl:
map: Made Theia Station's telecomms room properly receive power at round start.
/:cl:
