### PR TITLE
ghost kitchen fixes

### DIFF
--- a/_maps/fulp_maps/RandomRuins/SpaceRuins/allamericandiner_openforbusiness.dmm
+++ b/_maps/fulp_maps/RandomRuins/SpaceRuins/allamericandiner_openforbusiness.dmm
@@ -506,12 +506,11 @@
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "hY" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = 0;
-	pixel_y = 5
-	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "hZ" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
@@ -568,6 +567,10 @@
 "iO" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/food/flour,
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 13
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "ja" = (
@@ -1559,11 +1562,10 @@
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "xQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/wood/large,
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/newspaper,
+/turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "xR" = (
 /obj/machinery/door/airlock{
@@ -1958,9 +1960,11 @@
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "CL" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/newspaper,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/microwave{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "CT" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -2262,10 +2266,10 @@
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "Hq" = (
 /obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/desk_bell{
 	pixel_y = 7
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "Hy" = (
@@ -2777,10 +2781,6 @@
 	color = "#474747"
 	},
 /obj/structure/sign/poster/contraband/tea_over_tizira/directional/west,
-/obj/item/paper_bin{
-	pixel_x = 0;
-	pixel_y = 5
-	},
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "NF" = (
@@ -3010,6 +3010,13 @@
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "Qx" = (
 /obj/structure/table/reinforced,
+/obj/machinery/processor{
+	pixel_y = 11;
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/cup/rag{
+	pixel_x = -4
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "Qz" = (
@@ -3267,6 +3274,14 @@
 "UC" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
+/area/ruin/space/has_grav/powered/ghostkitchen)
+"UJ" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/powered/ghostkitchen)
 "UL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4249,7 +4264,7 @@ Ji
 iG
 MZ
 qp
-CL
+xQ
 Se
 si
 NF
@@ -4354,13 +4369,13 @@ tP
 TO
 qp
 qp
-hY
+CL
 qp
 IP
 nH
 XL
 Xo
-bb
+UJ
 QS
 si
 Sb
@@ -4492,7 +4507,7 @@ tP
 fC
 jg
 xH
-xQ
+hY
 Mi
 Ry
 NQ


### PR DESCRIPTION
## About The Pull Request
"The kitchen setup is close to the way most stations are set"
She lied
adds these two machines to the ruin, also adds an not pictured microwave
![image](https://github.com/user-attachments/assets/bbabe9be-71e4-4732-8dbd-2af29ac19ae4)

## Why It's Good For The Game

you should actually be able to cook on the cooking ghost spawner

## Changelog

:cl:

fix: essential kitchen equipment added to the ghost diner

/:cl:
