### PR TITLE
Removes notify restart

### DIFF
--- a/fulp_modules/fulp_world/fulp_client.dm
+++ b/fulp_modules/fulp_world/fulp_client.dm
@@ -2,3 +2,4 @@
 	. = ..()
 	UNASSIGN_GAME_VERB(src, /client, linkforumaccount)
 	UNASSIGN_GAME_VERB(src, /client, verify_in_discord)
+	UNASSIGN_GAME_VERB(src, /client, notify_restart)


### PR DESCRIPTION
## About The Pull Request

Yet another verb related to linking accounts

## Why It's Good For The Game

The verb is useless for our players, so no point in having it around clogging up the verb list.

## Changelog

:cl:
del: Deleted the "Notify Restart" verb.
/:cl: