### PR TITLE
Adds Red Alert Access to Appropriate Doors on Fulp Maps

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -11430,10 +11430,10 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/door/window/left/directional/west{
 	name = "First-Aid Supplies";
-	red_alert_access = 1;
 	req_access = list("medical")
 	},
 /obj/structure/rack,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "bfb" = (
@@ -33152,6 +33152,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /obj/effect/landmark/navigate_destination,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
 "fKe" = (
@@ -43617,10 +43618,10 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/door/window/right/directional/east{
 	name = "First-Aid Supplies";
-	red_alert_access = 1;
 	req_access = list("medical")
 	},
 /obj/structure/rack,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "jHw" = (
@@ -45066,10 +45067,10 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/door/window/right/directional/west{
 	name = "First-Aid Supplies";
-	red_alert_access = 1;
 	req_access = list("medical")
 	},
 /obj/structure/rack,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "kjm" = (
@@ -70664,11 +70665,11 @@
 	},
 /obj/machinery/door/window/left/directional/east{
 	name = "First-Aid Supplies";
-	red_alert_access = 1;
 	req_access = list("medical")
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/rack,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "uav" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -9252,6 +9252,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "aLc" = (
@@ -17183,6 +17184,7 @@
 	req_access = list("medical")
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron,
 /area/station/medical/storage)
 "bwv" = (
@@ -47692,6 +47694,7 @@
 	req_access = list("medical")
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron,
 /area/station/medical/storage)
 "rNj" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1459,6 +1459,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "ayA" = (
@@ -10968,12 +10969,12 @@
 "dVd" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "First-Aid Supplies";
-	red_alert_access = 1;
 	req_access = list("medical")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "dVv" = (
@@ -29192,6 +29193,7 @@
 /obj/effect/landmark/navigate_destination/eva,
 /obj/effect/mapping_helpers/airlock/access/all/command/hop,
 /obj/effect/turf_decal/tile/command/opposingcorners,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "kAF" = (
@@ -60435,6 +60437,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/command/hop,
 /obj/effect/turf_decal/tile/command/opposingcorners,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/command/storage/eva)
 "vXu" = (

--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -1876,6 +1876,7 @@
 /obj/effect/landmark/navigate_destination/eva,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/engine,
 /area/station/ai_monitored/command/storage/eva)
 "aDW" = (
@@ -6123,6 +6124,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 4
 	},
@@ -16418,6 +16420,7 @@
 	name = "First Aid Supplies";
 	req_access = list("medical")
 	},
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 4
 	},


### PR DESCRIPTION

## About The Pull Request
This PR makes use of the "red alert access" helper recently added through the last TGU. It has applied to EVA and medical storage doors on every Fulpstation map. This is consistent with the helper's [implementation on our upstream](https://github.com/tgstation/tgstation/pull/89424). 
## Why It's Good For The Game
This is a minor thing that might've been overlooked in the last TGU. Accounting for it maintains map consistency.
## Changelog
:cl:
fix: EVA and medical storage airlocks on Fulpstation maps now have their access requirements lifted on red alert.
/:cl:
