### PR TITLE
A Small Bloodsucker Bite Fix and a Bit of QOL

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
@@ -47,6 +47,23 @@
 	if(!chosen_clan)
 		to_chat(person_selecting, span_announce("You choose to remain ignorant, for now."))
 		return
+
+	/// If they chose Brujah then warn them about their increased Frenzy threshold.
+	if(chosen_clan == /datum/bloodsucker_clan/brujah)
+		var/warning_accepted = tgui_alert(person_selecting, \
+			"You are selecting the Brujah clan; Brujah vampires start with a decent amount of \
+			Humanity loss. Selecting this clan will put \
+			[admin_selecting ? "this player's" : "your"] Frenzy threshold at \
+			[src.frenzy_threshold + 375]. Please ensure that \
+			[admin_selecting ? "this player has" : "you have"] enough blood before \
+			continuing or else risk \
+			[admin_selecting ? "them entering" : "entering"] Frenzy.", \
+			"Warning", \
+			list("Accept Warning", "Abort Clan Selection"))
+		if(warning_accepted != "Accept Warning")
+			to_chat(person_selecting, span_announce("You choose to remain ignorant, for now."))
+			return
+
 	my_clan = new chosen_clan(src)
 
 /datum/antagonist/bloodsucker/proc/remove_clan(mob/admin)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
@@ -92,7 +92,6 @@
 	owner.balloon_alert(owner, "feeding off [feed_target]...")
 	if(!do_after(owner, feed_timer, feed_target, NONE, TRUE))
 		owner.balloon_alert(owner, "feed stopped")
-		target_ref = null
 		DeactivatePower()
 		return
 	if(owner.pulling == feed_target && owner.grab_state >= GRAB_AGGRESSIVE)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
@@ -49,16 +49,11 @@
 	return TRUE
 
 /datum/action/cooldown/bloodsucker/feed/DeactivatePower()
-	// Check if active and early return if not to avoid spamming logs.
-	if(!active)
-		return
 	var/mob/living/user = owner
 	var/mob/living/feed_target
 	if(target_ref)
 		feed_target = target_ref.resolve()
-	if(isnull(feed_target))
-		log_combat(user, user, "fed on blood (target not found)", addition="(and took [blood_taken] blood)")
-	else
+	if(!isnull(feed_target))
 		log_combat(user, feed_target, "fed on blood", addition="(and took [blood_taken] blood)")
 		to_chat(user, span_notice("You slowly release [feed_target]."))
 		if(feed_target.stat == DEAD && blood_taken > 0)


### PR DESCRIPTION

## About The Pull Request
This PR does two things:
1. Fixes a couple of issues which make the bloodsucker Feed ability unusable. These issues were partially addressed in PR #1315, but they ultimately seem to be caused by an early return implemented in PR #1300. That early return has been removed in favor of just not logging feed attempts where 'feed_target = null'.
2. Adds a TGUI warning to the Brujah clan on selection so as to make players aware that joining the clan will increase their Frenzy threshold.
## Why It's Good For The Game
1. I don't _think_ we need to log bite attempts where 'feed_target = null', and as it currently stands that only seems to cause a lot of attack log spam.
2. Players should really know ahead of time that joining the Brujah clan will raise their Frenzy threshold by 375.
## Changelog
:cl:
qol: Made players attempting to join the Brujah clan receive a warning about the clan increasing their Frenzy threshold.
fix: (Hopefully) fixed a few bugs which could render the bloodsucker Bite ability unusable. 
admin: Made the bloodsucker bite ability no longer log bite attempts where no bite target is present.
/:cl:
