### PR TITLE
Adds Two Minor Cateor Hit Effects

### DIFF
--- a/fulp_modules/features/events/cateors/cateor.dm
+++ b/fulp_modules/features/events/cateors/cateor.dm
@@ -210,8 +210,20 @@
 		cateor_ion_laws += "Seek out a roboticist (or similar humanoid equivalent) immediately, \
 		for you are a starving Victorian child in cat form and require sustenance."
 
-		var/mob/living/silicon/unfortunate_robot = target
-		unfortunate_robot.add_ion_law(pick(cateor_ion_laws))
+		var/mob/living/silicon/unfortunate_silicon = target
+		unfortunate_silicon.add_ion_law(pick(cateor_ion_laws))
+
+	if(istype(target, /mob/living/silicon/robot))
+		var/mob/living/silicon/robot/unfortunate_robot = target
+		if(!(unfortunate_robot.hat && HAS_TRAIT(unfortunate_robot.hat, TRAIT_NODROP)))
+			var/obj/item/clothing/head/costume/kitty/cat_ears = new /obj/item/clothing/head/costume/kitty
+			unfortunate_robot.place_on_head(cat_ears)
+
+	if(istype(target, /mob/living/silicon/pai))
+		var/mob/living/silicon/pai/unfortunate_pai = target
+		unfortunate_pai.chassis = "cat"
+		unfortunate_pai.update_appearance()
+
 
 	playsound(src.loc, 'fulp_modules/sounds/effects/anime_wow.ogg', 50) // (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧ WOAW!!!
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR gives cateors two unique interactions with cyborgs and pAIs. Cyborgs hit by cateors will get the cat ears hat, and pAIs hit by cateors will have their holochassis changed to `"cat"`.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a small thing that makes cateors a bit more interactive.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Gave cateors a couple more hit effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
