### PR TITLE
Fixes disfigured Bloodsuckers

### DIFF
--- a/code/__DEFINES/fulp_defines/bloodsuckers.dm
+++ b/code/__DEFINES/fulp_defines/bloodsuckers.dm
@@ -111,6 +111,8 @@
 #define COMSIG_SOL_WARNING_GIVEN "comsig_sol_warning_given"
 ///Called on a Bloodsucker's Lifetick.
 #define COMSIG_BLOODSUCKER_ON_LIFETICK "comsig_bloodsucker_on_lifetick"
+///Called when a Bloodsucker's organs are all revived. /proc/heal_vampire_organs()
+#define COMSIG_BLOODSUCKER_REVIVAL "bloodsucker_revival"
 
 #define DANGER_LEVEL_FIRST_WARNING 1
 #define DANGER_LEVEL_SECOND_WARNING 2

--- a/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -130,7 +130,7 @@
 	for(var/missing_limb in missing) //Find ONE Limb and regenerate it.
 		user.regenerate_limb(missing_limb, FALSE)
 		AddBloodVolume(-limb_regen_cost)
-		var/obj/item/bodypart/missing_bodypart = user.get_bodypart(missing_limb) // 2) Limb returns Damaged
+		var/obj/item/bodypart/missing_bodypart = user.get_bodypart(missing_limb) // Limb returns Damaged
 		missing_bodypart.brute_dam = 60
 		to_chat(user, span_notice("Your flesh knits as it regrows your [missing_bodypart]!"))
 		playsound(user, 'sound/effects/magic/demon_consume.ogg', 50, TRUE)
@@ -183,6 +183,8 @@
 			continue
 		yucky_organs.Remove(bloodsuckeruser)
 		yucky_organs.forceMove(get_turf(bloodsuckeruser))
+
+	SEND_SIGNAL(src, COMSIG_BLOODSUCKER_REVIVAL)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_nosferatu.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_nosferatu.dm
@@ -12,19 +12,27 @@
 
 /datum/bloodsucker_clan/nosferatu/New(datum/antagonist/bloodsucker/owner_datum)
 	. = ..()
+	RegisterSignal(bloodsuckerdatum, COMSIG_BLOODSUCKER_REVIVAL, PROC_REF(on_organs_revived))
 	for(var/datum/action/cooldown/bloodsucker/power as anything in bloodsuckerdatum.powers)
 		if(istype(power, /datum/action/cooldown/bloodsucker/masquerade) || istype(power, /datum/action/cooldown/bloodsucker/veil))
 			bloodsuckerdatum.RemovePower(power)
 	if(!bloodsuckerdatum.owner.current.has_quirk(/datum/quirk/badback))
 		bloodsuckerdatum.owner.current.add_quirk(/datum/quirk/badback)
-	bloodsuckerdatum.owner.current.add_traits(list(TRAIT_VENTCRAWLER_ALWAYS, TRAIT_DISFIGURED), BLOODSUCKER_TRAIT)
+	ADD_TRAIT(bloodsuckerdatum.owner.current, TRAIT_VENTCRAWLER_ALWAYS, BLOODSUCKER_TRAIT)
+	var/obj/item/bodypart/head = bloodsuckerdatum.owner.current.get_bodypart(BODY_ZONE_HEAD)
+	if(head)
+		ADD_TRAIT(head, TRAIT_DISFIGURED, BLOODSUCKER_TRAIT)
 
 /datum/bloodsucker_clan/nosferatu/Destroy(force)
+	UnregisterSignal(bloodsuckerdatum, COMSIG_BLOODSUCKER_REVIVAL)
 	for(var/datum/action/cooldown/bloodsucker/power in bloodsuckerdatum.powers)
 		bloodsuckerdatum.RemovePower(power)
 	bloodsuckerdatum.give_starting_powers()
 	bloodsuckerdatum.owner.current.remove_quirk(/datum/quirk/badback)
-	bloodsuckerdatum.owner.current.remove_traits(list(TRAIT_VENTCRAWLER_ALWAYS, TRAIT_DISFIGURED), BLOODSUCKER_TRAIT)
+	REMOVE_TRAIT(bloodsuckerdatum.owner.current, TRAIT_VENTCRAWLER_ALWAYS, BLOODSUCKER_TRAIT)
+	var/obj/item/bodypart/head = bloodsuckerdatum.owner.current.get_bodypart(BODY_ZONE_HEAD)
+	if(head)
+		REMOVE_TRAIT(head, TRAIT_DISFIGURED, BLOODSUCKER_TRAIT)
 	return ..()
 
 /datum/bloodsucker_clan/nosferatu/handle_clan_life(datum/antagonist/bloodsucker/source)
@@ -41,6 +49,14 @@
 /datum/bloodsucker_clan/nosferatu/on_favorite_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/favorite/vassaldatum)
 	vassaldatum.owner.current.add_traits(list(TRAIT_VENTCRAWLER_NUDE, TRAIT_DISFIGURED), BLOODSUCKER_TRAIT)
 	to_chat(vassaldatum.owner.current, span_notice("Additionally, you can now ventcrawl while naked, and are permanently disfigured."))
+
+///Called when Bloodsucker organs are all revived, we'll ensure the head (new or not) is still disfigured.
+/datum/bloodsucker_clan/nosferatu/proc/on_organs_revived(datum/antagonist/bloodsucker/source)
+	SIGNAL_HANDLER
+
+	var/obj/item/bodypart/head = source.owner.current.get_bodypart(BODY_ZONE_HEAD)
+	if(head)
+		ADD_TRAIT(head, TRAIT_DISFIGURED, BLOODSUCKER_TRAIT)
 
 /**
  * Clan objective

--- a/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_nosferatu.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/clans/clan_nosferatu.dm
@@ -47,7 +47,10 @@
 			our_switch.interact(source.owner.current)
 
 /datum/bloodsucker_clan/nosferatu/on_favorite_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/favorite/vassaldatum)
-	vassaldatum.owner.current.add_traits(list(TRAIT_VENTCRAWLER_NUDE, TRAIT_DISFIGURED), BLOODSUCKER_TRAIT)
+	ADD_TRAIT(vassaldatum.owner.current, TRAIT_VENTCRAWLER_NUDE, BLOODSUCKER_TRAIT)
+	var/obj/item/bodypart/head = vassaldatum.owner.current.get_bodypart(BODY_ZONE_HEAD)
+	if(head)
+		ADD_TRAIT(head, TRAIT_DISFIGURED, BLOODSUCKER_TRAIT)
 	to_chat(vassaldatum.owner.current, span_notice("Additionally, you can now ventcrawl while naked, and are permanently disfigured."))
 
 ///Called when Bloodsucker organs are all revived, we'll ensure the head (new or not) is still disfigured.

--- a/fulp_modules/features/antagonists/bloodsuckers/code/powers/veil.dm
+++ b/fulp_modules/features/antagonists/bloodsuckers/code/powers/veil.dm
@@ -26,7 +26,8 @@
 	var/prev_underwear
 	var/prev_undershirt
 	var/prev_socks
-	var/prev_disfigured
+	///List of sources that the user is disfigured by, so we give it back afterwards.
+	var/list/prev_disfigured
 	var/list/prev_features // For lizards and such
 	var/disguise_name
 
@@ -36,7 +37,7 @@
 //	if(blahblahblah)
 //		Disguise_Outfit()
 	veil_user()
-	owner.balloon_alert(owner, "veil turned on.")
+	owner.balloon_alert(owner, "veil on")
 
 /* // Meant to disguise your character's clothing into fake ones.
 /datum/action/cooldown/bloodsucker/veil/proc/Disguise_Outfit()
@@ -61,7 +62,8 @@
 	prev_undershirt = user.undershirt
 	prev_socks = user.socks
 //	prev_eye_color
-	prev_disfigured = HAS_TRAIT(user, TRAIT_DISFIGURED) // I was disfigured! //prev_disabilities = user.disabilities
+	var/obj/item/bodypart/head = user.get_bodypart(BODY_ZONE_HEAD)
+	prev_disfigured = head ? GET_TRAIT_SOURCES(head, TRAIT_DISFIGURED) : list() // I was disfigured! //prev_disabilities = user.disabilities
 	prev_features = user.dna.features
 
 	// Change Appearance
@@ -75,8 +77,12 @@
 	user.undershirt = random_undershirt(user.gender)
 	user.socks = random_socks(user.gender)
 	//user.eye_color = random_eye_color()
-	if(prev_disfigured)
-		REMOVE_TRAIT(user, TRAIT_DISFIGURED, null)
+
+	//we know there's a head cause otherwise this wouldn't pass
+	if(LAZYLEN(prev_disfigured))
+		for(var/source in prev_disfigured)
+			REMOVE_TRAIT(head, TRAIT_DISFIGURED, source)
+
 	user.dna.features = user.dna.species.randomize_features()
 
 	// Apply Appearance
@@ -110,10 +116,12 @@
 	user.undershirt = prev_undershirt
 	user.socks = prev_socks
 
-	//user.disabilities = prev_disabilities // Restore HUSK, CLUMSY, etc.
-	if(prev_disfigured)
-		//We are ASSUMING husk. // user.status_flags |= DISFIGURED // Restore "Unknown" disfigurement
-		ADD_TRAIT(user, TRAIT_DISFIGURED, TRAIT_HUSK)
+	var/obj/item/bodypart/head = user.get_bodypart(BODY_ZONE_HEAD)
+	if(LAZYLEN(prev_disfigured) && head)
+		for(var/source in prev_disfigured)
+			ADD_TRAIT(head, TRAIT_DISFIGURED, source)
+		prev_disfigured = null
+
 	user.dna.features = prev_features
 
 	// Apply Appearance
@@ -121,7 +129,7 @@
 	user.update_body_parts(update_limb_data = TRUE) // Body itself, maybe skin color?
 
 	cast_effect() // POOF
-	owner.balloon_alert(owner, "veil turned off.")
+	owner.balloon_alert(owner, "veil off")
 
 	UnregisterSignal(user, COMSIG_HUMAN_GET_VISIBLE_NAME)
 


### PR DESCRIPTION
## About The Pull Request

Bloodsuckers are now properly disfigured again, it seems the trait was moved from the mob to its head at some point and I never realized.

## Changelog

:cl:
fix: Bloodsuckers can now be disfigured again.
/:cl: