### PR TITLE
Minor Selene Station Wiring Correction

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -58158,10 +58158,6 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"vfG" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/maintenance/department/engine)
 "vfH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -86172,7 +86168,7 @@ whO
 whO
 rKB
 xub
-vfG
+dSh
 whO
 jXT
 whO
@@ -86429,7 +86425,7 @@ bHB
 qyH
 rKB
 xub
-vfG
+dSh
 hGt
 enk
 vks
@@ -86686,7 +86682,7 @@ nKe
 sYt
 rKB
 xub
-vfG
+dSh
 hGt
 riQ
 hGt
@@ -86943,7 +86939,7 @@ dSh
 sYt
 rKB
 xub
-vfG
+dSh
 vDm
 whO
 jdm
@@ -87200,7 +87196,7 @@ dSh
 ktZ
 rKB
 xub
-vfG
+dSh
 whO
 sqA
 htQ
@@ -87457,7 +87453,7 @@ dSh
 ajp
 rKB
 xub
-vfG
+dSh
 whO
 whO
 jXT
@@ -87714,7 +87710,7 @@ dSh
 fmm
 rKB
 xub
-vfG
+dSh
 whO
 whO
 sYt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR removes this one really prominent line of stray wiring in Selene Station's engineering maintenance area:

![image](https://github.com/user-attachments/assets/40b326e1-3f50-4de2-94e1-0517959dca7c)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is probably written somewhere that wiring in Space Station Thirteen should never be mapped under walls (except where _absolutely_ necessary).
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: Removed a stray line of wiring from engineering maintenance on Selene Station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
