### PR TITLE
Fixes a Couple of Client Colours Being Permanent

### DIFF
--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_frenzy.dm
@@ -70,7 +70,7 @@
 	bloodsuckerdatum.frenzygrab = new(src)
 	bloodsuckerdatum.frenzygrab.teach(user)
 	bloodsuckerdatum.frenzygrab.locked_to_use = TRUE
-	owner.add_client_colour(/datum/client_colour/manual_heart_blood)
+	owner.add_client_colour(/datum/client_colour/manual_heart_blood, REF(src))
 	var/obj/cuffs = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
 	var/obj/legcuffs = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
 	if(user.handcuffed || user.legcuffed)
@@ -92,7 +92,7 @@
 		was_tooluser = FALSE
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/dna_vault_speedup)
 	QDEL_NULL(bloodsuckerdatum.frenzygrab)
-	owner.remove_client_colour(/datum/client_colour/manual_heart_blood)
+	owner.remove_client_colour(REF(src))
 
 	SEND_SIGNAL(bloodsuckerdatum, BLOODSUCKER_EXITS_FRENZY)
 	bloodsuckerdatum.frenzied = FALSE

--- a/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_mirror.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/structures/bloodsucker_mirror.dm
@@ -209,7 +209,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/bloodsucker/mirror/broken, 28)
 	stop_observe.Grant(user)
 
 	START_PROCESSING(SSobj, src)
-	user.add_client_colour(/datum/client_colour/glass_colour/red)
+	user.add_client_colour(/datum/client_colour/glass_colour/red, REF(src))
 	set_light_on(TRUE)
 
 	bloodsuckerdatum.blood_structure_in_use = src
@@ -227,7 +227,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/bloodsucker/mirror/broken, 28)
 	change_observe.Remove(user)
 	stop_observe.Remove(user)
 	STOP_PROCESSING(SSobj, src)
-	user.remove_client_colour(/datum/client_colour/glass_colour/red)
+	user.remove_client_colour(REF(src))
 	set_light_on(FALSE)
 
 	observed.eye_color_left = original_eye_color_left


### PR DESCRIPTION

## About The Pull Request
This PR brings a couple lines of (mainly bloodsucker-related) code up to date with a recent TG refactor of client colours (TGstation PR [#89843](https://github.com/tgstation/tgstation/pull/89843)).
## Why It's Good For The Game
The red overlay provided by bloodsucker frenzying and blood mirror usage is permanent without this.
## Changelog
:cl:
fix: Fixed the overlay provided by bloodsucker frenzying and blood mirror usage being permanent.
/:cl:
