### PR TITLE
Adjusts the Gravity Generator Blackout Event on Low Population Rounds

### DIFF
--- a/fulp_modules/Z_edits/event_overrides/grav_gen_blackout.dm
+++ b/fulp_modules/Z_edits/event_overrides/grav_gen_blackout.dm
@@ -1,0 +1,9 @@
+/datum/round_event_control/gravity_generator_blackout/New()
+	. = ..()
+	if(at_lowpop(15))
+		weight = 0
+		max_occurrences = 0
+
+	if(at_lowpop(30))
+		weight = 20
+		max_occurrences = 3

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6788,6 +6788,7 @@
 #include "fulp_modules\Z_edits\emote_edits\scream.dm"
 #include "fulp_modules\Z_edits\erp_removal\double_beds.dm"
 #include "fulp_modules\Z_edits\erp_removal\clothing\clothing.dm"
+#include "fulp_modules\Z_edits\event_overrides\grav_gen_blackout.dm"
 #include "fulp_modules\Z_edits\fixes\radio.dm"
 #include "fulp_modules\Z_edits\inititalize_edits\closet_init.dm"
 #include "fulp_modules\Z_edits\inititalize_edits\techweb_init.dm"


### PR DESCRIPTION

## About The Pull Request
This PR makes the gravity generator blackout event much less common on low population rounds. It is outright removed on rounds with less than fifteen players, and it is still possible (albeit less likely) on rounds with less than thirty. This PR does NOT prevent the gravitational anomaly event from causing the generator to malfunction when its anomaly delaminates.
## Why It's Good For The Game
The gravity generator blackout event has a max occurrence limit of twenty, and its weight is set to thirty whereas most events fall within the range of ten to twenty. It also doesn't have any population requirements by default, so it can become _very_ annoying on low population rounds (especially when there's nobody around with the access required to reset the generator).
## Changelog
:cl:
balance: Made the gravity generator blackout event much less common on low population rounds.
/:cl:
