### PR TITLE
Makes Brawn and its Subtype (Brash) Useable While Handcuffed

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/brawn.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/brawn.dm
@@ -9,7 +9,7 @@
 		At level 4, this ability wlil bash airlocks open as long as they aren't bolted.\n\
 		Higher levels will increase this ability's damage and knockdown."
 	power_flags = BP_AM_TOGGLE
-	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_IN_FRENZY|BP_CANT_USE_WHILE_INCAPACITATED|BP_CANT_USE_WHILE_UNCONSCIOUS
+	check_flags = BP_CANT_USE_IN_TORPOR|BP_CANT_USE_IN_FRENZY|BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY|VASSAL_CAN_BUY
 	bloodcost = 8
 	cooldown_time = 9 SECONDS


### PR DESCRIPTION

## About The Pull Request
This PR removes the 'BP_CANT_USE_WHILE_INCAPACITATED' flag from the bloodsucker Brawn ability.
## Why It's Good For The Game
Part of this abilities function is allowing you to escape from restraints, and you can't use it to do that if you can't use it while incapacitated.
## Changelog
:cl:
fix: Made the bloodsucker Brawn and Brash abilities useable while handcuffed.
/:cl:
