### PR TITLE
Adds Telecomms Flaps to Every Fulpstation Map

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -21196,6 +21196,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -53620,6 +53620,7 @@
 /area/station/science/ordnance/testlab)
 "nDq" = (
 /obj/structure/cable,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "nDF" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -25334,6 +25334,7 @@
 /area/station/tcommsat/server)
 "cmF" = (
 /obj/structure/cable,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "cmG" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -30582,6 +30582,7 @@
 	cycle_id = "sci-rnd-servers"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/rd,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "eVv" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -56266,6 +56266,7 @@
 	dir = 6
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/rd,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "urE" = (

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -50432,6 +50432,7 @@
 /area/station/cargo/bitrunning/den)
 "skd" = (
 /obj/structure/cable,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark/textured,
 /area/station/tcommsat/server)
 "ske" = (

--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -15239,6 +15239,7 @@
 "fhv" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "fhK" = (

--- a/_maps/map_files/TheiaStation/TheiaStation.dmm
+++ b/_maps/map_files/TheiaStation/TheiaStation.dmm
@@ -19406,6 +19406,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "gDR" = (


### PR DESCRIPTION

## About The Pull Request
This pull request adds airtight coldroom flaps to telecomms on every Fulpstation map. Images may be found in the results of the MapDiffBot check on this PR as per always.
## Why It's Good For The Game
This is a relatively minor thing that might've been missed in the last TGU. Implementing it maintains map consistency between our maps and TG's.
## Changelog
:cl:
fix: Added airtight coldroom flaps to telecomms on every Fulpstation map.
/:cl:
