### PR TITLE
Chef Ghost Role Fixes, Edits, and Minor Additions

### DIFF
--- a/_maps/fulp_maps/RandomRuins/SpaceRuins/allamericandiner_openforbusiness.dmm
+++ b/_maps/fulp_maps/RandomRuins/SpaceRuins/allamericandiner_openforbusiness.dmm
@@ -6,24 +6,22 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ak" = (
 /obj/structure/table/wood{
 	color = "#474747"
 	},
 /obj/item/reagent_containers/condiment/ketchup{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "al" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/billboard/american_diner,
 /obj/item/food/burger/chicken{
-	pixel_x = -1;
-	pixel_y = 0
+	pixel_x = -1
 	},
 /turf/open/space/basic,
 /area/space)
@@ -34,7 +32,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ar" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -44,7 +42,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/wood/parquet,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "aB" = (
 /obj/structure/chair/sofa/left/maroon{
 	dir = 4
@@ -55,41 +53,38 @@
 	},
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "aC" = (
 /obj/structure/chair/sofa/left/maroon{
 	dir = 8
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
-"aM" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "bb" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "bs" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/suit_storage_unit/open,
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "bD" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "bM" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "bN" = (
 /obj/structure/fake_stairs/wood/directional/north,
 /obj/structure/fake_stairs/wood/directional/south,
@@ -97,7 +92,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "bP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -106,12 +101,12 @@
 /obj/effect/decal/cleanable/insectguts,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ca" = (
 /obj/structure/table,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ce" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /turf/open/space/basic,
@@ -123,7 +118,7 @@
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "cu" = (
 /obj/machinery/door/airlock{
 	name = "Ranch"
@@ -132,20 +127,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/ghostkitchen)
 "cC" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "cE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mop_bucket,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "cL" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/stripes/red/line{
@@ -158,7 +153,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "cN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
@@ -173,12 +168,12 @@
 	pixel_y = 9
 	},
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "dg" = (
 /obj/effect/spawner/random/structure/closet_private,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/blue,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "dx" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/lattice,
@@ -190,12 +185,11 @@
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/item/radio/intercom/directional/south{
-	pixel_x = 0;
 	pixel_y = -23
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "dA" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 8
@@ -206,18 +200,18 @@
 	},
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "dD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "dG" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "dN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -227,7 +221,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "dZ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -240,7 +234,7 @@
 /obj/effect/decal/cleanable/confetti,
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ea" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/blood/drip{
@@ -249,24 +243,26 @@
 /obj/structure/sign/poster/contraband/pizza_imperator/directional/east,
 /obj/item/trash/ready_donk,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ey" = (
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/misc/hay{
 	baseturfs = /turf/open/floor/plating
 	},
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "eC" = (
 /obj/machinery/door/airlock/public,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/ghostkitchen)
 "eF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "eG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -274,15 +270,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "eL" = (
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "eM" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/food/pie/cherrypie{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/food/pie/applepie{
+	pixel_x = -3;
+	pixel_y = 9
+	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "eS" = (
 /obj/structure/chair/sofa/left/maroon{
 	dir = 1
@@ -294,22 +298,25 @@
 /obj/effect/decal/cleanable/insectguts,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
+"eU" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/ghostkitchen)
 "fj" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "fk" = (
 /obj/machinery/door/airlock/external/glass/ruin{
 	name = "The All-American Diner"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/turf/open/floor/iron/textured_half,
+/area/ruin/space/has_grav/ghostkitchen)
 "fq" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
@@ -319,49 +326,40 @@
 	pixel_y = 9
 	},
 /obj/item/storage/toolbox/fishing/master{
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /obj/structure/chair/plastic{
 	dir = 4
 	},
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "fw" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "fx" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
-"fB" = (
-/obj/structure/extinguisher_cabinet/directional/east{
-	pixel_x = 25;
-	pixel_y = 29
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "fC" = (
 /obj/structure/sign/calendar/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/west,
 /obj/machinery/vending/medical,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "fG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "fK" = (
 /obj/structure/table/wood{
 	color = "#474747"
@@ -376,13 +374,14 @@
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "gt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "gL" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
@@ -390,10 +389,6 @@
 /area/space)
 "gN" = (
 /obj/structure/sink/directional/west,
-/obj/structure/mirror/broken/directional/east{
-	pixel_x = 23;
-	pixel_y = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/floor,
@@ -402,19 +397,19 @@
 	pixel_x = -9;
 	pixel_y = -18
 	},
+/obj/structure/mirror/broken/directional/east,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "gV" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /obj/item/food/burger/chicken{
-	pixel_x = 0;
 	pixel_y = -4
 	},
 /turf/open/space/basic,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "he" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom 2"
@@ -425,7 +420,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "hq" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/balloon{
@@ -443,21 +438,22 @@
 	pixel_y = -3
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ht" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "hw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/power/smes/magical{
-	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. Uses bluespace technology to draw power from nearby bluespace substations.";
-	name = "bluespace power storage unit"
+/obj/machinery/power/terminal{
+	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/power/rtg/advanced,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "hE" = (
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/food/tomato_smudge{
@@ -465,7 +461,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "hF" = (
 /obj/structure/chair/sofa/left/maroon{
 	dir = 1
@@ -480,12 +476,12 @@
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "hN" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/chair/plastic,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "hP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -494,29 +490,29 @@
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "hR" = (
 /obj/structure/grille,
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "hU" = (
 /obj/effect/spawner/random/structure/closet_private,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/red,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "hY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "hZ" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /turf/open/floor/holofloor/beach/water,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "in" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cabin6";
@@ -525,8 +521,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/ghostkitchen)
 "io" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -539,50 +535,44 @@
 /obj/effect/decal/cleanable/garbage,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "iG" = (
-/obj/structure/table{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table,
 /obj/item/plate/large{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/plate/large{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/plate/large{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "iJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/grille/broken,
+/obj/structure/cable,
+/obj/machinery/computer/monitor,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "iO" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/food/flour,
-/obj/machinery/reagentgrinder{
-	pixel_x = -1;
-	pixel_y = 13
+/obj/machinery/reagentgrinder,
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_x = -25
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ja" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north{
-	pixel_x = 0;
 	pixel_y = 41
 	},
 /obj/item/food/burger/mcguffin{
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /obj/item/food/salt_chilli_fries{
 	pixel_x = -5;
@@ -591,7 +581,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "jg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -604,7 +594,7 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "jr" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
@@ -619,30 +609,32 @@
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "jO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/obj/effect/turf_decal/siding/dark/inner_corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/ghostkitchen)
 "jS" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "jV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/ready_donk{
-	pixel_x = 0;
 	pixel_y = -6
 	},
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "jX" = (
 /obj/machinery/chem_master/condimaster,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/ghostkitchen)
 "kc" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -652,27 +644,24 @@
 	},
 /obj/effect/mob_spawn/ghost_role/human/allamerican/cook,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "kl" = (
 /obj/structure/sink/directional/west,
-/obj/structure/mirror/directional/east{
-	pixel_x = 23;
-	pixel_y = 5
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/xenoblood,
+/obj/structure/mirror/directional/east,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "kq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "kt" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/food/flour,
@@ -685,22 +674,21 @@
 	pixel_y = 7
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "kz" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "kA" = (
 /turf/open/space/basic,
 /area/space)
 "kF" = (
 /obj/machinery/light/small/dim/directional/north,
-/obj/item/trash/shok_roks/citrus{
-	pixel_x = -5;
-	pixel_y = 2
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "kI" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
@@ -719,19 +707,19 @@
 /obj/effect/decal/cleanable/insectguts,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "la" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "lo" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ls" = (
 /obj/effect/turf_decal/siding/dark/inner_corner{
 	dir = 4
@@ -740,7 +728,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "lE" = (
 /obj/structure/table/wood{
 	color = "#474747"
@@ -755,7 +743,7 @@
 	pixel_y = -4
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "lJ" = (
 /obj/structure/chair/sofa/left/maroon{
 	dir = 4
@@ -766,14 +754,15 @@
 	},
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "mm" = (
 /obj/machinery/door/airlock/maintenance/external{
 	name = "Engineering"
 	},
-/obj/effect/mapping_helpers/airlock/access,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/duct,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "mn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -782,13 +771,14 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/beacon,
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "mt" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/machinery/hydroponics/constructable/fullupgrade,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "nc" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -797,7 +787,7 @@
 	},
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ng" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/food/flour,
@@ -806,12 +796,8 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 10;
-	pixel_y = 7
-	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "nm" = (
 /obj/structure/toilet{
 	dir = 4
@@ -821,36 +807,37 @@
 /obj/machinery/light/small/dim/directional/north,
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/iron/white/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "nw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/structure/electrified_grille,
+/obj/structure/cable,
+/obj/machinery/power/rtg/advanced,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "nB" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /obj/structure/sign/flag/nanotrasen/directional/north,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "nH" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "nS" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "nT" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "nV" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 8
@@ -861,24 +848,24 @@
 	},
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "oa" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/sign/poster/contraband/eat/directional/north,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "od" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "of" = (
 /obj/machinery/portable_atmospherics/pump/lil_pump,
 /obj/structure/sign/poster/contraband/have_a_puff/directional/west,
 /obj/structure/sign/poster/official/wtf_is_co2/directional/north,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "oQ" = (
 /obj/effect/turf_decal/siding/dark/inner_corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -887,13 +874,13 @@
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "pc" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/machinery/hydroponics/constructable/fullupgrade,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "pf" = (
 /obj/machinery/door/airlock{
 	name = "Shower Room"
@@ -902,20 +889,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/mapping_helpers/airlock/access,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "pq" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "pr" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/poster/contraband/blood_geometer/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "pv" = (
 /obj/item/bedsheet/patriot{
 	dir = 1
@@ -924,35 +912,41 @@
 	dir = 1
 	},
 /obj/item/toy/plush/nukeplushie{
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /obj/structure/sign/poster/contraband/the_griffin/directional/north,
 /turf/open/floor/carpet/blue,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "py" = (
 /obj/structure/lattice,
 /obj/structure/sign/poster/contraband/eat/directional/east,
 /turf/open/space/basic,
 /area/space)
+"pA" = (
+/obj/structure/sign/poster/contraband/eat/directional/north,
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/teal,
+/turf/open/space/basic,
+/area/space)
 "pF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 4;
+	name = "Supply to Distro"
+	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "pP" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	pixel_x = 0;
-	pixel_y = 13
-	},
+/obj/machinery/chem_dispenser/drinks,
 /obj/item/storage/box/drinkingglasses{
 	pixel_x = 6;
 	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "pT" = (
 /obj/structure/chair/sofa/right/maroon,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
@@ -966,11 +960,16 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "pV" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom,
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
+"qe" = (
+/obj/machinery/door/airlock/public,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/ghostkitchen)
 "qf" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -987,7 +986,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ql" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	dir = 4
@@ -996,15 +995,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access,
 /obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/obj/effect/turf_decal/siding/dark/inner_corner,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/ghostkitchen)
 "qn" = (
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "qo" = (
 /obj/structure/chair/sofa/right/maroon,
 /obj/effect/turf_decal/siding/dark_red/inner_corner{
@@ -1014,22 +1014,22 @@
 /obj/structure/sign/calendar/directional/north,
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "qp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "qw" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "qx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "qy" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/lattice,
@@ -1043,11 +1043,11 @@
 /obj/effect/decal/cleanable/xenoblood,
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "rd" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /turf/open/floor/holofloor/beach,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "re" = (
 /obj/structure/table/reinforced,
 /obj/item/food/burger/chappy{
@@ -1056,17 +1056,16 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "rf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "rg" = (
 /obj/structure/table/reinforced,
 /obj/item/food/frenchtoast{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/food/waffles{
@@ -1075,7 +1074,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "rr" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
@@ -1086,8 +1085,7 @@
 /obj/effect/decal/cleanable/confetti,
 /obj/item/toy/balloon{
 	color = "#0000FF";
-	pixel_x = -2;
-	pixel_y = 0
+	pixel_x = -2
 	},
 /obj/item/toy/balloon{
 	color = "#FF0000";
@@ -1095,7 +1093,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "rs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood{
@@ -1117,7 +1115,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "rM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -1127,7 +1125,7 @@
 /obj/effect/decal/cleanable/insectguts,
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "rV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bookcase/random,
@@ -1140,44 +1138,42 @@
 	pixel_y = -5
 	},
 /obj/item/book/manual/hydroponics_pod_people{
-	pixel_x = -1;
-	pixel_y = 0
+	pixel_x = -1
 	},
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "sh" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 4
 	},
 /obj/structure/sign/picture_frame/showroom/one{
 	pixel_x = -26;
-	pixel_y = 0;
 	name = "employee of the quadrum"
 	},
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "si" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "sx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "sy" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "sA" = (
 /turf/open/misc/hay{
 	baseturfs = /turf/open/floor/plating
 	},
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "sF" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/lattice,
@@ -1186,7 +1182,7 @@
 "sK" = (
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "sL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1194,7 +1190,7 @@
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "sZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1205,28 +1201,31 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
+"te" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/ghostkitchen)
 "tg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "tm" = (
-/obj/structure/table{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table,
 /obj/machinery/cell_charger{
 	pixel_x = 2;
 	pixel_y = 12
 	},
 /obj/machinery/recharger{
-	pixel_x = 0;
 	pixel_y = -2
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "tx" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/stripes/red/line{
@@ -1238,20 +1237,20 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "tA" = (
-/obj/effect/spawner/structure/electrified_grille,
+/obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "tI" = (
 /obj/effect/turf_decal/siding/dark/inner_corner,
 /obj/item/kirbyplants/organic/plant12,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "tP" = (
-/turf/closed/wall,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/ghostkitchen)
 "ua" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -1264,7 +1263,7 @@
 	},
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/wood/parquet,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ug" = (
 /obj/structure/lattice,
 /obj/structure/sign/poster/contraband/missing_gloves/directional/north,
@@ -1273,12 +1272,12 @@
 "ui" = (
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "um" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/curtain/bounty/start_closed,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ut" = (
 /obj/effect/turf_decal/siding/dark/inner_corner{
 	dir = 1
@@ -1287,7 +1286,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "uD" = (
 /obj/effect/decal/cleanable/food/tomato_smudge{
 	pixel_x = -4;
@@ -1295,14 +1294,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "uE" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/garbage,
+/obj/machinery/duct,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "uW" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -1310,7 +1310,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "vj" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /turf/open/space/basic,
@@ -1319,7 +1319,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north{
-	pixel_x = 0;
 	pixel_y = 41
 	},
 /obj/item/food/burger{
@@ -1332,20 +1331,21 @@
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "vm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/insectguts,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "vt" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "vy" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
@@ -1355,27 +1355,27 @@
 	},
 /obj/item/trash/spacers_sidekick,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "vz" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "vB" = (
 /obj/effect/light_emitter/fake_outdoors,
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/misc/hay{
 	baseturfs = /turf/open/floor/plating
 	},
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "vE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/flag/ssc/directional/west,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "vR" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 1
@@ -1386,7 +1386,7 @@
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "vU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/bin,
@@ -1394,7 +1394,7 @@
 /obj/effect/decal/cleanable/insectguts,
 /mob/living/basic/mouse/rat,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "vV" = (
 /obj/effect/turf_decal/siding/dark/inner_corner{
 	dir = 8
@@ -1402,12 +1402,10 @@
 /obj/item/kirbyplants/organic/plant22,
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "vZ" = (
 /obj/item/bedsheet/nanotrasen{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/maint,
@@ -1422,7 +1420,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/carpet/executive,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "wv" = (
 /obj/structure/chair/sofa/corp/left,
 /obj/item/trash/candy{
@@ -1438,7 +1436,7 @@
 /obj/structure/sign/flag/nanotrasen/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "wx" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -1446,7 +1444,7 @@
 /obj/structure/chair/plastic,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "wB" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 4
@@ -1454,7 +1452,7 @@
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "wE" = (
 /obj/structure/table/wood{
 	color = "#474747"
@@ -1468,11 +1466,11 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "wQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "wV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1480,7 +1478,7 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "wW" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
@@ -1490,32 +1488,36 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "wZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/xenoblood,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "xc" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "xk" = (
 /obj/machinery/smartfridge,
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_x = 25
+	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "xp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "xD" = (
 /obj/structure/sign/poster/contraband/eat/directional/east,
 /obj/structure/lattice,
@@ -1540,12 +1542,11 @@
 /obj/item/gun/ballistic/shotgun/doublebarrel/slugs{
 	pin = /obj/item/firing_pin/explorer;
 	name = "boomstick";
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/carpet/executive,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "xH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1553,20 +1554,20 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/vending/clothing,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "xJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "xQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/newspaper,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "xR" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom 1"
@@ -1578,14 +1579,14 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "xS" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
 	},
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "xU" = (
 /obj/structure/rack,
 /obj/item/gps/spaceruin{
@@ -1597,7 +1598,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ye" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/item/storage/bag/trash{
@@ -1617,13 +1618,14 @@
 	pixel_y = 2
 	},
 /obj/item/mop,
+/obj/item/lightreplacer,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "yj" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "yz" = (
 /obj/structure/chair/sofa/left/maroon,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
@@ -1636,26 +1638,23 @@
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "yF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/tank/air,
 /obj/machinery/light/small/dim/directional/east,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "zb" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/all_access,
 /obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "zd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "zf" = (
 /obj/machinery/door/airlock{
 	name = "Dormitories"
@@ -1663,8 +1662,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/ghostkitchen)
 "zg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1672,22 +1671,23 @@
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "zh" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/table,
 /obj/item/trash/tray,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "zi" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "zv" = (
 /obj/effect/decal/cleanable/garbage,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "zx" = (
 /obj/structure/table/reinforced,
 /obj/item/food/meat/steak{
@@ -1699,7 +1699,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "zG" = (
 /obj/structure/closet/secure_closet/freezer/meat/all_access,
 /obj/effect/decal/cleanable/dirt,
@@ -1707,7 +1707,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "zK" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	dir = 8
@@ -1715,32 +1715,34 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/obj/effect/turf_decal/siding/dark/inner_corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/ghostkitchen)
 "zM" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "zQ" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Aj" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/food/burger/chicken{
-	pixel_x = 0;
 	pixel_y = 17
 	},
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ao" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -1750,7 +1752,7 @@
 	pixel_y = -17
 	},
 /turf/open/floor/carpet/executive,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ar" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1758,7 +1760,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "As" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -1774,12 +1776,11 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/gloves/color/yellow{
-	pixel_x = 0;
 	pixel_y = -5
 	},
 /obj/structure/sign/poster/contraband/tools/directional/north,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Au" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty{
@@ -1791,8 +1792,7 @@
 	pixel_y = 8
 	},
 /obj/item/weldingtool/experimental{
-	pixel_x = -1;
-	pixel_y = 0
+	pixel_x = -1
 	},
 /obj/item/multitool{
 	pixel_x = 7;
@@ -1800,7 +1800,7 @@
 	},
 /obj/structure/sign/poster/contraband/hacking_guide/directional/north,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ax" = (
 /obj/structure/table/wood{
 	color = "#474747"
@@ -1809,13 +1809,11 @@
 	dir = 8
 	},
 /obj/item/reagent_containers/condiment/ketchup{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /obj/machinery/light/directional/west,
 /obj/item/toy/balloon{
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/item/toy/balloon{
 	color = "#FF0000";
@@ -1823,14 +1821,14 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "AK" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/chair/plastic{
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Bc" = (
 /obj/machinery/door/airlock/external/glass/ruin{
 	name = "The All-American Diner"
@@ -1838,7 +1836,7 @@
 /obj/effect/mapping_helpers/airlock/access,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Bd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1846,39 +1844,34 @@
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Bf" = (
 /obj/machinery/biogenerator,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
-"Bk" = (
-/obj/structure/extinguisher_cabinet/directional/west{
-	pixel_x = -25;
-	pixel_y = 27
-	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
+"Bk" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/ghostkitchen)
 "Bm" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/decal/cleanable/confetti,
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Bo" = (
 /obj/structure/fans/tiny,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/grunge{
-	name = "Freezer"
-	},
-/obj/effect/mapping_helpers/airlock/access,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/obj/machinery/door/airlock/freezer,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/ghostkitchen)
 "Br" = (
 /turf/open/floor/holofloor/beach/coast{
 	dir = 4
 	},
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "BT" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -1887,19 +1880,19 @@
 /obj/item/holosign_creator/robot_seat/restaurant,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Cb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/parquet,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ce" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/light/small/dim/directional/east,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Cn" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -1908,12 +1901,9 @@
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Co" = (
-/obj/structure/table{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table,
 /obj/item/storage/box/stockparts/deluxe{
 	pixel_x = -5;
 	pixel_y = 12
@@ -1927,7 +1917,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Cw" = (
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /obj/effect/decal/cleanable/dirt,
@@ -1935,7 +1925,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "CF" = (
 /obj/structure/chair/sofa/left/maroon,
 /obj/effect/turf_decal/siding/dark_red{
@@ -1944,11 +1934,10 @@
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "CI" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/food/burger/chicken{
@@ -1957,30 +1946,24 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "CL" = (
 /obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_x = 0;
-	pixel_y = 10
-	},
+/obj/machinery/microwave,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "CT" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/trash/shok_roks{
-	pixel_x = 0;
-	pixel_y = 3
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/structure/electrified_grille,
+/obj/structure/cable,
+/obj/machinery/power/rtg/advanced,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "CV" = (
 /obj/structure/sign/flag/tizira/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Dj" = (
 /obj/structure/table/wood{
 	color = "#474747"
@@ -1999,13 +1982,13 @@
 	pixel_y = 2
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Dz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/meter,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "DQ" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 1
@@ -2021,7 +2004,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "DU" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/structure/sign/clock/directional/north,
@@ -2038,7 +2021,7 @@
 	pixel_y = -14
 	},
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "DW" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/balloon{
@@ -2048,8 +2031,7 @@
 	},
 /obj/item/toy/balloon{
 	color = "#0000FF";
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /obj/item/toy/balloon{
 	pixel_x = -6;
@@ -2057,7 +2039,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ee" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
@@ -2069,21 +2051,19 @@
 /obj/effect/decal/cleanable/xenoblood,
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Er" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/food/tomato_smudge,
 /obj/effect/decal/cleanable/food/tomato_smudge,
-/obj/item/food/pie/applepie{
-	pixel_x = -3;
-	pixel_y = 9
+/obj/item/storage/bag/tray{
+	pixel_y = 7
 	},
-/obj/item/food/pie/cherrypie{
-	pixel_x = 4;
-	pixel_y = 1
+/obj/item/storage/bag/tray{
+	pixel_y = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ex" = (
 /obj/structure/lattice,
 /obj/structure/sign/poster/contraband/moffuchis_pizza/directional/north,
@@ -2096,7 +2076,7 @@
 	},
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ED" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -2119,11 +2099,11 @@
 	dir = 8
 	},
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "EO" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "EY" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/lattice,
@@ -2139,7 +2119,13 @@
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
+"Fj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/ghostkitchen)
 "Fw" = (
 /mob/living/basic/cow{
 	name = "Betsy";
@@ -2148,7 +2134,7 @@
 /turf/open/misc/hay{
 	baseturfs = /turf/open/floor/plating
 	},
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Fy" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cabin7";
@@ -2158,32 +2144,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/ghostkitchen)
 "FC" = (
 /obj/structure/rack,
 /obj/item/holosign_creator/atmos{
-	pixel_x = 0;
 	pixel_y = -2
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "FQ" = (
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "FZ" = (
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ga" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Gv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2191,24 +2176,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Gy" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "GI" = (
 /obj/effect/mine/sound/bwoink{
 	icon = 'icons/obj/tools.dmi';
 	icon_state = "rpd";
-	pixel_x = 0;
 	pixel_y = 40;
 	desc = "Dunno what this is for, better leave it alone.";
 	name = "rapid pipe dispenser"
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "GY" = (
 /obj/structure/table/wood{
 	color = "#474747"
@@ -2218,7 +2202,7 @@
 	},
 /obj/item/trash/syndi_cakes,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ha" = (
 /obj/machinery/door/airlock/command{
 	name = "Manager's Quarters"
@@ -2236,34 +2220,35 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Hb" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "He" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/moisture_trap,
+/obj/machinery/duct,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Hf" = (
 /obj/structure/fake_stairs/wood/directional/north,
 /obj/structure/fake_stairs/wood/directional/south,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Hl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Hq" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -2271,7 +2256,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Hy" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/green/line{
@@ -2279,7 +2264,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "HP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/teal,
@@ -2291,7 +2276,7 @@
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Iw" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2300,7 +2285,7 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "IA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2309,13 +2294,11 @@
 	dir = 8
 	},
 /turf/open/floor/wood/parquet,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "IH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/cabinet{
-	name = "medicine cabinet";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "medicine cabinet"
 	},
 /obj/item/storage/medkit/ancient{
 	pixel_x = 3;
@@ -2326,7 +2309,6 @@
 	pixel_y = 4
 	},
 /obj/item/clothing/neck/stethoscope{
-	pixel_x = 0;
 	pixel_y = -3
 	},
 /obj/item/storage/pill_bottle/multiver{
@@ -2339,7 +2321,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "IP" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/ketchup{
@@ -2355,7 +2337,6 @@
 	pixel_y = 16
 	},
 /obj/item/reagent_containers/condiment/bbqsauce{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/condiment/hotsauce{
@@ -2371,7 +2352,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "IQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2379,10 +2360,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Jc" = (
-/obj/structure/lattice,
 /obj/structure/sign/poster/contraband/eat/directional/north,
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
 /turf/open/space/basic,
 /area/space)
 "Jh" = (
@@ -2394,41 +2376,17 @@
 /obj/structure/sign/clock/directional/north,
 /obj/structure/sign/poster/contraband/donut_corp/directional/east,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ji" = (
 /obj/machinery/griddle,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ju" = (
-/obj/structure/table,
-/obj/item/plate/oven_tray{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/food/bun{
-	pixel_x = 9;
-	pixel_y = 14
-	},
-/obj/item/food/bun{
-	pixel_x = 9;
-	pixel_y = 10
-	},
-/obj/item/plate/oven_tray{
-	pixel_x = -8;
-	pixel_y = 1
-	},
-/obj/item/food/doughslice{
-	pixel_x = 9;
-	pixel_y = 4
-	},
-/obj/item/food/doughslice{
-	pixel_x = 9;
-	pixel_y = 0
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/order_console/cook,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Jv" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 8
@@ -2438,7 +2396,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Jy" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -2449,12 +2407,12 @@
 	},
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "JP" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/machinery/hydroponics/constructable/fullupgrade,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "JT" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/trimline/green/line{
@@ -2462,28 +2420,27 @@
 	},
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Kb" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/structure/chair/sofa/right/maroon{
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/south{
-	pixel_x = 0;
 	pixel_y = -23
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Kc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Kf" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Kh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/billboard/nanotrasen,
@@ -2497,15 +2454,16 @@
 	},
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Kr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/insectguts,
 /obj/machinery/light/directional/west,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ks" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
@@ -2516,7 +2474,7 @@
 /obj/effect/decal/cleanable/food/flour,
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Kx" = (
 /mob/living/basic/chicken{
 	name = "Featherbottom";
@@ -2526,7 +2484,7 @@
 /turf/open/misc/hay{
 	baseturfs = /turf/open/floor/plating
 	},
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ky" = (
 /obj/structure/table/reinforced,
 /obj/item/knife/kitchen{
@@ -2538,15 +2496,16 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Kz" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/duct,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "KJ" = (
 /obj/item/kirbyplants/organic/plant2,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "KV" = (
 /mob/living/basic/chicken{
 	name = "Kentucky";
@@ -2555,20 +2514,15 @@
 /turf/open/misc/hay{
 	baseturfs = /turf/open/floor/plating
 	},
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Lc" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Lh" = (
-/obj/structure/sink/directional/west,
-/obj/structure/mirror/directional/east{
-	pixel_x = 23;
-	pixel_y = 5
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2581,16 +2535,15 @@
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/decal/cleanable/insectguts,
 /obj/item/trash/semki/healthy,
+/obj/structure/mirror/directional/east,
+/obj/structure/sink/directional/west,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Lp" = (
 /obj/effect/decal/cleanable/garbage,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Lr" = (
 /obj/structure/sign/poster/contraband/eat/directional/west,
 /obj/structure/lattice,
@@ -2602,7 +2555,7 @@
 	dir = 8
 	},
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "LG" = (
 /obj/structure/sign/poster/contraband/eat/directional/south,
 /turf/open/space/basic,
@@ -2621,32 +2574,28 @@
 	},
 /obj/item/toy/balloon{
 	color = "#0000FF";
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "LM" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "LW" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /turf/open/floor/holofloor/beach/water,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "LX" = (
 /obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
 /obj/item/food/burger/chicken{
-	pixel_x = 8;
-	pixel_y = 0
+	pixel_x = 8
 	},
+/obj/machinery/power/smes/full,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "LY" = (
 /obj/structure/table/reinforced,
 /obj/item/food/burger/baconburger{
@@ -2654,7 +2603,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Mc" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
@@ -2673,17 +2622,17 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Mg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Mi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Mp" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/stripes/red/line{
@@ -2695,7 +2644,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Mw" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /turf/open/space/basic,
@@ -2704,7 +2653,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "MN" = (
 /obj/structure/chair/sofa/left/maroon{
 	dir = 4
@@ -2714,7 +2663,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "MP" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
@@ -2729,15 +2678,11 @@
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "MZ" = (
-/obj/structure/table{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table,
 /obj/machinery/coffeemaker/impressa{
-	pixel_x = -1;
-	pixel_y = 10
+	pixel_x = 1
 	},
 /obj/item/reagent_containers/cup/glass/mug{
 	pixel_x = 13;
@@ -2750,13 +2695,13 @@
 	color = "#830000"
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ne" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/machinery/hydroponics/constructable/fullupgrade,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Nn" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -2766,7 +2711,7 @@
 /obj/effect/decal/cleanable/confetti,
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Nw" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/turf_decal/trimline/green/line{
@@ -2774,7 +2719,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "NA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood{
@@ -2782,7 +2727,7 @@
 	},
 /obj/structure/sign/poster/contraband/tea_over_tizira/directional/west,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "NF" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/suit_storage_unit/open,
@@ -2790,7 +2735,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "NI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -2799,7 +2744,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/wood/parquet,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "NQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2808,13 +2753,14 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "NV" = (
 /obj/machinery/shower/directional/east,
-/obj/item/soap,
 /obj/machinery/light/small/dim/directional/north,
+/obj/structure/fluff/shower_drain,
+/obj/item/soap,
 /turf/open/floor/catwalk_floor/iron_white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "NZ" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/food/tomato_smudge,
@@ -2837,7 +2783,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Oc" = (
 /obj/structure/table/wood{
 	color = "#474747"
@@ -2855,11 +2801,11 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Od" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "On" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
@@ -2868,10 +2814,10 @@
 /obj/machinery/door/airlock/maintenance/external{
 	name = "Atmospherics"
 	},
-/obj/effect/mapping_helpers/airlock/access,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Oq" = (
 /obj/structure/chair/sofa/right/maroon,
 /obj/effect/turf_decal/siding/dark_red/inner_corner{
@@ -2882,18 +2828,18 @@
 	pixel_y = 30
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ot" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "OF" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/table,
 /obj/item/trash/tray,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "OK" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/balloon_animal/fly{
@@ -2901,7 +2847,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "OO" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/balloon_animal/fly{
@@ -2910,7 +2856,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "OS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/shotgun/buckshot/spent{
@@ -2924,7 +2870,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/carpet/executive,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "OT" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -2934,7 +2880,7 @@
 	},
 /obj/effect/mob_spawn/ghost_role/human/allamerican/regular,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "OW" = (
 /obj/structure/table/wood{
 	color = "#474747"
@@ -2945,16 +2891,19 @@
 /obj/item/trash/tray,
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Pb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Access"
 	},
-/obj/effect/mapping_helpers/airlock/access,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Pf" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/phone{
@@ -2969,12 +2918,12 @@
 	pixel_y = 1
 	},
 /turf/open/floor/carpet/executive,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Pk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Po" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
@@ -2986,20 +2935,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Qb" = (
 /obj/machinery/oven/range,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Qk" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Access"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/ghostkitchen)
 "Qt" = (
 /obj/machinery/chem_master/condimaster,
 /obj/effect/turf_decal/trimline/green/line{
@@ -3007,53 +2956,46 @@
 	},
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Qx" = (
 /obj/structure/table/reinforced,
-/obj/machinery/processor{
-	pixel_y = 11;
-	pixel_x = 1
-	},
+/obj/machinery/processor,
 /obj/item/reagent_containers/cup/rag{
 	pixel_x = -4
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Qz" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/machinery/hydroponics/constructable/fullupgrade,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "QS" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "QZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/spacecash/c1000{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/stack/spacecash/c1000{
-	pixel_x = 0;
 	pixel_y = -3
 	},
 /obj/item/stack/spacecash/c500{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/documents/nanotrasen{
-	pixel_x = 0;
 	pixel_y = -1;
 	desc = "Hold on, the previous owner never signed this..";
 	name = "acquisition documents"
 	},
 /obj/structure/safe,
 /turf/open/floor/carpet/executive,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ri" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cabin5";
@@ -3063,14 +3005,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/ghostkitchen)
 "Rr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Rx" = (
 /obj/structure/bed{
 	dir = 1
@@ -3084,25 +3026,25 @@
 	},
 /obj/structure/sign/poster/contraband/robust_softdrinks/directional/north,
 /turf/open/floor/carpet/red,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ry" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "RC" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "RI" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "RK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3111,8 +3053,9 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/insectguts,
 /obj/effect/decal/cleanable/vomit,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "RS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -3120,13 +3063,13 @@
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "RT" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/light/floor,
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Sb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -3134,7 +3077,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Se" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/decal/cleanable/vomit{
@@ -3143,11 +3086,11 @@
 	},
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Sn" = (
 /obj/effect/spawner/random/trash/hobo_squat,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "So" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 1
@@ -3155,12 +3098,12 @@
 /obj/effect/turf_decal/trimline/green/line,
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Sp" = (
 /obj/structure/flora/bush/sunny/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "SC" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
@@ -3172,38 +3115,29 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Tk" = (
-/obj/structure/table,
-/obj/item/storage/bag/tray{
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/obj/item/storage/bag/tray{
-	pixel_x = 0;
-	pixel_y = 7
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
-"Tv" = (
-/obj/machinery/fishing_portal_generator/full,
-/turf/open/floor/holofloor/beach/water,
-/area/ruin/space/has_grav/powered/ghostkitchen)
-"TO" = (
 /obj/machinery/deepfryer,
 /obj/item/reagent_containers/condiment/vegetable_oil{
 	pixel_x = -1;
 	pixel_y = -12
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
+"Tv" = (
+/obj/machinery/fishing_portal_generator/full,
+/turf/open/floor/holofloor/beach/water,
+/area/ruin/space/has_grav/ghostkitchen)
+"TO" = (
+/obj/structure/sink/kitchen/directional/south,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/ghostkitchen)
 "TQ" = (
 /obj/effect/decal/cleanable/food/flour,
 /obj/effect/decal/cleanable/food/egg_smudge,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "TX" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
@@ -3219,7 +3153,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Uh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3227,19 +3161,19 @@
 /obj/structure/sign/poster/contraband/fake_bombable/directional/north,
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Uj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/insectguts,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Uk" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/sign/poster/contraband/the_big_gas_giant_truth/directional/west,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Uq" = (
 /obj/machinery/gibber{
 	pixel_y = 3;
@@ -3251,7 +3185,7 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Uv" = (
 /obj/structure/table/wood{
 	color = "#474747"
@@ -3262,7 +3196,7 @@
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Uz" = (
 /obj/structure/closet/secure_closet/freezer/meat/all_access,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -3270,31 +3204,31 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "UC" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "UJ" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "UL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "UO" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "UQ" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -3303,32 +3237,36 @@
 	},
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Vp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Access"
 	},
-/obj/effect/mapping_helpers/airlock/access,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Vu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Vy" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "VG" = (
 /obj/machinery/oven/range,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "VL" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
@@ -3342,31 +3280,31 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Wh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/west,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Wj" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Wk" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/item/radio/intercom/directional/south{
-	pixel_x = 0;
 	pixel_y = -23
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Wr" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -3386,7 +3324,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "WD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3394,7 +3332,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "WF" = (
 /obj/item/trash/shok_roks/lanternfruit{
 	pixel_x = 1;
@@ -3403,19 +3341,20 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "WP" = (
 /obj/effect/decal/cleanable/food/flour,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "WW" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
 /obj/structure/sign/poster/contraband/red_rum/directional/north,
+/obj/machinery/duct,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Xa" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -3426,11 +3365,8 @@
 	},
 /obj/effect/decal/cleanable/xenoblood,
 /obj/structure/chair/stool/bar/directional/west,
-/turf/open/floor/iron/kitchen{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/turf/open/floor/iron/kitchen,
+/area/ruin/space/has_grav/ghostkitchen)
 "Xb" = (
 /obj/structure/toilet{
 	dir = 4
@@ -3444,27 +3380,28 @@
 	pixel_y = -2
 	},
 /turf/open/floor/iron/white/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Xo" = (
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Xp" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Access"
 	},
-/obj/effect/mapping_helpers/airlock/access,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/duct,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/ghostkitchen)
 "XA" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "XD" = (
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "XL" = (
 /obj/structure/table,
 /obj/structure/closet/mini_fridge{
@@ -3494,31 +3431,31 @@
 /obj/effect/decal/cleanable/food/tomato_smudge,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "XO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Ye" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Yk" = (
 /obj/effect/spawner/random/structure/closet_private,
 /obj/item/food/burger/chicken{
-	pixel_x = 0;
 	pixel_y = -4
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/royalblue,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Yv" = (
 /obj/structure/table,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "YA" = (
 /obj/structure/bed{
 	dir = 1
@@ -3532,13 +3469,13 @@
 	},
 /obj/structure/sign/poster/contraband/revolver/directional/north,
 /turf/open/floor/carpet/royalblue,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "YE" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/sign/poster/contraband/eat/directional/west,
 /turf/open/floor/grass,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "YH" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -3548,7 +3485,7 @@
 	},
 /obj/effect/mob_spawn/ghost_role/human/allamerican/chef,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "YQ" = (
 /obj/structure/chair/sofa/left/maroon{
 	dir = 4
@@ -3559,7 +3496,7 @@
 	},
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "YW" = (
 /obj/structure/table/wood{
 	color = "#474747"
@@ -3578,7 +3515,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "YZ" = (
 /obj/structure/closet/secure_closet/freezer/meat/all_access,
 /obj/effect/decal/cleanable/dirt,
@@ -3587,7 +3524,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Za" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3595,7 +3532,7 @@
 /obj/effect/decal/cleanable/insectguts,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Zh" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/decal/cleanable/vomit{
@@ -3605,35 +3542,61 @@
 /obj/effect/decal/cleanable/xenoblood,
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Zi" = (
 /obj/machinery/door/airlock/external/glass/ruin{
 	name = "The All-American Diner"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/turf/open/floor/iron/textured_half,
+/area/ruin/space/has_grav/ghostkitchen)
 "Zp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/kirbyplants/organic/plant1,
 /turf/open/floor/wood/tile,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "Zs" = (
 /obj/effect/decal/cleanable/food/flour,
 /obj/effect/decal/cleanable/food/egg_smudge{
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/structure/closet/crate/bin,
-/obj/item/storage/bag/trash,
 /obj/machinery/light/directional/south,
-/mob/living/basic/mouse/rat,
 /obj/effect/decal/cleanable/food/pie_smudge,
+/obj/structure/table,
+/obj/item/plate/oven_tray{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/item/plate/oven_tray{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/food/doughslice{
+	pixel_x = 9
+	},
+/obj/item/food/doughslice{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/food/bun{
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/obj/item/food/bun{
+	pixel_x = 9;
+	pixel_y = 14
+	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
+"Zt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/ghostkitchen)
 "ZK" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/beaker/large{
@@ -3649,11 +3612,10 @@
 	pixel_y = 15
 	},
 /obj/item/food/cheese/wedge{
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ZN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3661,8 +3623,9 @@
 	name = "Restroom"
 	},
 /obj/effect/mapping_helpers/airlock/access,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/ghostkitchen)
 "ZP" = (
 /obj/effect/turf_decal/siding/dark/inner_corner{
 	dir = 8
@@ -3672,14 +3635,14 @@
 	},
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ZW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/parquet,
-/area/ruin/space/has_grav/powered/ghostkitchen)
+/area/ruin/space/has_grav/ghostkitchen)
 "ZX" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
@@ -3993,24 +3956,24 @@ yF
 Dz
 Rr
 Ce
-tP
+eU
 NV
-tP
+eU
 nm
-tP
+eU
 Xb
 tP
 tP
 hR
-tP
-tP
+eU
+eU
 hR
 hR
 jO
 ql
 hR
 hR
-tP
+eU
 oa
 nT
 Mw
@@ -4025,18 +3988,18 @@ qf
 tP
 tP
 tP
-tP
-tP
+eU
+eU
 On
-tP
-tP
-tP
+eU
+eU
+eU
 pf
-tP
+eU
 he
-tP
+eU
 xR
-tP
+eU
 Oq
 Ax
 hF
@@ -4047,7 +4010,7 @@ bP
 rM
 MN
 wB
-tP
+eU
 RC
 sy
 Mw
@@ -4063,7 +4026,7 @@ tP
 Au
 io
 Co
-tP
+eU
 pF
 XO
 He
@@ -4073,7 +4036,7 @@ Kr
 RK
 Wh
 vm
-tP
+eU
 CF
 GY
 kU
@@ -4090,8 +4053,8 @@ MB
 ZX
 qf
 Kh
-qf
 cN
+kA
 "}
 (12,1,1) = {"
 kA
@@ -4100,18 +4063,18 @@ tP
 As
 Ye
 tm
-tP
-XO
+eU
+Fj
 zv
 cE
-tP
+eU
 vU
 Lh
 gN
 kl
 wZ
 ZN
-si
+te
 wV
 hP
 zg
@@ -4121,7 +4084,7 @@ xJ
 Bd
 nV
 dz
-tP
+eU
 ca
 Hb
 Mw
@@ -4141,13 +4104,13 @@ mm
 UL
 Sn
 ye
-tP
+eU
 Aj
-tP
-tP
-tP
-tP
-tP
+eU
+eU
+eU
+eU
+eU
 WW
 BT
 Jy
@@ -4158,14 +4121,14 @@ vV
 tg
 lJ
 Wk
-tP
+eU
 UQ
 cC
 ZX
 qf
 ua
+qf
 HP
-kA
 "}
 (14,1,1) = {"
 kA
@@ -4174,19 +4137,19 @@ tP
 iJ
 EO
 WF
-tP
+eU
 IQ
-tP
-tP
-tP
-tP
-tP
+eU
+eU
+eU
+eU
+eU
 ng
 ZK
 Zs
-tP
+eU
 eC
-tP
+eU
 ja
 re
 rg
@@ -4211,13 +4174,13 @@ tP
 tA
 LX
 tA
-tP
+eU
 eG
-tP
+eU
 Mp
 tx
 cL
-tP
+eU
 Kt
 TQ
 FQ
@@ -4248,18 +4211,18 @@ tP
 CT
 hw
 nw
-tP
+eU
 Hl
-tP
+eU
 Cw
 Kc
 YZ
-tP
+eU
 Qb
 qp
 TQ
 kt
-qp
+Zt
 Ji
 iG
 MZ
@@ -4274,29 +4237,29 @@ Od
 tP
 tP
 Jc
-kA
+qf
 kA
 kA
 "}
 (17,1,1) = {"
 kA
 qf
-aM
-aM
-aM
-aM
-aM
-fG
 tP
+tP
+tP
+tP
+tP
+fG
+eU
 Cw
 Pk
 zG
-tP
+eU
 VG
 qp
 qp
 Qx
-Xo
+Bk
 Tk
 nH
 Er
@@ -4310,30 +4273,30 @@ fk
 wQ
 bD
 Bc
-cN
-HP
-cN
+ua
+ua
+qf
 HP
 "}
 (18,1,1) = {"
 kA
 kA
-aM
+tP
 xF
 Ao
 vZ
-aM
-Uh
 tP
+Uh
+eU
 qn
 Pk
 Uz
-tP
+eU
 Ju
 WP
 qp
 Ky
-Xo
+Bk
 Xo
 Xo
 qp
@@ -4347,30 +4310,30 @@ tP
 xp
 Ar
 tP
-qf
-qf
-qf
+ua
+ua
+kA
 qf
 "}
 (19,1,1) = {"
 kA
 kA
-aM
+tP
 Pf
 OS
 QZ
-aM
-Hl
 tP
+Hl
+eU
 CI
 aa
 Uq
-tP
+eU
 TO
-qp
-qp
+Zt
+Zt
 CL
-qp
+Zt
 IP
 nH
 XL
@@ -4384,30 +4347,30 @@ Zi
 Mg
 zM
 Bc
+ua
+ua
+qf
 cN
-HP
-cN
-HP
 "}
 (20,1,1) = {"
 kA
 qf
-aM
+tP
 DU
 Wr
 Wj
-aM
-Hl
 tP
+Hl
+eU
 pV
 eF
 dN
 Bo
 rf
 rf
-qp
+Zt
 Xp
-qp
+Zt
 Ji
 NZ
 pP
@@ -4421,30 +4384,30 @@ tP
 xU
 tP
 tP
-Jc
-kA
+pA
+qf
 kA
 kA
 "}
 (21,1,1) = {"
 cN
 qf
-aM
+tP
 wv
 ED
 Wj
-aM
+tP
 Pb
-tP
-tP
-tP
-tP
-tP
+eU
+eU
+eU
+eU
+eU
 zb
 rf
 qp
 xk
-fB
+qp
 FZ
 qp
 qp
@@ -4466,23 +4429,23 @@ HP
 (22,1,1) = {"
 kA
 kA
-aM
-aM
+tP
+tP
 Ha
-aM
-aM
+tP
+tP
 Zp
 rV
 NA
 rs
 sh
-tP
+eU
 Bf
 Qk
 jX
-tP
-eC
-tP
+eU
+qe
+eU
 vl
 LY
 zx
@@ -4517,7 +4480,7 @@ vE
 si
 PD
 KJ
-tP
+eU
 nB
 Cn
 fx
@@ -4528,14 +4491,14 @@ tI
 kq
 Jv
 dz
-tP
+eU
 nS
 Hb
 ZX
 qf
 al
+qf
 cN
-kA
 "}
 (24,1,1) = {"
 kA
@@ -4565,7 +4528,7 @@ si
 xJ
 YQ
 Kb
-tP
+eU
 EB
 cC
 Mw
@@ -4580,18 +4543,18 @@ kA
 tP
 um
 Ri
-tP
+eU
 um
 in
-tP
+eU
 um
 Fy
-tP
-tP
+eU
+eU
 yj
 cu
 yj
-tP
+eU
 qo
 OW
 eS
@@ -4608,8 +4571,8 @@ MB
 ZX
 qf
 ua
-qf
 HP
+kA
 "}
 (26,1,1) = {"
 kA
@@ -4617,18 +4580,18 @@ qf
 tP
 pv
 wW
-tP
+eU
 Rx
 wW
-tP
+eU
 YA
 wW
-tP
+eU
 ao
 NI
 ar
 JT
-tP
+eU
 Jh
 Dj
 DQ
@@ -4639,7 +4602,7 @@ RS
 sZ
 dA
 aC
-tP
+eU
 LE
 sy
 Mw
@@ -4654,29 +4617,29 @@ qf
 tP
 dg
 YH
-tP
+eU
 hU
 kc
-tP
+eU
 Yk
 OT
-tP
+eU
 Qt
 IA
 ub
 Nw
-tP
-tP
+eU
+eU
 hR
-tP
-tP
+eU
+eU
 hR
 hR
 jO
 zK
 hR
 hR
-tP
+eU
 LM
 pq
 Mw
@@ -4690,14 +4653,14 @@ HP
 qf
 tP
 tP
-tP
-tP
-tP
-tP
-tP
-tP
-tP
-tP
+eU
+eU
+eU
+eU
+eU
+eU
+eU
+eU
 Hy
 ZW
 Cb

--- a/_maps/fulp_maps/RandomRuins/SpaceRuins/allamericandiner_openforbusiness.dmm
+++ b/_maps/fulp_maps/RandomRuins/SpaceRuins/allamericandiner_openforbusiness.dmm
@@ -63,7 +63,10 @@
 /area/ruin/space/has_grav/ghostkitchen)
 "bs" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/freedom;
+	suit_type = /obj/item/clothing/suit/space/freedom
+	},
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/large,

--- a/_maps/fulp_maps/RandomRuins/SpaceRuins/allamericandiner_openforbusiness.dmm
+++ b/_maps/fulp_maps/RandomRuins/SpaceRuins/allamericandiner_openforbusiness.dmm
@@ -24,7 +24,7 @@
 	pixel_x = -1
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "ao" = (
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /obj/effect/turf_decal/trimline/green/line{
@@ -61,14 +61,11 @@
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/iron/kitchen/small,
 /area/ruin/space/has_grav/ghostkitchen)
-"bb" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/ghostkitchen)
 "bs" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/suit_storage_unit/open,
 /obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/large,
 /area/ruin/space/has_grav/ghostkitchen)
 "bD" = (
@@ -110,7 +107,7 @@
 "ce" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "cs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -158,7 +155,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "cQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/directional/east,
@@ -178,7 +175,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "dz" = (
 /obj/structure/chair/sofa/left/maroon{
 	dir = 8
@@ -315,6 +312,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "staffed-diner-entrance"
+	},
 /turf/open/floor/iron/textured_half,
 /area/ruin/space/has_grav/ghostkitchen)
 "fq" = (
@@ -375,6 +375,13 @@
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/kitchen/small,
 /area/ruin/space/has_grav/ghostkitchen)
+"fY" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/large,
+/area/ruin/space/has_grav/ghostkitchen)
 "gt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -386,7 +393,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "gN" = (
 /obj/structure/sink/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -451,7 +458,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/power/rtg/advanced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "hE" = (
@@ -599,7 +605,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "jx" = (
 /obj/structure/chair/sofa/left/maroon{
 	dir = 1
@@ -681,7 +687,7 @@
 /area/ruin/space/has_grav/ghostkitchen)
 "kA" = (
 /turf/open/space/basic,
-/area/space)
+/area/template_noop)
 "kF" = (
 /obj/machinery/light/small/dim/directional/north,
 /obj/structure/reagent_dispensers/plumbed{
@@ -695,7 +701,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "kU" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 1
@@ -767,17 +773,22 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/beacon,
 /turf/open/floor/iron/herringbone,
 /area/ruin/space/has_grav/ghostkitchen)
 "mt" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/machinery/hydroponics/constructable/fullupgrade,
 /turf/open/floor/grass,
+/area/ruin/space/has_grav/ghostkitchen)
+"mZ" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/large,
 /area/ruin/space/has_grav/ghostkitchen)
 "nc" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
@@ -811,7 +822,6 @@
 "nw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/obj/machinery/power/rtg/advanced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "nB" = (
@@ -921,13 +931,13 @@
 /obj/structure/lattice,
 /obj/structure/sign/poster/contraband/eat/directional/east,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "pA" = (
 /obj/structure/sign/poster/contraband/eat/directional/north,
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/teal,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "pF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
@@ -973,7 +983,7 @@
 "qf" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "qi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1021,8 +1031,8 @@
 /area/ruin/space/has_grav/ghostkitchen)
 "qw" = (
 /obj/effect/turf_decal/stripes,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/herringbone,
 /area/ruin/space/has_grav/ghostkitchen)
 "qx" = (
@@ -1034,7 +1044,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "qI" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -1178,7 +1188,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "sK" = (
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
@@ -1254,7 +1264,7 @@
 "ua" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "ub" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1268,7 +1278,7 @@
 /obj/structure/lattice,
 /obj/structure/sign/poster/contraband/missing_gloves/directional/north,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "ui" = (
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/wood/large,
@@ -1314,7 +1324,7 @@
 "vj" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "vl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/north,
@@ -1522,7 +1532,7 @@
 /obj/structure/sign/poster/contraband/eat/directional/east,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "xF" = (
 /obj/structure/closet{
 	icon_state = "cap";
@@ -1546,6 +1556,13 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/carpet/executive,
+/area/ruin/space/has_grav/ghostkitchen)
+"xG" = (
+/obj/structure/table/reinforced,
+/obj/structure/desk_bell{
+	pixel_y = 7
+	},
+/turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/ghostkitchen)
 "xH" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1835,6 +1852,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access,
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "staffed-diner-entrance"
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "Bd" = (
@@ -1956,7 +1976,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/obj/machinery/power/rtg/advanced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "CV" = (
@@ -2044,7 +2063,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Ej" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/light/floor,
@@ -2068,7 +2087,7 @@
 /obj/structure/lattice,
 /obj/structure/sign/poster/contraband/moffuchis_pizza/directional/north,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "EB" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/chair/plastic{
@@ -2108,7 +2127,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Fa" = (
 /obj/structure/table/wood{
 	color = "#474747"
@@ -2173,8 +2192,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/herringbone,
 /area/ruin/space/has_grav/ghostkitchen)
 "Gy" = (
@@ -2250,11 +2269,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "Hq" = (
-/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/desk_bell{
-	pixel_y = 7
-	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/ghostkitchen)
 "Hy" = (
@@ -2269,7 +2285,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/teal,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Ie" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 4
@@ -2279,11 +2295,9 @@
 /area/ruin/space/has_grav/ghostkitchen)
 "Iw" = (
 /obj/effect/turf_decal/stripes,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/jukebox/no_access,
 /turf/open/floor/iron/herringbone,
 /area/ruin/space/has_grav/ghostkitchen)
 "IA" = (
@@ -2366,7 +2380,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Jh" = (
 /obj/structure/chair/sofa/left/maroon,
 /obj/effect/turf_decal/siding/dark_red{
@@ -2445,7 +2459,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/billboard/nanotrasen,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Kp" = (
 /obj/structure/chair/sofa/left/maroon,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
@@ -2469,7 +2483,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Kt" = (
 /obj/effect/decal/cleanable/food/flour,
 /obj/machinery/vending/dinnerware,
@@ -2548,7 +2562,7 @@
 /obj/structure/sign/poster/contraband/eat/directional/west,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "LE" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/chair/plastic{
@@ -2559,7 +2573,7 @@
 "LG" = (
 /obj/structure/sign/poster/contraband/eat/directional/south,
 /turf/open/space/basic,
-/area/space)
+/area/template_noop)
 "LJ" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
@@ -2593,7 +2607,9 @@
 /obj/item/food/burger/chicken{
 	pixel_x = 8
 	},
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/full{
+	output_level = 30000
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "LY" = (
@@ -2648,7 +2664,7 @@
 "Mw" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "MB" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -2668,7 +2684,7 @@
 /obj/structure/lattice,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "MV" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 1
@@ -2734,6 +2750,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/large,
 /area/ruin/space/has_grav/ghostkitchen)
 "NI" = (
@@ -2928,7 +2945,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/south,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "PD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3074,8 +3091,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/herringbone,
 /area/ruin/space/has_grav/ghostkitchen)
 "Se" = (
@@ -3108,7 +3125,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Th" = (
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -3143,7 +3160,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Ug" = (
 /obj/structure/chair/sofa/right/maroon,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
@@ -3271,7 +3288,7 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "VN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3394,8 +3411,8 @@
 /area/ruin/space/has_grav/ghostkitchen)
 "XA" = (
 /obj/effect/turf_decal/stripes,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/herringbone,
 /area/ruin/space/has_grav/ghostkitchen)
 "XD" = (
@@ -3549,6 +3566,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "staffed-diner-entrance"
+	},
 /turf/open/floor/iron/textured_half,
 /area/ruin/space/has_grav/ghostkitchen)
 "Zp" = (
@@ -3647,7 +3667,7 @@
 /obj/structure/lattice,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 
 (1,1,1) = {"
 kA
@@ -4338,7 +4358,7 @@ IP
 nH
 XL
 Xo
-UJ
+xG
 QS
 si
 Sb
@@ -4375,11 +4395,11 @@ Ji
 NZ
 pP
 qp
-bb
+UJ
 QS
 Mi
-NF
-bs
+mZ
+fY
 tP
 xU
 tP

--- a/_maps/fulp_maps/RandomRuins/SpaceRuins/allamericandiner_openforbusiness.dmm
+++ b/_maps/fulp_maps/RandomRuins/SpaceRuins/allamericandiner_openforbusiness.dmm
@@ -63,7 +63,7 @@
 /area/ruin/space/has_grav/ghostkitchen)
 "bs" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/open,
+/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/large,
@@ -454,10 +454,8 @@
 /area/ruin/space/has_grav/ghostkitchen)
 "hw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/power/rtg/advanced/pre_upgraded,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "hE" = (
@@ -538,8 +536,24 @@
 	},
 /obj/effect/mapping_helpers/apc/unlocked,
 /obj/effect/mapping_helpers/apc/full_charge,
-/obj/effect/decal/cleanable/garbage,
 /obj/structure/cable,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = -5
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/welding{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = 10
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "iG" = (
@@ -557,9 +571,7 @@
 /area/ruin/space/has_grav/ghostkitchen)
 "iJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/grille/broken,
-/obj/structure/cable,
-/obj/machinery/computer/monitor,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "iO" = (
@@ -689,7 +701,6 @@
 /turf/open/space/basic,
 /area/template_noop)
 "kF" = (
-/obj/machinery/light/small/dim/directional/north,
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 8
 	},
@@ -820,8 +831,8 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/ghostkitchen)
 "nw" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/machinery/power/rtg/advanced/pre_upgraded,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "nB" = (
@@ -941,9 +952,8 @@
 "pF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 4;
-	name = "Supply to Distro"
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
@@ -1113,10 +1123,8 @@
 	pixel_y = 9;
 	pixel_x = -32
 	},
-/obj/item/paper/crumpled{
-	name = "NOTICE: Feeling lonely?";
-	default_raw_text = "<center>No customers? Try hailing the nearby station's crew over the intercomm. You'll have to change the name of the handheld GPS unit in the front airlock if you want a better chance of anyone finding you. Enjoy your new life. Note: All proceeds from the Nanotrasen Brand restaurant portal tourism system legally belongs to them. You will receive your salary in full after your 6 quadrum employment period has ceased. Ensure these proceeds are kept secure in the manager's safe. Glory to Nanotrasen.</center>";
-	pixel_x = 4;
+/obj/item/paper/crumpled/fluff/space_diner_general{
+	pixel_x = 3;
 	pixel_y = 2
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -1249,7 +1257,9 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/ghostkitchen)
 "tA" = (
-/obj/effect/spawner/random/structure/grille,
+/obj/machinery/power/rtg/advanced/pre_upgraded,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/greenglow/filled,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "tI" = (
@@ -1779,23 +1789,10 @@
 /turf/open/floor/iron/herringbone,
 /area/ruin/space/has_grav/ghostkitchen)
 "As" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -3;
-	pixel_y = 10
-	},
-/obj/item/clothing/glasses/welding{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/clothing/gloves/color/yellow{
-	pixel_y = -5
-	},
 /obj/structure/sign/poster/contraband/tools/directional/north,
+/obj/structure/cable,
+/obj/machinery/computer/monitor,
+/obj/machinery/light/small/dim/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "Au" = (
@@ -1976,6 +1973,8 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/machinery/power/rtg/advanced/pre_upgraded,
+/obj/effect/decal/cleanable/greenglow/filled,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "CV" = (
@@ -2003,7 +2002,9 @@
 /turf/open/floor/iron/kitchen/small,
 /area/ruin/space/has_grav/ghostkitchen)
 "Dz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/meter,
 /turf/open/floor/plating,
@@ -2121,6 +2122,12 @@
 /area/ruin/space/has_grav/ghostkitchen)
 "EO" = (
 /obj/structure/cable,
+/obj/machinery/power/smes/full{
+	output_level = 49000
+	},
+/obj/item/food/burger/chicken{
+	pixel_y = 12
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "EY" = (
@@ -2604,11 +2611,8 @@
 /area/ruin/space/has_grav/ghostkitchen)
 "LX" = (
 /obj/structure/cable,
-/obj/item/food/burger/chicken{
-	pixel_x = 8
-	},
-/obj/machinery/power/smes/full{
-	output_level = 30000
+/obj/machinery/power/terminal{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
@@ -3351,12 +3355,9 @@
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/ghostkitchen)
 "WF" = (
-/obj/item/trash/shok_roks/lanternfruit{
-	pixel_x = 1;
-	pixel_y = 2
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/grille/broken,
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
 "WP" = (
@@ -3457,7 +3458,15 @@
 /area/ruin/space/has_grav/ghostkitchen)
 "Ye" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/item/trash/shok_roks/lanternfruit{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/ghostkitchen)
+"Yh" = (
+/obj/machinery/power/rtg/advanced/pre_upgraded,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ghostkitchen)
@@ -4191,7 +4200,7 @@ kA
 kA
 kA
 tP
-tA
+Yh
 LX
 tA
 eU

--- a/code/__DEFINES/fulp_defines/fulp_defines.dm
+++ b/code/__DEFINES/fulp_defines/fulp_defines.dm
@@ -55,4 +55,5 @@
 #define ROLE_GHOST_REGULAR "Fake Health Inspector"
 
 ///Define for the diner ghost role's z-level restriction component.
+///This does NOT work with the regular "stationstuck" component.
 #define PIZZAFICATION "pizzafy"

--- a/code/__DEFINES/fulp_defines/fulp_defines.dm
+++ b/code/__DEFINES/fulp_defines/fulp_defines.dm
@@ -42,14 +42,17 @@
 ///Define for the 'Rabbits' Faction.
 #define FACTION_RABBITS "rabbits"
 
-//Define for the Syndicate Engineer Ruin, used in 'syndicate_engineer.dm"
+///Define for the Syndicate Engineer Ruin, used in 'syndicate_engineer.dm"
 #define ROLE_SYNDICATE_ENGINEER "Syndicate Engineer"
 
-//Defines for "Alert Level Deltaww"
+///Defines for "Alert Level Deltaww"
 #define SEC_LEVEL_DELTAWW 4
 #define ALERT_COEFF_DELTAWW 255 //This alert level should only be temporary; might as well mess with everyone.
 
-//Defines for "Ghost Kitchen" diner ghost spawners
+///Defines for "Ghost Kitchen" diner ghost spawners
 #define ROLE_GHOST_CHEF "All-American Chef"
 #define ROLE_GHOST_COOK "All-American Cook"
 #define ROLE_GHOST_REGULAR "Fake Health Inspector"
+
+///Define for the diner ghost role's z-level restriction component.
+#define PIZZAFICATION "pizzafy"

--- a/fulp_modules/mapping/areas/areas.dm
+++ b/fulp_modules/mapping/areas/areas.dm
@@ -238,5 +238,5 @@
 	name = "Prototype Dormitories"
 	icon_state = "dorms"
 
-/area/ruin/space/has_grav/powered/ghostkitchen
+/area/ruin/space/has_grav/ghostkitchen
 	name = "The All American Diner"

--- a/fulp_modules/mapping/ruins/space/ghost_diner/ghost_diner.dm
+++ b/fulp_modules/mapping/ruins/space/ghost_diner/ghost_diner.dm
@@ -13,10 +13,37 @@
 /datum/job/fulp_ghostregular
 	title = ROLE_GHOST_REGULAR
 
+/datum/component/stationstuck/diner
+	punishment = PIZZAFICATION
+
+// Copied over from "/datum/smite/objectify/effect()"
+// in 'code\modules\admin\smites\become_object.dm'
+/datum/component/stationstuck/diner/punish()
+	if(punishment != PIZZAFICATION)
+		return ..()
+
+	// We're turning them into a Hawaiian pizza for extra shock value.
+	var/atom/transform_path = /obj/item/food/pizza/pineapple
+	var/mutable_appearance/pizzafied_player = mutable_appearance(initial(transform_path.icon), initial(transform_path.icon_state))
+	pizzafied_player.pixel_x = initial(transform_path.pixel_x)
+	pizzafied_player.pixel_y = initial(transform_path.pixel_y)
+	var/mutable_appearance/transform_scanline = mutable_appearance('icons/effects/effects.dmi', "transform_effect")
+	var/mob/living/future_pizza = parent
+	future_pizza.transformation_animation(pizzafied_player, 5 SECONDS, transform_scanline.appearance)
+	future_pizza.Immobilize(5 SECONDS, ignore_canstun = TRUE)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(objectify), future_pizza, transform_path), 5 SECONDS)
+
 /obj/effect/mob_spawn/ghost_role/human/allamerican
 	prompt_name = "A real american"
 	you_are_text = "A real american, fight for the rights of every man!"
 	flavour_text = "Fight what's right, fight for your life!"
+
+// (Implementation of the stationstuck component has been copied over from
+// 'fulp_modules\mapping\ruins\space\syndicate_engineer\syndicate_engineer.dm')
+/obj/effect/mob_spawn/ghost_role/human/all_american/special(mob/living/new_spawn)
+	. = ..()
+	to_chat(new_spawn, "<b>You have been implanted with a pizzafication implant that will activate if you stray too far from the diner. Glory to Nanotrasen.</b>")
+	new_spawn.AddComponent(/datum/component/stationstuck/diner, PIZZAFICATION, "You have left the vicinity of the diner. Your pizzafication implant has been triggered.")
 
 /obj/effect/mob_spawn/ghost_role/human/allamerican/chef
 	name = "All-American Chef"
@@ -51,9 +78,10 @@
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 	you_are_text = "You are a lover of fine dining."
-	flavour_text = "After realizing you could claim to be a health inspector, and recieve free meals, \
-	you began a journey across the Spinward sector, on a quest for free meals."
-	important_text = "Don't get yourself kicked out, you're stranded!"
+	flavour_text = "After realizing you could claim to be a health inspector (and recieve free meals) \
+	you began a journey across the Spinward sector (on a quest for free meals). As an ironic punishment \
+	for impersonating a food safety official, you are now unwillingly imprisoned on a space diner."
+	important_text = "Don't get yourself kicked out: you'll turn into a pizza!"
 	spawner_job_path = /datum/job/fulp_ghostregular
 	outfit = /datum/outfit/fulp_ghostregular
 
@@ -63,6 +91,7 @@
 	suit = /obj/item/clothing/suit/toggle/chef
 	head = /obj/item/clothing/head/utility/chefhat
 	shoes = /obj/item/clothing/shoes/sneakers/black
+	id = /obj/item/card/id
 	id_trim = /datum/id_trim/job/cook/chef
 
 /datum/outfit/fulp_ghostcook
@@ -71,6 +100,7 @@
 	suit = /obj/item/clothing/suit/apron/chef
 	head = /obj/item/clothing/head/soft/mime
 	shoes = /obj/item/clothing/shoes/sneakers/black
+	id = /obj/item/card/id
 	id_trim = /datum/id_trim/job/cook
 
 /datum/outfit/fulp_ghostregular

--- a/fulp_modules/mapping/ruins/space/ghost_diner/ghost_diner.dm
+++ b/fulp_modules/mapping/ruins/space/ghost_diner/ghost_diner.dm
@@ -135,7 +135,7 @@
 	color = "#e0e010"
 	default_raw_text = {"
 <center><h1>No customers?</h1></center>
-<p>Try hailing nearby stations over your wall intercomms and telling them that your open! Anyone with a functional teleporter should be able to make a one-way trip to your restaurant once you and your tracking beacons are out of cryostasis.</p>
+<p>Try hailing nearby stations over your wall intercomms and telling them that you're open! Anyone with a functional teleporter should be able to make a one-way trip to your restaurant once you and your tracking beacons are out of cryostasis.</p>
 <p>Changing the name of the handheld GPS unit in the front airlock will help non-teleporting spacefarers locate you manually. Enjoy your new life.</p>
 <p><i><b>NOTE</b>: All proceeds from the Nanotrasen Brand restaurant portal tourism system legally belong to the Nanotrasen Revenue Department. You will receive your salary in full after your six quadrum employment period has ceased. Ensure that these proceeds are kept secure in the manager's safe. Glory to Nanotrasen.</i></p>
 	"}

--- a/fulp_modules/mapping/ruins/space/ghost_diner/ghost_diner.dm
+++ b/fulp_modules/mapping/ruins/space/ghost_diner/ghost_diner.dm
@@ -1,9 +1,16 @@
+// - MAP TEMPLATE DATUM - //
 /datum/map_template/ruin/space/fulp/ghost_diner
 	name = "Space-Ruin Staffed All-American Diner"
 	id = "ghost diner"
 	description = "A fully staffed american diner, floating in the void of space."
 	suffix = "allamericandiner_openforbusiness.dmm"
 
+
+// - CUSTOM RTG SUBTYPE FOR THE DINER MAP - //
+/obj/machinery/power/rtg/diner
+	component_parts = ""
+
+// - JOB DATUMS - //
 /datum/job/fulp_ghostchef
 	title = ROLE_GHOST_CHEF
 
@@ -13,6 +20,12 @@
 /datum/job/fulp_ghostregular
 	title = ROLE_GHOST_REGULAR
 
+
+// - GHOST ROLE COMPONENT DATUM(S) - //
+
+/// A subtype of the stationstuck component that's primarily intended for use in one ghost role.
+/// Turns its (presumably '/mob/living') owner into a pizza if they leave the z-level the component
+/// is attatched on.
 /datum/component/stationstuck/diner
 	punishment = PIZZAFICATION
 
@@ -22,17 +35,27 @@
 	if(punishment != PIZZAFICATION)
 		return ..()
 
+	var/mob/living/future_pizza = parent
+	if(message)
+		to_chat(future_pizza, span_userdanger("[message]"))
+
 	// We're turning them into a Hawaiian pizza for extra shock value.
 	var/atom/transform_path = /obj/item/food/pizza/pineapple
 	var/mutable_appearance/pizzafied_player = mutable_appearance(initial(transform_path.icon), initial(transform_path.icon_state))
 	pizzafied_player.pixel_x = initial(transform_path.pixel_x)
 	pizzafied_player.pixel_y = initial(transform_path.pixel_y)
 	var/mutable_appearance/transform_scanline = mutable_appearance('icons/effects/effects.dmi', "transform_effect")
-	var/mob/living/future_pizza = parent
+
+	var/turf/future_pizza_turf = get_turf(future_pizza)
+	message_admins("[future_pizza.real_name] ([future_pizza.ckey]) has been turned into a pizza near \
+		[ADMIN_VERBOSEJMP(future_pizza_turf)] for attempting to move to a different z_level.")
+
 	future_pizza.transformation_animation(pizzafied_player, 5 SECONDS, transform_scanline.appearance)
 	future_pizza.Immobilize(5 SECONDS, ignore_canstun = TRUE)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(objectify), future_pizza, transform_path), 5 SECONDS)
 
+
+// - GHOST ROLE SPAWNERS - //
 /obj/effect/mob_spawn/ghost_role/human/allamerican
 	prompt_name = "A real american"
 	you_are_text = "A real american, fight for the rights of every man!"
@@ -40,9 +63,9 @@
 
 // (Implementation of the stationstuck component has been copied over from
 // 'fulp_modules\mapping\ruins\space\syndicate_engineer\syndicate_engineer.dm')
-/obj/effect/mob_spawn/ghost_role/human/all_american/special(mob/living/new_spawn)
+/obj/effect/mob_spawn/ghost_role/human/allamerican/special(mob/living/new_spawn)
 	. = ..()
-	to_chat(new_spawn, "<b>You have been implanted with a pizzafication implant that will activate if you stray too far from the diner. Glory to Nanotrasen.</b>")
+	to_chat(new_spawn, span_warning("You have been implanted with a pizzafication implant that will activate if you stray too far from the diner. Glory to Nanotrasen."))
 	new_spawn.AddComponent(/datum/component/stationstuck/diner, PIZZAFICATION, "You have left the vicinity of the diner. Your pizzafication implant has been triggered.")
 
 /obj/effect/mob_spawn/ghost_role/human/allamerican/chef
@@ -56,7 +79,7 @@
 	Lead the kitchen and ensure your cook has direction. Create culinary masterpieces."
 	important_text = "Do not abandon the kitchen! Lead with grace."
 	spawner_job_path = /datum/job/fulp_ghostchef
-	outfit = /datum/outfit/fulp_ghostchef
+	outfit = /datum/outfit/diner_ghost/fulp_ghostchef
 
 /obj/effect/mob_spawn/ghost_role/human/allamerican/cook
 	name = "All-American Cook"
@@ -69,11 +92,11 @@
 	Follow the chef's direction. Do menial tasks. Clean up after the recent Flyperson birthday bash."
 	important_text = "Yes chef! You answer directly to the chef."
 	spawner_job_path = /datum/job/fulp_ghostcook
-	outfit = /datum/outfit/fulp_ghostcook
+	outfit = /datum/outfit/diner_ghost/fulp_ghostcook
 
 /obj/effect/mob_spawn/ghost_role/human/allamerican/regular
-	name = "All-American Regular"
-	desc = "A cryogenics pod, storing a regular customer of the diner. They seem to be sleeping off a serious food coma."
+	name = "All-American \"Customer\""
+	desc = "A cryogenics pod storing a regular customer of the diner. They seem to be sleeping off a serious food coma."
 	prompt_name = "an all american customer"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
@@ -83,29 +106,86 @@
 	for impersonating a food safety official, you are now unwillingly imprisoned on a space diner."
 	important_text = "Don't get yourself kicked out: you'll turn into a pizza!"
 	spawner_job_path = /datum/job/fulp_ghostregular
-	outfit = /datum/outfit/fulp_ghostregular
+	outfit = /datum/outfit/diner_ghost/fulp_ghostregular
 
-/datum/outfit/fulp_ghostchef
+
+// - EXPOSITIONAL POCKET NOTES FOR GHOST ROLE OUTFITS - //
+/obj/item/paper/fluff/space_diner_staff
+	name = "Notice of Employment"
+	desc = "A formal document detailing employment information."
+
+	default_raw_text = {"
+<center><h1>Notice of Employment</h1></center>
+<center><h2>Issued by the Nanotrasen Department of Humanoid Resource Management</h1></center>
+<small><i>This document is to be kept on its recipient at all times as a contingency against any possible amnesia caused by prolonged cryostasis.</small></i>
+<p>Welcome to your new life employee. You have applied for the position of <b>CULINARY STAFF</b> on a state of the art stellar dining platform. Given that your employment is not nullified due to a contract violation, you will be receiving <b>WAGE</b> credits at the end of your <b>LONG-TERM</b> shift on <b>STANDARDIZED_INTERSTELLAR_DATE</b>.</p>
+<p>On your person you may find the following equipment:</p>
+<ol>
+<li><b>JOB_EQUIPMENT</b> for <b>EQUIPMENT_PURPOSE</b>.
+<li>A Nanotrasen patented tracking beacon to allow for easy transportation between your work
+site and any others that might intersect with its orbit. (Please note that you are requested to
+turn this beacon off as a means of closing your work site prior to resting.)
+<li>One Unauthorized Workplace Leave Prevention (UWLP) subdermal implant.
+<li><b><i>INK CARTRIDGE LOW</i></b>
+</ol>
+	"}
+
+/obj/item/paper/fluff/space_diner_customer
+	name = "Notice of Penalization"
+	desc = "A stern document conveying civil penalties."
+	color = "#b07020"
+
+	default_raw_text = {"
+<center><h1>Notice of Penalization</h1></center>
+<center><h2>Issued by the Nanotrasen Department of Justice</h2></center>
+<small><i>This document is to be kept on its recipient at all times as a contingency against any possible amnesia caused by prolonged cryostasis.</small></i>
+<p>By order of the <b>COURT_NAME</b> you, <b>CONVICT_NAME</b>, are hereby sentenced to <b>SENTENCE_DURATION</b> quarter(s) of interment on <b>CORRECTIONAL_FACILITY_NAME</b> for the crime of <b>FELONY_NAME</b>.
+<p>Sentencing notes: "Repeat offender, court authorized unusual punishment. Send to a restaurant or something."</p>
+	"}
+
+
+// - OUTFIT DATUMS - //
+
+// Parent datum for our diner ghost roll outfits
+/datum/outfit/diner_ghost
+	name = "PARENT OUTFIT DATUM; DO NOT USE"
+
+// Sets up the outfit's ID; seen throughout a lot of outfit code for some reason.
+// Original source for copied code unknown.
+/datum/outfit/diner_ghost/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
+		return
+
+	var/obj/item/card/id/W = H.wear_id
+	W.registered_name = H.real_name
+	W.update_label()
+	W.update_icon()
+
+/datum/outfit/diner_ghost/fulp_ghostchef
 	name = "All-American Chef"
 	uniform = /obj/item/clothing/under/misc/patriotsuit
 	suit = /obj/item/clothing/suit/toggle/chef
 	head = /obj/item/clothing/head/utility/chefhat
 	shoes = /obj/item/clothing/shoes/sneakers/black
-	id = /obj/item/card/id
+	id = /obj/item/card/id/advanced
 	id_trim = /datum/id_trim/job/cook/chef
+	l_hand = /obj/item/paper/fluff/space_diner_staff
+	l_pocket = /obj/item/beacon
 
-/datum/outfit/fulp_ghostcook
+/datum/outfit/diner_ghost/fulp_ghostcook
 	name = "All-American Cook"
 	uniform = /obj/item/clothing/under/misc/patriotsuit
 	suit = /obj/item/clothing/suit/apron/chef
 	head = /obj/item/clothing/head/soft/mime
 	shoes = /obj/item/clothing/shoes/sneakers/black
-	id = /obj/item/card/id
+	id = /obj/item/card/id/advanced
 	id_trim = /datum/id_trim/job/cook
+	l_hand = /obj/item/paper/fluff/space_diner_staff
+	l_pocket = /obj/item/beacon
 
-/datum/outfit/fulp_ghostregular
+/datum/outfit/diner_ghost/fulp_ghostregular
 	name = "Diner Regular"
 	uniform = /obj/item/clothing/under/suit/black
 	shoes = /obj/item/clothing/shoes/laceup
 	r_hand = /obj/item/storage/briefcase
-
+	l_pocket = /obj/item/paper/fluff/space_diner_customer

--- a/fulp_modules/mapping/ruins/space/ghost_diner/ghost_diner.dm
+++ b/fulp_modules/mapping/ruins/space/ghost_diner/ghost_diner.dm
@@ -7,8 +7,23 @@
 
 
 // - CUSTOM RTG SUBTYPE FOR THE DINER MAP - //
-/obj/machinery/power/rtg/diner
-	component_parts = ""
+/obj/item/circuitboard/machine/rtg/advanced/pre_upgraded
+	name = "Prebuilt RTG"
+	build_path = /obj/machinery/power/rtg/advanced/pre_upgraded
+	specific_parts = TRUE
+	req_components = list(
+		/obj/item/stack/cable_coil = 5,
+		/datum/stock_part/capacitor/tier4 = 1,
+		/datum/stock_part/micro_laser/tier4 = 1,
+		/obj/item/stack/sheet/mineral/uranium = 10,
+		/obj/item/stack/sheet/mineral/plasma = 5,
+	)
+
+/obj/machinery/power/rtg/advanced/pre_upgraded
+	name = "prebuilt radioisotope thermoelectric generator"
+	desc = "An incredibly expensive RTG that requires highly specific parts to function. "
+	circuit = /obj/item/circuitboard/machine/rtg/advanced/pre_upgraded
+
 
 // - JOB DATUMS - //
 /datum/job/fulp_ghostchef
@@ -68,6 +83,11 @@
 	to_chat(new_spawn, span_warning("You have been implanted with a pizzafication implant that will activate if you stray too far from the diner. Glory to Nanotrasen."))
 	new_spawn.AddComponent(/datum/component/stationstuck/diner, PIZZAFICATION, "You have left the vicinity of the diner. Your pizzafication implant has been triggered.")
 
+	// Beacons won't spawn as a part of outfit datums for some reason, so we'll spawn ours here.
+	var/turf/beacon_spawn_turf = get_turf(new_spawn)
+	var/obj/item/beacon/new_beacon = new /obj/item/beacon(beacon_spawn_turf)
+	new_spawn.put_in_hands(new_beacon, ignore_animation = TRUE)
+
 /obj/effect/mob_spawn/ghost_role/human/allamerican/chef
 	name = "All-American Chef"
 	desc = "A cryogenics pod, storing a trained chef to prepare meals when activity is detected in this sector."
@@ -109,7 +129,17 @@
 	outfit = /datum/outfit/diner_ghost/fulp_ghostregular
 
 
-// - EXPOSITIONAL POCKET NOTES FOR GHOST ROLE OUTFITS - //
+// - EXPOSITIONAL POCKET NOTES - //
+/obj/item/paper/crumpled/fluff/space_diner_general
+	name = "NOTICE: Feeling lonely?"
+	color = "#e0e010"
+	default_raw_text = {"
+<center><h1>No customers?</h1></center>
+<p>Try hailing nearby stations over your wall intercomms and telling them that your open! Anyone with a functional teleporter should be able to make a one-way trip to your restaurant once you and your tracking beacons are out of cryostasis.</p>
+<p>Changing the name of the handheld GPS unit in the front airlock will help non-teleporting spacefarers locate you manually. Enjoy your new life.</p>
+<p><i><b>NOTE</b>: All proceeds from the Nanotrasen Brand restaurant portal tourism system legally belong to the Nanotrasen Revenue Department. You will receive your salary in full after your six quadrum employment period has ceased. Ensure that these proceeds are kept secure in the manager's safe. Glory to Nanotrasen.</i></p>
+	"}
+
 /obj/item/paper/fluff/space_diner_staff
 	name = "Notice of Employment"
 	desc = "A formal document detailing employment information."
@@ -169,8 +199,7 @@ turn this beacon off as a means of closing your work site prior to resting.)
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	id = /obj/item/card/id/advanced
 	id_trim = /datum/id_trim/job/cook/chef
-	l_hand = /obj/item/paper/fluff/space_diner_staff
-	l_pocket = /obj/item/beacon
+	l_pocket = /obj/item/paper/fluff/space_diner_staff
 
 /datum/outfit/diner_ghost/fulp_ghostcook
 	name = "All-American Cook"
@@ -180,8 +209,7 @@ turn this beacon off as a means of closing your work site prior to resting.)
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	id = /obj/item/card/id/advanced
 	id_trim = /datum/id_trim/job/cook
-	l_hand = /obj/item/paper/fluff/space_diner_staff
-	l_pocket = /obj/item/beacon
+	l_pocket = /obj/item/paper/fluff/space_diner_staff
 
 /datum/outfit/diner_ghost/fulp_ghostregular
 	name = "Diner Regular"


### PR DESCRIPTION
## About The Pull Request
This PR makes a fair number of fixes and edits to the chef ghost role ruin introduced in PR #1356 by @sylvia-from-fulp-station. These changes affect both the ghost role itself and its map. What follows is a (mostly) comprehensive list of everything done in this PR sorted into the categories of fixes, edits, and additions:

### Fixes

1. Resets the icon offsets for a lot of machines on tables in the diner ruin. (Machines automatically offset themselves on tables, and doing it manually through varediting will cause them overcorrect their offset).
2. Adds tiling that was missing under a number of airlocks.
3. Adds the "template passthrough" area to blank portions of the map (unoccupied space areas).
4. Adds the nearstation area to occupied space areas on the map.
5. Gives the chef ghost roles proper IDs so they can both interact with the restaurant service portal and have airlock access permissions separate from the customer.
6. Properly links the atmospheric distribution pipe network to its main air tank.
7. Takes the ruin's area off of the '/powered' subtype so that its APC and SMES can actually function. (The powered area subtype is _always_ powered regardless of how its actual electric grid is doing).
8. Swaps out the ruin's bluespace SMES for a regular one linked to several machines of a new "prebuilt" RTG subtype.
9. Plumbs the ruin's bathroom and adds an equally plumbed sink to the kitchen.

### Edits

1. Reinforces all exterior walls on the ruin ~~for the sake of realism~~ as a stylistic choice.
2. Replaces the cold room's current airlock with a freezer airlock.
3. Gives the ruin's kitchen a produce orders console.
4. Links up the ruin's entrance airlocks.
5. Adds a jukebox to the ruin.
6. Adjusts/reformats/proofreads the content of the main tip/lore paper on the ruin.
7. Adds a singular patriotic space suit to the ruin to account for the possibility of station crew teleporting to it without a way to get back to the station.

### Additions
1. Makes the ghost roles present on the ruin unable to leave its z-level. This has been accomplished by copying the "explosive implant" idea/code from the Syndicate Engineer ruin. I have put a slight twist on it though— instead of crudely exploding the ghost roles, this "implant" will turn them into Hawaiian pizzas if they ever dare to leave.
2. Gives the ghost roles tracking beacons upon spawning.
3. Added a couple of additional lore papers for the ghost roles. The chefs have employment notices and the customer has a penalization notice (because the only way I could think to justify the customer also being implant-bound to the diner was by canonizing them as its prisoner).
## Why It's Good For The Game
These changes aim make the chef ghost role both a bit more functional and a bit more fun. 
## Changelog
:cl:
add: Added a couple of minor features to the chef ghost role.
map: Made a lot of adjustments to the "Staffed All-American Diner" ruin. See the GitHub pull request associated with this change for exact details.
/:cl:
