### PR TITLE
Beefman Cytology Adjustments 

### DIFF
--- a/_maps/fulp_maps/RandomRuins/IceRuins/beef_cytology.dmm
+++ b/_maps/fulp_maps/RandomRuins/IceRuins/beef_cytology.dmm
@@ -382,10 +382,6 @@
 /obj/machinery/oven/range,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/powered/beefcyto)
-"nl" = (
-/mob/living/basic/pet/penguin/emperor/snowdin,
-/turf/open/misc/asteroid/snow/atmosphere,
-/area/icemoon/underground/explored)
 "nr" = (
 /obj/machinery/button/door/directional/west{
 	specialfunctions = 4;
@@ -415,6 +411,9 @@
 	dir = 1
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"oc" = (
+/turf/open/misc/ice,
 /area/icemoon/underground/explored)
 "oi" = (
 /obj/structure/flora/ash/chilly,
@@ -700,7 +699,7 @@
 /area/icemoon/underground/explored)
 "wX" = (
 /mob/living/basic/pet/penguin/emperor/snowdin,
-/turf/open/misc/ice/icemoon,
+/turf/open/misc/ice,
 /area/icemoon/underground/explored)
 "wZ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -916,6 +915,11 @@
 /obj/item/borg/upgrade/modkit/cooldown,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
+"Ch" = (
+/obj/structure/fence/door,
+/obj/structure/fans/tiny/invisible,
+/turf/open/misc/asteroid/snow/standard_air,
+/area/icemoon/underground/explored)
 "Ci" = (
 /obj/item/toy/plush/phos,
 /obj/item/reagent_containers/cup/glass/coffee{
@@ -1247,6 +1251,11 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
+"ME" = (
+/obj/structure/marker_beacon/fuchsia,
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/underground/explored)
 "Nf" = (
 /obj/machinery/light{
 	dir = 1
@@ -1491,6 +1500,10 @@
 /obj/structure/fence/door,
 /obj/structure/fans/tiny/invisible,
 /turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"Xh" = (
+/obj/structure/fans/tiny/invisible,
+/turf/open/misc/asteroid/snow/standard_air,
 /area/icemoon/underground/explored)
 "Xs" = (
 /obj/machinery/button/door/directional/west{
@@ -2284,7 +2297,7 @@ pv
 yD
 yD
 yD
-bq
+ME
 pv
 Hd
 pv
@@ -2342,7 +2355,7 @@ yF
 pv
 pv
 pv
-bq
+ME
 Kq
 sH
 LX
@@ -2548,7 +2561,7 @@ nP
 ve
 sH
 ak
-WQ
+Ch
 yD
 yD
 yD
@@ -2750,7 +2763,7 @@ pg
 pv
 pv
 pv
-bq
+ME
 ak
 sH
 cQ
@@ -2792,9 +2805,9 @@ pv
 pv
 pv
 pv
-sY
-GL
-bq
+Xh
+oi
+ME
 pv
 Av
 pv
@@ -2843,9 +2856,9 @@ Em
 oB
 xF
 sH
-bB
-nl
-bB
+ak
+Kq
+ak
 cP
 De
 Sp
@@ -2894,14 +2907,14 @@ nP
 aI
 Cc
 sH
-bB
-bB
-ps
+ak
+ak
+oc
 pv
 De
 Ib
 pv
-ps
+oc
 oi
 ak
 ak
@@ -2952,8 +2965,8 @@ pv
 De
 FS
 pv
-ps
-ps
+oc
+oc
 ak
 ak
 NV
@@ -3003,7 +3016,7 @@ uO
 De
 Ds
 pv
-ps
+oc
 wX
 Kq
 ak
@@ -3054,9 +3067,9 @@ pv
 De
 Vx
 pv
-ps
-ps
-ps
+oc
+oc
+oc
 ak
 sH
 kt

--- a/_maps/fulp_maps/RandomRuins/IceRuins/beef_cytology.dmm
+++ b/_maps/fulp_maps/RandomRuins/IceRuins/beef_cytology.dmm
@@ -36,17 +36,21 @@
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "bk" = (
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/powered/beefcyto)
+"bq" = (
+/obj/structure/marker_beacon/fuchsia,
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "by" = (
 /obj/structure/sign/departments/xenobio,
 /turf/closed/wall/r_wall,
 /area/ruin/powered/beefcyto)
 "bA" = (
 /obj/structure/closet/crate/wooden,
-/obj/item/stack/sheet/mineral/wood{
-	amount = 10
-	},
+/obj/item/stack/sheet/mineral/wood/fifty,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "bB" = (
@@ -116,10 +120,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
-"eP" = (
-/mob/living/basic/mouse/gray,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
+"eE" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "fg" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -146,6 +152,12 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered/beefcyto)
+"fX" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "gh" = (
 /obj/structure/flora/grass/both/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -153,6 +165,7 @@
 "gD" = (
 /obj/item/food/badrecipe/moldy/bacteria,
 /obj/effect/decal/cleanable/food/flour,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/powered/beefcyto)
 "gG" = (
@@ -173,9 +186,26 @@
 /obj/machinery/light,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
+"hM" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/underground/explored)
 "il" = (
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/powered/beefcyto)
+"ip" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/underground/explored)
 "iB" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/box/white{
@@ -276,7 +306,25 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/food/flour,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
+/area/ruin/powered/beefcyto)
+"ll" = (
+/obj/item/bodypart/leg/left,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"lo" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/underground/explored)
+"lv" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered/beefcyto)
 "lF" = (
 /obj/structure/flora/rock/pile/icy/style_random,
@@ -310,6 +358,15 @@
 	},
 /obj/structure/fence/post,
 /turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"mK" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
 "nb" = (
 /obj/machinery/duct,
@@ -353,6 +410,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
+"oa" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "oi" = (
 /obj/structure/flora/ash/chilly,
 /turf/open/misc/asteroid/snow/standard_air,
@@ -453,6 +516,12 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/powered/beefcyto)
+"ql" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "qG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
@@ -533,10 +602,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/ruin/powered/beefcyto)
-"tK" = (
-/obj/structure/marker_beacon/fuchsia,
-/turf/open/misc/asteroid/snow/standard_air,
-/area/icemoon/underground/explored)
 "tT" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -552,6 +617,7 @@
 	},
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
 "ut" = (
@@ -579,6 +645,12 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
+"vm" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "vA" = (
 /obj/structure/fence{
 	dir = 4
@@ -617,7 +689,14 @@
 /area/ruin/powered/beefcyto)
 "wE" = (
 /obj/structure/marker_beacon/fuchsia,
+/obj/effect/mapping_helpers/no_atoms_ontop,
 /turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/underground/explored)
+"wN" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "wX" = (
 /mob/living/basic/pet/penguin/emperor/snowdin,
@@ -630,6 +709,12 @@
 /obj/item/kirbyplants/fern,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
+"xx" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "xA" = (
 /obj/machinery/door/airlock/vault{
 	id_tag = "blobbernaut door";
@@ -659,6 +744,10 @@
 /obj/item/clothing/suit/hooded/wintercoat/science,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
+"xG" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall/ice,
+/area/icemoon/underground/explored)
 "xJ" = (
 /obj/structure/fireplace,
 /obj/effect/turf_decal/siding/wood,
@@ -732,11 +821,19 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "zQ" = (
 /mob/living/basic/pet/penguin/baby/permanent/snowdin,
 /turf/open/misc/asteroid/snow/standard_air,
+/area/icemoon/underground/explored)
+"zW" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "Ag" = (
 /obj/structure/fireplace{
@@ -753,6 +850,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
 "Ay" = (
@@ -761,6 +859,11 @@
 "AA" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"AN" = (
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "AP" = (
 /obj/machinery/chem_master/condimaster,
@@ -788,6 +891,14 @@
 /obj/item/clothing/head/costume/chicken,
 /turf/open/floor/grass,
 /area/ruin/powered/beefcyto)
+"BP" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "Cc" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -814,9 +925,7 @@
 /turf/open/misc/asteroid/snow/atmosphere,
 /area/icemoon/underground/explored)
 "Cj" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/sink/kitchen/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/powered/beefcyto)
 "Cu" = (
@@ -834,10 +943,6 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/ruin/powered/beefcyto)
-"CM" = (
-/mob/living/basic/mouse/white,
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
 "CP" = (
@@ -863,6 +968,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
+"DF" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/underground/explored)
 "DP" = (
 /turf/open/floor/iron/white/herringbone,
 /area/ruin/powered/beefcyto)
@@ -898,6 +1009,7 @@
 /area/ruin/powered/beefcyto)
 "EW" = (
 /obj/effect/spawner/random/trash/bacteria,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
 "FM" = (
@@ -912,7 +1024,7 @@
 /area/ruin/powered/beefcyto)
 "GG" = (
 /obj/structure/fence/door,
-/turf/open/misc/asteroid/snow/icemoon,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "GL" = (
 /obj/structure/flora/ash/chilly,
@@ -922,6 +1034,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/wood,
 /area/ruin/powered/beefcyto)
 "GX" = (
@@ -949,6 +1062,13 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
+"Hh" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/flora/ash/chilly,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "HG" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/monkeycubes{
@@ -985,7 +1105,10 @@
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "Iz" = (
-/turf/closed/mineral/snowmountain/cavern/icemoon,
+/turf/closed/mineral/random/snow,
+/area/icemoon/underground/explored)
+"IC" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "ID" = (
 /obj/effect/turf_decal/siding/wood,
@@ -1048,6 +1171,12 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/powered/beefcyto)
+"Ka" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "Kq" = (
 /mob/living/basic/pet/penguin/emperor/snowdin,
 /turf/open/misc/asteroid/snow/standard_air,
@@ -1060,6 +1189,12 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/grass,
 /area/ruin/powered/beefcyto)
+"KR" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "Lo" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
@@ -1112,12 +1247,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
-"MU" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/powered/beefcyto)
 "Nf" = (
 /obj/machinery/light{
 	dir = 1
@@ -1130,6 +1259,10 @@
 	},
 /obj/item/clothing/suit/toggle/labcoat/science,
 /turf/open/floor/iron/white,
+/area/ruin/powered/beefcyto)
+"NE" = (
+/obj/machinery/duct,
+/turf/open/floor/wood,
 /area/ruin/powered/beefcyto)
 "NV" = (
 /turf/closed/wall,
@@ -1162,6 +1295,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/wood,
 /area/ruin/powered/beefcyto)
 "PN" = (
@@ -1189,8 +1323,13 @@
 /area/ruin/powered/beefcyto)
 "QD" = (
 /obj/machinery/light/small/directional/east,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
+"QX" = (
+/obj/structure/railing/corner,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "Rd" = (
 /obj/machinery/smartfridge/petri/preloaded,
 /turf/open/floor/iron/white,
@@ -1269,6 +1408,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/iron/white/textured,
 /area/ruin/powered/beefcyto)
+"SS" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "Tw" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -1283,6 +1428,7 @@
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/ruin/powered/beefcyto)
 "UH" = (
@@ -1305,9 +1451,28 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/ruin/powered/beefcyto)
+"Vi" = (
+/obj/structure/flora/grass/both,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "Vk" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/ruin/powered/beefcyto)
+"Vo" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/underground/explored)
+"Vx" = (
+/obj/structure/closet/crate/trashcart,
+/mob/living/basic/mouse/gray,
+/mob/living/basic/mouse/white,
+/turf/open/floor/plating,
 /area/ruin/powered/beefcyto)
 "Wk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -1373,6 +1538,7 @@
 /area/icemoon/underground/explored)
 "Zs" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/all_access,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/powered/beefcyto)
 "ZX" = (
@@ -1865,14 +2031,14 @@ yD
 yD
 oW
 lF
-yD
+bq
 yD
 yD
 yD
 yD
 yD
 gh
-yD
+bq
 yD
 yD
 yD
@@ -1880,7 +2046,7 @@ yD
 yD
 LV
 yD
-yD
+bq
 yD
 yD
 yD
@@ -2118,7 +2284,7 @@ pv
 yD
 yD
 yD
-yD
+bq
 pv
 Hd
 pv
@@ -2176,7 +2342,7 @@ yF
 pv
 pv
 pv
-tK
+bq
 Kq
 sH
 LX
@@ -2211,8 +2377,8 @@ mH
 yD
 pv
 dr
+lv
 yT
-MU
 yT
 yT
 fU
@@ -2262,9 +2428,9 @@ vA
 yD
 pv
 pv
-pv
 Tx
-pv
+sH
+sH
 pv
 pv
 wE
@@ -2339,7 +2505,7 @@ pv
 pv
 pv
 pv
-yD
+bq
 yD
 yD
 oW
@@ -2365,7 +2531,7 @@ PY
 yD
 yD
 yD
-yD
+PY
 yD
 yD
 yD
@@ -2441,7 +2607,7 @@ pv
 pv
 pv
 pv
-yD
+bq
 yD
 yD
 yD
@@ -2467,8 +2633,8 @@ yD
 DW
 yD
 yD
-yD
-PY
+ll
+AN
 zk
 CD
 yD
@@ -2511,7 +2677,7 @@ tb
 tb
 tb
 tb
-yD
+Ka
 yD
 vA
 yD
@@ -2562,8 +2728,8 @@ tb
 tb
 tb
 tb
-yD
-yD
+lo
+hM
 vA
 yD
 Pg
@@ -2584,7 +2750,7 @@ pg
 pv
 pv
 pv
-tK
+bq
 ak
 sH
 cQ
@@ -2613,8 +2779,8 @@ tb
 tb
 tb
 tb
-yD
-yD
+mK
+IC
 mH
 YW
 FM
@@ -2628,7 +2794,7 @@ pv
 pv
 sY
 GL
-bB
+bq
 pv
 Av
 pv
@@ -2662,9 +2828,9 @@ Iz
 tb
 tb
 tb
-tb
-tb
-yD
+Vi
+fX
+oa
 yD
 vA
 yD
@@ -2681,7 +2847,7 @@ bB
 nl
 bB
 cP
-uO
+De
 Sp
 pv
 ak
@@ -2710,12 +2876,12 @@ Iz
 "}
 (27,1,1) = {"
 Iz
-tb
-tb
-tb
-tb
-tb
-yD
+xG
+BP
+fX
+SS
+IC
+IC
 yD
 GG
 yD
@@ -2732,7 +2898,7 @@ bB
 bB
 ps
 pv
-uO
+De
 Ib
 pv
 ps
@@ -2761,13 +2927,13 @@ Iz
 "}
 (28,1,1) = {"
 Iz
-tb
-tb
-tb
-tb
-tb
+IC
+yD
+IC
+IC
 yD
 yD
+IC
 vA
 yD
 yD
@@ -2783,7 +2949,7 @@ pv
 pv
 pv
 pv
-eP
+De
 FS
 pv
 ps
@@ -2798,7 +2964,7 @@ nt
 qP
 Sj
 pv
-yD
+bq
 yD
 yD
 yD
@@ -2812,14 +2978,14 @@ Iz
 "}
 (29,1,1) = {"
 Iz
-tb
-tb
-tb
-tb
-tb
+yD
+IC
 yD
 yD
-vA
+yD
+IC
+yD
+zW
 yD
 yD
 ra
@@ -2834,7 +3000,7 @@ uO
 uO
 Re
 uO
-uO
+De
 Ds
 pv
 ps
@@ -2863,12 +3029,12 @@ Iz
 "}
 (30,1,1) = {"
 Iz
-tb
-tb
-tb
-tb
-tb
-yD
+DF
+KR
+QX
+wN
+ql
+IC
 yD
 vA
 yD
@@ -2885,8 +3051,8 @@ pv
 pv
 pv
 pv
-uO
-uO
+De
+Vx
 pv
 ps
 ps
@@ -2914,13 +3080,13 @@ Iz
 "}
 (31,1,1) = {"
 Iz
+xG
+ip
+Hh
 tb
-tb
-tb
-tb
-tb
-yD
-yD
+eE
+ql
+IC
 GG
 yD
 yD
@@ -2937,7 +3103,7 @@ ps
 ps
 pv
 EW
-uO
+De
 pv
 pv
 pv
@@ -2945,7 +3111,7 @@ pv
 pv
 pv
 wA
-Mc
+NE
 WM
 Js
 lg
@@ -2970,7 +3136,7 @@ tb
 tb
 tb
 tb
-yD
+xx
 yD
 vA
 yD
@@ -2988,15 +3154,15 @@ yD
 ps
 pv
 UI
-CM
-uO
-uO
+De
+De
+De
 QD
-uO
-uO
+De
+De
 us
-Mc
-Mc
+NE
+NE
 Mc
 YH
 gD
@@ -3021,9 +3187,9 @@ tb
 tb
 tb
 tb
+Ka
 yD
-yD
-vA
+vm
 yD
 yD
 yD
@@ -3072,8 +3238,8 @@ tb
 tb
 tb
 tb
-yD
-yD
+eE
+Vo
 vA
 yD
 PY
@@ -3094,8 +3260,8 @@ yD
 yD
 aX
 yD
-yD
 CD
+bq
 pv
 RK
 YN

--- a/code/__DEFINES/fulp_defines/fulp_defines.dm
+++ b/code/__DEFINES/fulp_defines/fulp_defines.dm
@@ -53,3 +53,7 @@
 #define ROLE_GHOST_CHEF "All-American Chef"
 #define ROLE_GHOST_COOK "All-American Cook"
 #define ROLE_GHOST_REGULAR "Fake Health Inspector"
+
+/// Define for the beefman cytology ghost role's z-level restriction component.
+/// This does NOT work with the regular "stationstuck" component.
+#define MEATIFICATION "meatify"

--- a/fulp_modules/mapping/ruins/icemoon/beefman_cytology/beefcyto_spawner.dm
+++ b/fulp_modules/mapping/ruins/icemoon/beefman_cytology/beefcyto_spawner.dm
@@ -1,9 +1,44 @@
+// - MAP TEMPLATE DATUM - //
 /datum/map_template/ruin/icemoon/underground/fulp/cyto
 	name = "Beefman Research Outpost"
 	id = "beef cyto"
 	description = "A remote research outpost."
 	suffix = "beef_cytology.dmm"
 
+
+// - GHOST ROLE COMPONENT DATUM(S) - //
+
+/// A subtype of the stationstuck component that's primarily intended for use in one ghost role.
+/// Turns its (presumably '/mob/living') owner into a slab of meat if they leave the z-level the
+/// component is attatched on.
+/datum/component/stationstuck/beef_cyto
+	punishment = MEATIFICATION
+
+// Copied over from "/datum/smite/objectify/effect()"
+// in 'code\modules\admin\smites\become_object.dm'
+/datum/component/stationstuck/beef_cyto/punish()
+	if(punishment != MEATIFICATION)
+		return ..()
+
+	var/mob/living/future_meat = parent
+	if(message)
+		to_chat(future_meat, span_userdanger("[message]"))
+
+	var/atom/transform_path = /obj/item/food/meat/slab
+	var/mutable_appearance/meatified_player = mutable_appearance(initial(transform_path.icon), initial(transform_path.icon_state))
+	meatified_player.pixel_x = initial(transform_path.pixel_x)
+	meatified_player.pixel_y = initial(transform_path.pixel_y)
+	var/mutable_appearance/transform_scanline = mutable_appearance('icons/effects/effects.dmi', "transform_effect")
+
+	var/turf/future_meat_turf = get_turf(future_meat)
+	message_admins("[future_meat.real_name] ([future_meat.ckey]) has been turned into meat near [ADMIN_VERBOSEJMP(future_meat_turf)] for attempting to move to a different z_level.")
+
+	future_meat.transformation_animation(meatified_player, 5 SECONDS, transform_scanline.appearance)
+	future_meat.Immobilize(5 SECONDS, ignore_canstun = TRUE)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(objectify), future_meat, transform_path), 5 SECONDS)
+
+
+// - GHOST ROLE SPAWNERS - //
 /obj/effect/mob_spawn/ghost_role/human/beefman
 	name = "Beefman Cytology Researcher"
 	desc = "A cryogenics pod, storing meat for future consumption."
@@ -14,17 +49,30 @@
 	you_are_text = "You are a cytological researcher in a remote scientific outpost."
 	flavour_text = "You and your fellow researcher are studying cellular biology to better understand the origins of your species. \
 	Sample the subjects provided and the surrounding area for testing."
-	important_text = "This is meant as a way to learn how to play Cytology!"
+	important_text = "This is meant as a way to learn how to play Cytology! \
+		If leave the lab's z-level then you'll turn into meat!"
 	outfit = /datum/outfit/russian_beefman
 	spawner_job_path = /datum/job/fulp_cytology
 
+// (Implementation of the stationstuck component has been copied over from
+// 'fulp_modules\mapping\ruins\space\syndicate_engineer\syndicate_engineer.dm')
 /obj/effect/mob_spawn/ghost_role/human/beefman/special(mob/living/carbon/human/spawned_human)
 	. = ..()
 	spawned_human.fully_replace_character_name(null, random_unique_beefman_name())
+	to_chat(spawned_human, span_warning("You have been implanted with a meatification implant that \
+		will activate if you go to any level of the Icemoon except the one you are currently \
+		on. Glory to the USSP."))
+	spawned_human.AddComponent(/datum/component/stationstuck/beef_cyto, MEATIFICATION, "You have \
+		strayed too far from the cytology lab. Your meatification implant has been triggered; \
+		you may use the ghost command to leave your body if desired.")
 
+
+// - JOB DATUMS - //
 /datum/job/fulp_cytology
 	title = ROLE_BEEFMAN_CYTOLOGY
 
+
+// - OUTFIT DATUMS - //
 /datum/outfit/russian_beefman
 	name = "Russian Beefman"
 	uniform = /obj/item/clothing/under/bodysash/russia


### PR DESCRIPTION
## About The Pull Request
This PR makes a couple adjustments to the beefman cytology ghost role. The main addition to the role is a z-level restriction component (much like the one implemented in PR #1359) that turns those spawned on the ruin into meat slabs if they leave their z-level. The map has been adjusted to account for this, with a small bridge being added to allow beef cytologists to cross their liquid plasma moat and explore the lower levels of the Icemoon if they desire.
## Why It's Good For The Game
This change permits a bit more freedom to the beefman cytology ghost role while at the same keeping it focused on cytology (and away from the station).
## Changelog
:cl:
add: Restricted those spawned in on the beefman cytology ruin to their ruin's z-level. The ruin's map has been made less restrictive accordingly.
/:cl:
