### PR TITLE
add fulp custom maps to build flags

### DIFF
--- a/tools/build/build_flags.json
+++ b/tools/build/build_flags.json
@@ -36,6 +36,9 @@
 			"description": "Overrides the map loaded at round start.",
 			"options": [
 				{ "value": "", "label": "default" },
+				{ "value": "heliostation", "label": "Helio Station" },
+				{ "value": "pubbystation", "label": "Pubby Station" },
+				{ "value": "selenestation", "label": "Selene Station" },
 				{ "value": "deltastation", "label": "Delta Station" },
 				{ "value": "icebox", "label": "Ice Box Station" },
 				{ "value": "metastation", "label": "MetaStation" },


### PR DESCRIPTION

## About The Pull Request
adds fulp custom maps to build_json
## Why It's Good For The Game
for map testing this makes it easy to force the desired map. [use this vscode extension ](https://marketplace.visualstudio.com/items?itemName=ss13.ss13buildflags)
<img width="392" height="984" alt="image" src="https://github.com/user-attachments/assets/f071f830-754e-4bce-b2d6-28109f20e620" />
## Changelog
:cl:
/:cl:
