### PR TITLE
Monster Hunter Contract Improvements

### DIFF
--- a/fulp_modules/features/antagonists/monster_hunter/assets/monster_hunter_assets.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/assets/monster_hunter_assets.dm
@@ -1,0 +1,12 @@
+// Partially copied from 'fulp_modules\features\antagonists\bloodsuckers\code\assets\bloodsucker_assets.dm'
+// Currently only contains the "white_rabbit" icon.
+
+/datum/asset/simple/monster_hunter_icons
+
+/datum/asset/simple/monster_hunter_icons/register()
+	add_monster_hunter_icon('fulp_modules/icons/antagonists/monster_hunter/rabbit.dmi', "white_rabbit")
+	return ..()
+
+/datum/asset/simple/monster_hunter_icons/proc/add_monster_hunter_icon(monster_hunter_icon, monster_hunter_icon_state)
+	assets[SANITIZE_FILENAME("monster_hunter.[monster_hunter_icon_state].png")] = icon(monster_hunter_icon, monster_hunter_icon_state)
+

--- a/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
+++ b/fulp_modules/features/antagonists/monster_hunter/hunting_contract.dm
@@ -52,27 +52,38 @@
 /obj/item/hunting_contract/ui_data(mob/user)
 	var/list/data = list()
 	data["bought"] = bought
-	data["items"] = list()
-	data["objectives"] = list()
+
 	if(weapons.len)
 		for(var/datum/hunter_weapons/contraband as anything in weapons)
-			data["items"] += list(list(
-				"id" = contraband.type,
-				"name" = contraband.name,
-				"desc" = contraband.desc,
-			))
+			var/list/item_data = list()
+
+			item_data["item_id"] = contraband.type
+			item_data["item_name"] = contraband.name
+			item_data["item_desc"] = contraband.desc
+
+			data["items"] += list(item_data)
+
 	if(owner)
 		data["rabbits_found"] = !(owner.rabbits.len)
 		data["used_up"] = used_up
 		var/objective_unfinished = FALSE
+
 		for(var/datum/objective/existing_objective as anything in owner.objectives)
 			var/completed = existing_objective.check_completion()
 			if(completed)
 				continue
-			data["objectives"] += list(list("explanation" = existing_objective.explanation_text))
+
 			objective_unfinished = TRUE
+			var/list/objective_data = list()
+
+			objective_data["name"] += existing_objective.name
+			objective_data["explanation"] += existing_objective.explanation_text
+
+			data["objectives"] += list(objective_data)
+
 		objectives_completed = !objective_unfinished
 		data["all_completed"] = objectives_completed
+
 	return data
 
 /obj/item/hunting_contract/ui_act(action, params)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6664,6 +6664,7 @@
 #include "fulp_modules\features\antagonists\monster_hunter\white_rabbit.dm"
 #include "fulp_modules\features\antagonists\monster_hunter\wonderland.dm"
 #include "fulp_modules\features\antagonists\monster_hunter\wonderland_apocalypse.dm"
+#include "fulp_modules\features\antagonists\monster_hunter\assets\monster_hunter_assets.dm"
 #include "fulp_modules\features\antagonists\monster_hunter\ported_content\afterimage.dm"
 #include "fulp_modules\features\antagonists\monster_hunter\ported_content\glitched_state.dm"
 #include "fulp_modules\features\antagonists\rulesets\bloodsucker_rulesets.dm"

--- a/tgui/packages/tgui/fulpui-patches/HunterContract.tsx
+++ b/tgui/packages/tgui/fulpui-patches/HunterContract.tsx
@@ -38,15 +38,17 @@ const HunterApocalypseButton = (props) => {
 
   return (
     <>
-      <Section noTopPadding>
+      <Section noTopPadding align="center">
         <Image
-          align="center"
           height="96px"
           width="96px"
           src={resolveAsset(`monster_hunter.white_rabbit.png`)}
           verticalAlign="middle"
+          style={{
+            marginTop: '-32px',
+          }}
         />
-        <Box textAlign="center" fontSize="150%" className="candystripe">
+        <Box textAlign="center" fontSize="150%" className="candystripe" bold>
           Rabbits Found: {rabbits_count.toString()}&#47;5
         </Box>
       </Section>
@@ -60,7 +62,7 @@ const HunterApocalypseButton = (props) => {
           disabled={!all_completed || !all_rabbits_found || used_up}
           onClick={() => act('claim_reward')}
           tooltip={
-            'Only unlocked once all objectives are completed and rabbits are found, this will allow you to start your Final Reckoning.'
+            'Unlocked once all objectives are completed and all rabbits are found. This will allow you to merge the station with Wonderland.'
           }
         />
       </Box>
@@ -70,11 +72,36 @@ const HunterApocalypseButton = (props) => {
 
 export const HunterContract = () => {
   const { act, data } = useBackend<Info>();
-  const { items, bought } = data;
+  const { items, bought, used_up } = data;
+  if (bought && used_up) {
+    return (
+      <Window
+        width={300}
+        height={150}
+        theme="spookyconsole"
+        title="Completed Hunter's Contract"
+      >
+        <Window.Content>
+          <Stack vertical fill>
+            <Stack.Divider />
+            <Box textAlign="center" fontSize="200%" pt={1}>
+              Contract completed!
+            </Box>
+            <Box textAlign="center" italic pt={1} pb={1}>
+              You are now obliged to do as you will— just don't interfere with
+              the rabbits from Wonderland!
+            </Box>
+            <Stack.Divider />
+          </Stack>
+        </Window.Content>
+      </Window>
+    );
+  }
+
   return (
     <Window
       width={bought ? 325 : 425}
-      height={bought ? 325 : 575}
+      height={bought ? 295 : 550}
       theme="spookyconsole"
       title="Hunter's Contract"
     >
@@ -104,7 +131,7 @@ export const HunterContract = () => {
                       <Stack.Item grow bold>
                         {item.item_name}
                       </Stack.Item>
-                      <Stack.Item>
+                      <Stack.Item pb={0.5}>
                         <Button
                           content="Claim"
                           disabled={bought}

--- a/tgui/packages/tgui/fulpui-patches/HunterContract.tsx
+++ b/tgui/packages/tgui/fulpui-patches/HunterContract.tsx
@@ -29,52 +29,42 @@ const HunterObjectives = (props: any) => {
     return;
   }
 
-  return (
-    <Stack vertical fill>
-      <Stack.Item grow>
-        <ObjectivePrintout fill objectives={objectives} />
-      </Stack.Item>
-    </Stack>
-  );
+  return <ObjectivePrintout fill objectives={objectives} />;
 };
 
-const HunterApocalypseButton = (props: any) => {
+const HunterApocalypseButton = (props) => {
   const { act, data } = useBackend<Info>();
   const { all_completed, all_rabbits_found, rabbits_count, used_up } = data;
+
   return (
-    <Stack fill vertical align="center">
-      <Stack.Item grow>
-        <Section bold fontSize="125%" fill>
-          <Image
-            height="96px"
-            width="96px"
-            src={resolveAsset(`monster_hunter.white_rabbit.png`)}
-            style={{
-              verticalAlign: 'middle',
-            }}
-          />
-          <Box textAlign="center">
-            Rabbits Found: {rabbits_count.toString()}&#47;5
-          </Box>
-        </Section>
-      </Stack.Item>
-      <Stack.Item grow>
-        <Box>
-          <Button
-            fluid
-            textAlign="center"
-            align="center"
-            content={'Commence Apocalypse'}
-            fontSize="200%"
-            disabled={!all_completed || !all_rabbits_found || used_up}
-            onClick={() => act('claim_reward')}
-            tooltip={
-              'Only unlocked once all objectives are completed and rabbits are found, this will allow you to start your Final Reckoning.'
-            }
-          />
+    <>
+      <Section noTopPadding>
+        <Image
+          align="center"
+          height="96px"
+          width="96px"
+          src={resolveAsset(`monster_hunter.white_rabbit.png`)}
+          verticalAlign="middle"
+        />
+        <Box textAlign="center" fontSize="150%" className="candystripe">
+          Rabbits Found: {rabbits_count.toString()}&#47;5
         </Box>
-      </Stack.Item>
-    </Stack>
+      </Section>
+      <Box>
+        <Button
+          fluid
+          textAlign="center"
+          align="center"
+          content={'Commence Apocalypse'}
+          fontSize="200%"
+          disabled={!all_completed || !all_rabbits_found || used_up}
+          onClick={() => act('claim_reward')}
+          tooltip={
+            'Only unlocked once all objectives are completed and rabbits are found, this will allow you to start your Final Reckoning.'
+          }
+        />
+      </Box>
+    </>
   );
 };
 
@@ -83,8 +73,8 @@ export const HunterContract = () => {
   const { items, bought } = data;
   return (
     <Window
-      width={bought ? 325 : 400}
-      height={bought ? 325 : 550}
+      width={bought ? 325 : 425}
+      height={bought ? 325 : 575}
       theme="spookyconsole"
       title="Hunter's Contract"
     >
@@ -132,16 +122,13 @@ export const HunterContract = () => {
               </Stack.Item>
             </>
           )}
+          <Stack.Divider />
           <Stack.Item>
-            <Section>
-              <HunterObjectives />
-            </Section>
+            <HunterObjectives />
           </Stack.Item>
           <Stack.Divider />
           <Stack.Item>
-            <Box>
-              <HunterApocalypseButton />
-            </Box>
+            <HunterApocalypseButton />
           </Stack.Item>
         </Stack>
       </Window.Content>

--- a/tgui/packages/tgui/fulpui-patches/HunterContract.tsx
+++ b/tgui/packages/tgui/fulpui-patches/HunterContract.tsx
@@ -1,19 +1,45 @@
+import { useState } from 'react';
 import { Box, Button, Dropdown, Stack } from 'tgui-core/components';
+import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
 
-const HunterObjectives = (props) => {
-  const { act, data } = useBackend();
-  const { objectives = [], all_completed, rabbits_found, used_up } = data;
+type HunterAndContractInformation = {
+  objectives: Objective[];
+  items: ItemInfo[];
+  rabbits_found: BooleanLike;
+  all_completed: BooleanLike;
+  used_up: BooleanLike;
+  bought: BooleanLike;
+};
+
+type ItemInfo = {
+  item_id: string;
+  item_name: string;
+  item_desc: string;
+};
+
+type Objective = {
+  name: string;
+  explanation: string;
+};
+
+const HunterObjectives = () => {
+  const { act, data } = useBackend<HunterAndContractInformation>();
+  const { objectives, all_completed, rabbits_found, used_up } = data;
+
+  const [selectedObjective, setSelectedObjective] = useState(objectives[0]);
   return (
     <Stack vertical fill>
-      <Stack.Item>
+      <Stack.Item grow>
         <Dropdown
           over
+          displayText={selectedObjective.name}
+          selected={selectedObjective.name}
           width="100%"
-          options={objectives.map((objective) => objective.explanation)}
-          displayText={'Incomplete Objectives'}
+          options={objectives.map((objective) => objective.name)}
+          onSelected={(objective: Objective) => setSelectedObjective(objective)}
         />
       </Stack.Item>
       <Stack.Item>
@@ -36,9 +62,9 @@ const HunterObjectives = (props) => {
   );
 };
 
-export const HunterContract = (props) => {
-  const { act, data } = useBackend();
-  const { items = [], bought } = data;
+export const HunterContract = () => {
+  const { act, data } = useBackend<HunterAndContractInformation>();
+  const { items, bought } = data;
   return (
     <Window
       width={500}
@@ -61,10 +87,10 @@ export const HunterContract = (props) => {
             </Button>
             <Stack.Item>
               {items.map((item) => (
-                <Box key={item.name} className="candystripe" p={1} pb={2}>
+                <Box key={item.item_name} className="candystripe" p={1} pb={2}>
                   <Stack align="baseline">
                     <Stack.Item grow bold>
-                      {item.name}
+                      {item.item_name}
                     </Stack.Item>
                     <Stack.Item>
                       <Button
@@ -72,13 +98,13 @@ export const HunterContract = (props) => {
                         disabled={bought}
                         onClick={() =>
                           act('select', {
-                            item: item.id,
+                            item: item.item_id,
                           })
                         }
                       />
                     </Stack.Item>
                   </Stack>
-                  {item.desc}
+                  {item.item_desc}
                 </Box>
               ))}
             </Stack.Item>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This contract makes a few improvements to the monster hunter contract UI. The exact improvements made are as follows:

1. The addition of a "fabbits found" counter.
2. The replacement of the (previously nonfunctional) objectives dropdown with a plain objectives list.
3. The addition of automatic UI closing on weapon purchase/apocalypse commencement as a small bit of QoL.
4. The removal of certain elements of the AI when they are no longer needed during gameplay.

<details><summary>Expand for images of the new UI appearances...</summary>
<hr>

- Standard UI:
![image](https://github.com/user-attachments/assets/cf300209-79e4-4165-9146-a05ba16ef892)

- UI after weapon purchase:
![image](https://github.com/user-attachments/assets/769cb37e-3573-4a0c-b53c-f45191ab39d2)

- UI after apocalypse commencement:
![image](https://github.com/user-attachments/assets/cd5cbb6f-931f-4efe-a5fe-9417624fa9d5)


<hr>
</details>
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These changes should make the hunter contract both a bit easier to use and slightly more useful.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Made a few improvements to the monster hunter contract UI (including a rabbits found counter, a functional objectives list, and a couple QoL features).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
