### PR TITLE
Mentorwho box uses header

### DIFF
--- a/fulp_modules/features/mentors/mentorwho.dm
+++ b/fulp_modules/features/mentors/mentorwho.dm
@@ -10,13 +10,12 @@
 
 	var/list/lines = list()
 	var/payload_string = generate_mentorwho_string()
-	var/header = "Current Mentors:"
+	var/header = "Current Mentors"
 
 	lines += span_bold(header)
 	lines += payload_string
 
-	var/finalized_string = boxed_message(jointext(lines, "\n"))
-	to_chat(src, finalized_string)
+	to_chat(src, fieldset_block(span_bold(header), jointext(lines, "\n"), "boxed_message"), type = MESSAGE_TYPE_INFO)
 
 /// Proc that returns a list of cliented mentors. Remember that this list can contain nulls!
 /// Also, will return null if we don't have any mentors.


### PR DESCRIPTION
## About The Pull Request

Before


<img width="330" height="143" alt="image" src="https://github.com/user-attachments/assets/f8a1e4a0-a787-4aa1-a021-a835efd9a43c" />


After


<img width="299" height="84" alt="image" src="https://github.com/user-attachments/assets/e595ba63-e370-464d-a44d-30a84afbb6f8" />


## Why It's Good For The Game

Looks consistent with Adminwho now.

## Changelog

:cl:
fix: Mentorwho now properly uses a header.
/:cl: