### PR TITLE
Adds a mentorhelp button to the esc menu

### DIFF
--- a/code/modules/escape_menu/home_page.dm
+++ b/code/modules/escape_menu/home_page.dm
@@ -47,12 +47,24 @@
 	)
 
 	page_holder.give_screen_object(
+		new /atom/movable/screen/escape_menu/text/clickable/mentorhelp(
+			null,
+			/* hud_owner = */ null,
+			/* escape_menu = */ src,
+			/* button_text = */ "Mentor Help",
+			/* offset = */ list(-276, 30),
+			/* font_size = */ 24,
+			/* on_click_callback = */ CALLBACK(src, PROC_REF(home_open_mentorhelp)),
+		)
+	)
+
+	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/text/clickable/leave_body(
 			null,
 			/* hud_owner = */ null,
 			/* escape_menu = */ src,
 			/* button_text = */ "Leave Body",
-			/* offset = */ list(-276, 30),
+			/* offset = */ list(-311, 30),
 			/* font_size = */ 24,
 			/* on_click_callback = */ CALLBACK(src, PROC_REF(open_leave_body)),
 		)
@@ -64,7 +76,7 @@
 			/* hud_owner = */ null,
 			/* escape_menu = */ src,
 			/* button_text = */ "Quit",
-			/* offset = */ list(-311, 30),
+			/* offset = */ list(-346, 30),
 			/* font_size = */ 24,
 			/* on_click_callback = */ CALLBACK(src, PROC_REF(quit_game_prompt)),
 		)

--- a/fulp_modules/Z_edits/esc_menu_edit.dm
+++ b/fulp_modules/Z_edits/esc_menu_edit.dm
@@ -1,0 +1,10 @@
+/atom/movable/screen/escape_menu/text/clickable/mentorhelp/enabled()
+	. = ..()
+	if (!.)
+		return FALSE
+
+	return !(escape_menu.client?.prefs.muted & MUTE_ADMINHELP)
+
+/datum/escape_menu/proc/home_open_mentorhelp()
+	INVOKE_ASYNC(client, TYPE_PROC_REF(/client, get_mentor_help))
+	qdel(src)

--- a/fulp_modules/features/mentors/mentorhelp.dm
+++ b/fulp_modules/features/mentors/mentorhelp.dm
@@ -1,3 +1,7 @@
+/client/proc/get_mentor_help()
+	var/msg = tgui_input_text(src, null, "Mentorhelp")
+	mentorhelp(msg)
+
 /client/verb/mentorhelp(msg as text)
 	set category = "Mentor"
 	set name = "Mentorhelp"

--- a/fulp_modules/tg_edits.md
+++ b/fulp_modules/tg_edits.md
@@ -1,10 +1,10 @@
 ## List of all TG edits:
 
-- .github/workflows/compile_changelogs.yml > Same as above. //Not currently there, is this broken?
-
 - code/datums/greyscale/_greyscale_config.dm > Adds our greyscales folder to the sanity check
 
 - code/game/area/areas/shuttles.dm > Plays ApproachingFulp instead of ApproachingTG
+
+- code/modules/escape_menu/home_page.dm > Added Mentorhelp button & Moves other buttons down one each.
 
 - interface\interface.dm > Changes the TG Changelog verb to a new path & name.
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7144,6 +7144,7 @@
 #include "fulp_modules\mapping\station_objects\trees.dm"
 #include "fulp_modules\sounds\code\credits.dm"
 #include "fulp_modules\tgsbot\fulptgs.dm"
+#include "fulp_modules\Z_edits\esc_menu_edit.dm"
 #include "fulp_modules\Z_edits\felinid_edit.dm"
 #include "fulp_modules\Z_edits\fulp_bans.dm"
 #include "fulp_modules\Z_edits\fulp_languages.dm"


### PR DESCRIPTION
## About The Pull Request

You can mentorhelp from the esc menu which prompts a TGUI input box.

## Why It's Good For The Game

Moving away from the stat panel shouldn't mean mentor stuff becomes less visible.

## Changelog

:cl:
add: Added a Mentorhelp button to the Escape menu.
/:cl: