### PR TITLE
Fixes Pubby cargo shuttle doors

### DIFF
--- a/_maps/shuttles/cargo_pubby.dmm
+++ b/_maps/shuttles/cargo_pubby.dmm
@@ -19,11 +19,20 @@
 /area/shuttle/supply)
 "g" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door/directional/west{
-	id = "cargoload";
-	name = "Loading Doors"
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "ShuttleLoad"
 	},
 /turf/open/floor/iron/dark,
+/area/shuttle/supply)
+"i" = (
+/obj/machinery/button/door/directional/west{
+	id = "cargounload";
+	name = "Loading Doors"
+	},
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
 /area/shuttle/supply)
 "j" = (
 /obj/effect/decal/cleanable/dirt,
@@ -53,14 +62,18 @@
 "s" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
+/obj/machinery/button/door/directional/west{
+	id = "cargoload";
+	name = "Loading Doors"
+	},
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
 /area/shuttle/supply)
 "t" = (
-/obj/machinery/button/door/directional/west{
-	id = "cargounload";
-	name = "Loading Doors"
+/obj/machinery/conveyor/inverted{
+	dir = 6;
+	id = "ShuttleUnload"
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)
@@ -116,8 +129,8 @@
 "I" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	dir = 4;
-	id = "ShuttleLoad"
+	id = "ShuttleLoad";
+	dir = 5
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
@@ -154,8 +167,8 @@
 "T" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	dir = 8;
-	id = "ShuttleUnload"
+	id = "ShuttleUnload";
+	dir = 9
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
@@ -171,15 +184,15 @@
 
 (1,1,1) = {"
 a
-k
 a
+k
 a
 a
 R
 a
 a
-a
 J
+a
 a
 B
 "}
@@ -191,7 +204,7 @@ s
 X
 w
 K
-X
+i
 t
 T
 a

--- a/_maps/shuttles/cargo_pubby.dmm
+++ b/_maps/shuttles/cargo_pubby.dmm
@@ -2,20 +2,24 @@
 "a" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/supply)
+"b" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/supply)
 "e" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "ShuttleLoad"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "f" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "ShuttleLoad"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "g" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25,28 +29,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)
-"i" = (
-/obj/machinery/button/door/directional/west{
-	id = "cargounload";
-	name = "Loading Doors"
-	},
-/turf/open/floor/iron/chapel{
-	dir = 8
-	},
-/area/shuttle/supply)
 "j" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "k" = (
-/obj/machinery/door/poddoor{
-	id = "cargoload";
-	name = "Supply Dock Loading Door"
-	},
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "ShuttleLoad"
 	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "m" = (
@@ -62,10 +54,6 @@
 "s" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
-/obj/machinery/button/door/directional/west{
-	id = "cargoload";
-	name = "Loading Doors"
-	},
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
@@ -86,14 +74,14 @@
 	dir = 8;
 	id = "ShuttleUnload"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "y" = (
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "ShuttleUnload"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "z" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -126,30 +114,50 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/supply)
+"F" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/shuttle/supply)
+"H" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "ShuttleLoad";
+	name = "Shuttle Load";
+	pixel_x = -5;
+	pixel_y = 16
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/supply)
 "I" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	id = "ShuttleLoad";
-	dir = 5
+	dir = 5;
+	id = "ShuttleLoad"
 	},
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "J" = (
-/obj/machinery/door/poddoor{
-	id = "cargounload";
-	name = "Supply Dock Loading Door"
-	},
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "ShuttleUnload"
 	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "K" = (
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
+/area/shuttle/supply)
+"Q" = (
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "ShuttleUnload";
+	name = "Shuttle Unload";
+	pixel_x = -5
+	},
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "R" = (
 /obj/docking_port/mobile/supply{
@@ -162,16 +170,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/supply)
 "T" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	id = "ShuttleUnload";
-	dir = 9
+	dir = 9;
+	id = "ShuttleUnload"
 	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "U" = (
 /turf/open/floor/iron/chapel,
@@ -204,7 +212,7 @@ s
 X
 w
 K
-i
+X
 t
 T
 a
@@ -213,13 +221,13 @@ C
 (3,1,1) = {"
 a
 f
-w
+H
 m
 U
 w
 m
 U
-w
+Q
 x
 z
 D
@@ -255,13 +263,13 @@ D
 (6,1,1) = {"
 a
 f
-j
-m
-U
-q
+F
 m
 U
 w
+m
+U
+q
 y
 a
 E
@@ -270,11 +278,11 @@ E
 a
 a
 a
-a
-a
-a
-a
-a
+b
+b
+b
+b
+b
 a
 a
 a


### PR DESCRIPTION

## About The Pull Request

This fixes some misaligned doors in the Pubbystation cargo shuttle
## Why It's Good For The Game

Currently the loading doors for the cargo shuttle in Pubbystation do not line up with the conveyors to and from the Cargo Department. This slows down cargo quite a lot as you have to load/unload from the airlocks.
This pull request fixes that issue, making cargo faster overall at the cost of adding a single extra tile to both conveyors.
## Changelog
:cl:
fix: Moved the shuttle loading doors to line up with the department loading doors
/:cl:
