### PR TITLE
Selene Station N2O Leak Replacement

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -3485,9 +3485,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "blX" = (
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
+/turf/open/floor/bamboo,
 /area/station/maintenance/starboard/fore)
 "bmc" = (
 /obj/structure/transit_tube/diagonal,
@@ -4129,12 +4127,6 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"bxz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/grille/broken,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "bxC" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/wood,
@@ -5372,6 +5364,11 @@
 /obj/structure/sign/warning/test_chamber/directional/west,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/bomb)
+"bSB" = (
+/obj/effect/spawner/random/maintenance/four,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "bSK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5783,11 +5780,6 @@
 /obj/structure/transit_tube/curved,
 /turf/open/space/basic,
 /area/space/nearstation)
-"bZY" = (
-/obj/effect/spawner/random/maintenance/four,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "cai" = (
 /obj/structure/transit_tube/crossing{
 	dir = 4
@@ -6518,6 +6510,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
+"coU" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "coZ" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -8603,11 +8599,10 @@
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "daV" = (
-/obj/item/storage/belt/utility,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/station/maintenance/department/medical)
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/item/kirbyplants/organic/plant21,
+/turf/open/floor/grass,
+/area/station/maintenance/starboard/fore)
 "daY" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/grenades,
@@ -9777,6 +9772,7 @@
 /area/station/service/lawoffice)
 "dzw" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "dzA" = (
@@ -14294,8 +14290,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science)
 "fge" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "fgf" = (
@@ -18107,6 +18102,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science)
+"gDe" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/item/kirbyplants/organic,
+/turf/open/floor/grass,
+/area/station/maintenance/starboard/fore)
 "gDX" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -22153,6 +22153,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
+"ifj" = (
+/obj/item/clothing/head/costume/tmc,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/bamboo,
+/area/station/maintenance/starboard/fore)
 "ifn" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Research - Ordnance Launch";
@@ -23641,16 +23647,6 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
-"iFv" = (
-/obj/item/toy/katana,
-/obj/item/toy/figure/ninja{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/station/maintenance/starboard/fore)
 "iFE" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -28767,12 +28763,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/command/storage/eva)
-"kuP" = (
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/station/maintenance/starboard/fore)
 "kuT" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -30005,6 +29995,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
+"kRH" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "kRI" = (
 /obj/structure/chair{
 	dir = 8
@@ -35154,6 +35151,11 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/iron/white,
 /area/station/security/prison/safe)
+"mDn" = (
+/obj/item/kirbyplants/organic/plant22,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/grass,
+/area/station/maintenance/starboard/fore)
 "mDx" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -35600,10 +35602,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "mLg" = (
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/station/maintenance/department/medical)
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/bamboo,
+/area/station/maintenance/starboard/fore)
 "mLm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -39427,8 +39428,7 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "ogU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/grille/broken,
+/obj/effect/spawner/random/trash/bin,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "ogX" = (
@@ -39517,10 +39517,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"ojh" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "ojJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -39978,6 +39974,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"orm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "ors" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -41532,10 +41534,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "oXs" = (
-/obj/effect/wisp,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+/obj/item/toy/figure/ninja{
+	pixel_x = -8;
+	pixel_y = 6
 	},
+/obj/item/toy/katana,
+/turf/open/floor/bamboo,
 /area/station/maintenance/starboard/fore)
 "oXP" = (
 /obj/machinery/light/directional/north,
@@ -41936,10 +41940,10 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "peR" = (
-/obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+/obj/structure/chair/comfy/beige{
+	dir = 8
 	},
+/turf/open/floor/bamboo,
 /area/station/maintenance/starboard/fore)
 "peX" = (
 /obj/structure/cable,
@@ -46916,7 +46920,6 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "qZi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
@@ -47660,6 +47663,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
+"rmv" = (
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "rmy" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
@@ -47982,21 +47993,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "rsL" = (
-/obj/item/wrench,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/station/maintenance/department/medical)
+/obj/effect/decal/cleanable/blood/trails,
+/turf/open/floor/bamboo,
+/area/station/maintenance/starboard/fore)
 "rsT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"rsV" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "rsX" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -49621,11 +49625,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "rZd" = (
-/obj/effect/mob_spawn/corpse/human/assistant,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
-	},
-/area/station/maintenance/department/medical)
+/obj/item/kirbyplants/organic/plant10,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/grass,
+/area/station/maintenance/starboard/fore)
 "rZh" = (
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -52305,6 +52308,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"taF" = (
+/obj/effect/spawner/random/trash/moisture,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "taN" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -52457,6 +52464,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"tcJ" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "tcM" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -55966,6 +55977,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"uoT" = (
+/obj/item/flashlight/lantern/lit_lantern,
+/turf/open/floor/bamboo,
+/area/station/maintenance/starboard/fore)
 "uoX" = (
 /obj/effect/turf_decal/tile/command/half,
 /obj/structure/sign/plaques/kiddie{
@@ -62805,6 +62820,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
+"wTb" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "wTi" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -64343,6 +64364,11 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
+"xrZ" = (
+/obj/machinery/duct,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "xsk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -109998,8 +110024,8 @@ rvY
 rvY
 rvY
 rvY
-ygs
-ygs
+coU
+taF
 ygs
 isa
 ycg
@@ -110255,13 +110281,13 @@ uPn
 tIS
 onJ
 rvY
-ygs
+ogU
 ygs
 ygs
 isa
 isa
 isa
-ygs
+isa
 ycg
 ycg
 ycg
@@ -110512,14 +110538,14 @@ uPn
 vzb
 uwR
 rvY
-ycg
-ycg
-ycg
-ycg
-ygs
-isa
+rvY
+rvY
+rvY
+rvY
+rvY
+fge
 hJa
-tcM
+xrZ
 dHz
 ycg
 jpu
@@ -110769,11 +110795,11 @@ sPX
 pKQ
 jAt
 rvY
-mLg
+mDn
 rZd
 daV
-ycg
-ygs
+gDe
+rvY
 doC
 hJa
 tcM
@@ -111026,11 +111052,11 @@ xYF
 xYF
 vzb
 rvY
-mLg
+blX
 mLg
 rsL
-ycg
-ycg
+ifj
+rvY
 kPy
 isa
 qZi
@@ -111285,12 +111311,12 @@ gPZ
 rvY
 blX
 oXs
-kuP
 blX
+blX
+rvY
 ycg
-ycg
-ycg
-bxz
+isa
+tcM
 ogU
 ycg
 eAc
@@ -111539,16 +111565,16 @@ bOo
 vzb
 sPX
 vzb
-vzb
-iFv
+rvY
+uoT
 blX
 peR
-blX
-ycg
+uoT
+rvY
 rmL
-ygs
-tcM
 isa
+tcM
+tcJ
 ycg
 ycg
 ycg
@@ -111795,18 +111821,18 @@ rvY
 vzb
 vzb
 sPX
-pXQ
-pXQ
+vzb
+rvY
+rvY
+rmv
 rvY
 rvY
 rvY
-rvY
-ycg
-ttg
-kqZ
-rsV
-eSK
-ttg
+bSB
+hJa
+wTb
+kRH
+wTb
 ycg
 lBT
 dGm
@@ -112059,11 +112085,11 @@ pXQ
 pXQ
 eln
 ttg
-bZY
-ygs
-tcM
+ttg
+ttg
+ttg
 fge
-wNT
+orm
 ycg
 ycg
 ycg
@@ -112311,7 +112337,7 @@ wBH
 rvY
 rvY
 vzb
-ojh
+nVC
 sAu
 vkm
 rvY


### PR DESCRIPTION

## About The Pull Request
This pull request removes the round start N2O leak near Selene Station's medical maintenance area. This PR also spruces up the area around where that leak was and replaces the main portion of the removed area with an equivalent gimmick room.
## Why It's Good For The Game
N2O can permanently render player characters unconscious without external assistance. It is very dangerous on low population rounds and can lead to very negative player experiences when leaked at round start.
## Changelog
:cl:
map: Replaced the round start N2O leak near medical maintenance on Selene Station with something a bit more standard.
/:cl:
