### PR TITLE
Govyadina Station Atmospherics/Piping Edits

### DIFF
--- a/_maps/fulp_maps/RandomRuins/SpaceRuins/beef_station.dmm
+++ b/_maps/fulp_maps/RandomRuins/SpaceRuins/beef_station.dmm
@@ -32,23 +32,12 @@
 	color = "#414ad1";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
-"aJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/beef/atmos)
 "aK" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/siding/blue,
@@ -67,16 +56,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef)
-"aT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "bz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -94,29 +73,6 @@
 	},
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/beef/beef_restroom)
-"bJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/effect/turf_decal/siding{
-	color = "#4a4a4a"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
-"bY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	color = "#414ad1";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "bZ" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1";
@@ -129,24 +85,18 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "ca" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef/hyrdroponics)
 "ci" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/machinery/door/airlock/freezer,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/cold_room)
 "ck" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -164,12 +114,8 @@
 	name = "Brig";
 	id_tag = "beefbrig"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/beef/security)
 "cz" = (
@@ -182,12 +128,8 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/beef)
 "cJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/kitchen)
@@ -253,8 +195,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "cX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 8
@@ -273,13 +215,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
+"dd" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/obj/item/toy/plush/beefplushie/living,
+/turf/open/space/basic,
+/area/space)
 "dj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
-/obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
 "dl" = (
@@ -324,7 +270,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/beef)
 "dD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -332,6 +280,7 @@
 /obj/machinery/door/window/left/directional/east{
 	name = "Fun Center"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
 "dG" = (
@@ -354,14 +303,6 @@
 /obj/item/clothing/under/bodysash/cook,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/kitchen)
-"dO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "dR" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	req_access = null
@@ -369,11 +310,26 @@
 /obj/item/slimepotion/slime/sentience,
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/beef)
+"dV" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#414ad1";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#2e2e2e";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/beef)
 "dY" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/bookbinder,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/all_access,
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef/library)
 "ed" = (
@@ -408,14 +364,15 @@
 	color = "#2e2e2e";
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "ev" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 8
@@ -429,22 +386,9 @@
 /obj/effect/mapping_helpers/apc/unlocked,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
-"eB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#414ad1"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "eD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 4
-	},
 /obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "eE" = (
@@ -460,30 +404,8 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/obj/structure/closet/crate/secure/gear,
-/obj/item/clothing/under/bodysash/security,
-/obj/item/gun/energy/disabler,
-/obj/item/clothing/head/helmet/sec,
-/obj/item/clothing/suit/armor/vest/alt,
-/obj/item/clothing/head/beret/sec,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/beef/security)
-"eO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
-"eT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "eW" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
@@ -504,8 +426,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "eZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#4a4a4a"
 	},
@@ -513,19 +435,23 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "fh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "fk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1";
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
+"fo" = (
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/beef/atmos)
 "fp" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1";
@@ -546,10 +472,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "fr" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/beef_mix_input{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/vacuum,
 /area/ruin/space/has_grav/beef/atmos)
 "fv" = (
 /turf/open/floor/carpet/red,
@@ -594,7 +520,6 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
 "go" = (
@@ -610,7 +535,7 @@
 /area/ruin/space/has_grav/beef/beef_storage)
 "gu" = (
 /obj/item/storage/toolbox/emergency,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
@@ -618,11 +543,20 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/eighties/red,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
-"hb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+"gM" = (
+/obj/effect/turf_decal/tile/neutral{
+	color = "#2e2e2e";
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#414ad1"
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/beef)
+"hb" = (
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef)
 "hc" = (
@@ -637,10 +571,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "hs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/button/door/directional/west{
 	name = "Brig Bolt Control";
@@ -675,16 +607,16 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/space/nearstation)
 "hM" = (
+/obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/kitchen)
 "hX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "if" = (
@@ -730,17 +662,11 @@
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
 "iO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
-"iP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/beef/beef_entrance)
 "iS" = (
-/obj/item/storage/toolbox/mechanical,
+/obj/item/circuitboard/machine/crystallizer,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "iU" = (
@@ -748,11 +674,6 @@
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/parquet,
-/area/ruin/space/has_grav/beef/beef_bar)
-"jb" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/beef/beef_bar)
 "jc" = (
 /obj/effect/turf_decal/siding/blue{
@@ -786,26 +707,25 @@
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "jt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
-"ju" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/clothing/under/bodysash/engineer,
-/obj/item/clothing/head/utility/hardhat/welding,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/beef/atmos)
+"jv" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/beef/beef_bar)
 "jy" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "jz" = (
@@ -834,9 +754,9 @@
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/beef/hyrdroponics)
 "jT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/closet/toolcloset,
-/obj/structure/cable,
+/obj/structure/closet/secure_closet/engineering_welding{
+	req_access = null
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "jU" = (
@@ -860,15 +780,16 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "ke" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/beef/beef_bar)
 "kh" = (
 /obj/structure/table/glass,
 /obj/item/canvas/twentythree_twentythree,
 /obj/item/canvas/twentythree_twentythree,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef/library)
 "kl" = (
@@ -879,6 +800,8 @@
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
 "kq" = (
@@ -888,7 +811,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef/hyrdroponics)
 "kr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -913,17 +838,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
-"kD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/beef/beef_entertainment_center)
 "kF" = (
 /obj/structure/railing{
 	dir = 6
@@ -933,44 +849,13 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/beef)
-"kK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
-"kL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/ruin/space/has_grav/beef/beef_ball_room)
-"kP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "kS" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/light/floor,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/beef)
-"kX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	color = "#414ad1";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "lo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
@@ -981,16 +866,6 @@
 /obj/machinery/power/solar,
 /turf/open/floor/iron/solarpanel/airless,
 /area/space/nearstation)
-"lr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/beef/kitchen)
 "ls" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1012,12 +887,17 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/beef/atmos)
+"lw" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space/basic,
+/area/space)
 "lH" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 8
@@ -1042,18 +922,18 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	name = "Brig Door Shutters";
 	id = "beefbrigdoor"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/beef/security)
 "lQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/beef)
@@ -1086,14 +966,18 @@
 /area/ruin/space/has_grav/beef/security)
 "mw" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/beef)
-"mN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
+"mx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/beef/atmos)
+"mN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
@@ -1113,6 +997,10 @@
 /obj/effect/mapping_helpers/apc/unlocked,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/beef/beef_entrance)
+"nh" = (
+/obj/machinery/air_sensor/beef_mix_tank,
+/turf/open/floor/engine/vacuum,
+/area/ruin/space/has_grav/beef/atmos)
 "nj" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -1125,20 +1013,6 @@
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/beef/cold_room)
-"ny" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding{
-	color = "#4a4a4a";
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "nE" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/beef/beef_entrance)
@@ -1149,14 +1023,11 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
-"nR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/ruin/space/has_grav/beef/beef_ball_room)
 "nV" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -1165,10 +1036,8 @@
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "oa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/beef/security)
@@ -1192,6 +1061,17 @@
 "or" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/beef/beef_restroom)
+"os" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/computer/atmos_control/beef_mix_tank,
+/obj/machinery/button/ignition{
+	id = "beefcinerator";
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/beef/atmos)
 "ot" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/carpet/orange,
@@ -1202,42 +1082,17 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
-"oz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/beef/kitchen)
+"oB" = (
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/beef/library)
 "oG" = (
 /obj/structure/sign/poster/contraband/clown/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/eighties/red,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
-"oM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e"
-	},
-/obj/structure/cable,
+"oP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "oS" = (
@@ -1249,20 +1104,20 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "oY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef/hyrdroponics)
 "pa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "pd" = (
@@ -1304,10 +1159,18 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/beef)
+"pX" = (
+/obj/effect/mapping_helpers/airalarm/all_access,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/beef/beef_entertainment_center)
 "pZ" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
+"qa" = (
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/beef)
 "qe" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/siding/wood{
@@ -1324,11 +1187,8 @@
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/beef/beef_bar)
 "qp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/light/small/directional/east,
-/obj/structure/cable,
+/obj/structure/closet/secure_closet/beef_atmospherics,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "qq" = (
@@ -1345,12 +1205,8 @@
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
 "qr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
@@ -1365,13 +1221,13 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "qv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef/library)
 "qy" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 1
 	},
@@ -1410,22 +1266,17 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/beef)
+"qI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/beef/beef_bar)
 "qJ" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/beef/library)
-"qM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "qQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 8
@@ -1434,24 +1285,16 @@
 	color = "#414ad1"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
-"qU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "qY" = (
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/beef)
 "ra" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
@@ -1485,9 +1328,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "rA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "rM" = (
@@ -1504,10 +1346,8 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/beef/cold_room)
 "rU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 8
@@ -1517,6 +1357,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "sk" = (
@@ -1536,12 +1377,13 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef/hyrdroponics)
 "st" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/public{
 	name = "Restrooms"
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/beef/beef_restroom)
 "sw" = (
@@ -1551,6 +1393,16 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/beef)
+"sA" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/clothing/under/bodysash/engineer,
+/obj/item/clothing/head/utility/hardhat/welding,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/beef/atmos)
 "sI" = (
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_bar)
@@ -1582,8 +1434,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/kitchen)
 "ta" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 8
@@ -1600,12 +1452,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/kitchen)
 "tj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
@@ -1638,25 +1486,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
-"tG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/large,
-/area/ruin/space/has_grav/beef/beef_bar)
-"tH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding{
-	color = "#4a4a4a";
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "tJ" = (
 /turf/open/floor/mineral/gold,
 /area/ruin/space/has_grav/beef/beef_storage)
@@ -1679,18 +1508,14 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/beef/atmos)
 "tY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "ua" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/beef)
@@ -1721,16 +1546,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
-"uw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/beef/kitchen)
 "uz" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
@@ -1781,18 +1596,16 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
 "vg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "vh" = (
 /obj/structure/table/wood/shuttle_bar,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/item/pai_card,
 /obj/machinery/button/door/directional/west{
 	name = "Dorm Bolt Control";
@@ -1810,12 +1623,8 @@
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "vr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding{
 	color = "#4a4a4a"
 	},
@@ -1858,8 +1667,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef/hyrdroponics)
 "we" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 8
@@ -1868,6 +1677,7 @@
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "wf" = (
@@ -1891,6 +1701,7 @@
 	color = "#414ad1";
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "wo" = (
@@ -1901,7 +1712,6 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/beef/cold_room)
 "wB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -1910,10 +1720,8 @@
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
 "wG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 8
-	},
 /obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "wO" = (
@@ -1929,22 +1737,21 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "wP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/eighties/red,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
 "wS" = (
 /obj/machinery/door/window/right/directional/east{
 	name = "Hydroponics"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef/hyrdroponics)
 "xi" = (
@@ -1967,6 +1774,7 @@
 "xv" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/kitchen)
 "xx" = (
@@ -1982,6 +1790,15 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/unlocked,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/machinery/light_switch/directional/west,
+/obj/structure/closet/crate/secure/gear,
+/obj/item/clothing/head/beret/sec,
+/obj/item/clothing/suit/armor/vest/alt,
+/obj/item/clothing/head/helmet/sec,
+/obj/item/gun/energy/disabler,
+/obj/item/clothing/under/bodysash/security,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/beef/security)
 "yc" = (
@@ -1993,21 +1810,11 @@
 "yk" = (
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/beef)
-"yq" = (
-/obj/structure/cable,
-/obj/machinery/computer/monitor{
-	dir = 4;
-	name = "Beef Station Power Monitoring Console"
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/beef/atmos)
 "yA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/eighties/red,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
 "yJ" = (
@@ -2019,8 +1826,8 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/beef/cold_room)
 "yN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 1
@@ -2064,9 +1871,7 @@
 /area/ruin/space/has_grav/beef/beef_restroom)
 "yS" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -2074,6 +1879,9 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/beef)
+"zi" = (
+/turf/open/floor/iron/white/herringbone,
+/area/ruin/space/has_grav/beef/medical)
 "zz" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/beef/security)
@@ -2113,24 +1921,12 @@
 "Ad" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/beef/cold_room)
-"Ae" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "Ah" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef/library)
 "AD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/ruin/space/has_grav/beef/beef_ball_room)
@@ -2140,15 +1936,13 @@
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/beef/library)
 "AL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/engineering_welding{
-	req_access = null
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/mapping_helpers/apc/unlocked,
+/obj/structure/rack,
+/obj/item/storage/box/lights,
+/obj/item/lightreplacer/blue,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "AM" = (
@@ -2167,6 +1961,11 @@
 /obj/structure/cable,
 /turf/open/floor/eighties/red,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
+"Bk" = (
+/obj/machinery/light/small/directional/north,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/beef/atmos)
 "Bn" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet,
@@ -2187,21 +1986,14 @@
 /area/ruin/space/has_grav/beef/beef_bar)
 "BH" = (
 /obj/machinery/door/airlock/public,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/eighties/red,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
 "BS" = (
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
-"BW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/ruin/space/has_grav/beef/beef_ball_room)
 "BZ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/teal,
@@ -2224,8 +2016,8 @@
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/beef/beef_bar)
 "Co" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
@@ -2243,12 +2035,8 @@
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "CF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/beef/beef_entrance)
@@ -2259,14 +2047,12 @@
 /area/ruin/space/has_grav/beef/library)
 "CM" = (
 /obj/item/wrench,
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "CP" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -2276,9 +2062,7 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/beef/atmos)
 "Df" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
@@ -2290,7 +2074,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "Di" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
 "Dm" = (
@@ -2310,9 +2094,7 @@
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
 "Dz" = (
-/obj/structure/rack,
-/obj/item/storage/box/lights,
-/obj/item/lightreplacer/blue,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "DB" = (
@@ -2322,10 +2104,8 @@
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "DF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/beef)
 "DG" = (
@@ -2385,15 +2165,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/beef/beef_restroom)
 "EV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
@@ -2406,25 +2183,16 @@
 	id_tag = "beefdorms1";
 	name = "Dorm Room One"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef)
 "Fb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood/large,
-/area/ruin/space/has_grav/beef/beef_bar)
-"Fd" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/beef/atmos)
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/beef/beef_bar)
 "Fe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -2442,18 +2210,8 @@
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/beef/beef_entrance)
-"Fy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "Fz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -2467,13 +2225,14 @@
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "FF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
 "FJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/light/small/directional/east,
 /obj/structure/cable,
+/obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "FU" = (
@@ -2483,6 +2242,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "FW" = (
@@ -2493,18 +2253,16 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/beef/beef_bar)
 "Gc" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/beef)
 "Gn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#4a4a4a";
 	dir = 4
@@ -2525,12 +2283,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef/hyrdroponics)
 "GB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
@@ -2581,8 +2335,8 @@
 	color = "#2e2e2e";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
@@ -2593,6 +2347,9 @@
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/beef/library)
 "Hk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/beef)
 "Hl" = (
@@ -2604,9 +2361,8 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/beef/library)
 "Hs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "Hu" = (
@@ -2614,12 +2370,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef/hyrdroponics)
 "Hv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1"
 	},
@@ -2656,16 +2408,29 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "HI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/ruin/space/has_grav/beef/beef_ball_room)
+"HN" = (
+/obj/effect/turf_decal/tile/neutral{
+	color = "#2e2e2e";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#414ad1"
+	},
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/beef)
 "HO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef/library)
@@ -2679,47 +2444,42 @@
 /obj/machinery/igniter{
 	id = "beefcinerator"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/vacuum,
 /area/ruin/space/has_grav/beef/atmos)
-"Ie" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "Ii" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/kitchen)
 "Ik" = (
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/item/restraints/handcuffs,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/beef/security)
 "Il" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/beef/atmos)
+"Ir" = (
+/obj/machinery/light/small/directional/south,
+/obj/machinery/computer/monitor{
+	dir = 4;
+	name = "Beef Station Power Monitoring Console"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "Is" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
 "Iu" = (
@@ -2749,6 +2509,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
+"IM" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/beef/atmos)
 "IO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -2771,38 +2538,14 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/security)
-"Jb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "Ji" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/machinery/light_switch/directional/south,
 /obj/machinery/light/small/directional/east,
 /obj/machinery/button/door/directional/east{
 	name = "Brig Window Blast Door Control";
 	id = "beefbrigwindow"
 	},
+/obj/machinery/recharger,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/beef/security)
 "Jk" = (
@@ -2813,15 +2556,9 @@
 /area/ruin/space/has_grav/beef/hyrdroponics)
 "Jm" = (
 /obj/machinery/light_switch/directional/north,
+/obj/machinery/duct,
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/beef/beef_restroom)
-"Jn" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/beef/atmos)
 "Jq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -2829,6 +2566,10 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_bar)
+"Jw" = (
+/obj/machinery/portable_atmospherics/canister/bz,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/beef/atmos)
 "JD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -2838,6 +2579,12 @@
 "JE" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
+"JG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
+/area/ruin/space/has_grav/beef/atmos)
 "JU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -2847,6 +2594,7 @@
 /area/ruin/space/has_grav/beef/security)
 "Kc" = (
 /obj/effect/turf_decal/tile/blue/anticorner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
 "Kd" = (
@@ -2860,39 +2608,23 @@
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/beef/beef_bar)
 "Ke" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/beef/security)
 "Kf" = (
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/beef/beef_entrance)
-"Kn" = (
-/obj/machinery/griddle,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/beef/kitchen)
-"KF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue{
-	color = "#414ad1";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
-"KY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers{
+"Kg" = (
+/obj/structure/reagent_dispensers/plumbed{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
+"Kn" = (
+/obj/machinery/griddle,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/beef/kitchen)
 "Ld" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/beef/atmos)
@@ -2941,13 +2673,10 @@
 	color = "#414ad1";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "Mj" = (
@@ -2955,9 +2684,6 @@
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "Ml" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 4
@@ -2966,9 +2692,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef/hyrdroponics)
 "Mu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef/hyrdroponics)
@@ -2986,27 +2710,10 @@
 /area/ruin/space/has_grav/beef/atmos)
 "MQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/beef/cold_room)
-"MS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding{
-	color = "#4a4a4a"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "MU" = (
 /obj/structure/closet{
 	anchored = 1
@@ -3018,19 +2725,9 @@
 /obj/item/storage/backpack/satchel,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/beef/beef_entrance)
-"Nj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/beef/atmos)
 "Nm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding{
 	color = "#4a4a4a";
 	dir = 1
@@ -3054,27 +2751,9 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_ball_room)
-"Nx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
-"Ny" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "Nz" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -3086,26 +2765,10 @@
 "NF" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/beef/cold_room)
-"NG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding{
-	color = "#4a4a4a";
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "NL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
 	},
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef)
@@ -3114,16 +2777,18 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/beef/cold_room)
 "NU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/kitchen)
 "NX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/beef/beef_restroom)
 "Oj" = (
@@ -3131,12 +2796,8 @@
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/beef/library)
 "Ok" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#4a4a4a";
 	dir = 1
@@ -3144,45 +2805,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
-"Ol" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#414ad1";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "Or" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_ball_room)
-"Ot" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#414ad1";
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "Oy" = (
 /obj/structure/chair/sofa/middle/maroon{
 	dir = 8
@@ -3209,17 +2840,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"OQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding{
-	color = "#4a4a4a"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "OR" = (
 /obj/structure/table/glass,
 /obj/item/storage/bag/plants,
@@ -3254,12 +2874,8 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/beef/cold_room)
 "Pp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#4a4a4a";
 	dir = 8
@@ -3287,14 +2903,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "PH" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/portable_atmospherics/pipe_scrubber,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/beef/atmos)
-"PJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/duct,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "PM" = (
@@ -3319,11 +2929,12 @@
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef/library)
 "PZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef/library)
 "Qd" = (
@@ -3333,8 +2944,8 @@
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/beef/beef_restroom)
 "Qi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	color = "#2e2e2e";
 	dir = 8
@@ -3359,20 +2970,18 @@
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "QC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/kitchen)
 "QD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "QE" = (
@@ -3381,9 +2990,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "QH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/bed{
 	dir = 1
 	},
@@ -3411,16 +3018,14 @@
 	id_tag = "beefdorms2";
 	name = "Dorm Room Two"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/beef)
 "QW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "Rd" = (
@@ -3503,15 +3108,25 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "St" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/beef)
+"Sx" = (
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/beef/beef_bar)
 "Sy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "SH" = (
-/obj/machinery/portable_atmospherics/canister/bz,
-/obj/machinery/light/small/directional/west,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "SJ" = (
@@ -3549,45 +3164,20 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
-"SZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
-"Tc" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/burgundy,
-/obj/item/toy/plush/beefplushie/living,
-/turf/open/space/basic,
-/area/space/nearstation)
 "Te" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "Tg" = (
 /obj/structure/grille,
 /turf/closed/indestructible/reinforced,
 /area/ruin/space/has_grav/beef/atmos)
-"Tj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/beef/atmos)
-"Tk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "Tm" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Corral"
@@ -3604,6 +3194,7 @@
 /area/ruin/space/has_grav/beef/beef_bar)
 "TG" = (
 /obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/beef/beef_entertainment_center)
 "TP" = (
@@ -3620,10 +3211,13 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/beef)
 "Ud" = (
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/kitchen)
 "Uh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#414ad1";
 	dir = 1
@@ -3667,47 +3261,26 @@
 /obj/machinery/light/floor,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/beef)
-"UF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/button/ignition{
-	id = "beefcinerator";
-	pixel_x = -6;
-	pixel_y = -24
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/beef/atmos)
 "UI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
-"US" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
-"UY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#414ad1"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 "Vc" = (
 /obj/structure/sign/poster/contraband/communist_state/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/beef/beef_entrance)
+"Vs" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/beef/atmos)
+"Vx" = (
+/obj/machinery/portable_atmospherics/pipe_scrubber,
+/obj/machinery/duct,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/beef/atmos)
 "Vz" = (
 /obj/effect/mob_spawn/ghost_role/human/beefman/beef_station,
 /turf/open/floor/mineral/plastitanium,
@@ -3725,16 +3298,6 @@
 	color = "#4a4a4a";
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
-"VT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "VY" = (
@@ -3789,6 +3352,13 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/space/basic,
 /area/space/nearstation)
+"WG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/beef)
 "WM" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
@@ -3800,35 +3370,19 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "WS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/beef/beef_restroom)
 "Xc" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/beef)
-"Xo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#2e2e2e";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#414ad1";
-	dir = 1
-	},
-/obj/structure/cable,
+"XA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/beef)
 "XP" = (
@@ -3846,7 +3400,8 @@
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
 "Yb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/meter,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
 "Yt" = (
@@ -3890,6 +3445,7 @@
 /area/ruin/space/has_grav/beef/beef_storage)
 "YF" = (
 /obj/machinery/light_switch/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/kitchen)
 "YI" = (
@@ -3916,12 +3472,8 @@
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/beef/library)
 "YW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/beef/kitchen)
@@ -3964,7 +3516,7 @@
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
 "ZL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/beef/atmos)
@@ -3978,9 +3530,7 @@
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_bar)
 "ZP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/window/left/directional/west{
 	name = "Ballroom"
 	},
@@ -3990,6 +3540,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/beef/beef_ball_room)
 "ZS" = (
@@ -3997,18 +3548,11 @@
 	dir = 8
 	},
 /mob/living/basic/bot/cleanbot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/space/has_grav/beef/medical)
-"ZY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/beef)
 
 (1,1,1) = {"
 uq
@@ -4069,7 +3613,7 @@ uf
 uq
 Tg
 HV
-SJ
+nh
 lv
 uq
 WA
@@ -4108,7 +3652,7 @@ WP
 WP
 lv
 fr
-pj
+JG
 lv
 WP
 WP
@@ -4139,8 +3683,8 @@ uq
 uq
 uq
 uq
-uq
 uf
+uq
 uq
 uq
 WP
@@ -4153,8 +3697,8 @@ uq
 WP
 uq
 uq
-uf
 uq
+uf
 uq
 uq
 uq
@@ -4176,26 +3720,26 @@ uq
 uq
 uq
 uq
+lw
 uq
-uq
-uq
 WP
 WP
 WP
 WP
+lq
 QE
 QE
 Nz
 yS
 QE
 QE
+lq
 WP
 WP
 WP
 WP
 uq
-uq
-uq
+dd
 uq
 uq
 uq
@@ -4215,26 +3759,26 @@ uq
 uq
 uq
 uq
-uf
-uq
+WP
 uq
 WP
 uq
-lq
 QE
 lq
+QE
 MA
-Jn
-Fd
 MA
-lq
+eD
+wG
+MA
+MA
 QE
 lq
+QE
 uq
 WP
 uq
-uq
-Tc
+WP
 uq
 uq
 uq
@@ -4252,30 +3796,30 @@ uq
 uq
 uq
 uq
-uq
-uq
-WP
+lw
 uq
 WP
 WP
-uq
+WP
 QE
+lq
 MA
 MA
 MA
+os
 QD
-UF
+iO
+Fv
 MA
 MA
 MA
+lq
 QE
-uq
 WP
 WP
-uq
 WP
 uq
-uq
+BZ
 uq
 uq
 uq
@@ -4291,30 +3835,30 @@ uq
 uq
 uq
 uq
-uf
+WP
 uq
 WP
-WP
-WP
+uq
+hL
 QE
-QE
-lq
+MA
 MA
 RY
+IM
 tD
 ka
-KY
-Fv
-pv
+iO
+SJ
+Vx
+Kg
 MA
+MA
+QE
 lq
-QE
-QE
-WP
-WP
+uq
 WP
 uq
-BZ
+WP
 uq
 uq
 uq
@@ -4331,24 +3875,24 @@ uq
 uq
 uq
 WP
-uq
+WP
 WP
 lq
 QE
-hL
 MA
 MA
-MA
-aJ
+Bk
+IO
+SJ
 CM
 JD
-PJ
+iO
 SJ
 PH
+pv
+Ir
 MA
 MA
-MA
-lq
 QE
 lq
 WP
@@ -4371,22 +3915,22 @@ uq
 uq
 WP
 WP
-WP
+lq
 QE
 MA
 MA
-MA
+Jw
 SH
-IO
-Nj
+II
+jz
 iS
 jm
-PJ
-SJ
+cS
+DG
 Dz
-ju
-yq
-MA
+SJ
+rw
+sA
 MA
 MA
 QE
@@ -4411,20 +3955,20 @@ WP
 WP
 uq
 QE
-lq
+MA
 MA
 Aa
 IB
 pZ
-II
-jz
+nm
+WM
 tD
 ka
-cS
 iO
-DG
 SJ
-rw
+Dz
+SJ
+uG
 Zx
 wf
 MA
@@ -4451,17 +3995,17 @@ uq
 uq
 QE
 MA
-MA
+fo
 jE
 IB
 pZ
-nm
-WM
 SY
+QD
+mx
 JD
-Tj
-SJ
-uG
+iO
+pj
+Vs
 uG
 uG
 jm
@@ -4494,7 +4038,7 @@ mW
 Yb
 SN
 Il
-Yb
+QD
 uE
 qp
 jT
@@ -4573,7 +4117,7 @@ wP
 QH
 mZ
 Ui
-Ot
+ta
 ev
 Qi
 ta
@@ -4657,7 +4201,7 @@ qY
 rr
 pS
 Nm
-eB
+js
 lo
 HO
 eG
@@ -4689,13 +4233,13 @@ Hz
 kr
 dj
 qy
-KF
-bJ
+bZ
+vr
 qH
 qY
 fQ
 qY
-ny
+Nm
 qQ
 PZ
 qv
@@ -4724,17 +4268,17 @@ ek
 lq
 JE
 uV
-BS
+pX
 TG
 BS
 ao
 bZ
-MS
+vr
 sw
 qY
 qY
 dz
-tH
+Nm
 js
 pJ
 eG
@@ -4742,7 +4286,7 @@ ot
 eG
 eG
 fG
-fv
+oB
 Oj
 qJ
 zC
@@ -4765,15 +4309,15 @@ JE
 uu
 ST
 dD
-kD
+ST
 Is
-kX
-OQ
+bZ
+vr
 OJ
 Oy
 Oy
 kF
-NG
+Nm
 js
 CJ
 eG
@@ -4842,16 +4386,16 @@ QE
 He
 lR
 NB
-el
+Sx
 Fb
-tG
-KF
-dO
+Bq
+bZ
+ra
 QL
 eE
 eE
 bz
-kK
+ra
 js
 DY
 pd
@@ -4881,16 +4425,16 @@ lq
 He
 SW
 qg
-el
-Tx
-Bq
-bZ
-Nx
+Sx
+qI
+jv
+dV
+ra
 kS
 yV
 yV
 Ut
-Nx
+ra
 js
 DY
 pd
@@ -4922,14 +4466,14 @@ Ce
 QO
 el
 ke
-jb
-Ol
-eT
+Bq
+bZ
+mN
 Rn
 yk
 yk
 cF
-qM
+ra
 js
 DY
 pd
@@ -4963,12 +4507,12 @@ Tx
 Tx
 Bq
 bZ
-qU
+ra
 mw
 iy
 op
 cF
-Ie
+ra
 js
 Gu
 Nn
@@ -5002,12 +4546,12 @@ Mw
 el
 Bq
 bZ
-Ae
+mN
 Rn
 yk
 yk
 cF
-Ie
+ra
 Qm
 sk
 ca
@@ -5041,12 +4585,12 @@ Pa
 el
 Bq
 bZ
-VT
+ra
 Rn
 yk
 yk
 cF
-qM
+ra
 js
 cL
 Ml
@@ -5080,20 +4624,20 @@ iU
 el
 Bq
 bZ
-Nx
+ra
 cz
 yk
 QM
 IT
-US
+ra
 we
 yN
-oM
-Jb
+cX
+cX
 cX
 cX
 Co
-iP
+CF
 CF
 Kf
 Dp
@@ -5119,12 +4663,12 @@ Pa
 el
 Bq
 bZ
-qM
+ra
 Rn
 iz
 yk
 cF
-qM
+ra
 js
 XV
 cK
@@ -5158,17 +4702,17 @@ dJ
 Kd
 YI
 bZ
-Nx
+ra
 Rn
 yk
 yk
 cF
-aT
-eB
+ra
+js
 ck
 Di
 kB
-kl
+zi
 jW
 Cr
 Up
@@ -5194,10 +4738,10 @@ Sa
 yP
 sM
 Uh
-bY
-bY
+sM
+sM
 fk
-kK
+ra
 Rn
 yk
 Ly
@@ -5207,7 +4751,7 @@ js
 qD
 Kc
 DL
-kl
+zi
 aK
 AW
 aG
@@ -5232,17 +4776,17 @@ QE
 fC
 if
 kx
-eE
+XA
 oV
-eE
-eE
-Ie
+XA
+XA
+ra
 Rn
 yk
 yk
 cF
-Nx
-js
+ra
+HN
 nM
 ZS
 kp
@@ -5271,19 +4815,19 @@ lq
 fC
 bZ
 ox
-eE
+oP
 kx
 SU
 eE
-Ie
+ra
 TV
 Xc
 Xc
 fU
-qU
-UY
+ra
+js
 wB
-FF
+zi
 FF
 LY
 dr
@@ -5311,15 +4855,15 @@ fC
 bZ
 eE
 QW
-SZ
-SZ
-SZ
-eO
+eE
+eE
+eE
+ra
 eE
 eE
 eE
 bz
-kK
+ra
 js
 jA
 Dr
@@ -5358,7 +4902,7 @@ eE
 eE
 eE
 eE
-VT
+ra
 et
 hc
 sM
@@ -5397,10 +4941,10 @@ SO
 eE
 eE
 SO
-ZY
+ra
+WG
 ra
 ra
-Tk
 ra
 ra
 Hv
@@ -5431,13 +4975,13 @@ Ud
 Ud
 xv
 VC
-Xo
+tj
 eE
 eE
-eE
-eE
+qa
+qa
 jy
-tv
+gM
 tv
 GB
 hD
@@ -5471,9 +5015,9 @@ dp
 YF
 VC
 aI
-eE
-eE
-eE
+qa
+qa
+qa
 eE
 zZ
 Gc
@@ -5510,8 +5054,8 @@ cJ
 QC
 NU
 Mg
-Ny
-Fy
+mN
+mN
 rA
 eE
 rh
@@ -5545,13 +5089,13 @@ sZ
 dK
 Ud
 te
-uw
+cJ
 mk
 VC
 fp
 eE
 tY
-kP
+rA
 eE
 uz
 Gc
@@ -5584,7 +5128,7 @@ sZ
 cl
 hM
 YW
-oz
+cJ
 vz
 VC
 eW
@@ -5622,7 +5166,7 @@ QE
 Dm
 vE
 Zz
-lr
+cJ
 iv
 OB
 VC
@@ -5745,9 +5289,9 @@ du
 NF
 rM
 Sy
-BW
-nR
-kL
+AD
+aL
+Mj
 Or
 or
 Jm

--- a/code/__DEFINES/fulp_defines/fulp_defines.dm
+++ b/code/__DEFINES/fulp_defines/fulp_defines.dm
@@ -53,3 +53,6 @@
 #define ROLE_GHOST_CHEF "All-American Chef"
 #define ROLE_GHOST_COOK "All-American Cook"
 #define ROLE_GHOST_REGULAR "Fake Health Inspector"
+
+/// Define for the atmospherics chamber on the beefman space station ruin.
+#define ATMOS_GAS_MONITOR_BEEF_MIX "govyadina mix"

--- a/fulp_modules/mapping/ruins/space/beefman_station/beefman_station.dm
+++ b/fulp_modules/mapping/ruins/space/beefman_station/beefman_station.dm
@@ -1,9 +1,11 @@
+/// Beefstation map template
 /datum/map_template/ruin/space/fulp/beef_station
 	name = "Govyadina Station"
 	id = "beef station"
 	description = "A station built for beefmen"
 	suffix = "beef_station.dmm"
 
+/// Beefstation ghost role spawner
 /obj/effect/mob_spawn/ghost_role/human/beefman/beef_station
 	name = "Govyadina Station Inhabitant"
 	desc = "A cryogenics pod, storing meat for future consumption."
@@ -12,16 +14,18 @@
 	icon_state = "sleeper"
 	mob_species = /datum/species/beefman
 	you_are_text = "You are an inhabitant of Govyadina Station, a station made specificially for beefmen."
-	flavour_text = "After undergoing many experiments at the hands of the Union of Soviet Socialist Planets researchers, \
+	flavour_text = "After undergoing many experiments at the hands of the Union of Soviet Socialist Planets, \
 	you and your fellow beefmen have been given freedom aboard Govyadina Station. \
 	Work with your fellow beefmen to embrace your new community and home."
 	important_text = "Try to avoid leaving the station and be careful with the Atmospherics equipment!"
 	spawner_job_path = /datum/job/fulp_beefstation
 
 
+/// Beefstation job
 /datum/job/fulp_beefstation
 	title = ROLE_BEEFMAN_STATION
 
+/// Beefstation item spawner
 /obj/effect/spawner/random/beef_station
 	name = "Beef Station spawner"
 	loot = list(
@@ -40,3 +44,45 @@
 		/obj/item/toy/plush/beefplushie = 3,
 	)
 
+/// Mostly just a copy of '/secure_closet/atmospherics' but with the access requirement and
+/// engineering headset removed.
+/obj/structure/closet/secure_closet/beef_atmospherics
+	name = "atmospheric locker"
+	icon_state = "atmos"
+
+/obj/structure/closet/secure_closet/beef_atmospherics/PopulateContents()
+	..()
+
+	new /obj/item/storage/toolbox/mechanical(src)
+	new /obj/item/tank/internals/emergency_oxygen/engi(src)
+	new /obj/item/holosign_creator/atmos(src)
+	new /obj/item/watertank/atmos(src)
+	new /obj/item/clothing/suit/utility/fire/atmos(src)
+	new /obj/item/clothing/gloves/atmos(src)
+	new /obj/item/clothing/mask/gas/atmos(src)
+	new /obj/item/clothing/head/utility/hardhat/welding/atmos(src)
+	new /obj/item/clothing/glasses/meson/engine/tray(src)
+	new /obj/item/extinguisher/advanced(src)
+
+/obj/structure/closet/secure_closet/beef_atmospherics/populate_contents_immediate()
+	. = ..()
+
+	new /obj/item/pipe_dispenser(src)
+
+/// Beefstation atmos chamber
+/obj/machinery/air_sensor/beef_mix_tank
+	name = "Govyadina Station mix tank gas sensor"
+	chamber_id = ATMOS_GAS_MONITOR_BEEF_MIX
+
+/obj/item/circuitboard/computer/atmos_control/beef_mix_tank
+	name = "Govyadina Mix Supply Control"
+	build_path = /obj/machinery/computer/atmos_control/beef_mix_tank
+
+/obj/machinery/computer/atmos_control/beef_mix_tank
+	name = "Govyadina Mix Chamber Control"
+	circuit = /obj/item/circuitboard/computer/atmos_control/beef_mix_tank
+	atmos_chambers = list(ATMOS_GAS_MONITOR_BEEF_MIX = "Govyadina Mix Chamber")
+
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/beef_mix_input
+	name = "Govyadina mix tank input injector"
+	chamber_id = ATMOS_GAS_MONITOR_BEEF_MIX


### PR DESCRIPTION
## About The Pull Request
This PR improves the atmospherics/piping on the Govyadina (Beef) Station ruin/ghost spawner by expanding the atmospherics area a bit, replacing most piping with smart piping where possible, adding nitrogen to the atmospherics area, providing the atmospherics area with a functional gas mix chamber, and plumbing the entire ruin.

<sup>I also took this opportunity to add a few light switches, a crystallizer circuit board, and a custom atmospherics locker.</sup>
## Why It's Good For The Game
You can't do much with the atmospherics setup on this ruin currently, and this PR addresses that.
## Changelog
:cl:
map: Improved the atmospherics setup on the Govyadina (Beef) Station ruin/ghost spawner.
/:cl:
