### PR TITLE
Changes and fixes to Selene's Engineering

### DIFF
--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -1559,7 +1559,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "axU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -3611,18 +3611,14 @@
 /area/station/hallway/primary/aft)
 "bjt" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access"
-	},
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/lobby)
 "bjw" = (
@@ -11996,6 +11992,10 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Foyer E";
+	network = list("ss13","engineering")
+	},
 /turf/open/floor/iron/half,
 /area/station/engineering/lobby)
 "eof" = (
@@ -29257,7 +29257,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
@@ -31727,6 +31727,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/cargo)
 "luW" = (
+/obj/structure/reagent_dispensers/water_cooler{
+	pixel_x = -3;
+	pixel_y = 10
+	},
 /turf/open/floor/iron/half{
 	dir = 8
 	},
@@ -38413,8 +38417,8 @@
 /turf/open/misc/asteroid/basalt,
 /area/station/maintenance/fore)
 "nGU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -44961,9 +44965,7 @@
 /area/station/maintenance/starboard/fore)
 "qga" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qgc" = (
@@ -53571,10 +53573,6 @@
 /area/station/service/library/artgallery)
 "tmT" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering - Foyer E";
-	network = list("ss13","engineering")
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -56979,10 +56977,6 @@
 /turf/open/floor/plating,
 /area/station/security/office)
 "uzC" = (
-/obj/structure/reagent_dispensers/water_cooler{
-	pixel_x = -3;
-	pixel_y = 10
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -59349,9 +59343,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "vqJ" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access"
-	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
@@ -59364,6 +59355,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Access"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "vqT" = (
@@ -99653,7 +99647,7 @@ kiB
 tni
 tVi
 qum
-ljo
+kiB
 tmT
 pRH
 nBI
@@ -100167,7 +100161,7 @@ kiB
 xUt
 cdM
 iYD
-ljo
+kiB
 uzC
 thT
 bSU

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -927,6 +927,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "aoE" = (
@@ -6933,6 +6934,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "cub" = (
@@ -10104,6 +10106,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dEq" = (
@@ -11987,15 +11990,10 @@
 /turf/closed/wall,
 /area/station/command/heads_quarters/captain)
 "eob" = (
-/obj/structure/chair,
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering - Foyer E";
-	network = list("ss13","engineering")
-	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/half,
 /area/station/engineering/lobby)
 "eof" = (
@@ -19933,6 +19931,7 @@
 /area/station/service/kitchen/coldroom)
 "hiF" = (
 /obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "hiN" = (
@@ -20897,6 +20896,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "hDE" = (
@@ -26387,6 +26387,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/ai_all,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "jCe" = (
@@ -28686,6 +28687,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "koX" = (
@@ -30463,6 +30465,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
 "kWT" = (
@@ -31256,13 +31259,10 @@
 /turf/open/floor/vault,
 /area/station/command/bridge)
 "llZ" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Engineering - Secure Tech Storage";
-	network = list("ss13","engineering")
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
+/obj/structure/lattice,
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lmj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31727,10 +31727,8 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/cargo)
 "luW" = (
-/obj/structure/reagent_dispensers/water_cooler{
-	pixel_x = -3;
-	pixel_y = 10
-	},
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/camera/directional/east,
 /turf/open/floor/iron/half{
 	dir = 8
 	},
@@ -32478,6 +32476,11 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/iron/white,
 /area/station/commons/locker)
+"lHm" = (
+/obj/structure/cable,
+/obj/machinery/camera/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "lHq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34108,6 +34111,7 @@
 "miu" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "miE" = (
@@ -34292,6 +34296,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mkG" = (
@@ -38916,6 +38921,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/textured,
 /area/station/tcommsat/computer)
 "nRg" = (
@@ -45333,6 +45339,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "qlX" = (
@@ -46657,6 +46664,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "qLT" = (
@@ -52894,6 +52902,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "tbM" = (
@@ -58104,6 +58113,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "uTY" = (
@@ -59345,7 +59355,6 @@
 "vqJ" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/engineering/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
@@ -59358,7 +59367,7 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Access"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/lobby)
 "vqT" = (
 /obj/structure/cable,
@@ -60765,6 +60774,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
+"vUf" = (
+/obj/effect/turf_decal/tile/engineering/half{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "vUi" = (
 /obj/structure/table,
 /obj/item/gavelhammer,
@@ -62906,6 +62922,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "wIH" = (
@@ -65530,7 +65547,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "xAu" = (
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -65618,6 +65634,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
 /obj/effect/turf_decal/tile/engineering/opposingcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "xBQ" = (
@@ -97588,10 +97605,10 @@ fVE
 ukk
 qis
 rbM
-iQW
-iQW
-iQW
-iQW
+llZ
+yju
+yju
+yju
 ljo
 lqU
 oAA
@@ -97845,8 +97862,8 @@ nyR
 auV
 gXU
 vBr
-vBr
-vBr
+nzy
+nzy
 vBr
 ljo
 ljo
@@ -98102,7 +98119,7 @@ xOM
 iVA
 hcv
 vBr
-llZ
+pwD
 vty
 vBr
 iom
@@ -98616,7 +98633,7 @@ cpq
 scw
 lmI
 vBr
-pwD
+lHm
 eQz
 vBr
 iom
@@ -99130,9 +99147,9 @@ kTa
 tmm
 xhe
 rbM
-iQW
-iQW
-iQW
+llZ
+yju
+yju
 ljo
 vMb
 jMJ
@@ -104022,7 +104039,7 @@ fuY
 uYt
 wHs
 bAT
-vAo
+vUf
 vAo
 vAo
 sqz

--- a/_maps/map_files/SeleneStation/SeleneStation.dmm
+++ b/_maps/map_files/SeleneStation/SeleneStation.dmm
@@ -29257,7 +29257,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)


### PR DESCRIPTION
## About The Pull Request
Makes the Engi entrance a bit friendlier to crew trying to talk with engineers by swapping the outward airlock for a public one and adding windows to the foyer.

![selene edit 2](https://github.com/user-attachments/assets/6f11a47d-b925-4d43-a2d0-462f05bf59c7)

Also fixes some not so hidden pipes, and missing firelocks to most of engineering, and missing firealarms, and kills the chair get up and go work lazy ass, and adds windows to the secure storage, and nearstation near secure storage, and the TCOMs air alarm won't trigger roundstart, and likely other small stuff I forgot.
## Why It's Good For The Game
Easier to check if any engineer is vibing at the foyer, and makes the hallways a bit prettier with hidden pipes.
## Changelog
:cl: Guillaume Prata
fix: Some not so hidden pipes at Selene's Engineering hallway
map: Change the entrance of Selene's Engineering by allowing crew to get access closer to the foyer and adding windows to it, now it is easier to chat with Engineering's crew.
/:cl:
