### PR TITLE
Fixes Certain Stealthy Bloodsucker Abilities Producing a Cogwheel

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/feed.dm
@@ -90,7 +90,7 @@
 		feed_timer = 2 SECONDS
 
 	owner.balloon_alert(owner, "feeding off [feed_target]...")
-	if(!do_after(owner, feed_timer, feed_target, NONE, TRUE))
+	if(!do_after(owner, feed_timer, feed_target, NONE, TRUE, hidden = TRUE))
 		owner.balloon_alert(owner, "feed stopped")
 		DeactivatePower()
 		return

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/mesmerize.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/targeted/mesmerize.dm
@@ -105,7 +105,7 @@
 	if(istype(mesmerized_target))
 		owner.balloon_alert(owner, "attempting to hypnotically gaze [mesmerized_target]...")
 
-	if(!do_after(user, 4 SECONDS, mesmerized_target, NONE, TRUE, extra_checks = CALLBACK(src, PROC_REF(ContinueActive), user, mesmerized_target)))
+	if(!do_after(user, 4 SECONDS, mesmerized_target, NONE, TRUE, hidden = TRUE, extra_checks = CALLBACK(src, PROC_REF(ContinueActive), user, mesmerized_target)))
 		return
 
 	var/power_time = max((9 SECONDS + level_current * 0.75 SECONDS), 15 SECONDS)

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/dominate.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/dominate.dm
@@ -119,7 +119,7 @@
 	attempt_mesmerize(target, user)
 
 /datum/action/cooldown/bloodsucker/targeted/tremere/dominate/proc/attempt_mesmerize(mob/living/target, mob/living/user)
-	owner.balloon_alert(owner, "attempting to mesmerize.")
+	owner.balloon_alert(owner, "mesmerizing...")
 	if(!do_after(user, 3 SECONDS, target, NONE, TRUE, hidden = TRUE))
 		return
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/dominate.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/dominate.dm
@@ -120,7 +120,7 @@
 
 /datum/action/cooldown/bloodsucker/targeted/tremere/dominate/proc/attempt_mesmerize(mob/living/target, mob/living/user)
 	owner.balloon_alert(owner, "attempting to mesmerize.")
-	if(!do_after(user, 3 SECONDS, target, NONE, TRUE))
+	if(!do_after(user, 3 SECONDS, target, NONE, TRUE, hidden = TRUE))
 		return
 
 	power_activated_sucessfully()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/vassal_fold.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/vassal_fold.dm
@@ -76,7 +76,7 @@
 		if(!former_vassal || former_vassal.revenge_vassal)
 			target_ref = null
 			return
-		if(do_after(owner, 5 SECONDS, target))
+		if(do_after(owner, 5 SECONDS, target, progress = TRUE, hidden = TRUE))
 			former_vassal.return_to_fold(revenge_vassal)
 		target_ref = null
 		DeactivatePower()


### PR DESCRIPTION
## About The Pull Request
This pull request fixes #1401 by setting the `hidden` parameter on several `do_after()` calls to `TRUE`. 
## Why It's Good For The Game
As described in the previously mentioned issue: these abilities are supposed to be stealthy and having cogwheels appear over their user hinders that.
## Changelog
:cl:
fix: Cogwheels will no longer appear over the users of certain bloodsucker abilities.
/:cl:
