### PR TITLE
Better Communicates Bloodsucker Power Leveling 

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_procs.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_procs.dm
@@ -84,6 +84,8 @@
 	for(var/datum/action/cooldown/bloodsucker/power as anything in powers)
 		if(power.purchase_flags & TREMERE_CAN_BUY)
 			continue
+		if(!power.should_level)
+			continue
 		power.upgrade_power()
 
 ///Disables all powers, accounting for torpor

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/_powers.dm
@@ -12,9 +12,9 @@
 	/// Cooldown you'll have to wait between each use, decreases depending on level.
 	cooldown_time = 2 SECONDS
 
-	///Background icon when the Power is active.
+	/// Background icon when the Power is active.
 	active_background_icon_state = "vamp_power_on"
-	///Background icon when the Power is NOT active.
+	/// Background icon when the Power is NOT active.
 	base_background_icon_state = "vamp_power_off"
 
 	/// The text that appears when using the help verb, meant to explain how the Power changes when ranking up.
@@ -33,22 +33,28 @@
 	// VARS //
 	/// If the Power is currently active, differs from action cooldown because of how powers are handled.
 	var/active = FALSE
-	///Can increase to yield new abilities - Each Power ranks up each Rank
+	/// Can increase to yield new abilities - Each Power ranks up each Rank
 	var/level_current = 0
-	///The cost to ACTIVATE this Power
+	/// Boolean indicating whether or not this power's level matters
+	/// for the sake of being both incremented and included in a description.
+	var/should_level = TRUE
+	/// The cost to ACTIVATE this Power
 	var/bloodcost = 0
-	///The cost to MAINTAIN this Power - Only used for Constant Cost Powers
+	/// The cost to MAINTAIN this Power - Only used for Constant Cost Powers
 	var/constant_bloodcost = 0
+	/**
+	 * The button movable associated with this power.
+	 * CURRENTLY only stored so we can update the
+	 * button's 'desc' every time this power ranks up.
+	 *
+	 * WARNING: ONLY STORED IF 'should_level' IS TRUE
+	**/
+	var/atom/movable/screen/movable/action_button/linked_button
 
 // Modify description to add cost.
 /datum/action/cooldown/bloodsucker/New(Target)
 	. = ..()
-	if(bloodcost > 0)
-		desc += "<br><br><b>COST:</b> [bloodcost] blood"
-	if(constant_bloodcost > 0)
-		desc += "<br><br><b>CONSTANT COST:</b><i> [name] costs [constant_bloodcost] blood maintain active.</i>"
-	if(power_flags & BP_AM_SINGLEUSE)
-		desc += "<br><br><b>SINGLE USE:</br><i> [name] can only be used once per night.</i>"
+	assemble_desc()
 
 /datum/action/cooldown/bloodsucker/Destroy()
 	bloodsuckerdatum_power = null
@@ -84,6 +90,13 @@
 		DeactivatePower()
 	return TRUE
 
+/datum/action/cooldown/bloodsucker/create_button()
+	if(!should_level) // We only store the button in a var if we change
+		return ..()   // its desc on levelling.
+
+	var/atom/movable/screen/movable/action_button/button = ..()
+	linked_button = button
+	return button
 
 /datum/action/cooldown/bloodsucker/proc/can_pay_cost()
 	if(!owner || !owner.mind)
@@ -107,9 +120,11 @@
 		return FALSE
 	return TRUE
 
-///Called when the Power is upgraded.
+///Called when the Power is upgraded if 'should_level' is TRUE.
 /datum/action/cooldown/bloodsucker/proc/upgrade_power()
 	level_current++
+	assemble_desc()
+	build_button_icon(linked_button, UPDATE_BUTTON_NAME)
 
 ///Checks if the Power is available to use.
 /datum/action/cooldown/bloodsucker/proc/can_use(mob/living/carbon/user, trigger_flags)
@@ -187,7 +202,7 @@
 		START_PROCESSING(SSprocessing, src)
 
 	owner.log_message("used [src][bloodcost != 0 ? " at the cost of [bloodcost]" : ""].", LOG_ATTACK, color="red")
-	build_all_button_icons()
+	build_all_button_icons(UPDATE_BUTTON_BACKGROUND)
 
 /datum/action/cooldown/bloodsucker/proc/DeactivatePower()
 	if(!active) //Already inactive? Return
@@ -199,7 +214,7 @@
 		return
 	active = FALSE
 	StartCooldown()
-	build_all_button_icons()
+	build_all_button_icons(UPDATE_BUTTON_BACKGROUND|UPDATE_BUTTON_STATUS)
 
 ///Used by powers that are continuously active (That have BP_AM_TOGGLE flag)
 /datum/action/cooldown/bloodsucker/process(seconds_per_tick)
@@ -229,3 +244,17 @@
 /datum/action/cooldown/bloodsucker/proc/remove_after_use()
 	bloodsuckerdatum_power?.powers -= src
 	Remove(owner)
+
+/// Assembles the description of this bloodsucker ability.
+/// (Mainly used so that we can keep updating it with 'current_level'.)
+/datum/action/cooldown/bloodsucker/proc/assemble_desc()
+	desc = initial(desc)
+	if(power_flags & BP_AM_SINGLEUSE)
+		desc += "<br><br><b>SINGLE USE:</b><i> [name] can only be used once per night.</i>"
+	if(should_level)
+		desc += "<br><br><b>ABILITY LEVEL:</b><i> [level_current]</i>" // "POWER LEVEL" sounds cliché.
+
+	if(bloodcost > 0)
+		desc += "<br><br><b>COST:</b> [bloodcost] blood"
+	if(constant_bloodcost > 0)
+		desc += "<br><br><b>CONSTANT COST:</b><i> [name] costs [constant_bloodcost] blood maintain active.</i>"

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/gohome.dm
@@ -25,6 +25,7 @@
 	bloodcost = 100
 	constant_bloodcost = 2
 	cooldown_time = 100 SECONDS
+	should_level = FALSE
 	///What stage of the teleportation are we in
 	var/teleporting_stage = GOHOME_START
 	///The types of mobs that will drop post-teleportation.

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/masquerade.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/masquerade.dm
@@ -28,6 +28,7 @@
 	bloodcost = 10
 	cooldown_time = 5 SECONDS
 	constant_bloodcost = 0.1
+	should_level = FALSE
 
 /datum/action/cooldown/bloodsucker/masquerade/ActivatePower(trigger_flags)
 	. = ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/_powers_tremere.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/tremere/_powers_tremere.dm
@@ -16,7 +16,7 @@
 	background_icon = 'fulp_modules/icons/antagonists/bloodsuckers/actions_tremere_bloodsucker.dmi'
 
 	// Tremere powers don't level up, we have them hardcoded.
-	level_current = 0
+	should_level = FALSE
 	// Re-defining these as we want total control over them
 	power_flags = BP_AM_TOGGLE|BP_AM_STATIC_COOLDOWN
 	purchase_flags = TREMERE_CAN_BUY

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/distress.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/distress.dm
@@ -9,6 +9,7 @@
 	purchase_flags = NONE
 	bloodcost = 10
 	cooldown_time = 10 SECONDS
+	should_level = FALSE
 
 /datum/action/cooldown/bloodsucker/distress/ActivatePower(trigger_flags)
 	. = ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/recuperate.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/recuperate.dm
@@ -13,6 +13,7 @@
 	purchase_flags = NONE
 	bloodcost = 1.5
 	cooldown_time = 10 SECONDS
+	should_level = FALSE
 
 /datum/action/cooldown/bloodsucker/recuperate/ActivatePower(trigger_flags)
 	. = ..()

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/vassal_fold.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/vassal/vassal_fold.dm
@@ -12,6 +12,7 @@
 	purchase_flags = NONE
 	bloodcost = 10
 	cooldown_time = 10 SECONDS
+	should_level = FALSE
 
 	///Bloodbag we have in our hands.
 	var/obj/item/reagent_containers/blood/bloodbag

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/veil.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/veil.dm
@@ -13,6 +13,7 @@
 	bloodcost = 15
 	constant_bloodcost = 0.1
 	cooldown_time = 10 SECONDS
+	should_level = FALSE
 	// Outfit Vars
 //	var/list/original_items = list()
 	// Identity Vars


### PR DESCRIPTION
## About The Pull Request
This PR aims to better communicate the fact that Bloodsucker powers have 'levels' separate from their owner's rank. This has been accomplished by adding the ability's level to its HUD icon's description.

<details><summary>Expand for example image of the new HUD icon description.</summary>

![image](https://github.com/user-attachments/assets/b07443df-5155-4dd5-be32-93dfedf63284)

</details>

While coding this I also _slightly_ refactored how powers are leveled and how their buttons are updated.
## Why It's Good For The Game
This aspect of bloodsucker powers isn't very intuitive[^1], but I do think that retaining it makes them interesting. Having to consider which powers you want to level up quicker via early selection does lend a fair bit of strategy towards the act of choosing them. 

(Also this may help with issue #1399.)
[^1]:  I myself recently forgot about it and replaced most instances of the word "level" (in reference to powers) on our wiki's [bloodsucker page](https://wiki.fulp.gg/en/Bloodsucker) with "rank"... I'm going to undo that once this PR is posted.

## Changelog
:cl:
qol: Made bloodsucker powers include their level in their button's description.
refactor: Slightly refactored bloodsucker power levelling and bloodsucker power button generation.
/:cl:
